### PR TITLE
fix(ingest,reupload): release the pooled connection before storage in the last two upload doors (#1848)

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -209,7 +209,8 @@ async def _bind_presigned_reupload(
     """Write the presigned facts onto the job; False when no row matched.
 
     No `staged_at` is stamped: nothing is staged until the completion door
-    binds the frozen object, and that key restarts the pending window.
+    binds the frozen key, which moves the row into the sweep's 24-hour
+    completion-bound class, still measured from `created_at`.
     """
     bound = await db.execute(
         _pending_reupload_update(job_id, dataset_id).values(user_metadata=metadata)
@@ -382,7 +383,9 @@ async def reupload_dataset(
             # already reclaimed keeps its terminal status and message.
             await db.execute(
                 _pending_reupload_update(job.id, dataset_id).values(
-                    status="failed", error_message=str(exc)
+                    status="failed",
+                    error_message=str(exc),
+                    completed_at=datetime.now(timezone.utc),
                 )
             )
             await db.commit()

--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -173,6 +173,51 @@ async def _cleanup_uncommitted_reupload_source(
         )
 
 
+def _pending_reupload_update(job_id: uuid.UUID, dataset_id: uuid.UUID):
+    """An UPDATE that matches the job only while it is pending and bound here.
+
+    Every write after the row is committed goes through this guard, so a row
+    the sweep reclaimed, or one a dataset deletion unbound, is left as it was
+    and the caller learns that from a zero rowcount.
+    """
+    return update(IngestJob).where(
+        IngestJob.id == job_id,
+        IngestJob.dataset_id == dataset_id,
+        IngestJob.status == "pending",
+    )
+
+
+def _reupload_bind_refusal() -> HTTPException:
+    """The 409 for a guarded write that matched no row."""
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=(
+            "This upload could not be attached to the dataset. It may "
+            "have taken too long, or the dataset may no longer exist. "
+            "Start the re-upload again."
+        ),
+    )
+
+
+async def _bind_presigned_reupload(
+    db: AsyncSession,
+    *,
+    job_id: uuid.UUID,
+    dataset_id: uuid.UUID,
+    metadata: dict,
+) -> bool:
+    """Write the presigned facts onto the job; False when no row matched.
+
+    No `staged_at` is stamped: nothing is staged until the completion door
+    binds the frozen object, and that key restarts the pending window.
+    """
+    bound = await db.execute(
+        _pending_reupload_update(job_id, dataset_id).values(user_metadata=metadata)
+    )
+    await db.commit()
+    return bool(bound.rowcount)
+
+
 def _assert_compatible_record_type(
     dataset,
     filename: str | None,
@@ -336,13 +381,9 @@ async def reupload_dataset(
             # fix(#1848 audit): guarded like the bind below, so a row the sweep
             # already reclaimed keeps its terminal status and message.
             await db.execute(
-                update(IngestJob)
-                .where(
-                    IngestJob.id == job.id,
-                    IngestJob.dataset_id == dataset_id,
-                    IngestJob.status == "pending",
+                _pending_reupload_update(job.id, dataset_id).values(
+                    status="failed", error_message=str(exc)
                 )
-                .values(status="failed", error_message=str(exc))
             )
             await db.commit()
             raise HTTPException(
@@ -354,13 +395,7 @@ async def reupload_dataset(
         # to this dataset, stamping `staged_at` so the pending window restarts
         # here. The carried-through metadata is what the binding gate reads.
         bound = await db.execute(
-            update(IngestJob)
-            .where(
-                IngestJob.id == job.id,
-                IngestJob.dataset_id == dataset_id,
-                IngestJob.status == "pending",
-            )
-            .values(
+            _pending_reupload_update(job.id, dataset_id).values(
                 file_path=str(saved_path),
                 user_metadata={
                     **(job.user_metadata or {}),
@@ -370,14 +405,7 @@ async def reupload_dataset(
         )
         await db.commit()
         if not bound.rowcount:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=(
-                    "This upload could not be attached to the dataset. It may "
-                    "have taken too long, or the dataset may no longer exist. "
-                    "Start the re-upload again."
-                ),
-            )
+            raise _reupload_bind_refusal()
     except BaseException:
         await _cleanup_uncommitted_reupload_source(saved_path, job_id=job.id)
         raise
@@ -1196,8 +1224,15 @@ async def request_presigned_reupload(
 
     job = await get_catalog_port().create_ingest_job(db, request.filename, "", user.id)
     job.dataset_id = dataset_id
+    # fix(#1848): the markers the binding gate reads are committed with the
+    # row; the presigned facts land through the guarded bind once storage
+    # has answered, so a row cancelled or unbound meanwhile is refused.
+    job.user_metadata = {"reupload": True, "dataset_id": str(dataset_id)}
+    job_id = job.id
+    job_created_at = job.created_at
+    job_metadata = job.user_metadata
     storage = get_storage()
-    s3_key = f"staging/{job.id}/{request.filename}"
+    s3_key = f"staging/{job_id}/{request.filename}"
     physical_s3_key = resolve_current_storage_key(s3_key)
     threshold = settings.presigned_multipart_threshold_mb * 1024 * 1024
 
@@ -1206,7 +1241,10 @@ async def request_presigned_reupload(
     # its own expiration inside the signing thread, and this call is here only
     # so a job with no usable lifetime left is refused before an upload id
     # exists. The return is deliberately discarded. Same as the upload door.
-    get_catalog_port().require_signable_job_lifetime(job.created_at)
+    get_catalog_port().require_signable_job_lifetime(job_created_at)
+    # fix(#1848): committed before storage is asked for anything, so the pooled
+    # connection is not held across the multipart initiation or the signing.
+    await db.commit()
 
     if request.file_size > threshold:
         upload_id: str | None = None
@@ -1226,7 +1264,7 @@ async def request_presigned_reupload(
                 await run_in_thread_draining(
                     get_catalog_port().sign_url_with_deadline,
                     storage.generate_presigned_part_url,
-                    job.created_at,
+                    job_created_at,
                     physical_s3_key,
                     upload_id,
                     part_num,
@@ -1239,7 +1277,7 @@ async def request_presigned_reupload(
                     storage,
                     key=physical_s3_key,
                     upload_id=upload_id,
-                    job_id=job.id,
+                    job_id=job_id,
                 )
             # fix(#1235 review r5): an HTTPException from here is the lifetime
             # refusal and must survive as its own 409; the abort above has
@@ -1251,27 +1289,32 @@ async def request_presigned_reupload(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="Storage service unavailable",
             ) from exc
-        job.user_metadata = {
-            "presigned": True,
-            "s3_key": s3_key,
-            "upload_id": upload_id,
-            "multipart": True,
-            "reupload": True,
-            "dataset_id": str(dataset_id),
-            "expected_size": request.file_size,
-        }
         try:
-            await db.commit()
+            bound = await _bind_presigned_reupload(
+                db,
+                job_id=job_id,
+                dataset_id=dataset_id,
+                metadata={
+                    **job_metadata,
+                    "presigned": True,
+                    "s3_key": s3_key,
+                    "upload_id": upload_id,
+                    "multipart": True,
+                    "expected_size": request.file_size,
+                },
+            )
+            if not bound:
+                raise _reupload_bind_refusal()
         except BaseException:
             await get_catalog_port().abort_presigned_multipart_upload(
                 storage,
                 key=physical_s3_key,
                 upload_id=upload_id,
-                job_id=job.id,
+                job_id=job_id,
             )
             raise
         return PresignedUploadResponse(
-            job_id=job.id,
+            job_id=job_id,
             urls=urls,
             s3_key=physical_s3_key,
             upload_id=upload_id,
@@ -1281,21 +1324,26 @@ async def request_presigned_reupload(
         url = await run_in_thread_draining(
             get_catalog_port().sign_url_with_deadline,
             storage.generate_presigned_put_url,
-            job.created_at,  # expires with the job, not 3600s from now
+            job_created_at,  # expires with the job, not 3600s from now
             physical_s3_key,
             request.content_type,
         )
-        job.user_metadata = {
-            "presigned": True,
-            "s3_key": s3_key,
-            "multipart": False,
-            "reupload": True,
-            "dataset_id": str(dataset_id),
-            "expected_size": request.file_size,
-        }
-        await db.commit()
+        bound = await _bind_presigned_reupload(
+            db,
+            job_id=job_id,
+            dataset_id=dataset_id,
+            metadata={
+                **job_metadata,
+                "presigned": True,
+                "s3_key": s3_key,
+                "multipart": False,
+                "expected_size": request.file_size,
+            },
+        )
+        if not bound:
+            raise _reupload_bind_refusal()
         return PresignedUploadResponse(
-            job_id=job.id,
+            job_id=job_id,
             urls=[url],
             s3_key=physical_s3_key,
         )

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -1175,9 +1175,9 @@ async def upload_file(
         job = await create_ingest_job(db, file.filename, "", user.id)
         job_id = job.id
         job_metadata = job.user_metadata
-        # fix(#1848): the job is committed BEFORE the upload so the pooled
-        # connection is not held across it. The row survives a failed upload
-        # as `pending` with no `file_path`, which the stale-pending sweep reaps.
+        # fix(#1848): committed BEFORE the spooled body is staged, so no pooled
+        # connection is held across the staging copy or put, the validation
+        # download and the content sniff; a failed staging leaves it for the sweep.
         await db.commit()
         saved_path = await save_upload_file(
             file, str(job_id), max_size_bytes=max_size_bytes
@@ -1197,7 +1197,9 @@ async def upload_file(
                 # already reclaimed keeps its terminal status and message.
                 await db.execute(
                     _pending_upload_update(job_id).values(
-                        status="failed", error_message=str(exc)
+                        status="failed",
+                        error_message=str(exc),
+                        completed_at=datetime.now(timezone.utc),
                     )
                 )
                 await db.commit()

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -571,6 +571,22 @@ async def _cleanup_saved_upload(
         )
 
 
+def _pending_upload_update(job_id: uuid.UUID):
+    """An UPDATE that matches the upload's job only while it is still pending.
+
+    Every write after the row is committed goes through this guard, so a row
+    the sweep reclaimed keeps its verdict and the caller learns that from a
+    zero rowcount.
+    """
+    from sqlalchemy import update as sa_update
+
+    from app.platform.jobs.models import IngestJob
+
+    return sa_update(IngestJob).where(
+        IngestJob.id == job_id, IngestJob.status == "pending"
+    )
+
+
 def _stamp_raster_metadata(job: "IngestJob", filename: str | None) -> None:
     """Stamp ``user_metadata["file_type"] = "raster"`` from the filename.
 
@@ -1157,41 +1173,73 @@ async def upload_file(
         await check_upload_quota(db, user.id, incoming_bytes, request)
 
         job = await create_ingest_job(db, file.filename, "", user.id)
+        job_id = job.id
+        job_metadata = job.user_metadata
+        # fix(#1848): the job is committed BEFORE the upload so the pooled
+        # connection is not held across it. The row survives a failed upload
+        # as `pending` with no `file_path`, which the stale-pending sweep reaps.
+        await db.commit()
         saved_path = await save_upload_file(
-            file, str(job.id), max_size_bytes=max_size_bytes
+            file, str(job_id), max_size_bytes=max_size_bytes
         )
         validation_path = str(saved_path)
         downloaded_validation_path: Path | None = None
         try:
             if not isinstance(saved_path, Path):
-                validation_path = await resolve_file_path(saved_path, str(job.id))
+                validation_path = await resolve_file_path(saved_path, str(job_id))
                 downloaded_validation_path = Path(validation_path)
 
             # Inline content validation for immediate feedback.
             try:
                 validate_file_content(validation_path, file.filename)
             except ValueError as exc:
+                # fix(#1848): guarded like the bind below, so a row the sweep
+                # already reclaimed keeps its terminal status and message.
+                await db.execute(
+                    _pending_upload_update(job_id).values(
+                        status="failed", error_message=str(exc)
+                    )
+                )
+                await db.commit()
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail=str(exc),
                 ) from exc
 
-            _stamp_raster_metadata(job, file.filename)
-
-            job.file_path = str(saved_path)
+            # fix(#1848): bind only while the row is still pending, stamping
+            # `staged_at` so the pending window restarts here rather than at
+            # creation, which the upload itself has already spent.
+            bound = await db.execute(
+                _pending_upload_update(job_id).values(
+                    file_path=str(saved_path),
+                    user_metadata={
+                        **(_raster_stamped_metadata(job_metadata, file.filename) or {}),
+                        "staged_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+            )
             await db.commit()
+            if not bound.rowcount:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        "This upload could not be attached to its job. It may "
+                        "have taken too long, or the job may have been "
+                        "cancelled. Upload the file again."
+                    ),
+                )
         except BaseException:
-            # Until the job commit below, this request exclusively owns the
-            # staged source. Resolve/provider/content failures must delete it;
-            # otherwise the transaction rolls back the only retention record.
-            await _cleanup_saved_upload(saved_path, str(job.id))
+            # fix(#1848): the request owns the staged source until the bind
+            # lands, so every failure before it deletes the file; the row
+            # itself stays for the sweep or carries the refusal above.
+            await _cleanup_saved_upload(saved_path, str(job_id))
             raise
         finally:
             if downloaded_validation_path is not None:
                 downloaded_validation_path.unlink(missing_ok=True)
 
         return UploadResponse(
-            job_id=job.id,
+            job_id=job_id,
             status="pending",
             message="File uploaded and ready for preview",
         )

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -127,14 +127,18 @@ class TestUpload:
         assert resp.status_code == 422
         assert "standalone vrt" in resp.json()["detail"].lower()
 
-    async def test_s3_validation_download_failure_deletes_uncommitted_source(
+    async def test_s3_validation_download_failure_deletes_the_staged_source(
         self,
         client: AsyncClient,
         admin_auth_header: dict,
         test_db_session,
         mock_file_save,
     ):
-        """A failed validation download cannot orphan its just-written S3 key."""
+        """A failed validation download cannot orphan its just-written S3 key.
+
+        The job row is committed before the upload, so it stays `pending` with
+        nothing bound for the sweep to reap; the staged source is what must go.
+        """
         source_filename = f"resolve-failure-{uuid.uuid4()}.geojson"
         storage_key = f"staging/{uuid.uuid4()}/{source_filename}"
         mock_file_save.side_effect = None
@@ -165,7 +169,10 @@ class TestUpload:
         result = await test_db_session.execute(
             select(IngestJob).where(IngestJob.source_filename == source_filename)
         )
-        assert result.scalar_one_or_none() is None
+        job = result.scalar_one_or_none()
+        assert job is not None
+        assert job.status == "pending"
+        assert not job.file_path
 
     async def test_upload_success(
         self,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3348,7 +3348,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # schema check's message is server-authored, names what was refused and
     # says what to upload instead, and the preview is where a presigned upload
     # first meets a whole-file check. Cap 2602 -> 2616, exact.
-    "backend/app/processing/ingest/router.py": 2616,
+    # fix(#1848): +48. `upload_file` commits the job before the body streams
+    # and binds through a guarded UPDATE that stamps `staged_at`; the lines
+    # are that guard helper, the two guarded writes and the 409. 2616 -> 2664.
+    "backend/app/processing/ingest/router.py": 2664,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
@@ -4441,7 +4444,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # guarded writes, because the early commit releases the foreign-key lock
     # and a dataset deleted mid-upload nulls the job's binding.
     # Cap 1396 -> 1455, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1455,
+    # fix(#1848): +48. The presigned door commits before storage is asked for
+    # anything and binds through the guard; the guard, the refusal and the
+    # bind are helpers the direct door now shares. Cap 1455 -> 1503, exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1503,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3348,10 +3348,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # schema check's message is server-authored, names what was refused and
     # says what to upload instead, and the preview is where a presigned upload
     # first meets a whole-file check. Cap 2602 -> 2616, exact.
-    # fix(#1848): +48. `upload_file` commits the job before the body streams
-    # and binds through a guarded UPDATE that stamps `staged_at`; the lines
-    # are that guard helper, the two guarded writes and the 409. 2616 -> 2664.
-    "backend/app/processing/ingest/router.py": 2664,
+    # fix(#1848): +50. `upload_file` commits the job before the spooled body
+    # is staged and binds through a guarded UPDATE that stamps `staged_at`; the
+    # lines are the guard helper, the two guarded writes and the 409. To 2666.
+    "backend/app/processing/ingest/router.py": 2666,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
@@ -4444,10 +4444,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # guarded writes, because the early commit releases the foreign-key lock
     # and a dataset deleted mid-upload nulls the job's binding.
     # Cap 1396 -> 1455, exact.
-    # fix(#1848): +48. The presigned door commits before storage is asked for
+    # fix(#1848): +51. The presigned door commits before storage is asked for
     # anything and binds through the guard; the guard, the refusal and the
-    # bind are helpers the direct door now shares. Cap 1455 -> 1503, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1503,
+    # bind are helpers the direct door now shares. Cap 1455 -> 1506, exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1506,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python

--- a/backend/tests/test_pooled_connection_release_1848.py
+++ b/backend/tests/test_pooled_connection_release_1848.py
@@ -1,4 +1,4 @@
-"""fix(#1848): five doors must not hold a pooled connection across their I/O.
+"""fix(#1848): seven doors must not hold a pooled connection across their I/O.
 
 `require_permission` queries the database before the handler body runs, so the
 request session has a connection checked out from the first line. Holding it
@@ -771,3 +771,415 @@ async def test_the_release_is_not_a_blanket_rollback_of_the_gates(
     assert resp.status_code == 404, resp.text
     assert ran.called is False
     assert dataset.id is not None
+
+
+# ---------------------------------------------------------------------------
+# datasets/api/router_reupload.py, presigned door
+# ---------------------------------------------------------------------------
+
+
+def _presigned_storage(request_sessions, held: list[bool]):
+    """A storage double whose signing calls record the request session's state."""
+    from unittest.mock import MagicMock
+
+    storage = MagicMock()
+
+    def _initiate(*_args):
+        held.append(_holds_connection(request_sessions))
+        return "upload-a2b"
+
+    def _sign_part(_key, _upload_id, part_number, _expiration):
+        held.append(_holds_connection(request_sessions))
+        return f"https://a2b.example.com/part/{part_number}"
+
+    def _sign_put(*_args):
+        held.append(_holds_connection(request_sessions))
+        return "https://a2b.example.com/put"
+
+    storage.initiate_multipart_upload.side_effect = _initiate
+    storage.generate_presigned_part_url.side_effect = _sign_part
+    storage.generate_presigned_put_url.side_effect = _sign_put
+    return storage
+
+
+async def _request_presigned(
+    client: AsyncClient, admin_auth_header: dict, dataset_id, *, filename, file_size
+):
+    return await client.post(
+        f"/datasets/{dataset_id}/reupload/presigned",
+        json={
+            "filename": filename,
+            "file_size": file_size,
+            "content_type": "application/geo+json",
+        },
+        headers=admin_auth_header,
+    )
+
+
+async def _job_named(session: AsyncSession, filename: str) -> IngestJob:
+    from sqlalchemy import select
+
+    row = (
+        await session.execute(
+            select(IngestJob).where(IngestJob.source_filename == filename)
+        )
+    ).scalar_one()
+    await session.refresh(row)
+    return row
+
+
+async def test_presigned_reupload_commits_the_job_before_asking_storage(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    request_sessions,
+):
+    """The multipart initiation and every part signature ran on a held connection.
+
+    Same shape as the direct door: the row is committed before storage is asked
+    for anything, and the presigned facts land afterwards through the guarded
+    bind rather than an ORM flush.
+    """
+    from app.modules.catalog.datasets.api import router_reupload
+
+    dataset = await _vector_dataset(test_db_session)
+    filename = f"a2b-{uuid.uuid4().hex[:8]}.geojson"
+    held: list[bool] = []
+    storage = _presigned_storage(request_sessions, held)
+
+    with (
+        patch.object(router_reupload.settings, "storage_provider", "s3"),
+        patch.object(router_reupload.settings, "presigned_multipart_threshold_mb", 1),
+        patch.object(router_reupload, "get_storage", return_value=storage),
+    ):
+        resp = await _request_presigned(
+            client,
+            admin_auth_header,
+            dataset.id,
+            filename=filename,
+            file_size=2 * 1024 * 1024,
+        )
+
+    assert resp.status_code == 201, resp.text
+    assert held == [False, False], (
+        "the request session was still in a transaction when storage was "
+        "asked to initiate the multipart upload or to sign a part"
+    )
+    body = resp.json()
+    assert body["upload_id"] == "upload-a2b"
+    job = await _job_named(test_db_session, filename)
+    assert str(job.id) == body["job_id"]
+    assert job.dataset_id == dataset.id
+    assert job.status == "pending"
+    # Everything the completion door reads is on the row, and nothing is
+    # staged yet, so the pending window keeps counting from creation.
+    assert job.user_metadata["presigned"] is True
+    assert job.user_metadata["multipart"] is True
+    assert job.user_metadata["upload_id"] == "upload-a2b"
+    assert job.user_metadata["s3_key"] == f"staging/{job.id}/{filename}"
+    assert job.user_metadata["expected_size"] == 2 * 1024 * 1024
+    assert job.user_metadata["reupload"] is True
+    assert job.user_metadata["dataset_id"] == str(dataset.id)
+    assert "staged_at" not in job.user_metadata
+
+
+async def test_a_presigned_reupload_swept_while_signing_is_refused_and_aborted(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    request_sessions,
+):
+    """The committed row is visible to the sweep while storage answers.
+
+    An ORM flush would have written the presigned facts onto a row the sweep
+    had already cancelled and answered 201 with an upload id whose job is
+    terminal. The bind is guarded instead, the multipart upload is aborted,
+    and the caller is told to start again.
+    """
+    from app.api.main import sweep_stale_jobs_once
+    from app.modules.catalog.datasets.api import router_reupload
+    from app.platform.jobs.sweep import stale_pending_cutoff_seconds
+
+    dataset = await _vector_dataset(test_db_session)
+    filename = f"a2b-{uuid.uuid4().hex[:8]}.geojson"
+    held: list[bool] = []
+    storage = _presigned_storage(request_sessions, held)
+
+    async def _sweep_while_initiating(fn, *args):
+        cutoff = stale_pending_cutoff_seconds(completion_bound=False)
+        aged = datetime.now(timezone.utc) - timedelta(seconds=cutoff + 60)
+        row = await _job_named(test_db_session, filename)
+        row.created_at = aged
+        await test_db_session.commit()
+        await sweep_stale_jobs_once()
+        return fn(*args), None
+
+    with (
+        patch.object(router_reupload.settings, "storage_provider", "s3"),
+        patch.object(router_reupload.settings, "presigned_multipart_threshold_mb", 1),
+        patch.object(router_reupload, "get_storage", return_value=storage),
+        patch.object(
+            router_reupload,
+            "run_in_thread_draining_capture_cancel",
+            new=_sweep_while_initiating,
+        ),
+    ):
+        resp = await _request_presigned(
+            client,
+            admin_auth_header,
+            dataset.id,
+            filename=filename,
+            file_size=2 * 1024 * 1024,
+        )
+
+    assert resp.status_code == 409, resp.text
+    job = await _job_named(test_db_session, filename)
+    # The sweep's verdict stands and no presigned fact was written onto it.
+    assert job.status == "cancelled"
+    assert "presigned" not in (job.user_metadata or {})
+    # The upload id storage handed out is given back on the refusal.
+    (aborted_key, aborted_upload_id), _kwargs = storage.abort_multipart_upload.call_args
+    assert aborted_key.endswith(f"staging/{job.id}/{filename}")
+    assert aborted_upload_id == "upload-a2b"
+
+
+async def test_a_dataset_deleted_while_signing_refuses_the_presigned_bind(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    request_sessions,
+):
+    """The binding is part of the guard on this door too.
+
+    The early commit releases the row's foreign-key lock, so a dataset deleted
+    while storage signs nulls the job's binding. A guard on id and status alone
+    would have written the presigned facts onto an orphan that every later
+    re-upload door refuses.
+    """
+    from app.modules.catalog.datasets.api import router_reupload
+
+    dataset = await _vector_dataset(test_db_session)
+    dataset_id = dataset.id
+    filename = f"a2b-{uuid.uuid4().hex[:8]}.geojson"
+    held: list[bool] = []
+    storage = _presigned_storage(request_sessions, held)
+
+    async def _delete_dataset_while_signing(fn, *args):
+        await test_db_session.delete(dataset)
+        await test_db_session.commit()
+        return fn(*args)
+
+    with (
+        patch.object(router_reupload.settings, "storage_provider", "s3"),
+        patch.object(router_reupload, "get_storage", return_value=storage),
+        patch.object(
+            router_reupload, "run_in_thread_draining", new=_delete_dataset_while_signing
+        ),
+    ):
+        resp = await _request_presigned(
+            client, admin_auth_header, dataset_id, filename=filename, file_size=128
+        )
+
+    assert resp.status_code == 409, resp.text
+    # The single-part signature ran on a released connection as well.
+    assert held == [False]
+    job = await _job_named(test_db_session, filename)
+    # The premise: the FK nulled the binding, and nothing was written onto it.
+    assert job.dataset_id is None
+    assert job.status == "pending"
+    assert "presigned" not in (job.user_metadata or {})
+
+
+# ---------------------------------------------------------------------------
+# processing/ingest/router.py
+# ---------------------------------------------------------------------------
+
+_EMPTY_COLLECTION = b'{"type":"FeatureCollection","features":[]}'
+
+
+async def _post_upload(client: AsyncClient, admin_auth_header: dict, filename: str):
+    return await client.post(
+        "/ingest/upload",
+        files={"file": (filename, BytesIO(_EMPTY_COLLECTION), "application/geo+json")},
+        headers=admin_auth_header,
+    )
+
+
+async def test_upload_commits_the_job_before_streaming_the_file(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    request_sessions,
+    tmp_path: Path,
+):
+    """The whole multipart body streamed on a held connection.
+
+    Same shape as the direct re-upload door: the row is committed first, which
+    frees the connection and leaves a `pending` row the sweep can reap if the
+    upload never finishes, and the bind afterwards is guarded.
+    """
+    from app.processing.ingest import router as ingest_router
+
+    filename = f"a2b-{uuid.uuid4().hex[:8]}.geojson"
+    staged_file = tmp_path / filename
+    held: list[bool] = []
+    visible: list[bool] = []
+
+    async def _recording_save(_file, job_id, **_kwargs):
+        held.append(_holds_connection(request_sessions))
+        # Durable before a byte arrives: another session can already see it.
+        visible.append(
+            await test_db_session.get(IngestJob, uuid.UUID(job_id)) is not None
+        )
+        staged_file.write_bytes(_EMPTY_COLLECTION)
+        return staged_file
+
+    with (
+        patch.object(ingest_router, "save_upload_file", new=_recording_save),
+        patch.object(ingest_router, "validate_file_content", return_value=None),
+    ):
+        resp = await _post_upload(client, admin_auth_header, filename)
+
+    assert resp.status_code == 201, resp.text
+    assert held == [False], (
+        "the request session was still in a transaction while the upload "
+        "streamed, so it held a pooled connection for the whole transfer"
+    )
+    assert visible == [True]
+    job = await _job_named(test_db_session, filename)
+    assert str(job.id) == resp.json()["job_id"]
+    assert job.status == "pending"
+    assert job.file_path == str(staged_file)
+    # The bind restarts the pending window from the moment the bytes landed.
+    assert job.user_metadata["staged_at"]
+
+
+async def test_a_sweep_during_the_upload_refuses_rather_than_binding_the_file(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    tmp_path: Path,
+):
+    """A row the sweep reclaimed mid-upload is left as the sweep left it.
+
+    Bound through an ORM flush, the path would land on a `cancelled` row and
+    the door would answer 201 with a job the preview refuses. The guarded bind
+    matches no row, the staged file is cleaned, and the caller gets a 409.
+    """
+    from app.api.main import sweep_stale_jobs_once
+    from app.platform.jobs.sweep import stale_pending_cutoff_seconds
+    from app.processing.ingest import router as ingest_router
+
+    filename = f"a2b-{uuid.uuid4().hex[:8]}.geojson"
+    staged_file = tmp_path / filename
+
+    async def _sweep_mid_upload(_file, job_id, **_kwargs):
+        cutoff = stale_pending_cutoff_seconds(completion_bound=False)
+        aged = datetime.now(timezone.utc) - timedelta(seconds=cutoff + 60)
+        row = await test_db_session.get(IngestJob, uuid.UUID(job_id))
+        assert row is not None, "the job must be committed before the upload"
+        row.created_at = aged
+        await test_db_session.commit()
+        await sweep_stale_jobs_once()
+        staged_file.write_bytes(_EMPTY_COLLECTION)
+        return staged_file
+
+    with (
+        patch.object(ingest_router, "save_upload_file", new=_sweep_mid_upload),
+        patch.object(ingest_router, "validate_file_content", return_value=None),
+    ):
+        resp = await _post_upload(client, admin_auth_header, filename)
+
+    assert resp.status_code == 409, resp.text
+    job = await _job_named(test_db_session, filename)
+    assert job.status == "cancelled"
+    assert not job.file_path
+    assert not staged_file.exists()
+
+
+async def test_a_slow_local_upload_that_binds_is_not_reaped_by_the_next_sweep(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    tmp_path: Path,
+):
+    """The bind stamps `staged_at`, so the pending window restarts there.
+
+    The local provider binds an absolute path, which never reaches the sweep's
+    `staging/%` completion class, so the row stays in the class measured from
+    `coalesce(staged_at, created_at)`. Without the stamp an upload slower than
+    the pending timeout was accepted with 201 and cancelled by the next sweep.
+    """
+    from app.api.main import sweep_stale_jobs_once
+    from app.platform.jobs.sweep import stale_pending_cutoff_seconds
+    from app.processing.ingest import router as ingest_router
+
+    filename = f"a2b-{uuid.uuid4().hex[:8]}.geojson"
+    staged_file = tmp_path / filename
+
+    async def _slow_local_upload(_file, job_id, **_kwargs):
+        cutoff = stale_pending_cutoff_seconds(completion_bound=False)
+        aged = datetime.now(timezone.utc) - timedelta(seconds=cutoff + 60)
+        row = await test_db_session.get(IngestJob, uuid.UUID(job_id))
+        assert row is not None
+        row.created_at = aged
+        await test_db_session.commit()
+        staged_file.write_bytes(_EMPTY_COLLECTION)
+        return staged_file
+
+    with (
+        patch.object(ingest_router, "save_upload_file", new=_slow_local_upload),
+        patch.object(ingest_router, "validate_file_content", return_value=None),
+    ):
+        resp = await _post_upload(client, admin_auth_header, filename)
+
+    assert resp.status_code == 201, resp.text
+    job = await _job_named(test_db_session, filename)
+    assert not job.file_path.startswith("staging/")
+
+    await sweep_stale_jobs_once()
+
+    await test_db_session.refresh(job)
+    assert job.status == "pending"
+    assert job.user_metadata["staged_at"]
+    assert staged_file.exists()
+
+
+async def test_an_upload_refused_for_content_leaves_a_failed_job(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    tmp_path: Path,
+):
+    """The cost of committing first on the content path, and its shape.
+
+    The 422 used to roll the uncommitted row back. The row is durable now, so
+    it is stamped `failed` with the refusal through the same guard as the bind,
+    which is what the presigned completion door already does for this 422.
+    """
+    from app.processing.ingest import router as ingest_router
+
+    filename = f"a2b-{uuid.uuid4().hex[:8]}.geojson"
+    staged_file = tmp_path / filename
+
+    async def _save(_file, _job_id, **_kwargs):
+        staged_file.write_bytes(b"not a dataset")
+        return staged_file
+
+    with (
+        patch.object(ingest_router, "save_upload_file", new=_save),
+        patch.object(
+            ingest_router,
+            "validate_file_content",
+            side_effect=ValueError("a2b: not a recognised dataset"),
+        ),
+    ):
+        resp = await _post_upload(client, admin_auth_header, filename)
+
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"] == "a2b: not a recognised dataset"
+    job = await _job_named(test_db_session, filename)
+    assert job.status == "failed"
+    assert job.error_message == "a2b: not a recognised dataset"
+    assert not job.file_path
+    assert not staged_file.exists()

--- a/backend/tests/test_pooled_connection_release_1848.py
+++ b/backend/tests/test_pooled_connection_release_1848.py
@@ -1005,18 +1005,20 @@ async def _post_upload(client: AsyncClient, admin_auth_header: dict, filename: s
     )
 
 
-async def test_upload_commits_the_job_before_streaming_the_file(
+async def test_upload_commits_the_job_before_staging_the_file(
     client: AsyncClient,
     admin_auth_header: dict,
     test_db_session: AsyncSession,
     request_sessions,
     tmp_path: Path,
 ):
-    """The whole multipart body streamed on a held connection.
+    """The staging step ran on a held connection.
 
-    Same shape as the direct re-upload door: the row is committed first, which
-    frees the connection and leaves a `pending` row the sweep can reap if the
-    upload never finishes, and the bind afterwards is guarded.
+    FastAPI spools the multipart body before any dependency runs, so the
+    connection was never held across the network stream. It was held across
+    `save_upload_file` (the copy into staging, or the S3 put), the validation
+    download and the content sniff. Same shape as the direct re-upload door:
+    the row is committed first and the bind afterwards is guarded.
     """
     from app.processing.ingest import router as ingest_router
 
@@ -1027,7 +1029,7 @@ async def test_upload_commits_the_job_before_streaming_the_file(
 
     async def _recording_save(_file, job_id, **_kwargs):
         held.append(_holds_connection(request_sessions))
-        # Durable before a byte arrives: another session can already see it.
+        # Durable before staging starts: another session can already see it.
         visible.append(
             await test_db_session.get(IngestJob, uuid.UUID(job_id)) is not None
         )
@@ -1042,8 +1044,8 @@ async def test_upload_commits_the_job_before_streaming_the_file(
 
     assert resp.status_code == 201, resp.text
     assert held == [False], (
-        "the request session was still in a transaction while the upload "
-        "streamed, so it held a pooled connection for the whole transfer"
+        "the request session was still in a transaction while the spooled "
+        "body was staged, so it held a pooled connection across that work"
     )
     assert visible == [True]
     job = await _job_named(test_db_session, filename)
@@ -1107,8 +1109,9 @@ async def test_a_slow_local_upload_that_binds_is_not_reaped_by_the_next_sweep(
 
     The local provider binds an absolute path, which never reaches the sweep's
     `staging/%` completion class, so the row stays in the class measured from
-    `coalesce(staged_at, created_at)`. Without the stamp an upload slower than
-    the pending timeout was accepted with 201 and cancelled by the next sweep.
+    `coalesce(staged_at, created_at)`. Without the stamp a staging step slower
+    than the pending timeout was accepted with 201 and cancelled by the next
+    sweep.
     """
     from app.api.main import sweep_stale_jobs_once
     from app.platform.jobs.sweep import stale_pending_cutoff_seconds
@@ -1181,5 +1184,50 @@ async def test_an_upload_refused_for_content_leaves_a_failed_job(
     job = await _job_named(test_db_session, filename)
     assert job.status == "failed"
     assert job.error_message == "a2b: not a recognised dataset"
+    # Terminal rows carry `completed_at`, as every other terminal writer stamps it.
+    assert job.completed_at is not None
     assert not job.file_path
+    assert not staged_file.exists()
+
+
+async def test_a_direct_reupload_refused_for_content_leaves_a_completed_failed_row(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    tmp_path: Path,
+):
+    """The direct door's refusal stamp carries `completed_at` like every other terminal writer."""
+    from app.modules.catalog.datasets.api import router_reupload
+
+    dataset = await _vector_dataset(test_db_session)
+    filename = f"a2b-{uuid.uuid4().hex[:8]}.geojson"
+    staged_file = tmp_path / filename
+    port = router_reupload.get_catalog_port()
+
+    async def _save(_file, _job_id, **_kwargs):
+        staged_file.write_bytes(b"not a dataset")
+        return staged_file
+
+    with (
+        patch.object(port, "save_upload_file", new=_save),
+        patch.object(
+            port,
+            "validate_file_content",
+            side_effect=ValueError("a2b: not a recognised dataset"),
+        ),
+        patch.object(router_reupload, "get_catalog_port", return_value=port),
+    ):
+        resp = await client.post(
+            f"/datasets/{dataset.id}/reupload",
+            files={
+                "file": (filename, BytesIO(_EMPTY_COLLECTION), "application/geo+json")
+            },
+            headers=admin_auth_header,
+        )
+
+    assert resp.status_code == 422, resp.text
+    job = await _job_named(test_db_session, filename)
+    assert job.status == "failed"
+    assert job.error_message == "a2b: not a recognised dataset"
+    assert job.completed_at is not None
     assert not staged_file.exists()

--- a/backend/tests/test_tenant_staging_storage_keys.py
+++ b/backend/tests/test_tenant_staging_storage_keys.py
@@ -339,7 +339,11 @@ async def test_presigned_reupload_round_trip_uses_tenant_provider_key(monkeypatc
         logical = f"staging/{job.id}/roads.geojson"
         physical = f"tenants/{TENANT_A}/{logical}"
         assert response.s3_key == physical
-        assert job.user_metadata["s3_key"] == logical
+        # fix(#1848): the presigned facts land through a guarded UPDATE rather
+        # than the ORM instance, so they are read off the statement the door ran.
+        bound = db.execute.await_args.args[0].compile().params["user_metadata"]
+        assert bound["s3_key"] == logical
+        job.user_metadata = bound
 
         port.create_ingest_job.reset_mock()
         with patch.object(

--- a/backend/tests/test_upload_size_limit.py
+++ b/backend/tests/test_upload_size_limit.py
@@ -166,7 +166,9 @@ async def test_upload_commit_failure_cleans_owned_staged_file(tmp_path):
     staged.write_bytes(b"{}")
     job = MagicMock(id=uuid.uuid4(), user_metadata={})
     db = AsyncMock()
-    db.commit.side_effect = RuntimeError("commit failed")
+    # fix(#1848): the first commit is the one that frees the pooled connection
+    # before the upload. The failure under test is still the one after it.
+    db.commit.side_effect = [None, RuntimeError("commit failed")]
     cleanup = AsyncMock()
 
     with (
@@ -180,8 +182,6 @@ async def test_upload_commit_failure_cleans_owned_staged_file(tmp_path):
         patch.object(router, "create_ingest_job", AsyncMock(return_value=job)),
         patch.object(router, "save_upload_file", AsyncMock(return_value=staged)),
         patch.object(router, "validate_file_content"),
-        # fix(#1186): _stamp_raster_metadata is a synchronous filename check now.
-        patch.object(router, "_stamp_raster_metadata", MagicMock()),
         patch.object(router, "_cleanup_saved_upload", cleanup),
     ):
         with pytest.raises(HTTPException) as exc:


### PR DESCRIPTION
Finishes the connection-holding class from the backend audit of 2026-09-04, tracked in #1848. #1880 released the pooled `AsyncSession` in five doors and named two more it left alone: `request_presigned_reupload` in `datasets/api/router_reupload.py` and `upload_file` in `processing/ingest/router.py`. Both still reproduced on `origin/main` at 56aa03abe: each door's source holds the session across its storage call, and the two release counterfactuals below are exactly that shape.

Both doors take the shape #1880 gave `reupload_dataset`. The row is committed before the handler talks to storage, which hands the connection back, and every later write is a compare-and-set that matches the row only while it is still `pending`. A zero rowcount is a 409 telling the caller to start again.

## The presigned re-upload door

`request_presigned_reupload` created the job, then initiated the multipart upload against S3 and signed one URL per part, all inside the request transaction. It now commits the row right after the lifetime gate, with the two markers the job-binding gate reads (`reupload` and `dataset_id`) already on it, then asks storage. The presigned facts (`presigned`, `s3_key`, `upload_id`, `multipart`, `expected_size`) land afterwards through the guarded bind. The guard carries `dataset_id` as well as `status`, for the reason #1880's third round found: the early commit releases the foreign-key lock, so a dataset deleted while storage signs nulls the binding.

Invariant: the request session is not in a transaction when `initiate_multipart_upload` or either signing method runs, and no presigned fact is ever written onto a row that is not `pending` and bound to the path's dataset.

The bind does not stamp `staged_at`. Nothing is staged when this door answers; the completion door binds the frozen object, and that key is what moves the row into the sweep's 24-hour class. Stamping here would equal `created_at`, which #1880 measured as a no-op.

On a refused multipart bind the upload id storage handed out is aborted, the same cleanup every other failure in that branch already runs. A refused single-part bind has nothing to clean: the PUT URL was minted but never returned.

The lifetime gate stays above the commit on purpose. It is a pure check on `created_at`, and a 409 from it still rolls the uncommitted row back exactly as before.

Committing first has the same durable-row consequence here as on the direct door. A storage 502 at initiation, a lifetime 409 inside the sign loop, or a client cancel during initiation now leaves a `pending` row carrying the reupload markers and no presigned marker, where before the PR that row rolled back with the request. It stays until `pending_job_timeout_seconds`, then the sweep marks it `cancelled` as abandoned. Nothing gates on it in the meantime: neither re-upload door has an active-job gate, `/jobs/by-dataset` lists completed jobs only, and the completion door answers 400 for a row with no presigned marker.

## The ingest upload door

FastAPI receives and spools the whole multipart body before any dependency runs, so `upload_file` never held the connection across the network stream. It held it across `save_upload_file`, which is the S3 put in S3 mode and the copy from the spool into staging in local mode, then across the validation download (S3 mode) and the content sniff, and bound `file_path` through an ORM flush at the end. It now commits the row before `save_upload_file` and binds through a guarded UPDATE that stamps `staged_at`, so a local upload slower than `pending_job_timeout_seconds` is not cancelled by the very next sweep. The raster stamp goes through `_raster_stamped_metadata`, the pure form `upload_from_url` already uses, because a dirtied ORM instance would flush a second, unguarded UPDATE on the commit and bypass the guard.

Invariant: the request session is not in a transaction while the spooled body is staged, downloaded back for validation, or sniffed, and `file_path` is only ever bound onto a row that is still `pending`.

The guard here is `id` and `status` only. A fresh upload has no dataset binding to protect.

Two behaviours change, and both are the two #1880 accepted for the direct re-upload door:

- A content refusal (422) used to roll the uncommitted row back. The row is durable now, so it is stamped `failed` with the refusal and `completed_at` through the same guard as the bind, the terminal-row shape every other terminal writer produces. That is what the presigned completion door already does for the same 422. The direct re-upload door's refusal stamp from #1880 gets the same `completed_at`.
- A provider failure, a 413 from the size check in `save_upload_file`, or a failed validation download leaves a `pending` row with nothing bound. That is the unbound half of `stale_pending_clauses`, and the sweep reaps it on the one-hour policy. One test in `test_ingest.py` asserted the old rollback by name and now asserts this.

## Shared helpers

The guard (`_pending_reupload_update`), the refusal (`_reupload_bind_refusal`) and the bind (`_bind_presigned_reupload`) are module helpers in `router_reupload.py`, and the two guarded writes #1880 put in `reupload_dataset` now go through the first two. The ingest router gets `_pending_upload_update` for its two writes. The two files cannot share one helper: `modules/catalog` may not import `app.processing`, and the ingest guard has no dataset clause.

## Tests

Eight cases added to `tests/test_pooled_connection_release_1848.py`, with the same `in_transaction()` recording as the twelve already there.

Presigned door: the release, with the multipart initiation and the part signature both recorded on a released session; a sweep that reclaims the row while storage answers (409, row stays `cancelled`, `abort_multipart_upload` called with the upload id); a dataset deleted while signing (409, row orphaned `pending` with no presigned fact).

Upload door: the release, with the row visible from a second session before staging starts; a sweep mid-upload (409, staged file cleaned); a slow local staging step that survives the next sweep because of `staged_at`; a content refusal that leaves a `failed` row with `completed_at`. One more case pins the same `completed_at` on the direct re-upload door's refusal stamp.

Three mock-mirror tests updated. `test_upload_commit_failure_cleans_owned_staged_file` fails the second commit rather than the first. `test_presigned_reupload_round_trip_uses_tenant_provider_key` reads the logical `s3_key` off the UPDATE statement the door ran instead of off the ORM instance. `test_s3_validation_download_failure_deletes_uncommitted_source` becomes `..._deletes_the_staged_source` and asserts the surviving pending row.

## Counterfactuals

Each run by reverting only that piece, keeping the tests, and restoring the file afterwards.

- Presigned release removed: `assert [True, True] == [False, False]`, held at the initiation and at the signature.
- Upload release removed: `assert [True] == [False]`, held across the staging step.
- Presigned guard reduced to `id` only: the swept test and the deleted-dataset test both get `201` with a full presigned response on a row that is `cancelled` or unbound.
- Upload guard reduced to `id` only: the mid-upload sweep test gets `201` with `{"status": "pending"}` on a row the sweep had already cancelled.
- `staged_at` removed from the upload bind: the slow-upload test finds the row `cancelled` right after a successful 201 (`assert 'cancelled' == 'pending'`).

## Verification

From the worktree against Postgres on localhost:5434.

```
tests/test_pooled_connection_release_1848.py      20 passed
tests/test_upload_size_limit.py                    8 passed
tests/test_tenant_staging_storage_keys.py         11 passed
tests/test_ingest.py                              45 passed
tests/test_reupload.py                            44 passed
tests/test_reupload_idor.py                        7 passed
tests/test_reupload_service.py                     5 passed
tests/test_reupload_expected_origin_1768.py       14 passed
tests/test_reupload_record_type_guard.py          13 passed
tests/test_reupload_completion_contract_1207.py   12 passed
tests/test_reupload_swap_lock_retry.py             8 passed
tests/test_job_cancel_reupload_commit.py           2 passed
tests/test_presigned_content_validation_1202.py   26 passed
tests/test_1184_body_limit_per_route.py           45 passed
tests/test_1224_ingest_quota_enforcement.py        7 passed
tests/test_api_contract_openapi.py                23 passed
tests/test_1183_s3_spool_upload.py                 4 passed
tests/test_layering.py + test_rule1_structural.py + test_rule2_structural.py   165 passed
ruff check .                                      All checks passed
ruff format --check .                             1176 files already formatted
```

## Schema, API and config impact

None. No migration, no request or response schema change, no new setting. The 409 the two doors can now answer is the one `reupload_dataset` has answered since #1880.

## Noticed and left alone

- `request_presigned_upload` in `processing/ingest/router.py`, the ingest twin of the presigned re-upload door, initiates the multipart upload and signs inside its transaction too. It is on neither #1848's list nor #1880's follow-up note, and its window is one S3 round trip rather than a stream, so it is not touched here. The same fix would apply.
- The `staged_at` comment in `platform/jobs/sweep.py` still says `upload_from_url` is the only writer of that key. That stopped being true in #1880 and is less true now. Left for a pass that otherwise touches that file.

Caps re-measured with `wc -l` and set exact: `router_reupload.py` 1455 to 1506, `ingest/router.py` 2616 to 2666.
