### PR TITLE
fix(sources): give the sign-in settle write a ceiling a loaded pool can meet (#1825)

### DIFF
--- a/backend/app/modules/catalog/sources/signin_guard.py
+++ b/backend/app/modules/catalog/sources/signin_guard.py
@@ -62,12 +62,10 @@ _ARCGIS_SIGNIN_WINDOW = timedelta(minutes=15)
 # running when the drain gives up on it, so nothing else would.
 _SETTLE_TASKS: set[asyncio.Task] = set()
 
-# fix(#1775): how long _signin_settle_shielded will keep handing the event
-# loop a turn so its shielded audit write can finish. One local INSERT and
-# COMMIT, so a second is three orders of magnitude of headroom; the ceiling is
-# there so a database that has stopped answering cannot hold a shutting-down
-# worker open, not because the write is expected to need it.
-_SETTLE_DRAIN_SECONDS = 1.0
+# fix(#1775, #1825): the ceiling on a settle write (a rollback, then one
+# INSERT and COMMIT on a fresh connection), so a database that has stopped
+# answering cannot hold a shutting-down worker open. A loaded pool needs seconds.
+_SETTLE_DRAIN_SECONDS = 5.0
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## What

`_SETTLE_DRAIN_SECONDS` in `backend/app/modules/catalog/sources/signin_guard.py` goes from 1.0 to 5.0. It is the ceiling `_signin_settle_shielded` gives the rollback of the request session plus the audit write on a fresh connection after a cancelled sign-in, and it still exists for the reason the comment gives: a database that has stopped answering must not hold a shutting-down worker open.

## Why

The merge-queue run for #1893 (CI run 33991058152, Backend Tests, `gw3`) failed one test out of 12717: `tests/test_arcgis_signin.py::test_a_signin_cancelled_mid_mint_is_already_counted`, with `assert [] == ['cancelled']`. The captured log shows the drain's own warning, "ArcGIS sign-in cancelled before its outcome could be recorded" with `error_type=CancelledError`, 1.45 s after the test started. That is the deadline in `_drain_shielded` cancelling the write, not the test's cancellation reaching it: under four xdist workers with coverage on one Postgres, a rollback plus a pooled connection checkout, INSERT and COMMIT took more than a second. The comment's "three orders of magnitude of headroom" was measured on an idle host.

The same test sits in every full-suite run, so every PR in the merge queue is exposed at the same rate until the ceiling fits the runner. #1893 was knocked out of the queue by it and re-queued.

## Not changed

The one test that pins the ceiling behaviour (`test_the_settle_outcome_reader_treats_pending_as_cancelled`'s neighbour at `tests/test_arcgis_signin.py:2382`) monkeypatches the constant to 0.05 s and is unaffected. No cap in `_MODULE_LOC_CAPS` names this file.

## Verification

Host, Postgres at localhost:5434, from a worktree at 56aa03abe plus this commit:

```
uv run pytest tests/test_arcgis_signin.py tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q
350 passed in 75.71s
uv run ruff check / ruff format --check: clean
```

Counterfactual: on this host the write finishes inside the old ceiling, so the test passes with either value here. The evidence for the defect is the CI run above; the evidence for the fix is that the run the merge queue does next completes the same write under the new ceiling.