### PR TITLE
fix(sources): refuse a credentialed WFS whose schema includes a location off the origin (#1828)

### DIFF
--- a/backend/app/modules/catalog/sources/preview.py
+++ b/backend/app/modules/catalog/sources/preview.py
@@ -30,6 +30,7 @@ from app.platform.service_endpoints import (
     CrossOriginEndpointError,
     EndpointCheckFailedError,
     assert_endpoints_stay_on_origin,
+    require_wfs_layer,
 )
 
 _SUBPROCESS_FLOOR_SECONDS = 1.0
@@ -373,6 +374,13 @@ async def run_service_preview(
             # rule can see. Checked again in the worker: the document can
             # change between a preview and the import it leads to.
             try:
+                # fix(#1828): a credentialed WFS never reaches GDAL without a
+                # layer, since GDAL opened layerless reads every layer's schema.
+                require_wfs_layer(
+                    layer_name,
+                    service_format=_gdal_source_format(gdal_source),
+                    credential_line=credential_header_line(pair),
+                )
                 await assert_endpoints_stay_on_origin(
                     _service_url(gdal_source),
                     service_format=_gdal_source_format(gdal_source),

--- a/backend/app/modules/catalog/sources/preview.py
+++ b/backend/app/modules/catalog/sources/preview.py
@@ -30,6 +30,7 @@ from app.platform.service_endpoints import (
     CrossOriginEndpointError,
     EndpointCheckFailedError,
     assert_endpoints_stay_on_origin,
+    gdal_transport_env,
     require_wfs_layer,
 )
 
@@ -456,6 +457,7 @@ async def run_service_preview(
                 os.close(fd)
             os.chmod(header_file_path, 0o600)
             env["GDAL_HTTP_HEADER_FILE"] = header_file_path
+            env.update(gdal_transport_env(_gdal_source_format(gdal_source)))
             # Plan rule A: GDAL forwards `Authorization` only to the host it
             # was given to, and forwards every other header name verbatim even
             # across hosts, so a service-chosen API key is redirect-exposed on

--- a/backend/app/platform/gdal_env.py
+++ b/backend/app/platform/gdal_env.py
@@ -1,4 +1,4 @@
-"""GDAL driver-registration clamps for every vector subprocess, wherever it runs.
+"""GDAL driver-registration and schema clamps for every vector subprocess.
 
 In ``platform/`` because ``modules/catalog/sources/preview.py`` calls these and
 ``modules/catalog/`` may not import ``app.processing.*`` (``test_layering.py``);
@@ -60,9 +60,16 @@ _NETWORK_AND_POINTER_DRIVERS: tuple[str, ...] = (
 _SERVICE_KEPT_DRIVERS = frozenset({"WFS", "OAPIF"})
 
 
+# fix(#1828): the GML driver fetches every `xs:import` location, credential
+# header attached, once GML_USE_SCHEMA_IMPORT is YES anywhere in the process
+# env. Set by value here so an operator's env cannot flip it on.
+_SCHEMA_IMPORT_CLAMP: dict[str, str] = {"GML_USE_SCHEMA_IMPORT": "NO"}
+
+
 def _gdal_skip_env(drivers: tuple[str, ...]) -> dict[str, str]:
-    """os.environ overlaid with a GDAL_SKIP clamp for ``drivers``."""
-    return {**os.environ, "GDAL_SKIP": " ".join(drivers)}
+    """os.environ overlaid with a GDAL_SKIP clamp for ``drivers`` and the
+    schema-import clamp, both by value."""
+    return {**os.environ, "GDAL_SKIP": " ".join(drivers), **_SCHEMA_IMPORT_CLAMP}
 
 
 def gdal_vector_safe_env() -> dict[str, str]:

--- a/backend/app/platform/gdal_env.py
+++ b/backend/app/platform/gdal_env.py
@@ -60,16 +60,19 @@ _NETWORK_AND_POINTER_DRIVERS: tuple[str, ...] = (
 _SERVICE_KEPT_DRIVERS = frozenset({"WFS", "OAPIF"})
 
 
-# fix(#1828): the GML driver fetches every `xs:import` location, credential
-# header attached, once GML_USE_SCHEMA_IMPORT is YES anywhere in the process
-# env. Set by value here so an operator's env cannot flip it on.
-_SCHEMA_IMPORT_CLAMP: dict[str, str] = {"GML_USE_SCHEMA_IMPORT": "NO"}
+# fix(#1828): at YES the GML driver fetches every `xs:import` location of a
+# schema, and the schema a GetFeature response points at, credential header
+# attached. Both are NO by value here so an operator's env cannot flip them.
+_SCHEMA_FETCH_CLAMP: dict[str, str] = {
+    "GML_USE_SCHEMA_IMPORT": "NO",
+    "GML_DOWNLOAD_SCHEMA": "NO",
+}
 
 
 def _gdal_skip_env(drivers: tuple[str, ...]) -> dict[str, str]:
     """os.environ overlaid with a GDAL_SKIP clamp for ``drivers`` and the
-    schema-import clamp, both by value."""
-    return {**os.environ, "GDAL_SKIP": " ".join(drivers), **_SCHEMA_IMPORT_CLAMP}
+    schema-fetch clamps, all by value."""
+    return {**os.environ, "GDAL_SKIP": " ".join(drivers), **_SCHEMA_FETCH_CLAMP}
 
 
 def gdal_vector_safe_env() -> dict[str, str]:

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -1198,26 +1198,27 @@ def _wfs_feature_types(root: Element) -> tuple[str, list[str]]:
     """The WFS version and the advertised feature type names, in document order.
 
     Read the way the driver reads them: the ``version`` of the first
-    ``WFS_Capabilities`` element (1.0.0 when absent) and the ``Name`` of every
-    ``FeatureType``, each name once.
+    ``WFS_Capabilities`` element (1.0.0 when absent; an empty value stays
+    empty, as the driver sends it) and the ``Name`` of every ``FeatureType``,
+    each name once.
     """
-    version = ""
-    found_root = False
+    version: str | None = None
     names: list[str] = []
     seen: set[str] = set()
     for element in root.iter():
         if not isinstance(element.tag, str):
             continue
         tag = _local_name(element.tag)
-        if not found_root and tag.lower() == "wfs_capabilities":
-            found_root = True
-            version = _xml_value(element, "version") or ""
+        if version is None and tag.lower() == "wfs_capabilities":
+            version = _xml_value(element, "version")
+            if version is None:
+                version = _WFS_DEFAULT_VERSION
         elif tag == "FeatureType":
             name = (_xml_value(element, "name") or "").strip()
             if name and name not in seen:
                 seen.add(name)
                 names.append(name)
-    return version or _WFS_DEFAULT_VERSION, names
+    return _WFS_DEFAULT_VERSION if version is None else version, names
 
 
 def _wfs_prefix(name: str) -> str:
@@ -1336,7 +1337,7 @@ class _WfsSchemaReads:
     """The bounded DescribeFeatureType and include reads of one check.
 
     `batch` is the schema the driver would parse for one request, or None where
-    the driver falls back to one request per type; `single` is a request the
+    the driver falls back to the single-type request; `single` is a request the
     driver has nothing to fall back from, so no schema is a refusal. `check`
     refuses the first include whose location the driver would fetch from
     another origin or open as a path, and reads a same-origin location the way
@@ -1405,39 +1406,23 @@ async def _check_wfs_schemas(
 ) -> None:
     """Refuse the first schema include the driver would fetch off the origin.
 
-    Reads what the driver reads. For a named layer: one DescribeFeatureType
-    for the layer and its prefix siblings, then one for the layer alone, which
-    the driver issues whenever the first answer does not cover it. For no
-    layer: one per prefix batch, then one per remaining type once a batch
-    answers with no schema. A capabilities document advertising no feature
-    type has nothing to read.
+    Reads what the driver reads for the layer it is about to open: one
+    DescribeFeatureType naming the layer and then its prefix siblings, fifty
+    at most, then one naming the layer alone, which the driver issues whenever
+    the first answer does not cover it. With no layer, or one the driver would
+    not resolve, nothing is read and the check is the capabilities check alone.
     """
     version, names = _wfs_feature_types(root)
-    if not names:
+    target = _wfs_layer_name(names, collection) if collection else None
+    if target is None:
         return
     reads = _WfsSchemaReads(client, url, headers)
-    target = _wfs_layer_name(names, collection) if collection else None
-    if target is not None:
-        batch = _wfs_batch(names, target)
-        schema = await reads.batch(version, batch)
-        if schema is not None:
-            await reads.check(schema)
-        if schema is None or batch != [target]:
-            await reads.check(await reads.single(version, target))
-        return
-    pending = list(names)
-    batching = True
-    while pending:
-        if batching:
-            batch = _wfs_batch(pending, pending[0])
-            schema = await reads.batch(version, batch)
-            if schema is None:
-                batching = False
-                continue
-            pending = [name for name in pending if name not in batch]
-        else:
-            schema = await reads.single(version, pending.pop(0))
+    batch = _wfs_batch(names, target)
+    schema = await reads.batch(version, batch)
+    if schema is not None:
         await reads.check(schema)
+    if schema is None or batch != [target]:
+        await reads.check(await reads.single(version, target))
 
 
 async def _check_wfs(

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -1390,17 +1390,32 @@ def _wfs_escape(value: str) -> str:
     return "".join(escaped)
 
 
-def _wfs_version_is_two_or_more(version: str) -> bool:
-    """``atoi(version) >= 2``, read from the digits so a version of any length
-    is compared without converting it."""
-    match = _C_INT_PREFIX.match(version)
+_LONG_MAX = (1 << 63) - 1
+_LONG_MIN = -(1 << 63)
+
+
+def _c_atoi(text: str) -> int:
+    """``atoi`` as the worker's C library computes it: ASCII whitespace and
+    sign, digits saturated to a 64-bit ``long``, then truncated to a signed
+    32-bit ``int``. A digit run of any length is handled without conversion."""
+    match = _C_INT_PREFIX.match(text)
     if match is None:
-        return False
-    digits = match.group(1)
-    if digits[0] == "-":
-        return False
-    digits = digits.lstrip("+").lstrip("0")
-    return len(digits) > 1 or digits >= "2"
+        return 0
+    literal = match.group(1)
+    negative = literal[0] == "-"
+    digits = literal.lstrip("+-").lstrip("0")
+    if len(digits) > 19:
+        value = _LONG_MIN if negative else _LONG_MAX
+    else:
+        value = int(digits or "0")
+        value = max(_LONG_MIN, min(_LONG_MAX, -value if negative else value))
+    value &= 0xFFFFFFFF
+    return value - (1 << 32) if value >= (1 << 31) else value
+
+
+def _wfs_version_is_two_or_more(version: str) -> bool:
+    """``atoi(version) >= 2``, the driver's WFS 2 test."""
+    return _c_atoi(version) >= 2
 
 
 def _wfs_base_url(url: str, version: str) -> str:

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -435,6 +435,46 @@ class EndpointCheckFailedError(Exception):
         super().__init__(self.policy)
 
 
+LAYER_REQUIRED_CODE = "layer_required"
+LAYER_REQUIRED_POLICY = (
+    "This request carries a credential and names no WFS layer. A credentialed "
+    "WFS import reads the description of the layer it opens before GDAL does, "
+    "so the layer has to be named. Choose a layer and try again."
+)
+
+
+class LayerRequiredError(EndpointCheckFailedError):
+    """A credentialed WFS reached a GDAL spawn point without a layer name.
+
+    A subclass, so the doors that already turn `EndpointCheckFailedError`
+    into a coded 422 or a job failure do the same with this one; the code,
+    field and policy are its own.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("no layer named")
+        self.code = LAYER_REQUIRED_CODE
+        self.field = "layer_name"
+        self.policy = LAYER_REQUIRED_POLICY
+        self.args = (self.policy,)
+
+
+def require_wfs_layer(
+    layer_name: str | None, *, service_format: str | None, credential_line: str | None
+) -> None:
+    """Refuse a credentialed WFS that names no layer, before GDAL is spawned.
+
+    fix(#1828): the schema check reads the description of the layer a door
+    opens, and GDAL opened without a layer reads every layer's. Does nothing
+    without a credential, for a format whose credential is not a header, or
+    for any other format. Raises :class:`LayerRequiredError`.
+    """
+    if not credential_line or not requires_header_token_policy(service_format):
+        return
+    if service_format == "wfs" and not (layer_name or "").strip():
+        raise LayerRequiredError()
+
+
 def _origin_of(url: str) -> str:
     """``scheme://host:port`` for a message, with userinfo and path dropped.
 

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -1210,7 +1210,7 @@ _WFS_DEFAULT_VERSION = "1.0.0"
 # part of a URI's identity, so it is folded here.
 _HTTP_LOCATION = re.compile(r"https?://", re.IGNORECASE)
 _ASCII_LOWER = str.maketrans("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
-_C_INT_PREFIX = re.compile(r"\s*([+-]?\d+)")
+_C_INT_PREFIX = re.compile(r"\s*([+-]?\d+)", re.ASCII)
 
 
 def _xml_value(element: Element, name: str) -> str | None:

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -1390,12 +1390,24 @@ def _wfs_escape(value: str) -> str:
     return "".join(escaped)
 
 
+def _wfs_version_is_two_or_more(version: str) -> bool:
+    """``atoi(version) >= 2``, read from the digits so a version of any length
+    is compared without converting it."""
+    match = _C_INT_PREFIX.match(version)
+    if match is None:
+        return False
+    digits = match.group(1)
+    if digits[0] == "-":
+        return False
+    digits = digits.lstrip("+").lstrip("0")
+    return len(digits) > 1 or digits >= "2"
+
+
 def _wfs_base_url(url: str, version: str) -> str:
     """The base URL the driver holds after opening a WFS: for a version whose
     leading integer is 2 or more, a ``MAXFEATURES`` with no ``COUNT`` beside it
     is rewritten to ``COUNT``; everything else is the submitted URL."""
-    match = _C_INT_PREFIX.match(version)
-    if match is None or int(match.group(1)) < 2 or _url_get_value(url, "COUNT"):
+    if not _wfs_version_is_two_or_more(version) or _url_get_value(url, "COUNT"):
         return url
     max_features = _url_get_value(url, "MAXFEATURES")
     if not max_features:

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -1256,15 +1256,63 @@ def _wfs_feature_types(root: Element) -> tuple[str, list[str]]:
     return _WFS_DEFAULT_VERSION if version is None else version, names
 
 
+def _wfs_required_output_formats(root: Element, version: str) -> dict[str, str]:
+    """The ``OUTPUTFORMAT`` the driver adds to a feature type's
+    DescribeFeatureType: on 1.1.0 exactly, the first ``Format`` under its
+    first ``OutputFormats`` when none of them mentions ``3.1``; else none."""
+    required: dict[str, str] = {}
+    if version != "1.1.0":
+        return required
+    seen: set[str] = set()
+    for element in root.iter():
+        if (
+            not isinstance(element.tag, str)
+            or _local_name(element.tag) != "FeatureType"
+        ):
+            continue
+        name = (_xml_value(element, "name") or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        outputs = next(
+            (
+                child
+                for child in element
+                if isinstance(child.tag, str)
+                and _local_name(child.tag) == "OutputFormats"
+            ),
+            None,
+        )
+        if outputs is None:
+            continue
+        formats = [
+            fmt.text
+            for fmt in outputs
+            if isinstance(fmt.tag, str)
+            and _local_name(fmt.tag) == "Format"
+            and fmt.text
+            and fmt.text.strip()
+        ]
+        if formats and not any("3.1" in fmt for fmt in formats):
+            required[name] = formats[0]
+    return required
+
+
 def _wfs_prefix(name: str) -> str:
     return name.split(":", 1)[0] if ":" in name else ""
 
 
-def _wfs_batch(names: list[str], first: str) -> list[str]:
+def _wfs_batch(names: list[str], first: str, required: dict[str, str]) -> list[str]:
     """The names one DescribeFeatureType carries: *first*, then the other
-    members of its prefix in order, fifty at most, as the driver batches."""
+    members of its prefix that share its required output format, in order,
+    fifty at most, as the driver batches."""
     prefix = _wfs_prefix(first)
-    siblings = [n for n in names if n != first and _wfs_prefix(n) == prefix]
+    output_format = required.get(first)
+    siblings = [
+        n
+        for n in names
+        if n != first and _wfs_prefix(n) == prefix and required.get(n) == output_format
+    ]
     return [first, *siblings[: _WFS_SCHEMA_BATCH - 1]]
 
 
@@ -1357,13 +1405,19 @@ def _wfs_base_url(url: str, version: str) -> str:
 
 
 def _describe_feature_type_url(
-    url: str, version: str, names: list[str], *, single: bool
+    url: str,
+    version: str,
+    names: list[str],
+    *,
+    single: bool,
+    output_format: str | None = None,
 ) -> str:
     """The DescribeFeatureType URL the driver builds from the submitted URL,
     byte for byte: the driver's own keys replaced or removed in place, the
     type names escaped as the driver escapes them, every other parameter
     kept as submitted. ``single`` is the one-layer request, which also
-    drops ``COUNT``; the batch request keeps it.
+    drops ``COUNT``; the batch request keeps it. ``output_format`` is the
+    driver's required ``OUTPUTFORMAT``, added escaped; absent, the key goes.
     """
     request = _wfs_base_url(url, version)
     steps: list[tuple[str, str | None]] = [
@@ -1376,7 +1430,10 @@ def _describe_feature_type_url(
     ]
     if single:
         steps.append(("COUNT", None))
-    steps.extend([("FILTER", None), ("OUTPUTFORMAT", None)])
+    steps.append(("FILTER", None))
+    steps.append(
+        ("OUTPUTFORMAT", _wfs_escape(output_format) if output_format else None)
+    )
     for key, value in steps:
         request = _url_add_kvp(request, key, value)
     return request
@@ -1486,18 +1543,33 @@ class _WfsSchemaReads:
             raise EndpointCheckFailedError("schema element budget exceeded")
         return tree
 
-    async def _describe(self, version: str, names: list[str], *, single: bool):
+    async def _describe(
+        self,
+        version: str,
+        names: list[str],
+        *,
+        single: bool,
+        output_format: str | None,
+    ):
         request_url = _describe_feature_type_url(
-            self._url, version, names, single=single
+            self._url, version, names, single=single, output_format=output_format
         )
         schema = _wfs_schema(await self._read(request_url, what="DescribeFeatureType"))
         return None if schema is None else self._counted(schema)
 
-    async def batch(self, version: str, names: list[str]) -> Element | None:
-        return await self._describe(version, names, single=False)
+    async def batch(
+        self, version: str, names: list[str], *, output_format: str | None = None
+    ) -> Element | None:
+        return await self._describe(
+            version, names, single=False, output_format=output_format
+        )
 
-    async def single(self, version: str, name: str) -> Element:
-        schema = await self._describe(version, [name], single=True)
+    async def single(
+        self, version: str, name: str, *, output_format: str | None = None
+    ) -> Element:
+        schema = await self._describe(
+            version, [name], single=True, output_format=output_format
+        )
         if schema is None:
             raise EndpointCheckFailedError("DescribeFeatureType is not a schema")
         return schema
@@ -1548,12 +1620,16 @@ async def _check_wfs_schemas(
     if target is None:
         return
     reads = _WfsSchemaReads(client, url, headers)
-    batch = _wfs_batch(names, target)
-    schema = await reads.batch(version, batch)
+    required = _wfs_required_output_formats(root, version)
+    output_format = required.get(target)
+    batch = _wfs_batch(names, target, required)
+    schema = await reads.batch(version, batch, output_format=output_format)
     if schema is not None:
         await reads.check(schema)
     if schema is None or batch != [target]:
-        await reads.check(await reads.single(version, target))
+        await reads.check(
+            await reads.single(version, target, output_format=output_format)
+        )
 
 
 async def _check_wfs(

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -1225,30 +1225,52 @@ def _xml_value(element: Element, name: str) -> str | None:
     return None
 
 
+def _wfs_capabilities_node(root: Element) -> Element | None:
+    """``WFSFindNode``: the root, else its first direct child, whose local name
+    is ``WFS_Capabilities`` in any case; the driver opens nothing else."""
+    for node in (root, *root):
+        if (
+            isinstance(node.tag, str)
+            and _local_name(node.tag).lower() == "wfs_capabilities"
+        ):
+            return node
+    return None
+
+
+def _wfs_feature_type_nodes(capabilities: Element) -> list[Element]:
+    """The direct ``FeatureType`` children of the first direct
+    ``FeatureTypeList``, the only ones the driver turns into layers."""
+    for child in capabilities:
+        if (
+            isinstance(child.tag, str)
+            and _local_name(child.tag).lower() == "featuretypelist"
+        ):
+            return [
+                node
+                for node in child
+                if isinstance(node.tag, str) and _local_name(node.tag) == "FeatureType"
+            ]
+    return []
+
+
 def _wfs_feature_types(root: Element) -> tuple[str, list[str]]:
     """The WFS version and the advertised feature type names, in document order.
 
-    Read the way the driver reads them: the ``version`` of the first
-    ``WFS_Capabilities`` element (1.0.0 when absent; an empty value stays
-    empty, as the driver sends it) and the ``Name`` of every ``FeatureType``,
-    each name once.
+    Read the way the driver reads them: the ``version`` of the capabilities
+    node (1.0.0 when absent; an empty value stays empty, as the driver sends
+    it) and the ``Name`` of each ``FeatureType`` the driver lists, once.
     """
-    version: str | None = None
+    capabilities = _wfs_capabilities_node(root)
+    if capabilities is None:
+        return _WFS_DEFAULT_VERSION, []
+    version = _xml_value(capabilities, "version")
     names: list[str] = []
     seen: set[str] = set()
-    for element in root.iter():
-        if not isinstance(element.tag, str):
-            continue
-        tag = _local_name(element.tag)
-        if version is None and tag.lower() == "wfs_capabilities":
-            version = _xml_value(element, "version")
-            if version is None:
-                version = _WFS_DEFAULT_VERSION
-        elif tag == "FeatureType":
-            name = (_xml_value(element, "name") or "").strip()
-            if name and name not in seen:
-                seen.add(name)
-                names.append(name)
+    for element in _wfs_feature_type_nodes(capabilities):
+        name = (_xml_value(element, "name") or "").strip()
+        if name and name not in seen:
+            seen.add(name)
+            names.append(name)
     return _WFS_DEFAULT_VERSION if version is None else version, names
 
 
@@ -1257,15 +1279,11 @@ def _wfs_required_output_formats(root: Element, version: str) -> dict[str, str]:
     DescribeFeatureType: on 1.1.0 exactly, the first ``Format`` under its
     first ``OutputFormats`` when none of them mentions ``3.1``; else none."""
     required: dict[str, str] = {}
-    if version != "1.1.0":
+    capabilities = _wfs_capabilities_node(root)
+    if version != "1.1.0" or capabilities is None:
         return required
     seen: set[str] = set()
-    for element in root.iter():
-        if (
-            not isinstance(element.tag, str)
-            or _local_name(element.tag) != "FeatureType"
-        ):
-            continue
+    for element in _wfs_feature_type_nodes(capabilities):
         name = (_xml_value(element, "name") or "").strip()
         if not name or name in seen:
             continue

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -1201,7 +1201,14 @@ def _parsed_json(body: bytes) -> object:
 # the driver fetches it with the credential (GDAL 3.10.3, the worker image).
 _WFS_SCHEMA_BATCH = 50
 _MAX_WFS_SCHEMA_READS = 50
+# fix(#1828): aggregate over every document one check parses, two maximum
+# documents each; a real schema and its includes sit an order of magnitude below.
+_MAX_WFS_SCHEMA_BYTES = 2 * MAX_DOCUMENT_BYTES
+_MAX_WFS_SCHEMA_ELEMENTS = 2 * MAX_DOCUMENT_ELEMENTS
 _WFS_DEFAULT_VERSION = "1.0.0"
+# The driver's HTTP branch is `http://` or `https://`; the scheme's case is not
+# part of a URI's identity, so it is folded here.
+_HTTP_LOCATION = re.compile(r"https?://", re.IGNORECASE)
 _ASCII_LOWER = str.maketrans("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
 _C_INT_PREFIX = re.compile(r"\s*([+-]?\d+)")
 
@@ -1438,8 +1445,12 @@ class _WfsSchemaReads:
     driver has nothing to fall back from, so no schema is a refusal. `check`
     refuses the first include whose location the driver would fetch from
     another origin or open as a path, and reads a same-origin location the way
-    the driver would, once. Every read counts against `_MAX_WFS_SCHEMA_READS`
-    and the check refuses past it.
+    the driver would, once, depth first: an included schema is checked and
+    dropped before its next sibling is fetched, so at most one included tree
+    is alive beside the root. Every read counts against
+    `_MAX_WFS_SCHEMA_READS`, and every document parsed against
+    `_MAX_WFS_SCHEMA_BYTES` and `_MAX_WFS_SCHEMA_ELEMENTS` together; past any
+    of the three the check refuses.
     """
 
     def __init__(
@@ -1449,6 +1460,8 @@ class _WfsSchemaReads:
         self._url = url
         self._headers = headers
         self._reads = 0
+        self._bytes = 0
+        self._elements = 0
         self._visited: set[str] = set()
 
     async def _read(self, request_url: str, *, what: str) -> bytes:
@@ -1462,13 +1475,23 @@ class _WfsSchemaReads:
         body, _from_url = await _fetch(
             self._client, request_url, self._headers, accept=WFS_XML_ACCEPT
         )
+        self._bytes += len(body)
+        if self._bytes > _MAX_WFS_SCHEMA_BYTES:
+            raise EndpointCheckFailedError("schema byte budget exceeded")
         return body
+
+    def _counted(self, tree: Element) -> Element:
+        self._elements += sum(1 for _ in tree.iter())
+        if self._elements > _MAX_WFS_SCHEMA_ELEMENTS:
+            raise EndpointCheckFailedError("schema element budget exceeded")
+        return tree
 
     async def _describe(self, version: str, names: list[str], *, single: bool):
         request_url = _describe_feature_type_url(
             self._url, version, names, single=single
         )
-        return _wfs_schema(await self._read(request_url, what="DescribeFeatureType"))
+        schema = _wfs_schema(await self._read(request_url, what="DescribeFeatureType"))
+        return None if schema is None else self._counted(schema)
 
     async def batch(self, version: str, names: list[str]) -> Element | None:
         return await self._describe(version, names, single=False)
@@ -1480,23 +1503,29 @@ class _WfsSchemaReads:
         return schema
 
     async def check(self, schema: Element) -> None:
-        pending = [schema]
+        pending = [iter(_schema_include_locations(schema))]
         while pending:
-            for location in _schema_include_locations(pending.pop()):
-                if location.startswith(("http://", "https://")):
-                    if not same_origin(self._url, location):
-                        raise CrossOriginEndpointError(_schema_location_label(location))
-                    if location not in self._visited:
-                        self._visited.add(location)
-                        pending.append(await self._include(location))
-                elif not _gdal_relative_filename(location):
+            location = next(pending[-1], None)
+            if location is None:
+                pending.pop()
+                continue
+            if _HTTP_LOCATION.match(location):
+                if not same_origin(self._url, location):
                     raise CrossOriginEndpointError(_schema_location_label(location))
+                if location not in self._visited:
+                    self._visited.add(location)
+                    included = await self._include(location)
+                    pending.append(iter(_schema_include_locations(included)))
+                    del included
+            elif not _gdal_relative_filename(location):
+                raise CrossOriginEndpointError(_schema_location_label(location))
 
     async def _include(self, location: str) -> Element:
         try:
-            return _wfs_root(await self._read(location, what="schemaLocation"))
+            tree = _wfs_root(await self._read(location, what="schemaLocation"))
         except (ET.ParseError, DefusedXmlException, RecursionError) as exc:
             raise EndpointCheckFailedError(str(exc)) from None
+        return self._counted(tree)
 
 
 async def _check_wfs_schemas(

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -83,6 +83,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import time
 import xml.parsers.expat
 from collections.abc import Callable
@@ -1201,21 +1202,8 @@ def _parsed_json(body: bytes) -> object:
 _WFS_SCHEMA_BATCH = 50
 _MAX_WFS_SCHEMA_READS = 50
 _WFS_DEFAULT_VERSION = "1.0.0"
-# What the driver replaces or drops on the URL it builds, whatever their case.
-_WFS_DESCRIBE_DROPPED_KEYS = frozenset(
-    {
-        "service",
-        "version",
-        "request",
-        "typename",
-        "typenames",
-        "propertyname",
-        "maxfeatures",
-        "count",
-        "filter",
-        "outputformat",
-    }
-)
+_ASCII_LOWER = str.maketrans("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
+_C_INT_PREFIX = re.compile(r"\s*([+-]?\d+)")
 
 
 def _xml_value(element: Element, name: str) -> str | None:
@@ -1294,28 +1282,97 @@ def _wfs_layer_name(names: list[str], requested: str) -> str | None:
     return None
 
 
-def _describe_feature_type_url(url: str, version: str, names: list[str]) -> str:
-    """The DescribeFeatureType URL the driver builds from the submitted URL.
+def _url_get_value(url: str, key: str) -> str:
+    """``CPLURLGetValue`` (GDAL 3.10.3): the raw value of the first
+    case-insensitive ``KEY=`` that follows ``?`` or ``&``, else empty."""
+    needle = f"{key}=".translate(_ASCII_LOWER)
+    position = url.translate(_ASCII_LOWER).find(needle)
+    if position > 0 and url[position - 1] in "?&":
+        value = url[position + len(needle) :]
+        separator = value.find("&")
+        return value if separator == -1 else value[:separator]
+    return ""
 
-    The caller's own parameters survive; the ones the driver sets or drops are
-    replaced whatever their case, and the type names are joined by commas.
-    ``url`` is the caller's own submission, never a value read out of a
-    response, so its query is unbounded for the reason `_capabilities_url`
-    gives.
+
+def _url_add_kvp(url: str, key: str, value: str | None) -> str:
+    """``CPLURLAddKVP`` (GDAL 3.10.3), byte for byte.
+
+    The first case-insensitive ``KEY=`` that follows ``?`` or ``&`` is
+    replaced in place with the driver's own spelling, or removed when
+    ``value`` is None; an absent key is appended. Every other byte of the
+    URL is left as submitted, and a URL with no query gains its ``?``.
     """
-    parsed = urlparse(url)
-    pairs = parse_qsl(parsed.query, keep_blank_values=True)  # parse_qs: unbounded
-    query = [(k, v) for k, v in pairs if k.lower() not in _WFS_DESCRIBE_DROPPED_KEYS]
-    query.extend(
-        [
-            ("SERVICE", "WFS"),
-            ("VERSION", version),
-            ("REQUEST", "DescribeFeatureType"),
-            ("TYPENAME", ",".join(names)),
-        ]
-    )
-    encoded = urlencode(query, safe=":,", quote_via=quote)
-    return urlunparse(parsed._replace(query=encoded))
+    if "?" not in url:
+        url += "?"
+    needle = f"{key}=".translate(_ASCII_LOWER)
+    position = url.translate(_ASCII_LOWER).find(needle)
+    if position > 0 and url[position - 1] in "?&":
+        rebuilt = url[:position]
+        if value is not None:
+            rebuilt += f"{key}={value}"
+        separator = url.find("&", position)
+        if separator != -1:
+            rest = url[separator:]
+            rebuilt += rest[1:] if rebuilt[-1] in "&?" else rest
+        return rebuilt
+    if value is None:
+        return url
+    if url[-1] not in "&?":
+        url += "&"
+    return f"{url}{key}={value}"
+
+
+def _wfs_escape(value: str) -> str:
+    """``WFS_EscapeURL``: ASCII letters and digits, ``_``, ``.``, ``:`` and
+    ``,`` pass; every other byte is percent-encoded."""
+    escaped: list[str] = []
+    for byte in value.encode("utf-8"):
+        char = chr(byte)
+        if (byte < 128 and char.isalnum()) or char in "_.:,":
+            escaped.append(char)
+        else:
+            escaped.append(f"%{byte:02X}")
+    return "".join(escaped)
+
+
+def _wfs_base_url(url: str, version: str) -> str:
+    """The base URL the driver holds after opening a WFS: for a version whose
+    leading integer is 2 or more, a ``MAXFEATURES`` with no ``COUNT`` beside it
+    is rewritten to ``COUNT``; everything else is the submitted URL."""
+    match = _C_INT_PREFIX.match(version)
+    if match is None or int(match.group(1)) < 2 or _url_get_value(url, "COUNT"):
+        return url
+    max_features = _url_get_value(url, "MAXFEATURES")
+    if not max_features:
+        return url
+    url = _url_add_kvp(url, "MAXFEATURES", None)
+    return _url_add_kvp(url, "COUNT", max_features)
+
+
+def _describe_feature_type_url(
+    url: str, version: str, names: list[str], *, single: bool
+) -> str:
+    """The DescribeFeatureType URL the driver builds from the submitted URL,
+    byte for byte: the driver's own keys replaced or removed in place, the
+    type names escaped as the driver escapes them, every other parameter
+    kept as submitted. ``single`` is the one-layer request, which also
+    drops ``COUNT``; the batch request keeps it.
+    """
+    request = _wfs_base_url(url, version)
+    steps: list[tuple[str, str | None]] = [
+        ("SERVICE", "WFS"),
+        ("VERSION", version),
+        ("REQUEST", "DescribeFeatureType"),
+        ("TYPENAME", _wfs_escape(",".join(names))),
+        ("PROPERTYNAME", None),
+        ("MAXFEATURES", None),
+    ]
+    if single:
+        steps.append(("COUNT", None))
+    steps.extend([("FILTER", None), ("OUTPUTFORMAT", None)])
+    for key, value in steps:
+        request = _url_add_kvp(request, key, value)
+    return request
 
 
 def _gdal_relative_filename(name: str) -> bool:
@@ -1407,12 +1464,17 @@ class _WfsSchemaReads:
         )
         return body
 
-    async def batch(self, version: str, names: list[str]) -> Element | None:
-        request_url = _describe_feature_type_url(self._url, version, names)
+    async def _describe(self, version: str, names: list[str], *, single: bool):
+        request_url = _describe_feature_type_url(
+            self._url, version, names, single=single
+        )
         return _wfs_schema(await self._read(request_url, what="DescribeFeatureType"))
 
+    async def batch(self, version: str, names: list[str]) -> Element | None:
+        return await self._describe(version, names, single=False)
+
     async def single(self, version: str, name: str) -> Element:
-        schema = await self.batch(version, [name])
+        schema = await self._describe(version, [name], single=True)
         if schema is None:
             raise EndpointCheckFailedError("DescribeFeatureType is not a schema")
         return schema

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -89,13 +89,10 @@ import xml.parsers.expat
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 from urllib.parse import (
-    parse_qs,
     parse_qsl,
     quote,
-    urlencode,
     urljoin,
     urlparse,
-    urlunparse,
 )
 
 import defusedxml.ElementTree as ET
@@ -511,35 +508,21 @@ def _origin_of(url: str) -> str:
 
 
 def _capabilities_url(url: str) -> str:
-    """The GetCapabilities form of a WFS URL, preserving existing parameters.
-
-    Built here rather than imported from the probe adapter, which is in a layer
-    this module may not reach. The two agree on the only thing that matters,
-    which is that the service and request parameters win over whatever the
-    caller's URL carried.
-
-    fix(#1770 round 47c): round 47b's `max_num_fields=MAX_QUERY_FIELDS` here
-    was wrong. This function is the `_check_wfs` capabilities read, reached
-    from `assert_endpoints_stay_on_origin` for EVERY WFS caller --
-    `preview.py`, `sources/router.py`'s `/probe`, and the worker
-    (`processing/ingest/ogr.py`) -- and every one of those three catches
-    only `(CrossOriginEndpointError, EndpointCheckFailedError)`, not a bare
-    `ValueError`. A `ValueError` past the field count therefore escaped
-    preview and `/probe` as an unclassified exception and killed a worker
-    job unclassified, the exact class rounds 44 and 47 both closed
-    elsewhere. On `/probe`, `url` is a fresh `ProbeRequest`/
-    `ServicePreviewRequest.url` field, schema-capped at 2048 chars; on
-    preview and the worker it is `origin_ref["url"]` instead -- caller-
-    derived JSONB persisted from that same submission one hop earlier, not a
-    fresh field itself. Either way it is never a value read out of a
-    THIRD-PARTY response, so `# parse_qs: unbounded` is the correct answer.
-    """
-    parsed = urlparse(url)
-    query = parse_qs(parsed.query)  # parse_qs: unbounded
-    params = {k: v[0] for k, v in query.items()}
-    params["service"] = "WFS"
-    params["request"] = "GetCapabilities"
-    return urlunparse(parsed._replace(query=urlencode(params)))
+    """The GetCapabilities URL the driver builds from the submitted URL, byte
+    for byte: its own two keys replaced in place with its spelling, the layer
+    and query keys removed, every other parameter kept as submitted."""
+    request = _url_add_kvp(url, "SERVICE", "WFS")
+    request = _url_add_kvp(request, "REQUEST", "GetCapabilities")
+    for key in (
+        "TYPENAME",
+        "TYPENAMES",
+        "FILTER",
+        "PROPERTYNAME",
+        "MAXFEATURES",
+        "OUTPUTFORMAT",
+    ):
+        request = _url_add_kvp(request, key, None)
+    return request
 
 
 # The two ways a WFS capabilities document names an operation endpoint.

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -30,6 +30,11 @@ than a pass. A credential-free source is still not checked at all: a public
 federated service advertising another origin is ordinary, and the credential is
 what makes it a problem.
 
+fix(#1828): the WFS driver also resolves every ``xs:include`` of the
+DescribeFeatureType schema through the same header-carrying fetch, before any
+GetFeature and under no option that turns it off, so `_check_wfs` reads the
+schemas the driver would read and refuses an include off the origin too.
+
 Lives in ``platform/`` because both callers are in layers that may not import
 each other: ``modules/catalog`` for the probe and preview doors, and
 ``processing/ingest`` for the worker that runs the same source through ogr2ogr
@@ -81,6 +86,7 @@ import json
 import time
 import xml.parsers.expat
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from urllib.parse import (
     parse_qs,
     parse_qsl,
@@ -104,6 +110,9 @@ from app.platform.security import (
     same_origin,
     validate_url_for_ssrf,
 )
+
+if TYPE_CHECKING:
+    from xml.etree.ElementTree import Element
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -527,7 +536,26 @@ _WFS_1_0_OPERATION_TAGS = frozenset(
 )
 
 
+def _local_name(tag: str) -> str:
+    """The tag without its ``{namespace}`` prefix."""
+    return tag.split("}")[-1] if "}" in tag else tag
+
+
+def _wfs_root(xml_bytes: bytes) -> Element:
+    """Parse an untrusted WFS document: bytes so an encoding declaration is
+    honoured, DTD refused."""
+    # fix(#1746 B2b review r26): `forbid_dtd=True`. defusedxml refuses entity
+    # declarations by default but allows a DOCTYPE naming an external subset,
+    # which a WFS document has no use for and the element bound cannot see.
+    return ET.fromstring(xml_bytes, forbid_dtd=True)
+
+
 def _wfs_operation_hrefs(xml_bytes: bytes) -> list[str]:
+    """`_operation_hrefs` of a capabilities document parsed here."""
+    return _operation_hrefs(_wfs_root(xml_bytes))
+
+
+def _operation_hrefs(root: Element) -> list[str]:
     """The operation endpoints a capabilities document advertises for a read.
 
     fix(#1770 round 36 P2): filtered to the operations
@@ -549,20 +577,6 @@ def _wfs_operation_hrefs(xml_bytes: bytes) -> list[str]:
     definition, and it is the document the whole check exists to distrust.
     """
     hrefs: list[str] = []
-    # Bytes rather than str: `ET` refuses a `str` carrying an XML encoding
-    # declaration outright, and reads the declaration correctly from bytes.
-    #
-    # fix(#1746 B2b review r26): `forbid_dtd=True`. defusedxml already refuses
-    # entity declarations by default (`forbid_entities`), which is the billion
-    # laughs case, but it allows a DOCTYPE, including one naming an external
-    # subset. A WFS capabilities document has no use for either, and the
-    # element bound above only counts what is in the body -- it cannot see a
-    # tree the doctype would have expanded.
-    root = ET.fromstring(xml_bytes, forbid_dtd=True)
-
-    def _local(tag: str) -> str:
-        return tag.split("}")[-1] if "}" in tag else tag
-
     # fix(#1770 round 47 P2): iterative, not recursive. `_xml_preflight`
     # (`require_decodable`'s XML branch, which runs before this ever does)
     # only bounds NESTING depth to `MAX_DOCUMENT_DEPTH` -- a document AT that
@@ -590,7 +604,7 @@ def _wfs_operation_hrefs(xml_bytes: bytes) -> list[str]:
     stack: list[tuple[object, str | None]] = [(root, None)]
     while stack:
         element, operation = stack.pop()
-        tag = _local(element.tag)
+        tag = _local_name(element.tag)
         if tag == "Operation":
             # 1.1/2.0: `ows:Operation name="GetFeature"`. A missing or blank
             # name leaves the context unattributed rather than guessing one,
@@ -603,7 +617,7 @@ def _wfs_operation_hrefs(xml_bytes: bytes) -> list[str]:
             operation is None or operation in _WFS_READ_OPERATIONS
         ):
             for name, value in element.attrib.items():
-                local = _local(name).lower()
+                local = _local_name(name).lower()
                 if local in _WFS_ENDPOINT_ATTRIBUTES and value:
                     hrefs.append(value)
         stack.extend((child, operation) for child in reversed(list(element)))
@@ -1141,12 +1155,305 @@ def _parsed_json(body: bytes) -> object:
         raise EndpointCheckFailedError(str(exc)) from None
 
 
+# fix(#1828): the DescribeFeatureType reads GDAL's WFS driver makes before any
+# GetFeature, mirrored so an `include` naming another origin is refused before
+# the driver fetches it with the credential (GDAL 3.10.3, the worker image).
+_WFS_SCHEMA_BATCH = 50
+_MAX_WFS_SCHEMA_READS = 50
+_WFS_DEFAULT_VERSION = "1.0.0"
+# What the driver replaces or drops on the URL it builds, whatever their case.
+_WFS_DESCRIBE_DROPPED_KEYS = frozenset(
+    {
+        "service",
+        "version",
+        "request",
+        "typename",
+        "typenames",
+        "propertyname",
+        "maxfeatures",
+        "count",
+        "filter",
+        "outputformat",
+    }
+)
+
+
+def _xml_value(element: Element, name: str) -> str | None:
+    """``CPLGetXMLValue`` as the driver reads it: the attribute, else a
+    text-only child element, matched by lower-cased local name."""
+    for key, value in element.attrib.items():
+        if _local_name(key).lower() == name:
+            return value
+    for child in element:
+        if (
+            isinstance(child.tag, str)
+            and _local_name(child.tag).lower() == name
+            and len(child) == 0
+        ):
+            return child.text or ""
+    return None
+
+
+def _wfs_feature_types(root: Element) -> tuple[str, list[str]]:
+    """The WFS version and the advertised feature type names, in document order.
+
+    Read the way the driver reads them: the ``version`` of the first
+    ``WFS_Capabilities`` element (1.0.0 when absent) and the ``Name`` of every
+    ``FeatureType``, each name once.
+    """
+    version = ""
+    found_root = False
+    names: list[str] = []
+    seen: set[str] = set()
+    for element in root.iter():
+        if not isinstance(element.tag, str):
+            continue
+        tag = _local_name(element.tag)
+        if not found_root and tag.lower() == "wfs_capabilities":
+            found_root = True
+            version = _xml_value(element, "version") or ""
+        elif tag == "FeatureType":
+            name = (_xml_value(element, "name") or "").strip()
+            if name and name not in seen:
+                seen.add(name)
+                names.append(name)
+    return version or _WFS_DEFAULT_VERSION, names
+
+
+def _wfs_prefix(name: str) -> str:
+    return name.split(":", 1)[0] if ":" in name else ""
+
+
+def _wfs_batch(names: list[str], first: str) -> list[str]:
+    """The names one DescribeFeatureType carries: *first*, then the other
+    members of its prefix in order, fifty at most, as the driver batches."""
+    prefix = _wfs_prefix(first)
+    siblings = [n for n in names if n != first and _wfs_prefix(n) == prefix]
+    return [first, *siblings[: _WFS_SCHEMA_BATCH - 1]]
+
+
+def _wfs_layer_name(names: list[str], requested: str) -> str | None:
+    """The advertised name the driver opens for *requested*, or None.
+
+    Exact first, then case-insensitive, then the part after the prefix when
+    the request carries none and no two advertised short names collide.
+    """
+    if requested in names:
+        return requested
+    folded = requested.lower()
+    for name in names:
+        if name.lower() == folded:
+            return name
+    shorts = [name.split(":", 1)[-1] for name in names]
+    if ":" in requested or len(set(shorts)) < len(shorts):
+        return None
+    for name, short in zip(names, shorts):
+        if ":" in name and short.lower() == folded:
+            return name
+    return None
+
+
+def _describe_feature_type_url(url: str, version: str, names: list[str]) -> str:
+    """The DescribeFeatureType URL the driver builds from the submitted URL.
+
+    The caller's own parameters survive; the ones the driver sets or drops are
+    replaced whatever their case, and the type names are joined by commas.
+    ``url`` is the caller's own submission, never a value read out of a
+    response, so its query is unbounded for the reason `_capabilities_url`
+    gives.
+    """
+    parsed = urlparse(url)
+    pairs = parse_qsl(parsed.query, keep_blank_values=True)  # parse_qs: unbounded
+    query = [(k, v) for k, v in pairs if k.lower() not in _WFS_DESCRIBE_DROPPED_KEYS]
+    query.extend(
+        [
+            ("SERVICE", "WFS"),
+            ("VERSION", version),
+            ("REQUEST", "DescribeFeatureType"),
+            ("TYPENAME", ",".join(names)),
+        ]
+    )
+    encoded = urlencode(query, safe=":,", quote_via=quote)
+    return urlunparse(parsed._replace(query=encoded))
+
+
+def _gdal_relative_filename(name: str) -> bool:
+    """``CPLIsFilenameRelative`` (GDAL 3.10.3). A relative include resolves under
+    the driver's in-memory directory and never leaves the process; anything
+    else is opened as a VSI path."""
+    if not name:
+        return True
+    if name[0] in "/\\" or name[1:3] in (":\\", ":/"):
+        return False
+    return "://" not in name[1:]
+
+
+def _schema_include_locations(root: Element) -> list[str]:
+    """Every ``include`` location in the tree, read as the driver reads it."""
+    locations: list[str] = []
+    for element in root.iter():
+        if (
+            isinstance(element.tag, str)
+            and _local_name(element.tag).lower() == "include"
+        ):
+            location = _xml_value(element, "schemalocation")
+            if location is not None:
+                locations.append(location)
+    return locations
+
+
+def _schema_location_label(location: str) -> str:
+    """What a refusal names: the location's origin when it has a host."""
+    try:
+        netloc = urlparse(location).netloc
+    except ValueError:
+        return "unparseable"
+    return _origin_of(location) if netloc else "a local path"
+
+
+def _wfs_schema(body: bytes) -> Element | None:
+    """The schema element the driver would parse out of a DescribeFeatureType
+    body, or None where the driver sees no schema and falls back.
+
+    Raises `EndpointCheckFailedError` for a body that does not parse: the
+    driver's own parser is more lenient, so what it would read is unknown.
+    """
+    if b"<ServiceExceptionReport" in body:
+        return None
+    try:
+        root = _wfs_root(body)
+    except (ET.ParseError, DefusedXmlException, RecursionError) as exc:
+        raise EndpointCheckFailedError(str(exc)) from None
+    if _local_name(root.tag).lower() == "schema":
+        return root
+    for child in root:
+        if isinstance(child.tag, str) and _local_name(child.tag).lower() == "schema":
+            return child
+    return None
+
+
+class _WfsSchemaReads:
+    """The bounded DescribeFeatureType and include reads of one check.
+
+    `batch` is the schema the driver would parse for one request, or None where
+    the driver falls back to one request per type; `single` is a request the
+    driver has nothing to fall back from, so no schema is a refusal. `check`
+    refuses the first include whose location the driver would fetch from
+    another origin or open as a path, and reads a same-origin location the way
+    the driver would, once. Every read counts against `_MAX_WFS_SCHEMA_READS`
+    and the check refuses past it.
+    """
+
+    def __init__(
+        self, client: httpx.AsyncClient, url: str, headers: dict[str, str]
+    ) -> None:
+        self._client = client
+        self._url = url
+        self._headers = headers
+        self._reads = 0
+        self._visited: set[str] = set()
+
+    async def _read(self, request_url: str, *, what: str) -> bytes:
+        self._reads += 1
+        if self._reads > _MAX_WFS_SCHEMA_READS:
+            raise EndpointCheckFailedError("schema read budget exceeded")
+        try:
+            request_url = bounded_service_url(request_url, what=what)
+        except HrefTooLongError as exc:
+            raise EndpointCheckFailedError(str(exc)) from None
+        body, _from_url = await _fetch(
+            self._client, request_url, self._headers, accept=WFS_XML_ACCEPT
+        )
+        return body
+
+    async def batch(self, version: str, names: list[str]) -> Element | None:
+        request_url = _describe_feature_type_url(self._url, version, names)
+        return _wfs_schema(await self._read(request_url, what="DescribeFeatureType"))
+
+    async def single(self, version: str, name: str) -> Element:
+        schema = await self.batch(version, [name])
+        if schema is None:
+            raise EndpointCheckFailedError("DescribeFeatureType is not a schema")
+        return schema
+
+    async def check(self, schema: Element) -> None:
+        pending = [schema]
+        while pending:
+            for location in _schema_include_locations(pending.pop()):
+                if location.startswith(("http://", "https://")):
+                    if not same_origin(self._url, location):
+                        raise CrossOriginEndpointError(_schema_location_label(location))
+                    if location not in self._visited:
+                        self._visited.add(location)
+                        pending.append(await self._include(location))
+                elif not _gdal_relative_filename(location):
+                    raise CrossOriginEndpointError(_schema_location_label(location))
+
+    async def _include(self, location: str) -> Element:
+        try:
+            return _wfs_root(await self._read(location, what="schemaLocation"))
+        except (ET.ParseError, DefusedXmlException, RecursionError) as exc:
+            raise EndpointCheckFailedError(str(exc)) from None
+
+
+async def _check_wfs_schemas(
+    client: httpx.AsyncClient,
+    url: str,
+    headers: dict[str, str],
+    root: Element,
+    collection: str | None,
+) -> None:
+    """Refuse the first schema include the driver would fetch off the origin.
+
+    Reads what the driver reads. For a named layer: one DescribeFeatureType
+    for the layer and its prefix siblings, then one for the layer alone, which
+    the driver issues whenever the first answer does not cover it. For no
+    layer: one per prefix batch, then one per remaining type once a batch
+    answers with no schema. A capabilities document advertising no feature
+    type has nothing to read.
+    """
+    version, names = _wfs_feature_types(root)
+    if not names:
+        return
+    reads = _WfsSchemaReads(client, url, headers)
+    target = _wfs_layer_name(names, collection) if collection else None
+    if target is not None:
+        batch = _wfs_batch(names, target)
+        schema = await reads.batch(version, batch)
+        if schema is not None:
+            await reads.check(schema)
+        if schema is None or batch != [target]:
+            await reads.check(await reads.single(version, target))
+        return
+    pending = list(names)
+    batching = True
+    while pending:
+        if batching:
+            batch = _wfs_batch(pending, pending[0])
+            schema = await reads.batch(version, batch)
+            if schema is None:
+                batching = False
+                continue
+            pending = [name for name in pending if name not in batch]
+        else:
+            schema = await reads.single(version, pending.pop(0))
+        await reads.check(schema)
+
+
 async def _check_wfs(
     client: httpx.AsyncClient,
     url: str,
     headers: dict[str, str],
+    collection: str | None,
     on_first_request: "Callable[[], None] | None" = None,
 ) -> None:
+    """Refuse a credentialed WFS whose description or schemas name another origin.
+
+    Reads the capabilities and every DescribeFeatureType the driver would,
+    with the credential, on the submitted origin only. Raises
+    `CrossOriginEndpointError` for a foreign endpoint or schema location and
+    `EndpointCheckFailedError` for a document that cannot be read.
+    """
     xml_bytes, from_url = await _fetch(
         client,
         _capabilities_url(url),
@@ -1155,7 +1462,8 @@ async def _check_wfs(
         accept=WFS_XML_ACCEPT,
     )
     try:
-        hrefs = _wfs_operation_hrefs(xml_bytes)
+        root = _wfs_root(xml_bytes)
+        hrefs = _operation_hrefs(root)
     except (ET.ParseError, DefusedXmlException) as exc:
         # fix(#1746 B2b review r26): `DefusedXmlException` is a `ValueError`,
         # NOT a `ParseError`, so catching only the latter let a capabilities
@@ -1174,6 +1482,7 @@ async def _check_wfs(
         # as `_parsed_json`'s own `RecursionError` handling (round 44).
         raise EndpointCheckFailedError(str(exc)) from None
     _assert_same_origin(url, hrefs, from_url)
+    await _check_wfs_schemas(client, url, headers, root, collection)
 
 
 async def _check_ogcapi(
@@ -1319,7 +1628,7 @@ async def assert_endpoints_stay_on_origin(
             ) as client:
                 arm = fire_once(on_first_request)
                 if service_format == "wfs":
-                    await _check_wfs(client, url, headers, arm)
+                    await _check_wfs(client, url, headers, collection, arm)
                 else:
                     await _check_ogcapi(client, url, headers, collection, arm)
     except TimeoutError:

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -1652,8 +1652,9 @@ async def _check_wfs_schemas(
     Reads what the driver reads for the layer it is about to open: one
     DescribeFeatureType naming the layer and then its prefix siblings, fifty
     at most, then one naming the layer alone, which the driver issues whenever
-    the first answer does not cover it. With no layer, or one the driver would
-    not resolve, nothing is read and the check is the capabilities check alone.
+    the first answer does not cover it; the check reads the second whenever it
+    is a different request, without deciding coverage. With no layer, or one
+    the driver would not resolve, nothing is read.
     """
     version, names = _wfs_feature_types(root)
     target = _wfs_layer_name(names, collection) if collection else None
@@ -1666,7 +1667,15 @@ async def _check_wfs_schemas(
     schema = await reads.batch(version, batch, output_format=output_format)
     if schema is not None:
         await reads.check(schema)
-    if schema is None or batch != [target]:
+    # fix(#1828): the driver retries the layer alone whenever the batch answer
+    # does not cover it; the check reads that request unless it is the same URL.
+    single_url = _describe_feature_type_url(
+        url, version, [target], single=True, output_format=output_format
+    )
+    batch_url = _describe_feature_type_url(
+        url, version, batch, single=False, output_format=output_format
+    )
+    if schema is None or single_url != batch_url:
         await reads.check(
             await reads.single(version, target, output_format=output_format)
         )

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -415,6 +415,19 @@ OGC_JSON_ACCEPT = "application/geo+json, application/json"
 # by header, so this states the expectation rather than driving it. No `*/*`
 # term: that is exactly what lets a server answer with HTML.
 WFS_XML_ACCEPT = "application/xml, text/xml"
+# fix(#1828): the check's reads and the driver's requests carry one User-Agent,
+# and for WFS one Accept and Accept-Encoding, so a server keyed on them sees one client.
+SERVICE_CHECK_USER_AGENT = "GeoLens"
+
+
+def gdal_transport_env(service_format: str) -> dict[str, str]:
+    """The env that makes a GDAL subprocess negotiate as this module's reads do."""
+    env = {"GDAL_HTTP_USERAGENT": SERVICE_CHECK_USER_AGENT}
+    if service_format == "wfs":
+        env["GDAL_HTTP_HEADERS"] = (
+            f"Accept: {WFS_XML_ACCEPT}\r\nAccept-Encoding: identity"
+        )
+    return env
 
 
 class EndpointCheckFailedError(Exception):
@@ -1119,7 +1132,7 @@ async def fetch_document(
     element_budget = MAX_DOCUMENT_ELEMENTS if element_budget is None else element_budget
     # Copied rather than mutated: the caller's dict is reused across the pages
     # of a walk, and the negotiation belongs to this read.
-    headers = {**headers, "Accept": accept}
+    headers = {**headers, "Accept": accept, "User-Agent": SERVICE_CHECK_USER_AGENT}
     try:
         await validate_url_for_ssrf(url)
         if on_first_request is not None:

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -20,8 +20,9 @@ from app.core.runtime.staging import (
 from app.platform.service_items import materialise_oapif_items
 from app.platform.service_endpoints import (
     assert_endpoints_stay_on_origin,
-    require_wfs_layer,
     fire_once,
+    gdal_transport_env,
+    require_wfs_layer,
 )
 from app.core.service_tokens import (
     BEARER_SCHEME,
@@ -1371,6 +1372,7 @@ async def run_ogr2ogr_service(
                 os.close(fd)
             os.chmod(header_file_path, 0o600)
             env["GDAL_HTTP_HEADER_FILE"] = header_file_path
+            env.update(gdal_transport_env(service_type))
             # Plan rule A: GDAL forwards `Authorization` only to the host it
             # was given to, and forwards every other header name verbatim even
             # across hosts, so a service-chosen API key is redirect-exposed on

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -20,6 +20,7 @@ from app.core.runtime.staging import (
 from app.platform.service_items import materialise_oapif_items
 from app.platform.service_endpoints import (
     assert_endpoints_stay_on_origin,
+    require_wfs_layer,
     fire_once,
 )
 from app.core.service_tokens import (
@@ -1312,6 +1313,11 @@ async def run_ogr2ogr_service(
                 token, service_format=service_type
             )  # SEC-FU-04: raises ValueError before subprocess
 
+            # fix(#1828): a credentialed WFS never reaches GDAL without a
+            # layer, since GDAL opened layerless reads every layer's schema.
+            require_wfs_layer(
+                layer_name, service_format=service_type, credential_line=header_line
+            )
             # fix(#1746 B2b review r13): GDAL applies the header file to the
             # operation endpoints the service's own description advertises,
             # and those are fresh requests no redirect rule can see. Checked

--- a/backend/tests/test_gdal_driver_clamp_1846.py
+++ b/backend/tests/test_gdal_driver_clamp_1846.py
@@ -111,7 +111,7 @@ def test_no_skipped_driver_name_contains_a_space():
 def test_vector_env_does_not_disturb_the_rest_of_the_environment():
     env = gdal_vector_safe_env()
     for key, value in os.environ.items():
-        if key not in ("GDAL_SKIP", "GML_USE_SCHEMA_IMPORT"):
+        if key not in ("GDAL_SKIP", "GML_USE_SCHEMA_IMPORT", "GML_DOWNLOAD_SCHEMA"):
             assert env[key] == value
 
 

--- a/backend/tests/test_gdal_driver_clamp_1846.py
+++ b/backend/tests/test_gdal_driver_clamp_1846.py
@@ -111,7 +111,7 @@ def test_no_skipped_driver_name_contains_a_space():
 def test_vector_env_does_not_disturb_the_rest_of_the_environment():
     env = gdal_vector_safe_env()
     for key, value in os.environ.items():
-        if key != "GDAL_SKIP":
+        if key not in ("GDAL_SKIP", "GML_USE_SCHEMA_IMPORT"):
             assert env[key] == value
 
 

--- a/backend/tests/test_gdal_env.py
+++ b/backend/tests/test_gdal_env.py
@@ -1,5 +1,9 @@
-"""fix(#579): GDAL /vsis3/ AWS_* derivation from the app's S3_* settings."""
+"""fix(#579): GDAL /vsis3/ AWS_* derivation from the app's S3_* settings, and
+fix(#1828): the schema-import clamp both vector subprocess envs carry."""
 
+import os
+import pathlib
+import re
 from types import SimpleNamespace
 
 from pydantic import SecretStr
@@ -103,3 +107,66 @@ def test_configure_sets_missing_and_never_clobbers(monkeypatch):
     assert os.environ["AWS_ACCESS_KEY_ID"] == "test-access-key"
     assert os.environ["AWS_HTTPS"] == "NO"
     assert os.environ["AWS_VIRTUAL_HOSTING"] == "FALSE"
+
+
+_SCHEMA_IMPORT_KEY = "GML_USE_SCHEMA_IMPORT"
+
+# The three shapes an assignment of the key can take in Python source: a dict
+# entry or `KEY=value` pair, an `os.environ[...] = ...` store, and a
+# `setenv("KEY", value)` call.
+_ASSIGNMENTS = (
+    re.compile(_SCHEMA_IMPORT_KEY + r'["\']?\]?\s*[:=]\s*["\']([^"\']*)["\']'),
+    re.compile(_SCHEMA_IMPORT_KEY + r'["\']\s*,\s*["\']([^"\']*)["\']'),
+)
+
+
+def _assigned_values(line: str) -> list[str]:
+    return [m.group(1) for pattern in _ASSIGNMENTS for m in pattern.finditer(line)]
+
+
+class TestSchemaImportResolutionStaysOffByValue:
+    """fix(#1828): `GML_USE_SCHEMA_IMPORT` is NO in both GDAL vector envs.
+
+    The GML driver reads it from the process env and, at YES, fetches every
+    `xs:import` location of a schema with the credential header attached. A
+    value rather than an absence, so an operator's env cannot flip it on.
+    """
+
+    def test_both_envs_pin_it_to_no(self) -> None:
+        from app.platform.gdal_env import gdal_service_safe_env, gdal_vector_safe_env
+
+        for env in (gdal_vector_safe_env(), gdal_service_safe_env()):
+            assert env[_SCHEMA_IMPORT_KEY] == "NO"
+
+    def test_a_process_env_value_cannot_flip_it(self, monkeypatch) -> None:
+        from app.platform.gdal_env import gdal_service_safe_env, gdal_vector_safe_env
+
+        monkeypatch.setenv(_SCHEMA_IMPORT_KEY, "YES")
+
+        for env in (gdal_vector_safe_env(), gdal_service_safe_env()):
+            assert env[_SCHEMA_IMPORT_KEY] == "NO"
+        assert os.environ[_SCHEMA_IMPORT_KEY] == "YES"
+
+    def test_the_grep_sees_every_assignment_shape(self) -> None:
+        """Positive control for the tree walk below."""
+        assert _assigned_values('{"GML_USE_SCHEMA_IMPORT": "YES"}') == ["YES"]
+        assert _assigned_values('env["GML_USE_SCHEMA_IMPORT"] = "YES"') == ["YES"]
+        assert _assigned_values("GML_USE_SCHEMA_IMPORT='YES'") == ["YES"]
+        assert _assigned_values('setenv("GML_USE_SCHEMA_IMPORT", "YES")') == ["YES"]
+        assert _assigned_values("once GML_USE_SCHEMA_IMPORT is YES anywhere") == []
+
+    def test_nothing_under_backend_app_sets_it_to_anything_else(self) -> None:
+        app_root = pathlib.Path(__file__).resolve().parents[1] / "app"
+        assignments: dict[str, list[str]] = {}
+        for path in sorted(app_root.rglob("*.py")):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                values = _assigned_values(line)
+                if values:
+                    rel = path.relative_to(app_root).as_posix()
+                    assignments.setdefault(rel, []).extend(values)
+
+        # The pin itself is found, so an empty answer elsewhere means absence
+        # rather than a blind walk.
+        assert assignments.get("platform/gdal_env.py") == ["NO"], assignments
+        for rel, values in assignments.items():
+            assert values == ["NO"] * len(values), (rel, values)

--- a/backend/tests/test_gdal_env.py
+++ b/backend/tests/test_gdal_env.py
@@ -109,55 +109,70 @@ def test_configure_sets_missing_and_never_clobbers(monkeypatch):
     assert os.environ["AWS_VIRTUAL_HOSTING"] == "FALSE"
 
 
-_SCHEMA_IMPORT_KEY = "GML_USE_SCHEMA_IMPORT"
+_SCHEMA_FETCH_KEYS = ("GML_USE_SCHEMA_IMPORT", "GML_DOWNLOAD_SCHEMA")
 
-# The three shapes an assignment of the key can take in Python source: a dict
+# The three shapes an assignment of a key can take in Python source: a dict
 # entry or `KEY=value` pair, an `os.environ[...] = ...` store, and a
 # `setenv("KEY", value)` call.
-_ASSIGNMENTS = (
-    re.compile(_SCHEMA_IMPORT_KEY + r'["\']?\]?\s*[:=]\s*["\']([^"\']*)["\']'),
-    re.compile(_SCHEMA_IMPORT_KEY + r'["\']\s*,\s*["\']([^"\']*)["\']'),
+_ASSIGNMENT_SHAPES = (
+    r'["\']?\]?\s*[:=]\s*["\']([^"\']*)["\']',
+    r'["\']\s*,\s*["\']([^"\']*)["\']',
 )
+_ASSIGNMENTS = [
+    (key, re.compile(key + shape))
+    for key in _SCHEMA_FETCH_KEYS
+    for shape in _ASSIGNMENT_SHAPES
+]
 
 
-def _assigned_values(line: str) -> list[str]:
-    return [m.group(1) for pattern in _ASSIGNMENTS for m in pattern.finditer(line)]
+def _assigned_values(line: str) -> list[tuple[str, str]]:
+    return [
+        (key, m.group(1))
+        for key, pattern in _ASSIGNMENTS
+        for m in pattern.finditer(line)
+    ]
 
 
-class TestSchemaImportResolutionStaysOffByValue:
-    """fix(#1828): `GML_USE_SCHEMA_IMPORT` is NO in both GDAL vector envs.
+class TestSchemaFetchesStayOffByValue:
+    """fix(#1828): `GML_USE_SCHEMA_IMPORT` and `GML_DOWNLOAD_SCHEMA` are NO in
+    both GDAL vector envs.
 
-    The GML driver reads it from the process env and, at YES, fetches every
-    `xs:import` location of a schema with the credential header attached. A
-    value rather than an absence, so an operator's env cannot flip it on.
+    The GML driver reads both from the process env. At YES the first fetches
+    every `xs:import` location of a schema and the second fetches the schema a
+    GetFeature response points at, each with the credential header attached.
+    A value rather than an absence, so an operator's env cannot flip either.
     """
 
-    def test_both_envs_pin_it_to_no(self) -> None:
+    def test_both_envs_pin_both_keys_to_no(self) -> None:
         from app.platform.gdal_env import gdal_service_safe_env, gdal_vector_safe_env
 
         for env in (gdal_vector_safe_env(), gdal_service_safe_env()):
-            assert env[_SCHEMA_IMPORT_KEY] == "NO"
+            for key in _SCHEMA_FETCH_KEYS:
+                assert env[key] == "NO", key
 
-    def test_a_process_env_value_cannot_flip_it(self, monkeypatch) -> None:
+    def test_a_process_env_value_cannot_flip_either(self, monkeypatch) -> None:
         from app.platform.gdal_env import gdal_service_safe_env, gdal_vector_safe_env
 
-        monkeypatch.setenv(_SCHEMA_IMPORT_KEY, "YES")
+        for key in _SCHEMA_FETCH_KEYS:
+            monkeypatch.setenv(key, "YES")
 
         for env in (gdal_vector_safe_env(), gdal_service_safe_env()):
-            assert env[_SCHEMA_IMPORT_KEY] == "NO"
-        assert os.environ[_SCHEMA_IMPORT_KEY] == "YES"
+            for key in _SCHEMA_FETCH_KEYS:
+                assert env[key] == "NO", key
+        assert all(os.environ[key] == "YES" for key in _SCHEMA_FETCH_KEYS)
 
     def test_the_grep_sees_every_assignment_shape(self) -> None:
-        """Positive control for the tree walk below."""
-        assert _assigned_values('{"GML_USE_SCHEMA_IMPORT": "YES"}') == ["YES"]
-        assert _assigned_values('env["GML_USE_SCHEMA_IMPORT"] = "YES"') == ["YES"]
-        assert _assigned_values("GML_USE_SCHEMA_IMPORT='YES'") == ["YES"]
-        assert _assigned_values('setenv("GML_USE_SCHEMA_IMPORT", "YES")') == ["YES"]
-        assert _assigned_values("once GML_USE_SCHEMA_IMPORT is YES anywhere") == []
+        """Positive control for the tree walk below, for both keys."""
+        for key in _SCHEMA_FETCH_KEYS:
+            assert _assigned_values(f'{{"{key}": "YES"}}') == [(key, "YES")]
+            assert _assigned_values(f'env["{key}"] = "YES"') == [(key, "YES")]
+            assert _assigned_values(f"{key}='YES'") == [(key, "YES")]
+            assert _assigned_values(f'setenv("{key}", "YES")') == [(key, "YES")]
+            assert _assigned_values(f"once {key} is YES anywhere") == []
 
-    def test_nothing_under_backend_app_sets_it_to_anything_else(self) -> None:
+    def test_nothing_under_backend_app_sets_either_to_anything_else(self) -> None:
         app_root = pathlib.Path(__file__).resolve().parents[1] / "app"
-        assignments: dict[str, list[str]] = {}
+        assignments: dict[str, list[tuple[str, str]]] = {}
         for path in sorted(app_root.rglob("*.py")):
             for line in path.read_text(encoding="utf-8").splitlines():
                 values = _assigned_values(line)
@@ -165,8 +180,10 @@ class TestSchemaImportResolutionStaysOffByValue:
                     rel = path.relative_to(app_root).as_posix()
                     assignments.setdefault(rel, []).extend(values)
 
-        # The pin itself is found, so an empty answer elsewhere means absence
-        # rather than a blind walk.
-        assert assignments.get("platform/gdal_env.py") == ["NO"], assignments
+        # The pins themselves are found, so an empty answer elsewhere means
+        # absence rather than a blind walk.
+        assert sorted(assignments.get("platform/gdal_env.py", [])) == sorted(
+            (key, "NO") for key in _SCHEMA_FETCH_KEYS
+        ), assignments
         for rel, values in assignments.items():
-            assert values == ["NO"] * len(values), (rel, values)
+            assert all(value == "NO" for _key, value in values), (rel, values)

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,7 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    "backend/app/platform/service_endpoints.py": 1330,
+    # fix(#1828): +309. `_check_wfs` now reads every DescribeFeatureType the
+    # WFS driver reads and refuses a schema `include` off the origin (the
+    # `_WfsSchemaReads` walk and its URL/name mirrors). Cap 1330 -> 1639, exact.
+    "backend/app/platform/service_endpoints.py": 1639,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +309. `_check_wfs` now reads every DescribeFeatureType the
-    # WFS driver reads and refuses a schema `include` off the origin (the
-    # `_WfsSchemaReads` walk and its URL/name mirrors). Cap 1330 -> 1639, exact.
-    "backend/app/platform/service_endpoints.py": 1639,
+    # fix(#1828): +294. `_check_wfs` now reads the DescribeFeatureType the WFS
+    # driver reads for the named layer and refuses a schema `include` off the
+    # origin (the `_WfsSchemaReads` walk and its mirrors). Cap 1330 -> 1624, exact.
+    "backend/app/platform/service_endpoints.py": 1624,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +533. `_check_wfs` reads the layer's DescribeFeatureType,
+    # fix(#1828): +551. `_check_wfs` reads the layer's DescribeFeatureType,
     # built byte for byte as the driver builds it, and refuses a schema
-    # `include` off the origin; `require_wfs_layer` at the spawn points. 1863.
-    "backend/app/platform/service_endpoints.py": 1863,
+    # `include` off the origin; `require_wfs_layer` at the spawn points. 1881.
+    "backend/app/platform/service_endpoints.py": 1881,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +541. `_check_wfs` reads the layer's DescribeFeatureType,
+    # fix(#1828): +550. `_check_wfs` reads the layer's DescribeFeatureType,
     # built byte for byte as the driver builds it, and refuses a schema
-    # `include` off the origin; `require_wfs_layer` at the spawn points. 1871.
-    "backend/app/platform/service_endpoints.py": 1871,
+    # `include` off the origin; `require_wfs_layer` at the spawn points. 1880.
+    "backend/app/platform/service_endpoints.py": 1880,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +294. `_check_wfs` now reads the DescribeFeatureType the WFS
-    # driver reads for the named layer and refuses a schema `include` off the
-    # origin (the `_WfsSchemaReads` walk and its mirrors). Cap 1330 -> 1624, exact.
-    "backend/app/platform/service_endpoints.py": 1624,
+    # fix(#1828): +334. `_check_wfs` reads the layer's DescribeFeatureType and
+    # refuses a schema `include` off the origin; `require_wfs_layer` refuses a
+    # layerless credentialed WFS at the spawn points. Cap 1330 -> 1664, exact.
+    "backend/app/platform/service_endpoints.py": 1664,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview
@@ -4838,7 +4838,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # content check through `run_in_thread_draining` instead of inline, so a
     # schema walk cannot sit on the event loop of the request that uploaded the
     # file. Cap 1428 -> 1433, exact.
-    "backend/app/processing/ingest/ogr.py": 1433,
+    # fix(#1828): +6. `run_ogr2ogr_service` refuses a credentialed WFS that
+    # names no layer before the origin check and the spawn. Cap 1433 -> 1439.
+    "backend/app/processing/ingest/ogr.py": 1439,
     # fix(#1846, GHSA-hrf5-v3cq-frx5): first entry. This module crossed the
     # 1000-line threshold when the content check landed: the SQLite schema
     # reader, the archive member walk that identifies members by their bytes

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +550. `_check_wfs` reads the layer's DescribeFeatureType,
+    # fix(#1828): +533. `_check_wfs` reads the layer's DescribeFeatureType,
     # built byte for byte as the driver builds it, and refuses a schema
-    # `include` off the origin; `require_wfs_layer` at the spawn points. 1880.
-    "backend/app/platform/service_endpoints.py": 1880,
+    # `include` off the origin; `require_wfs_layer` at the spawn points. 1863.
+    "backend/app/platform/service_endpoints.py": 1863,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +425. `_check_wfs` reads the layer's DescribeFeatureType,
+    # fix(#1828): +501. `_check_wfs` reads the layer's DescribeFeatureType,
     # built byte for byte as the driver builds it, and refuses a schema
-    # `include` off the origin; `require_wfs_layer` at the spawn points. 1755.
-    "backend/app/platform/service_endpoints.py": 1755,
+    # `include` off the origin; `require_wfs_layer` at the spawn points. 1831.
+    "backend/app/platform/service_endpoints.py": 1831,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +396. `_check_wfs` reads the layer's DescribeFeatureType,
+    # fix(#1828): +425. `_check_wfs` reads the layer's DescribeFeatureType,
     # built byte for byte as the driver builds it, and refuses a schema
-    # `include` off the origin; `require_wfs_layer` at the spawn points. 1726.
-    "backend/app/platform/service_endpoints.py": 1726,
+    # `include` off the origin; `require_wfs_layer` at the spawn points. 1755.
+    "backend/app/platform/service_endpoints.py": 1755,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +334. `_check_wfs` reads the layer's DescribeFeatureType and
-    # refuses a schema `include` off the origin; `require_wfs_layer` refuses a
-    # layerless credentialed WFS at the spawn points. Cap 1330 -> 1664, exact.
-    "backend/app/platform/service_endpoints.py": 1664,
+    # fix(#1828): +396. `_check_wfs` reads the layer's DescribeFeatureType,
+    # built byte for byte as the driver builds it, and refuses a schema
+    # `include` off the origin; `require_wfs_layer` at the spawn points. 1726.
+    "backend/app/platform/service_endpoints.py": 1726,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +513. `_check_wfs` reads the layer's DescribeFeatureType,
+    # fix(#1828): +528. `_check_wfs` reads the layer's DescribeFeatureType,
     # built byte for byte as the driver builds it, and refuses a schema
-    # `include` off the origin; `require_wfs_layer` at the spawn points. 1843.
-    "backend/app/platform/service_endpoints.py": 1843,
+    # `include` off the origin; `require_wfs_layer` at the spawn points. 1858.
+    "backend/app/platform/service_endpoints.py": 1858,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +528. `_check_wfs` reads the layer's DescribeFeatureType,
+    # fix(#1828): +541. `_check_wfs` reads the layer's DescribeFeatureType,
     # built byte for byte as the driver builds it, and refuses a schema
-    # `include` off the origin; `require_wfs_layer` at the spawn points. 1858.
-    "backend/app/platform/service_endpoints.py": 1858,
+    # `include` off the origin; `require_wfs_layer` at the spawn points. 1871.
+    "backend/app/platform/service_endpoints.py": 1871,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview
@@ -4840,7 +4840,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # file. Cap 1428 -> 1433, exact.
     # fix(#1828): +6. `run_ogr2ogr_service` refuses a credentialed WFS that
     # names no layer before the origin check and the spawn. Cap 1433 -> 1439.
-    "backend/app/processing/ingest/ogr.py": 1439,
+    "backend/app/processing/ingest/ogr.py": 1441,
     # fix(#1846, GHSA-hrf5-v3cq-frx5): first entry. This module crossed the
     # 1000-line threshold when the content check landed: the SQLite schema
     # reader, the archive member walk that identifies members by their bytes

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2595,10 +2595,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # caller's real `headers`, and the soft stop is safe because `_next_page`
     # itself refuses a cross-origin/unparseable `next`, not because the
     # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +501. `_check_wfs` reads the layer's DescribeFeatureType,
+    # fix(#1828): +513. `_check_wfs` reads the layer's DescribeFeatureType,
     # built byte for byte as the driver builds it, and refuses a schema
-    # `include` off the origin; `require_wfs_layer` at the spawn points. 1831.
-    "backend/app/platform/service_endpoints.py": 1831,
+    # `include` off the origin; `require_wfs_layer` at the spawn points. 1843.
+    "backend/app/platform/service_endpoints.py": 1843,
     # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview

--- a/backend/tests/test_ogr_subprocess_env.py
+++ b/backend/tests/test_ogr_subprocess_env.py
@@ -91,10 +91,12 @@ async def test_token_not_in_subprocess_env_via_header_file():
             schema="data",
         )
 
-    # 1) The deprecated GDAL_HTTP_HEADERS var MUST NOT be present.
-    assert "GDAL_HTTP_HEADERS" not in captured_env, (
-        f"Authorization must not appear via env var; got: {captured_env.get('GDAL_HTTP_HEADERS')}"
+    # 1) GDAL_HTTP_HEADERS carries the check's own negotiation and never the token.
+    assert captured_env["GDAL_HTTP_HEADERS"] == (
+        "Accept: application/xml, text/xml\r\nAccept-Encoding: identity"
     )
+    assert captured_env["GDAL_HTTP_USERAGENT"] == "GeoLens"
+    assert all(_BEARER_LINE.split()[-1] not in value for value in captured_env.values())
 
     # 2) GDAL_HTTP_HEADER_FILE points at a path, not a token.
     assert "GDAL_HTTP_HEADER_FILE" in captured_env

--- a/backend/tests/test_preview_token_sec021.py
+++ b/backend/tests/test_preview_token_sec021.py
@@ -120,9 +120,11 @@ async def test_preview_passes_bearer_via_header_file_not_env(monkeypatch, client
     )
 
     env = captured["env"]
-    assert "GDAL_HTTP_HEADERS" not in env, (
-        "SEC-021: bearer token must not be passed via the GDAL_HTTP_HEADERS env var"
+    assert env["GDAL_HTTP_HEADERS"] == (
+        "Accept: application/xml, text/xml\r\nAccept-Encoding: identity"
     )
+    assert env["GDAL_HTTP_USERAGENT"] == "GeoLens"
+    assert token not in env["GDAL_HTTP_HEADERS"]
     # fix(#937): GDAL_HTTP_FOLLOWLOCATION is not a GDAL option and provides no
     # redirect protection; the preview path must not claim it as a defense.
     assert "GDAL_HTTP_FOLLOWLOCATION" not in env

--- a/backend/tests/test_service_auth_transport_1746.py
+++ b/backend/tests/test_service_auth_transport_1746.py
@@ -2164,6 +2164,25 @@ def _capabilities(get_href: str) -> str:
 </WFS_Capabilities>"""
 
 
+_PLAIN_SCHEMA = """<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:topp="http://example.test/topp"
+    targetNamespace="http://example.test/topp">
+  <xs:element name="parcels" type="topp:parcelsType"
+      substitutionGroup="gml:AbstractFeature"/>
+</xs:schema>"""
+
+
+def _describe_or(request: httpx.Request, capabilities: str) -> httpx.Response:
+    """fix(#1828): the check reads a DescribeFeatureType after the
+    capabilities, so a double that answered every request with the
+    capabilities document answers that one with a plain schema."""
+    if request.url.params.get("REQUEST") == "DescribeFeatureType":
+        return httpx.Response(200, text=_PLAIN_SCHEMA)
+    return httpx.Response(200, text=capabilities)
+
+
 def _capabilities_ows(operations: dict[str, str]) -> str:
     """A WFS 2.0 capabilities document naming each *operations* entry.
 
@@ -2327,7 +2346,7 @@ class TestAWfsCheckOnlyValidatesTheOperationsTheReadPathUses:
         )
 
         def _handle(request: httpx.Request) -> httpx.Response:
-            return _as_stream(httpx.Response(200, text=document))
+            return _as_stream(_describe_or(request, document))
 
         monkeypatch.setattr(
             security, "make_safe_transport", lambda: httpx.MockTransport(_handle)
@@ -2363,7 +2382,7 @@ class TestAWfsCheckOnlyValidatesTheOperationsTheReadPathUses:
         )
 
         def _handle(request: httpx.Request) -> httpx.Response:
-            return _as_stream(httpx.Response(200, text=document))
+            return _as_stream(_describe_or(request, document))
 
         monkeypatch.setattr(
             security, "make_safe_transport", lambda: httpx.MockTransport(_handle)
@@ -2443,7 +2462,7 @@ class TestTheCapabilitiesUrlBuilderIsNotFieldCountBounded:
         document = _capabilities(_SVC_WFS)
 
         def _handle(request: httpx.Request) -> httpx.Response:
-            return _as_stream(httpx.Response(200, text=document))
+            return _as_stream(_describe_or(request, document))
 
         monkeypatch.setattr(
             security, "make_safe_transport", lambda: httpx.MockTransport(_handle)
@@ -2513,7 +2532,7 @@ class TestADeeplyNestedWfsBranchNeverBecomesARecursionError:
 
     def _transport(self, monkeypatch, document: str) -> None:
         def _handle(request: httpx.Request) -> httpx.Response:
-            return _as_stream(httpx.Response(200, text=document))
+            return _as_stream(_describe_or(request, document))
 
         monkeypatch.setattr(
             security, "make_safe_transport", lambda: httpx.MockTransport(_handle)
@@ -3190,6 +3209,8 @@ class TestAServiceCannotPointTheCredentialSomewhereElse:
                 return httpx.Response(401)
             if "GetCapabilities" in str(request.url):
                 return httpx.Response(200, text=_capabilities(get_href))
+            if request.url.params.get("REQUEST") == "DescribeFeatureType":
+                return httpx.Response(200, text=_PLAIN_SCHEMA)
             return httpx.Response(404)
 
         return handle
@@ -3820,6 +3841,8 @@ class TestAServiceCannotPointTheCredentialSomewhereElse:
         def handle(request: httpx.Request) -> httpx.Response:
             if "GetCapabilities" in str(request.url):
                 return httpx.Response(200, text=document)
+            if request.url.params.get("REQUEST") == "DescribeFeatureType":
+                return httpx.Response(200, text=_PLAIN_SCHEMA)
             return httpx.Response(404)
 
         value = _value()
@@ -6645,8 +6668,8 @@ class TestAServiceThatServesHtmlToAnyoneWhoAsks:
         assert pair is not None
         recorded = self._transport(
             monkeypatch,
-            lambda request: httpx.Response(
-                200, text=_capabilities(f"{_SVC_ORIGIN}/geoserver/wfs")
+            lambda request: _describe_or(
+                request, _capabilities(f"{_SVC_ORIGIN}/geoserver/wfs")
             ),
         )
 
@@ -6850,7 +6873,9 @@ class TestAnXmlDocumentIsBoundedByItsElements:
         elements = service_endpoints.structural_elements(raw)
         assert elements * 50 < service_endpoints.MAX_DOCUMENT_ELEMENTS, elements
 
-        self._transport(monkeypatch, lambda request: httpx.Response(200, content=raw))
+        self._transport(
+            monkeypatch, lambda request: _describe_or(request, raw.decode())
+        )
 
         await self._check()
 

--- a/backend/tests/test_service_auth_transport_1746.py
+++ b/backend/tests/test_service_auth_transport_1746.py
@@ -2431,16 +2431,16 @@ class TestTheCapabilitiesUrlBuilderIsNotFieldCountBounded:
 
         query = "&".join(f"a{n}=1" for n in range(10))
         url = _capabilities_url(f"{_SVC_ORIGIN}/geoserver/wfs?{query}")
-        assert "service=WFS" in url
-        assert "request=GetCapabilities" in url
+        assert "SERVICE=WFS" in url
+        assert "REQUEST=GetCapabilities" in url
 
     def test_a_query_over_the_old_field_count_bound_still_resolves(self) -> None:
         from app.platform.service_endpoints import MAX_QUERY_FIELDS, _capabilities_url
 
         query = "&".join(f"a{n}=1" for n in range(MAX_QUERY_FIELDS + 1))
         url = _capabilities_url(f"{_SVC_ORIGIN}/geoserver/wfs?{query}")
-        assert "service=WFS" in url
-        assert "request=GetCapabilities" in url
+        assert "SERVICE=WFS" in url
+        assert "REQUEST=GetCapabilities" in url
 
     async def test_a_many_param_probe_url_gets_a_coded_result_not_a_500(
         self, monkeypatch

--- a/backend/tests/test_service_auth_transport_1746.py
+++ b/backend/tests/test_service_auth_transport_1746.py
@@ -340,7 +340,9 @@ class TestTheHeaderFileHoldsOneComposedLine:
         credential, _username, password = _basic()
         capture = await _preview_with(monkeypatch, credential)
 
-        assert "GDAL_HTTP_HEADERS" not in capture.env
+        assert capture.env["GDAL_HTTP_HEADERS"] == (
+            "Accept: application/xml, text/xml\r\nAccept-Encoding: identity"
+        )
         assert password not in str(capture.env)
 
 

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -1394,7 +1394,7 @@ class TestTheVersionIsComparedAsTheDriverComparesIt:
             ("0002.0.0", True),
             ("10", True),
             ("0" * 5000 + "1.0", False),
-            ("9" * 5000, True),
+            ("9" * 5000, False),
             ("", False),
             ("x", False),
             ("\u0662.0.0", False),

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -6,6 +6,8 @@ the credential header attached, before any GetFeature. No GDAL option turns
 that off, so `_check_wfs` reads the DescribeFeatureType the driver reads for
 the layer a door is about to open, on the submitted origin, and refuses the
 first include the driver would fetch from another origin or open as a path.
+Both spawn points refuse a credentialed WFS that names no layer before GDAL
+starts, so GDAL never opens every layer on the credential's behalf.
 The import path and the GetFeature schema download are not refused: the
 vector envs pin both off (`test_gdal_env.py`), and a real schema imports GML
 from another origin.
@@ -17,6 +19,7 @@ never reached a host cannot pass by coincidence.
 from __future__ import annotations
 
 import asyncio
+import json
 import uuid
 from unittest.mock import AsyncMock, patch
 
@@ -803,3 +806,235 @@ class TestTheDoorsRefuseBeforeGdalRuns:
         assert raised.value.origin == _FOREIGN
         assert _described(recorded) == [[_LAYER]]
         assert _hosts(recorded) == {"service.example"}
+
+
+class TestACredentialedWfsNeverReachesGdalWithoutALayer:
+    """The schema check reads the description of the layer a door opens, and
+    GDAL opened without a layer reads every layer's. So both spawn points
+    refuse a credentialed WFS that names no layer before the process starts,
+    with the coded shape the origin check uses, and nothing is read from the
+    service at all. A credential-free layerless preview is unchanged."""
+
+    uses_the_real_endpoint_check = True
+
+    @pytest.mark.parametrize(
+        ("layer_name", "service_format", "credentialed", "refused"),
+        [
+            ("", "wfs", True, True),
+            ("   ", "wfs", True, True),
+            (None, "wfs", True, True),
+            (_LAYER, "wfs", True, False),
+            ("", "wfs", False, False),
+            ("", "ogcapi_features", True, False),
+            ("", "arcgis_featureserver", True, False),
+        ],
+        ids=[
+            "empty",
+            "blank",
+            "missing",
+            "named",
+            "no_credential",
+            "oapif",
+            "arcgis",
+        ],
+    )
+    def test_only_a_credentialed_layerless_wfs_is_refused(
+        self, layer_name, service_format, credentialed, refused
+    ) -> None:
+        from app.platform.service_endpoints import (
+            LayerRequiredError,
+            require_wfs_layer,
+        )
+
+        line = f"X-Api-Key: {_value()}" if credentialed else None
+        if not refused:
+            require_wfs_layer(
+                layer_name, service_format=service_format, credential_line=line
+            )
+            return
+        with pytest.raises(LayerRequiredError) as raised:
+            require_wfs_layer(
+                layer_name, service_format=service_format, credential_line=line
+            )
+        assert raised.value.code == "layer_required"
+        assert raised.value.field == "layer_name"
+        assert isinstance(raised.value, EndpointCheckFailedError)
+
+    async def test_the_worker_refuses_before_any_request_or_spawn(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from app.core.config import settings
+        from app.platform.service_endpoints import LayerRequiredError
+        from app.processing.ingest.ogr import run_ogr2ogr_service
+
+        monkeypatch.setattr(settings, "upload_staging_dir", str(tmp_path / "staging"))
+        recorded = _transport(monkeypatch, _wfs(_capabilities([_LAYER]), _schema))
+
+        async def _fake_exec(*cmd, **kwargs):
+            raise AssertionError("ogr2ogr must not run for a refused source")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+        with pytest.raises(LayerRequiredError):
+            await run_ogr2ogr_service(
+                gdal_source=f"WFS:{_SVC_WFS}",
+                layer_name="",
+                table_name="t",
+                db_conn_str="PG:dummy",
+                service_type="wfs",
+                token=f"X-Api-Key: {_value()}",
+                schema="data",
+            )
+
+        assert recorded == []
+
+    async def test_the_preview_refuses_before_any_request_or_spawn(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "upload_staging_dir", str(tmp_path / "staging"))
+        recorded = _transport(monkeypatch, _wfs(_capabilities([_LAYER]), _schema))
+        value = _value()
+        credential = ServiceCredential(
+            method=CredentialMethod.HEADER_KEY,
+            service_format="wfs",
+            header_name="X-Api-Key",
+            header_value=value,
+        )
+
+        async def _fake_exec(*cmd, **kwargs):
+            raise AssertionError("ogrinfo must not run for a refused source")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+        with pytest.raises(Exception) as raised:  # noqa: PT011 - HTTPException
+            await preview_mod.run_service_preview(
+                f"WFS:{_SVC_WFS}", "", credential=credential
+            )
+
+        assert raised.value.status_code == 422
+        assert raised.value.detail["code"] == "layer_required"
+        assert raised.value.detail["field"] == "layer_name"
+        assert value not in str(raised.value.detail)
+        assert recorded == []
+
+    async def test_a_credential_free_layerless_preview_still_lists_layers(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "upload_staging_dir", str(tmp_path / "staging"))
+        spawned: list[tuple] = []
+
+        class _FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                listing = {
+                    "layers": [
+                        {
+                            "name": "l",
+                            "fields": [],
+                            "features": [],
+                            "geometryFields": [],
+                        }
+                    ]
+                }
+                return (json.dumps(listing).encode(), b"")
+
+        async def _fake_exec(*cmd, **kwargs):
+            spawned.append(cmd)
+            return _FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+        result = await preview_mod.run_service_preview(f"WFS:{_SVC_WFS}", "")
+
+        assert result["layer_name"] == "l"
+        assert len(spawned) == 1
+        assert spawned[0][-1] == f"WFS:{_SVC_WFS}"
+
+    async def test_the_reupload_preview_door_answers_422_before_ogrinfo(
+        self, client, admin_auth_header: dict, test_db_session, monkeypatch
+    ) -> None:
+        from tests.factories import create_dataset, get_user_id
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session, created_by=admin_id, name="Layerless WFS"
+        )
+        recorded = _transport(monkeypatch, _wfs(_capabilities([_LAYER]), _schema))
+        monkeypatch.setattr(
+            "app.modules.catalog.datasets.api.router_reupload.validate_url_for_ssrf",
+            AsyncMock(),
+        )
+
+        async def _fake_exec(*cmd, **kwargs):
+            raise AssertionError("ogrinfo must not run for a refused source")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        value = _value()
+
+        resp = await client.post(
+            f"/datasets/{dataset.id}/reupload/service/preview",
+            json={
+                "url": _SVC_WFS,
+                "service_type": "WFS 2.0.0",
+                "layer_name": "",
+                "auth": {
+                    "method": "header",
+                    "header_name": "X-Api-Key",
+                    "header_value": value,
+                },
+            },
+            headers=admin_auth_header,
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["code"] == "layer_required"
+        assert value not in resp.text
+        assert recorded == []
+
+    def test_every_spawn_point_that_names_a_layer_passes_through_the_refusal(
+        self,
+    ) -> None:
+        """Every call of `assert_endpoints_stay_on_origin` that passes a
+        `collection` is a GDAL spawn point, and its function must call
+        `require_wfs_layer` first. The set is exact, so a new spawn point has
+        to be added here as well as inherit the refusal."""
+        import ast
+        import pathlib
+
+        app_root = pathlib.Path(__file__).resolve().parents[1] / "app"
+        spawn_points: dict[tuple[str, str], tuple[int, int | None]] = {}
+        for path in sorted(app_root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for func in ast.walk(tree):
+                if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                check_line = None
+                require_line = None
+                for node in ast.walk(func):
+                    if not isinstance(node, ast.Call):
+                        continue
+                    name = getattr(node.func, "id", None) or getattr(
+                        node.func, "attr", None
+                    )
+                    if name == "assert_endpoints_stay_on_origin" and any(
+                        kw.arg == "collection" for kw in node.keywords
+                    ):
+                        check_line = node.lineno
+                    elif name == "require_wfs_layer":
+                        require_line = node.lineno
+                if check_line is not None:
+                    rel = path.relative_to(app_root).as_posix()
+                    spawn_points[(rel, func.name)] = (check_line, require_line)
+
+        assert set(spawn_points) == {
+            ("modules/catalog/sources/preview.py", "run_service_preview"),
+            ("processing/ingest/ogr.py", "run_ogr2ogr_service"),
+        }, spawn_points
+        for site, (check_line, require_line) in spawn_points.items():
+            assert require_line is not None, site
+            assert require_line < check_line, site

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -424,8 +424,9 @@ class TestAnOrdinarySchemaPasses:
     async def test_the_request_is_built_the_way_the_driver_builds_it(
         self, monkeypatch
     ) -> None:
-        """The caller's own parameters survive; the operation parameters are
-        replaced whatever their case; VERSION is the capabilities' own."""
+        """The driver's own keys are replaced in place with its spelling, the
+        submitted parameters keep their order, and VERSION is the
+        capabilities' own."""
         handler = _wfs(
             _capabilities([_LAYER], version="1.1.0"), lambda names: _schema(names)
         )
@@ -439,16 +440,13 @@ class TestAnOrdinarySchemaPasses:
             r for r in recorded if _params(r).get("request") == "DescribeFeatureType"
         ]
         assert len(describe) == 1
-        pairs = describe[0].url.params.multi_items()
-        assert sorted(pairs) == sorted(
-            [
-                ("map", "x"),
-                ("SERVICE", "WFS"),
-                ("VERSION", "1.1.0"),
-                ("REQUEST", "DescribeFeatureType"),
-                ("TYPENAME", _LAYER),
-            ]
-        )
+        assert describe[0].url.params.multi_items() == [
+            ("REQUEST", "DescribeFeatureType"),
+            ("SERVICE", "WFS"),
+            ("VERSION", "1.1.0"),
+            ("map", "x"),
+            ("TYPENAME", _LAYER),
+        ]
         assert describe[0].url.path == "/geoserver/wfs"
 
     @pytest.mark.parametrize(
@@ -1038,3 +1036,182 @@ class TestACredentialedWfsNeverReachesGdalWithoutALayer:
         for site, (check_line, require_line) in spawn_points.items():
             assert require_line is not None, site
             assert require_line < check_line, site
+
+
+class TestTheRequestCarriesTheSubmittedParametersAsTheDriverDoes:
+    """`CPLURLAddKVP` replaces the first case-insensitive `KEY=` in place with
+    the driver's spelling, removes a key the same way, appends an absent one,
+    and leaves every other byte of the submitted URL alone. A parameter the
+    driver keeps, such as WFS 2.0's `TYPENAMES`, reaches the server on the
+    check's request exactly as it reaches it on the driver's."""
+
+    uses_the_real_endpoint_check = True
+
+    def test_add_kvp_is_the_drivers_byte_for_byte(self) -> None:
+        from app.platform.service_endpoints import _url_add_kvp
+
+        base = "https://s.example/wfs?service=wfs&map=x&TypeName=old&foo=bar"
+        assert (
+            _url_add_kvp(base, "SERVICE", "WFS")
+            == "https://s.example/wfs?SERVICE=WFS&map=x&TypeName=old&foo=bar"
+        )
+        assert (
+            _url_add_kvp(base, "TYPENAME", "topp:parcels")
+            == "https://s.example/wfs?service=wfs&map=x&TYPENAME=topp:parcels&foo=bar"
+        )
+        assert (
+            _url_add_kvp(base, "TYPENAME", None)
+            == "https://s.example/wfs?service=wfs&map=x&foo=bar"
+        )
+        assert (
+            _url_add_kvp(base, "REQUEST", "DescribeFeatureType")
+            == base + "&REQUEST=DescribeFeatureType"
+        )
+        assert _url_add_kvp("https://s.example/wfs", "SERVICE", "WFS") == (
+            "https://s.example/wfs?SERVICE=WFS"
+        )
+        assert _url_add_kvp("https://s.example/wfs", "COUNT", None) == (
+            "https://s.example/wfs?"
+        )
+        # Removing the last pair leaves its separator behind, as the driver does.
+        assert (
+            _url_add_kvp("https://s.example/wfs?a=1&COUNT=5", "COUNT", None)
+            == "https://s.example/wfs?a=1&"
+        )
+
+    def test_get_value_reads_the_raw_first_match(self) -> None:
+        from app.platform.service_endpoints import _url_get_value
+
+        url = "https://s.example/wfs?Count=5&count=6&x=%2F"
+        assert _url_get_value(url, "COUNT") == "5"
+        assert _url_get_value(url, "x") == "%2F"
+        assert _url_get_value(url, "missing") == ""
+        assert _url_get_value("https://s.example/wfs?acount=1", "count") == ""
+
+    def test_type_names_are_escaped_as_the_driver_escapes_them(self) -> None:
+        from app.platform.service_endpoints import _wfs_escape
+
+        assert _wfs_escape("topp:parcels,sf:x_1.2") == "topp:parcels,sf:x_1.2"
+        assert _wfs_escape("a b/c-d") == "a%20b%2Fc%2Dd"
+        assert _wfs_escape("caf\u00e9") == "caf%C3%A9"
+
+    def test_the_batch_and_single_requests_differ_only_by_count(self) -> None:
+        from app.platform.service_endpoints import _describe_feature_type_url
+
+        submitted = "https://s.example/wfs?TYPENAMES=other&foo=bar&count=7&filter=x"
+        batch = _describe_feature_type_url(
+            submitted, "2.0.0", ["topp:a", "topp:b"], single=False
+        )
+        single = _describe_feature_type_url(submitted, "2.0.0", ["topp:a"], single=True)
+        assert batch == (
+            "https://s.example/wfs?TYPENAMES=other&foo=bar&count=7"
+            "&SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=topp:a,topp:b"
+        )
+        assert single == (
+            "https://s.example/wfs?TYPENAMES=other&foo=bar"
+            "&SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=topp:a"
+        )
+
+    @pytest.mark.parametrize(
+        ("version", "submitted_query", "batch_keys", "single_keys"),
+        [
+            (
+                "2.0.0",
+                "MAXFEATURES=5",
+                [("COUNT", "5")],
+                [],
+            ),
+            (
+                "2.0.0",
+                "MAXFEATURES=5&COUNT=9",
+                [("COUNT", "9")],
+                [],
+            ),
+            (
+                "1.1.0",
+                "MAXFEATURES=5",
+                [],
+                [],
+            ),
+        ],
+        ids=["wfs2_rewrites_maxfeatures", "wfs2_keeps_count", "wfs1_drops_maxfeatures"],
+    )
+    def test_maxfeatures_and_count_follow_the_driver(
+        self, version, submitted_query, batch_keys, single_keys
+    ) -> None:
+        from urllib.parse import parse_qsl, urlparse
+
+        from app.platform.service_endpoints import _describe_feature_type_url
+
+        submitted = f"https://s.example/wfs?{submitted_query}"
+
+        def limits(url: str) -> list[tuple[str, str]]:
+            return [
+                (k, v)
+                for k, v in parse_qsl(urlparse(url).query)
+                if k.lower() in ("count", "maxfeatures")
+            ]
+
+        batch = _describe_feature_type_url(submitted, version, [_LAYER], single=False)
+        single = _describe_feature_type_url(submitted, version, [_LAYER], single=True)
+        assert limits(batch) == batch_keys
+        assert limits(single) == single_keys
+
+    async def test_a_submitted_typenames_and_an_unrelated_parameter_reach_both_requests(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(
+            _capabilities([_LAYER, "topp:roads"]), lambda names: _schema(names)
+        )
+        submitted = f"{_SVC_WFS}?TYPENAMES=other&foo=bar"
+
+        recorded, _value_ = await _check(
+            monkeypatch, handler, url=submitted, collection="topp:roads"
+        )
+
+        describe = [
+            r.url.params.multi_items()
+            for r in recorded
+            if _params(r).get("request") == "DescribeFeatureType"
+        ]
+        assert describe == [
+            [
+                ("TYPENAMES", "other"),
+                ("foo", "bar"),
+                ("SERVICE", "WFS"),
+                ("VERSION", "2.0.0"),
+                ("REQUEST", "DescribeFeatureType"),
+                ("TYPENAME", "topp:roads,topp:parcels"),
+            ],
+            [
+                ("TYPENAMES", "other"),
+                ("foo", "bar"),
+                ("SERVICE", "WFS"),
+                ("VERSION", "2.0.0"),
+                ("REQUEST", "DescribeFeatureType"),
+                ("TYPENAME", "topp:roads"),
+            ],
+        ]
+
+    async def test_a_lower_cased_typename_is_replaced_not_duplicated(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(_capabilities([_LAYER]), lambda names: _schema(names))
+        submitted = f"{_SVC_WFS}?typename=old&foo=bar"
+
+        recorded, _value_ = await _check(monkeypatch, handler, url=submitted)
+
+        describe = [
+            r.url.params.multi_items()
+            for r in recorded
+            if _params(r).get("request") == "DescribeFeatureType"
+        ]
+        assert describe == [
+            [
+                ("TYPENAME", _LAYER),
+                ("foo", "bar"),
+                ("SERVICE", "WFS"),
+                ("VERSION", "2.0.0"),
+                ("REQUEST", "DescribeFeatureType"),
+            ]
+        ]

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -1397,6 +1397,10 @@ class TestTheVersionIsComparedAsTheDriverComparesIt:
             ("9" * 5000, True),
             ("", False),
             ("x", False),
+            ("\u0662.0.0", False),
+            ("\uff12.0.0", False),
+            ("\u00a02.0.0", False),
+            (" \t2.0.0", True),
         ],
     )
     def test_the_count_rewrite_follows_the_leading_integer(

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -48,11 +48,26 @@ def _value() -> str:
     return uuid.uuid4().hex
 
 
-def _capabilities(names: list[str], *, version: str | None = "2.0.0") -> str:
-    """A WFS capabilities document advertising *names*, on this origin."""
+def _capabilities(
+    names: list[str],
+    *,
+    version: str | None = "2.0.0",
+    formats: dict[str, list[str]] | None = None,
+) -> str:
+    """A WFS capabilities document advertising *names*, on this origin;
+    ``formats`` adds an ``OutputFormats`` list to the named types."""
     version_attr = "" if version is None else f' version="{version}"'
+
+    def outputs(name: str) -> str:
+        listed = (formats or {}).get(name)
+        if not listed:
+            return ""
+        inner = "".join(f"<Format>{fmt}</Format>" for fmt in listed)
+        return f"<OutputFormats>{inner}</OutputFormats>"
+
     types = "".join(
-        f"<FeatureType><Name>{name}</Name><Title>{name}</Title></FeatureType>"
+        f"<FeatureType><Name>{name}</Name><Title>{name}</Title>"
+        f"{outputs(name)}</FeatureType>"
         for name in names
     )
     return f"""<?xml version="1.0"?>
@@ -1352,3 +1367,108 @@ class TestTheSchemeAndHostCaseDoNotDecideTheOrigin:
 
         assert error.origin == _FOREIGN
         assert _hosts(recorded) == {"service.example"}
+
+
+def _output_formats(recorded: list[httpx.Request]) -> list[str | None]:
+    """The ``OUTPUTFORMAT`` of every DescribeFeatureType request, in order."""
+    return [
+        _params(request).get("outputformat")
+        for request in recorded
+        if _params(request).get("request") == "DescribeFeatureType"
+    ]
+
+
+class TestTheRequiredOutputFormatIsMirrored:
+    """On WFS 1.1.0 the driver adds the first advertised ``Format`` of a type
+    whose formats never mention GML 3.1 as ``OUTPUTFORMAT`` on both schema
+    requests, and batches only types that share it; every other case removes
+    the key. The check sends what the driver sends."""
+
+    uses_the_real_endpoint_check = True
+
+    def test_the_builder_adds_the_escaped_format_or_removes_the_key(self) -> None:
+        from app.platform.service_endpoints import _describe_feature_type_url
+
+        submitted = "https://s.example/wfs?outputformat=old&x=1"
+        batch = _describe_feature_type_url(
+            submitted, "1.1.0", ["topp:a", "topp:b"], single=False, output_format="GML2"
+        )
+        single = _describe_feature_type_url(
+            submitted,
+            "1.1.0",
+            ["topp:a"],
+            single=True,
+            output_format="text/xml; subtype=gml/2.1.2",
+        )
+        removed = _describe_feature_type_url(
+            submitted, "1.1.0", ["topp:a"], single=True
+        )
+        assert batch == (
+            "https://s.example/wfs?OUTPUTFORMAT=GML2&x=1"
+            "&SERVICE=WFS&VERSION=1.1.0&REQUEST=DescribeFeatureType&TYPENAME=topp:a,topp:b"
+        )
+        assert single.startswith(
+            "https://s.example/wfs?OUTPUTFORMAT=text%2Fxml%3B%20subtype%3Dgml%2F2.1.2&x=1&"
+        )
+        assert "OUTPUTFORMAT" not in removed and "outputformat" not in removed
+
+    async def test_both_requests_carry_the_format_on_1_1_0(self, monkeypatch) -> None:
+        handler = _wfs(
+            _capabilities(
+                [_LAYER, "topp:roads"],
+                version="1.1.0",
+                formats={_LAYER: ["GML2", "GML3"], "topp:roads": ["GML2"]},
+            ),
+            lambda names: _schema(names),
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert _described(recorded) == [[_LAYER, "topp:roads"], [_LAYER]]
+        assert _output_formats(recorded) == ["GML2", "GML2"]
+
+    @pytest.mark.parametrize(
+        ("version", "formats"),
+        [
+            ("1.1.0", ["text/xml; subtype=gml/3.1.1", "GML2"]),
+            ("2.0.0", ["GML2"]),
+            ("1.0.0", ["GML2"]),
+            ("1.1.0", []),
+        ],
+        ids=["gml31_listed", "wfs_2", "wfs_1_0", "no_formats"],
+    )
+    async def test_every_other_case_removes_the_key(
+        self, monkeypatch, version: str, formats: list[str]
+    ) -> None:
+        handler = _wfs(
+            _capabilities([_LAYER], version=version, formats={_LAYER: formats}),
+            lambda names: _schema(names),
+        )
+
+        recorded, _value_ = await _check(
+            monkeypatch, handler, url=f"{_SVC_WFS}?OUTPUTFORMAT=old"
+        )
+
+        assert _described(recorded) == [[_LAYER]]
+        assert _output_formats(recorded) == [None]
+
+    async def test_the_batch_holds_only_types_that_share_the_format(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(
+            _capabilities(
+                [_LAYER, "topp:roads", "topp:blocks", "topp:rivers"],
+                version="1.1.0",
+                formats={
+                    _LAYER: ["GML2"],
+                    "topp:blocks": ["GML2"],
+                    "topp:rivers": ["KML"],
+                },
+            ),
+            lambda names: _schema(names),
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert _described(recorded) == [[_LAYER, "topp:blocks"], [_LAYER]]
+        assert _output_formats(recorded) == ["GML2", "GML2"]

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -1215,3 +1215,140 @@ class TestTheRequestCarriesTheSubmittedParametersAsTheDriverDoes:
                 ("REQUEST", "DescribeFeatureType"),
             ]
         ]
+
+
+class TestTheSchemaReadsAreBoundedTogether:
+    """One check parses at most `_MAX_WFS_SCHEMA_BYTES` and
+    `_MAX_WFS_SCHEMA_ELEMENTS` across every document it reads, whatever each
+    document's own size, and reads includes depth first so that one included
+    tree at most is alive beside the root. The budgets are lowered here so the
+    shape fits a unit test; the ratio to the per-document caps is what the
+    tests hold."""
+
+    uses_the_real_endpoint_check = True
+
+    @staticmethod
+    def _handler(count: int, body: str):
+        includes = "".join(
+            f'<xs:include schemaLocation="{_SVC_ORIGIN}/inc{n}.xsd"/>'
+            for n in range(count)
+        )
+        return _wfs(
+            _capabilities([_LAYER]),
+            lambda names: _schema(names, extra=includes),
+            files={f"/inc{n}.xsd": body for n in range(count)},
+        )
+
+    async def test_the_byte_budget_refuses_before_the_read_budget(
+        self, monkeypatch
+    ) -> None:
+        from app.platform import service_endpoints
+
+        monkeypatch.setattr(service_endpoints, "MAX_DOCUMENT_BYTES", 8192)
+        monkeypatch.setattr(service_endpoints, "_MAX_WFS_SCHEMA_BYTES", 3 * 8192)
+        padded = _schema(extra="<!--" + "x" * 6000 + "-->")
+        assert len(padded) < 8192
+        count = service_endpoints._MAX_WFS_SCHEMA_READS
+
+        recorded, error = await _refused(
+            monkeypatch, self._handler(count, padded), EndpointCheckFailedError
+        )
+
+        assert error.code == "endpoint_check_failed"
+        include_reads = [r for r in recorded if r.url.path.startswith("/inc")]
+        assert 0 < len(include_reads) < 5
+        assert len(include_reads) < service_endpoints._MAX_WFS_SCHEMA_READS
+
+    async def test_the_element_budget_refuses_before_the_read_budget(
+        self, monkeypatch
+    ) -> None:
+        from app.platform import service_endpoints
+
+        monkeypatch.setattr(service_endpoints, "MAX_DOCUMENT_ELEMENTS", 400)
+        monkeypatch.setattr(service_endpoints, "_MAX_WFS_SCHEMA_ELEMENTS", 1000)
+        wide = _schema(
+            extra="".join(
+                f'<xs:element name="e{n}" type="xs:string"/>' for n in range(350)
+            )
+        )
+        count = service_endpoints._MAX_WFS_SCHEMA_READS
+
+        recorded, error = await _refused(
+            monkeypatch, self._handler(count, wide), EndpointCheckFailedError
+        )
+
+        assert error.code == "endpoint_check_failed"
+        include_reads = [r for r in recorded if r.url.path.startswith("/inc")]
+        assert 0 < len(include_reads) < 5
+        assert len(include_reads) < service_endpoints._MAX_WFS_SCHEMA_READS
+
+    async def test_a_sibling_include_waits_until_the_previous_one_is_checked(
+        self, monkeypatch
+    ) -> None:
+        siblings = (
+            f'<xs:include schemaLocation="{_SVC_ORIGIN}/a.xsd"/>'
+            f'<xs:include schemaLocation="{_SVC_ORIGIN}/b.xsd"/>'
+        )
+        handler = _wfs(
+            _capabilities([_LAYER]),
+            lambda names: _schema(names, extra=siblings),
+            files={
+                "/a.xsd": _schema(include=f"{_SVC_ORIGIN}/a1.xsd"),
+                "/a1.xsd": _schema(),
+                "/b.xsd": _schema(),
+            },
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert [r.url.path for r in recorded] == [
+            "/geoserver/wfs",
+            "/geoserver/wfs",
+            "/a.xsd",
+            "/a1.xsd",
+            "/b.xsd",
+        ]
+
+
+class TestTheSchemeAndHostCaseDoNotDecideTheOrigin:
+    """A URI's scheme and host are case-insensitive, so a mixed-case spelling
+    of the submitted origin is that origin, and a mixed-case spelling of
+    another origin is still another origin."""
+
+    uses_the_real_endpoint_check = True
+
+    @pytest.mark.parametrize(
+        "location",
+        [
+            "HTTPS://service.example/inc.xsd",
+            "https://SERVICE.EXAMPLE/inc.xsd",
+            "Https://Service.Example/inc.xsd",
+        ],
+        ids=["scheme", "host", "both"],
+    )
+    async def test_a_mixed_case_same_origin_include_is_read_and_passes(
+        self, monkeypatch, location
+    ) -> None:
+        handler = _wfs(
+            _capabilities([_LAYER]),
+            lambda names: _schema(names, include=location),
+            files={"/inc.xsd": _schema()},
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert [r.url.path for r in recorded].count("/inc.xsd") == 1
+        assert _hosts(recorded) == {"service.example"}
+
+    async def test_a_mixed_case_off_origin_include_is_refused(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(
+            _capabilities([_LAYER]),
+            lambda names: _schema(names, include="HTTPS://Collector.example/inc.xsd"),
+        )
+
+        recorded, error = await _refused(monkeypatch, handler, CrossOriginEndpointError)
+
+        assert error.origin == _FOREIGN
+        assert _hosts(recorded) == {"service.example"}

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -3,12 +3,12 @@ location on another origin is refused before GDAL is handed the source.
 
 The WFS driver resolves every ``xs:include`` of the schema it is given, with
 the credential header attached, before any GetFeature. No GDAL option turns
-that off, so `_check_wfs` reads every DescribeFeatureType the driver would
-read, on the submitted origin, and refuses the first include the driver would
-fetch from another origin or open as a path. The import path is not refused:
-GDAL only fetches ``xs:import`` locations under a config value the vector envs
-pin off (`test_gdal_env.py`), and a real schema imports GML from another
-origin.
+that off, so `_check_wfs` reads the DescribeFeatureType the driver reads for
+the layer a door is about to open, on the submitted origin, and refuses the
+first include the driver would fetch from another origin or open as a path.
+The import path and the GetFeature schema download are not refused: the
+vector envs pin both off (`test_gdal_env.py`), and a real schema imports GML
+from another origin.
 
 Every credential value is generated per test, so an assertion that a value
 never reached a host cannot pass by coincidence.
@@ -23,6 +23,8 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
+from app.core.service_tokens import CredentialMethod, ServiceCredential
+from app.modules.catalog.sources import preview as preview_mod
 from app.platform import security
 from app.platform.service_endpoints import (
     CrossOriginEndpointError,
@@ -36,6 +38,7 @@ _SVC_ORIGIN = "https://service.example"
 _SVC_WFS = f"{_SVC_ORIGIN}/geoserver/wfs"
 _FOREIGN = "https://collector.example"
 _XS = "http://www.w3.org/2001/XMLSchema"
+_LAYER = "topp:parcels"
 
 
 def _value() -> str:
@@ -75,7 +78,7 @@ def _schema(
     declared = "".join(
         f'<xs:element name="{n.split(":", 1)[-1]}" type="topp:{n.split(":", 1)[-1]}Type"'
         ' substitutionGroup="gml:AbstractFeature"/>'
-        for n in names or ["topp:parcels"]
+        for n in names or [_LAYER]
     )
     included = "" if include is None else f'<xs:include schemaLocation="{include}"/>'
     return f"""<?xml version="1.0"?>
@@ -161,9 +164,11 @@ async def _check(
     handler,
     *,
     url: str = _SVC_WFS,
-    collection: str | None = None,
+    collection: str | None = _LAYER,
 ) -> tuple[list[httpx.Request], str]:
-    """Run the credentialed check; the recorded requests and the credential."""
+    """Run the credentialed check for a named layer, the shape the preview and
+    worker doors open under; ``collection=None`` is the capabilities-only
+    probe check. Returns the recorded requests and the credential value."""
     recorded = _transport(monkeypatch, handler)
     value = _value()
     await assert_endpoints_stay_on_origin(
@@ -174,6 +179,21 @@ async def _check(
         deadline=None,
     )
     return recorded, value
+
+
+async def _refused(
+    monkeypatch, handler, error: type[Exception], *, collection: str | None = _LAYER
+):
+    recorded = _transport(monkeypatch, handler)
+    with pytest.raises(error) as raised:
+        await assert_endpoints_stay_on_origin(
+            _SVC_WFS,
+            service_format="wfs",
+            credential_line=f"X-Api-Key: {_value()}",
+            collection=collection,
+            deadline=None,
+        )
+    return recorded, raised.value
 
 
 def _described(recorded: list[httpx.Request]) -> list[list[str]]:
@@ -196,7 +216,7 @@ class TestAnIncludeOffTheOriginIsRefused:
         self, monkeypatch
     ) -> None:
         handler = _wfs(
-            _capabilities(["topp:parcels"]),
+            _capabilities([_LAYER]),
             lambda names: _schema(names, include=f"{_FOREIGN}/inc.xsd"),
         )
         recorded = _transport(monkeypatch, handler)
@@ -207,6 +227,7 @@ class TestAnIncludeOffTheOriginIsRefused:
                 _SVC_WFS,
                 service_format="wfs",
                 credential_line=f"X-Api-Key: {value}",
+                collection=_LAYER,
                 deadline=None,
             )
 
@@ -217,13 +238,13 @@ class TestAnIncludeOffTheOriginIsRefused:
         # The check itself read the schema on the submitted origin and nothing
         # else: the other origin was never contacted.
         assert _hosts(recorded) == {"service.example"}
-        assert _described(recorded) == [["topp:parcels"]]
+        assert _described(recorded) == [[_LAYER]]
 
     async def test_every_read_carries_the_credential_to_the_submitted_origin_only(
         self, monkeypatch
     ) -> None:
         handler = _wfs(
-            _capabilities(["topp:parcels"]),
+            _capabilities([_LAYER]),
             lambda names: _schema(names, include=f"{_SVC_ORIGIN}/inc.xsd"),
             files={"/inc.xsd": _schema()},
         )
@@ -256,29 +277,34 @@ class TestAnIncludeOffTheOriginIsRefused:
         stripping any namespace prefix, and `CPLGetXMLValue` also answers a
         text-only child element by that name."""
         handler = _wfs(
-            _capabilities(["topp:parcels"]),
-            lambda names: _schema(names, extra=spelling),
+            _capabilities([_LAYER]), lambda names: _schema(names, extra=spelling)
         )
 
-        with pytest.raises(CrossOriginEndpointError) as raised:
-            await _check(monkeypatch, handler)
+        _recorded, error = await _refused(
+            monkeypatch, handler, CrossOriginEndpointError
+        )
 
-        assert raised.value.origin == _FOREIGN
+        assert error.origin == _FOREIGN
 
-    async def test_an_include_under_redefine_is_refused(self, monkeypatch) -> None:
+    async def test_an_include_under_redefine_is_refused_as_a_superset(
+        self, monkeypatch
+    ) -> None:
+        """The driver resolves only the direct children of the schema element.
+        The walk covers the whole tree, which refuses a shape no real schema
+        has rather than reasoning about which nesting the driver skips."""
         nested = (
             f'<xs:redefine schemaLocation="local.xsd">'
             f'<xs:include schemaLocation="{_FOREIGN}/inc.xsd"/></xs:redefine>'
         )
         handler = _wfs(
-            _capabilities(["topp:parcels"]),
-            lambda names: _schema(names, extra=nested),
+            _capabilities([_LAYER]), lambda names: _schema(names, extra=nested)
         )
 
-        with pytest.raises(CrossOriginEndpointError) as raised:
-            await _check(monkeypatch, handler)
+        _recorded, error = await _refused(
+            monkeypatch, handler, CrossOriginEndpointError
+        )
 
-        assert raised.value.origin == _FOREIGN
+        assert error.origin == _FOREIGN
 
     @pytest.mark.parametrize(
         ("location", "named"),
@@ -309,20 +335,12 @@ class TestAnIncludeOffTheOriginIsRefused:
         rejects is opened as a VSI path, and a VSI path can reach the network
         or the worker's own storage, so it is refused with the same outcome."""
         handler = _wfs(
-            _capabilities(["topp:parcels"]),
-            lambda names: _schema(names, include=location),
+            _capabilities([_LAYER]), lambda names: _schema(names, include=location)
         )
-        recorded = _transport(monkeypatch, handler)
 
-        with pytest.raises(CrossOriginEndpointError) as raised:
-            await assert_endpoints_stay_on_origin(
-                _SVC_WFS,
-                service_format="wfs",
-                credential_line=f"X-Api-Key: {_value()}",
-                deadline=None,
-            )
+        recorded, error = await _refused(monkeypatch, handler, CrossOriginEndpointError)
 
-        assert raised.value.origin == named
+        assert error.origin == named
         assert _hosts(recorded) == {"service.example"}
 
     async def test_a_same_origin_include_that_includes_another_origin_is_refused(
@@ -331,21 +349,14 @@ class TestAnIncludeOffTheOriginIsRefused:
         """The driver splices an included schema in and resolves its includes
         too, so a same-origin include is read the way the driver reads it."""
         handler = _wfs(
-            _capabilities(["topp:parcels"]),
+            _capabilities([_LAYER]),
             lambda names: _schema(names, include=f"{_SVC_ORIGIN}/first.xsd"),
             files={"/first.xsd": _schema(include=f"{_FOREIGN}/second.xsd")},
         )
-        recorded = _transport(monkeypatch, handler)
 
-        with pytest.raises(CrossOriginEndpointError) as raised:
-            await assert_endpoints_stay_on_origin(
-                _SVC_WFS,
-                service_format="wfs",
-                credential_line=f"X-Api-Key: {_value()}",
-                deadline=None,
-            )
+        recorded, error = await _refused(monkeypatch, handler, CrossOriginEndpointError)
 
-        assert raised.value.origin == _FOREIGN
+        assert error.origin == _FOREIGN
         assert [r.url.path for r in recorded][-1] == "/first.xsd"
         assert _hosts(recorded) == {"service.example"}
 
@@ -355,13 +366,13 @@ class TestAnOrdinarySchemaPasses:
 
     async def test_a_relative_include_passes(self, monkeypatch) -> None:
         handler = _wfs(
-            _capabilities(["topp:parcels"]),
+            _capabilities([_LAYER]),
             lambda names: _schema(names, include="types/parcels.xsd"),
         )
 
         recorded, _value_ = await _check(monkeypatch, handler)
 
-        assert _described(recorded) == [["topp:parcels"]]
+        assert _described(recorded) == [[_LAYER]]
         assert len(recorded) == 2
 
     async def test_an_import_on_another_origin_passes(self, monkeypatch) -> None:
@@ -373,8 +384,7 @@ class TestAnOrdinarySchemaPasses:
             f' schemaLocation="{_FOREIGN}/other.xsd"/>'
         )
         handler = _wfs(
-            _capabilities(["topp:parcels"]),
-            lambda names: _schema(names, extra=imported),
+            _capabilities([_LAYER]), lambda names: _schema(names, extra=imported)
         )
 
         recorded, _value_ = await _check(monkeypatch, handler)
@@ -389,7 +399,7 @@ class TestAnOrdinarySchemaPasses:
             f'<xs:include schemaLocation="{_SVC_ORIGIN}/inc.xsd"/>'
         )
         handler = _wfs(
-            _capabilities(["topp:parcels"]),
+            _capabilities([_LAYER]),
             lambda names: _schema(names, extra=twice),
             files={"/inc.xsd": _schema(include="nested-relative.xsd")},
         )
@@ -414,8 +424,7 @@ class TestAnOrdinarySchemaPasses:
         """The caller's own parameters survive; the operation parameters are
         replaced whatever their case; VERSION is the capabilities' own."""
         handler = _wfs(
-            _capabilities(["topp:parcels"], version="1.1.0"),
-            lambda names: _schema(names),
+            _capabilities([_LAYER], version="1.1.0"), lambda names: _schema(names)
         )
         submitted = (
             f"{_SVC_WFS}?request=GetCapabilities&service=wfs&Version=2.0.0&map=x"
@@ -434,68 +443,69 @@ class TestAnOrdinarySchemaPasses:
                 ("SERVICE", "WFS"),
                 ("VERSION", "1.1.0"),
                 ("REQUEST", "DescribeFeatureType"),
-                ("TYPENAME", "topp:parcels"),
+                ("TYPENAME", _LAYER),
             ]
         )
         assert describe[0].url.path == "/geoserver/wfs"
 
-    async def test_a_version_the_capabilities_do_not_state_is_the_drivers_default(
-        self, monkeypatch
+    @pytest.mark.parametrize(
+        ("version", "sent"), [(None, "1.0.0"), ("", "")], ids=["absent", "empty"]
+    )
+    async def test_a_version_the_capabilities_do_not_state_is_sent_as_the_driver_sends_it(
+        self, monkeypatch, version, sent
     ) -> None:
         handler = _wfs(
-            _capabilities(["topp:parcels"], version=None),
-            lambda names: _schema(names),
+            _capabilities([_LAYER], version=version), lambda names: _schema(names)
         )
 
         recorded, _value_ = await _check(monkeypatch, handler)
 
-        assert _params(recorded[-1])["version"] == "1.0.0"
+        assert _params(recorded[-1])["version"] == sent
 
 
-class TestEveryReadTheDriverMakesIsChecked:
-    """The driver asks for every type of a prefix in one DescribeFeatureType,
-    fifty at most, and then for a type alone whenever that answer does not
-    cover it. A schema that is clean for the batch and not for the single
-    request is the shape this class exists to catch."""
+class TestTheReadsTheDriverMakesForTheLayerAreChecked:
+    """The driver asks for the layer and the other types of its prefix in one
+    DescribeFeatureType, fifty at most, and then for the layer alone whenever
+    that answer does not cover it. A schema that is clean for the batch and
+    not for the single request is the shape this class exists to catch."""
 
     uses_the_real_endpoint_check = True
 
-    async def test_one_request_names_every_type_and_a_sibling_include_is_found(
+    async def test_the_batch_names_the_layer_first_then_its_prefix_siblings(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(
+            _capabilities([_LAYER, "topp:roads", "sf:x"]), lambda names: _schema(names)
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler, collection="topp:roads")
+
+        assert _described(recorded) == [["topp:roads", _LAYER], ["topp:roads"]]
+
+    async def test_a_sibling_include_in_the_batch_answer_is_found(
         self, monkeypatch
     ) -> None:
         def describe(names: list[str]) -> str:
             include = f"{_FOREIGN}/inc.xsd" if "topp:roads" in names else None
             return _schema(names, include=include)
 
-        handler = _wfs(_capabilities(["topp:parcels", "topp:roads"]), describe)
-        recorded = _transport(monkeypatch, handler)
+        handler = _wfs(_capabilities([_LAYER, "topp:roads"]), describe)
 
-        with pytest.raises(CrossOriginEndpointError):
-            await assert_endpoints_stay_on_origin(
-                _SVC_WFS,
-                service_format="wfs",
-                credential_line=f"X-Api-Key: {_value()}",
-                deadline=None,
-            )
+        recorded, _error = await _refused(
+            monkeypatch, handler, CrossOriginEndpointError
+        )
 
-        assert _described(recorded) == [["topp:parcels", "topp:roads"]]
+        assert _described(recorded) == [[_LAYER, "topp:roads"]]
 
-    async def test_types_are_batched_by_prefix_fifty_at_a_time(
-        self, monkeypatch
-    ) -> None:
+    async def test_a_batch_carries_at_most_fifty_names(self, monkeypatch) -> None:
         names = [f"a:t{n}" for n in range(1, 121)] + [f"b:t{n}" for n in range(1, 4)]
         handler = _wfs(_capabilities(names), lambda batch: _schema(batch))
 
-        recorded, _value_ = await _check(monkeypatch, handler)
+        recorded, _value_ = await _check(monkeypatch, handler, collection="a:t1")
 
-        assert _described(recorded) == [
-            names[0:50],
-            names[50:100],
-            names[100:120],
-            names[120:123],
-        ]
+        assert _described(recorded) == [names[0:50], ["a:t1"]]
 
-    async def test_a_batch_answered_with_an_exception_report_falls_back_per_type(
+    async def test_a_batch_answered_with_an_exception_report_falls_back_to_the_layer(
         self, monkeypatch
     ) -> None:
         def describe(names: list[str]) -> str:
@@ -504,44 +514,13 @@ class TestEveryReadTheDriverMakesIsChecked:
             include = f"{_FOREIGN}/inc.xsd" if names == ["topp:roads"] else None
             return _schema(names, include=include)
 
-        handler = _wfs(_capabilities(["topp:parcels", "topp:roads"]), describe)
-        recorded = _transport(monkeypatch, handler)
+        handler = _wfs(_capabilities([_LAYER, "topp:roads"]), describe)
 
-        with pytest.raises(CrossOriginEndpointError):
-            await assert_endpoints_stay_on_origin(
-                _SVC_WFS,
-                service_format="wfs",
-                credential_line=f"X-Api-Key: {_value()}",
-                deadline=None,
-            )
+        recorded, _error = await _refused(
+            monkeypatch, handler, CrossOriginEndpointError, collection="topp:roads"
+        )
 
-        assert _described(recorded) == [
-            ["topp:parcels", "topp:roads"],
-            ["topp:parcels"],
-            ["topp:roads"],
-        ]
-
-    async def test_after_a_rejected_batch_every_remaining_type_is_read_alone(
-        self, monkeypatch
-    ) -> None:
-        """The driver stops batching for the rest of the open after one batch
-        it cannot use, so the other prefix is read one type at a time too."""
-
-        def describe(names: list[str]) -> str:
-            return _exception_report() if len(names) > 1 else _schema(names)
-
-        names = ["a:one", "a:two", "b:one", "b:two"]
-        handler = _wfs(_capabilities(names), describe)
-
-        recorded, _value_ = await _check(monkeypatch, handler)
-
-        assert _described(recorded) == [
-            ["a:one", "a:two"],
-            ["a:one"],
-            ["a:two"],
-            ["b:one"],
-            ["b:two"],
-        ]
+        assert _described(recorded) == [["topp:roads", _LAYER], ["topp:roads"]]
 
     async def test_a_named_layer_reads_its_batch_and_then_itself(
         self, monkeypatch
@@ -553,30 +532,22 @@ class TestEveryReadTheDriverMakesIsChecked:
             include = f"{_FOREIGN}/inc.xsd" if names == ["topp:roads"] else None
             return _schema(names, include=include)
 
-        handler = _wfs(_capabilities(["topp:parcels", "topp:roads", "sf:x"]), describe)
-        recorded = _transport(monkeypatch, handler)
+        handler = _wfs(_capabilities([_LAYER, "topp:roads", "sf:x"]), describe)
 
-        with pytest.raises(CrossOriginEndpointError):
-            await assert_endpoints_stay_on_origin(
-                _SVC_WFS,
-                service_format="wfs",
-                credential_line=f"X-Api-Key: {_value()}",
-                collection="topp:roads",
-                deadline=None,
-            )
+        recorded, _error = await _refused(
+            monkeypatch, handler, CrossOriginEndpointError, collection="topp:roads"
+        )
 
-        assert _described(recorded) == [["topp:roads", "topp:parcels"], ["topp:roads"]]
+        assert _described(recorded) == [["topp:roads", _LAYER], ["topp:roads"]]
 
     async def test_a_named_layer_alone_in_its_prefix_is_read_once(
         self, monkeypatch
     ) -> None:
-        handler = _wfs(_capabilities(["topp:parcels"]), lambda names: _schema(names))
+        handler = _wfs(_capabilities([_LAYER]), lambda names: _schema(names))
 
-        recorded, _value_ = await _check(
-            monkeypatch, handler, collection="topp:parcels"
-        )
+        recorded, _value_ = await _check(monkeypatch, handler)
 
-        assert _described(recorded) == [["topp:parcels"]]
+        assert _described(recorded) == [[_LAYER]]
 
     @pytest.mark.parametrize("requested", ["TOPP:ROADS", "roads", "Roads"])
     async def test_a_named_layer_is_resolved_the_way_the_driver_resolves_it(
@@ -586,52 +557,59 @@ class TestEveryReadTheDriverMakesIsChecked:
         the prefix. The request names the advertised spelling, which is what
         the driver puts in its own TYPENAME."""
         handler = _wfs(
-            _capabilities(["topp:parcels", "topp:roads"]),
-            lambda names: _schema(names),
+            _capabilities([_LAYER, "topp:roads"]), lambda names: _schema(names)
         )
 
         recorded, _value_ = await _check(monkeypatch, handler, collection=requested)
 
-        assert _described(recorded) == [["topp:roads", "topp:parcels"], ["topp:roads"]]
+        assert _described(recorded) == [["topp:roads", _LAYER], ["topp:roads"]]
 
     @pytest.mark.parametrize(
         ("names", "requested"),
         [
             (["topp:roads", "sf:roads"], "roads"),
-            (["topp:parcels"], "topp:nothing"),
+            ([_LAYER], "topp:nothing"),
         ],
         ids=["short_name_two_prefixes_share", "not_advertised"],
     )
-    async def test_a_layer_the_driver_would_not_resolve_is_walked_like_no_layer(
+    async def test_a_layer_the_driver_would_not_resolve_makes_no_schema_read(
         self, monkeypatch, names, requested
     ) -> None:
-        handler = _wfs(_capabilities(names), lambda batch: _schema(batch))
+        """The driver opens no layer for such a name, so it reads no schema."""
+        handler = _wfs(
+            _capabilities(names),
+            lambda batch: _schema(batch, include=f"{_FOREIGN}/inc.xsd"),
+        )
 
         recorded, _value_ = await _check(monkeypatch, handler, collection=requested)
 
-        assert _described(recorded) == [[name] for name in names]
+        assert _described(recorded) == []
+
+    async def test_no_layer_is_the_capabilities_check_alone(self, monkeypatch) -> None:
+        """The probe names no layer and runs no GDAL."""
+        handler = _wfs(
+            _capabilities([_LAYER]),
+            lambda names: _schema(names, include=f"{_FOREIGN}/inc.xsd"),
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler, collection=None)
+
+        assert len(recorded) == 1
+        assert _described(recorded) == []
 
 
 class TestAnUnreadableSchemaFailsClosed:
     uses_the_real_endpoint_check = True
 
-    async def _refused(self, monkeypatch, handler, **kwargs) -> list[httpx.Request]:
-        recorded = _transport(monkeypatch, handler)
-        with pytest.raises(EndpointCheckFailedError) as raised:
-            await assert_endpoints_stay_on_origin(
-                _SVC_WFS,
-                service_format="wfs",
-                credential_line=f"X-Api-Key: {_value()}",
-                deadline=None,
-                **kwargs,
-            )
-        assert raised.value.code == "endpoint_check_failed"
+    async def _failed(self, monkeypatch, handler) -> list[httpx.Request]:
+        recorded, error = await _refused(monkeypatch, handler, EndpointCheckFailedError)
+        assert error.code == "endpoint_check_failed"
         return recorded
 
     async def test_a_body_that_is_not_xml_refuses(self, monkeypatch) -> None:
-        handler = _wfs(_capabilities(["topp:parcels"]), lambda names: "<not xml")
+        handler = _wfs(_capabilities([_LAYER]), lambda names: "<not xml")
 
-        await self._refused(monkeypatch, handler)
+        await self._failed(monkeypatch, handler)
 
     async def test_a_batch_that_does_not_parse_refuses_without_falling_back(
         self, monkeypatch
@@ -643,83 +621,92 @@ class TestAnUnreadableSchemaFailsClosed:
         def describe(names: list[str]) -> str:
             return "<not xml" if len(names) > 1 else _schema(names)
 
-        handler = _wfs(_capabilities(["topp:parcels", "topp:roads"]), describe)
+        handler = _wfs(_capabilities([_LAYER, "topp:roads"]), describe)
 
-        recorded = await self._refused(monkeypatch, handler)
+        recorded = await self._failed(monkeypatch, handler)
 
-        assert _described(recorded) == [["topp:parcels", "topp:roads"]]
+        assert _described(recorded) == [[_LAYER, "topp:roads"]]
 
     async def test_a_document_carrying_a_doctype_refuses(self, monkeypatch) -> None:
         with_doctype = (
             '<?xml version="1.0"?><!DOCTYPE schema>' + _schema().split("?>", 1)[1]
         )
-        handler = _wfs(_capabilities(["topp:parcels"]), lambda names: with_doctype)
+        handler = _wfs(_capabilities([_LAYER]), lambda names: with_doctype)
 
-        await self._refused(monkeypatch, handler)
+        await self._failed(monkeypatch, handler)
 
-    async def test_an_exception_report_for_a_single_type_refuses(
+    async def test_an_exception_report_for_the_layer_alone_refuses(
         self, monkeypatch
     ) -> None:
-        handler = _wfs(
-            _capabilities(["topp:parcels"]), lambda names: _exception_report()
-        )
+        handler = _wfs(_capabilities([_LAYER]), lambda names: _exception_report())
 
-        recorded = await self._refused(monkeypatch, handler)
+        recorded = await self._failed(monkeypatch, handler)
 
-        assert _described(recorded) == [["topp:parcels"], ["topp:parcels"]]
+        assert _described(recorded) == [[_LAYER], [_LAYER]]
 
     async def test_an_http_error_on_a_batch_refuses(self, monkeypatch) -> None:
         def describe(names: list[str]):
             return httpx.Response(500) if len(names) > 1 else _schema(names)
 
-        handler = _wfs(_capabilities(["topp:parcels", "topp:roads"]), describe)
+        handler = _wfs(_capabilities([_LAYER, "topp:roads"]), describe)
 
-        recorded = await self._refused(monkeypatch, handler)
+        recorded = await self._failed(monkeypatch, handler)
 
-        assert _described(recorded) == [["topp:parcels", "topp:roads"]]
+        assert _described(recorded) == [[_LAYER, "topp:roads"]]
 
     async def test_an_unreadable_same_origin_include_refuses(self, monkeypatch) -> None:
         handler = _wfs(
-            _capabilities(["topp:parcels"]),
+            _capabilities([_LAYER]),
             lambda names: _schema(names, include=f"{_SVC_ORIGIN}/inc.xsd"),
         )
 
-        recorded = await self._refused(monkeypatch, handler)
+        recorded = await self._failed(monkeypatch, handler)
 
         assert recorded[-1].url.path == "/inc.xsd"
 
     async def test_reads_past_the_budget_refuse(self, monkeypatch) -> None:
-        """Sixty types, a batch the server rejects, and clean single answers:
-        the fiftieth read is the last one made."""
+        """A schema naming more same-origin includes than the budget allows:
+        the last read the budget admits is the last one made."""
         from app.platform.service_endpoints import _MAX_WFS_SCHEMA_READS
 
-        def describe(names: list[str]) -> str:
-            return _exception_report() if len(names) > 1 else _schema(names)
+        count = _MAX_WFS_SCHEMA_READS + 5
+        includes = "".join(
+            f'<xs:include schemaLocation="{_SVC_ORIGIN}/inc{n}.xsd"/>'
+            for n in range(count)
+        )
+        handler = _wfs(
+            _capabilities([_LAYER]),
+            lambda names: _schema(names, extra=includes),
+            files={f"/inc{n}.xsd": _schema() for n in range(count)},
+        )
 
-        names = [f"a:t{n}" for n in range(1, 61)]
-        handler = _wfs(_capabilities(names), describe)
+        recorded = await self._failed(monkeypatch, handler)
 
-        recorded = await self._refused(monkeypatch, handler)
-
-        assert len(_described(recorded)) == _MAX_WFS_SCHEMA_READS
+        assert _described(recorded) == [[_LAYER]]
+        include_reads = [r for r in recorded if r.url.path.startswith("/inc")]
+        assert len(include_reads) == _MAX_WFS_SCHEMA_READS - 1
 
 
 class TestTheDoorsRefuseBeforeGdalRuns:
-    """The three doors share `assert_endpoints_stay_on_origin`, so the schema
-    check reaches the probe, the preview and the worker without edits. The
-    probe is the first door a caller meets; the worker is the one that spends
-    the credential."""
+    """The three doors share `assert_endpoints_stay_on_origin`. The probe
+    names no layer and runs no GDAL, so its check is the capabilities check
+    alone; the preview and the worker name the layer they open and are
+    refused before their subprocess exists."""
 
     uses_the_real_endpoint_check = True
 
-    async def test_the_probe_refuses_with_the_coded_outcome(
+    @staticmethod
+    def _handler():
+        return _wfs(
+            _capabilities([_LAYER]),
+            lambda names: _schema(names, include=f"{_FOREIGN}/inc.xsd"),
+        )
+
+    async def test_the_probe_reads_no_schema(
         self, client, admin_auth_header: dict
     ) -> None:
         recorded: list[httpx.Request] = []
-        handler = _wfs(
-            _capabilities(["topp:parcels"]),
-            lambda names: _schema(names, include=f"{_FOREIGN}/inc.xsd"),
-        )
+        handler = self._handler()
 
         def _handle(request: httpx.Request) -> httpx.Response:
             recorded.append(request)
@@ -753,9 +740,39 @@ class TestTheDoorsRefuseBeforeGdalRuns:
                 headers=admin_auth_header,
             )
 
-        assert resp.status_code == 422, resp.text
-        assert resp.json()["detail"]["code"] == "cross_origin_endpoint"
+        assert resp.status_code == 200, resp.text
         assert value not in resp.text
+        assert _described(recorded) == []
+        assert _hosts(recorded) == {"service.example"}
+
+    async def test_the_preview_refuses_before_spawning_ogrinfo(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "upload_staging_dir", str(tmp_path / "staging"))
+        recorded = _transport(monkeypatch, self._handler())
+        value = _value()
+        credential = ServiceCredential(
+            method=CredentialMethod.HEADER_KEY,
+            service_format="wfs",
+            header_name="X-Api-Key",
+            header_value=value,
+        )
+
+        async def _fake_exec(*cmd, **kwargs):
+            raise AssertionError("ogrinfo must not run for a refused source")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+        with pytest.raises(Exception) as raised:  # noqa: PT011 - HTTPException
+            await preview_mod.run_service_preview(
+                f"WFS:{_SVC_WFS}", _LAYER, credential=credential
+            )
+
+        assert raised.value.detail["code"] == "cross_origin_endpoint"
+        assert value not in str(raised.value.detail)
+        assert _described(recorded) == [[_LAYER]]
         assert _hosts(recorded) == {"service.example"}
 
     async def test_the_worker_refuses_before_spawning_ogr2ogr(
@@ -765,11 +782,7 @@ class TestTheDoorsRefuseBeforeGdalRuns:
         from app.processing.ingest.ogr import run_ogr2ogr_service
 
         monkeypatch.setattr(settings, "upload_staging_dir", str(tmp_path / "staging"))
-        handler = _wfs(
-            _capabilities(["topp:parcels"]),
-            lambda names: _schema(names, include=f"{_FOREIGN}/inc.xsd"),
-        )
-        recorded = _transport(monkeypatch, handler)
+        recorded = _transport(monkeypatch, self._handler())
 
         async def _fake_exec(*cmd, **kwargs):
             raise AssertionError("ogr2ogr must not run for a refused source")
@@ -779,7 +792,7 @@ class TestTheDoorsRefuseBeforeGdalRuns:
         with pytest.raises(CrossOriginEndpointError) as raised:
             await run_ogr2ogr_service(
                 gdal_source=f"WFS:{_SVC_WFS}",
-                layer_name="topp:parcels",
+                layer_name=_LAYER,
                 table_name="t",
                 db_conn_str="PG:dummy",
                 service_type="wfs",
@@ -788,4 +801,5 @@ class TestTheDoorsRefuseBeforeGdalRuns:
             )
 
         assert raised.value.origin == _FOREIGN
+        assert _described(recorded) == [[_LAYER]]
         assert _hosts(recorded) == {"service.example"}

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -1530,3 +1530,37 @@ class TestTheRequiredOutputFormatIsMirrored:
 
         assert _described(recorded) == [[_LAYER, "topp:blocks"], [_LAYER]]
         assert _output_formats(recorded) == ["GML2", "GML2"]
+
+
+class TestTheDriverNegotiatesAsTheCheckDoes:
+    """Every read the check makes and every request the driver makes carry the
+    same User-Agent, Accept and Accept-Encoding, so a server keyed on them
+    answers both with one document."""
+
+    uses_the_real_endpoint_check = True
+
+    async def test_every_read_carries_the_pinned_negotiation(self, monkeypatch) -> None:
+        handler = _wfs(
+            _capabilities([_LAYER, "topp:roads"]),
+            lambda names: _schema(names, include="inc.xsd"),
+            files={"/inc.xsd": _schema([_LAYER])},
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert len(recorded) >= 3
+        for request in recorded:
+            assert request.headers["user-agent"] == "GeoLens"
+            assert request.headers["accept"] == "application/xml, text/xml"
+            assert request.headers["accept-encoding"] == "identity"
+
+    def test_the_subprocess_env_pins_the_same_values(self) -> None:
+        from app.platform.service_endpoints import gdal_transport_env
+
+        assert gdal_transport_env("wfs") == {
+            "GDAL_HTTP_USERAGENT": "GeoLens",
+            "GDAL_HTTP_HEADERS": (
+                "Accept: application/xml, text/xml\r\nAccept-Encoding: identity"
+            ),
+        }
+        assert gdal_transport_env("oapif") == {"GDAL_HTTP_USERAGENT": "GeoLens"}

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -1401,6 +1401,14 @@ class TestTheVersionIsComparedAsTheDriverComparesIt:
             ("\uff12.0.0", False),
             ("\u00a02.0.0", False),
             (" \t2.0.0", True),
+            ("2147483648.0", False),
+            ("4294967298", True),
+            ("4294967297", False),
+            ("9223372036854775807", False),
+            ("9223372036854775808", False),
+            ("99999999999999999999999", False),
+            ("-8589934590", True),
+            ("-4294967294", True),
         ],
     )
     def test_the_count_rewrite_follows_the_leading_integer(
@@ -1410,6 +1418,22 @@ class TestTheVersionIsComparedAsTheDriverComparesIt:
 
         base = _wfs_base_url("https://s.example/wfs?MAXFEATURES=5", version)
         assert ("COUNT=5" in base) is rewritten
+
+    def test_atoi_saturates_to_long_and_truncates_to_int(self) -> None:
+        """The values a 64-bit glibc `atoi` returns, measured in the worker image."""
+        from app.platform.service_endpoints import _c_atoi
+
+        assert _c_atoi("2147483648.0") == -2147483648
+        assert _c_atoi("2147483647") == 2147483647
+        assert _c_atoi("4294967298") == 2
+        assert _c_atoi("9223372036854775807") == -1
+        assert _c_atoi("9223372036854775808") == -1
+        assert _c_atoi("99999999999999999999999") == -1
+        assert _c_atoi("-8589934590") == 2
+        assert _c_atoi("-9223372036854775808") == 0
+        assert _c_atoi("-" + "9" * 5000) == 0
+        assert _c_atoi("0" * 5000 + "7x") == 7
+        assert _c_atoi("x7") == 0
 
 
 class TestTheRequiredOutputFormatIsMirrored:

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -1609,3 +1609,46 @@ class TestTheLayerAloneIsReadWheneverItIsADifferentRequest:
         recorded, _value_ = await _check(monkeypatch, handler)
 
         assert _described(recorded) == [[_LAYER]]
+
+
+class TestTheCapabilitiesRequestIsTheDriversByteForByte:
+    """`Open` builds GetCapabilities with the same in-place, case-insensitive
+    first-match replacement the schema requests use, removing the layer and
+    query keys and keeping everything else, so the capabilities the check reads
+    are the ones the driver reads."""
+
+    uses_the_real_endpoint_check = True
+
+    def test_the_builder_replaces_removes_and_keeps_as_the_driver_does(self) -> None:
+        from app.platform.service_endpoints import _capabilities_url
+
+        submitted = (
+            "https://s.example/wfs?service=wfs&Request=x&TYPENAMES=a"
+            "&foo=bar&request=y&maxfeatures=3"
+        )
+        assert _capabilities_url(submitted) == (
+            "https://s.example/wfs?SERVICE=WFS&REQUEST=GetCapabilities"
+            "&foo=bar&request=y&"
+        )
+        assert _capabilities_url("https://s.example/wfs") == (
+            "https://s.example/wfs?SERVICE=WFS&REQUEST=GetCapabilities"
+        )
+
+    async def test_the_capabilities_read_drops_the_layer_keys_only(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(_capabilities([_LAYER]), lambda names: _schema(names))
+
+        recorded, _value_ = await _check(
+            monkeypatch, handler, url=f"{_SVC_WFS}?TYPENAMES=other&foo=bar&filter=x"
+        )
+
+        capabilities = [
+            request
+            for request in recorded
+            if _params(request).get("request") == "GetCapabilities"
+        ]
+        assert len(capabilities) == 1
+        assert str(capabilities[0].url) == (
+            f"{_SVC_WFS}?foo=bar&SERVICE=WFS&REQUEST=GetCapabilities"
+        )

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -53,9 +53,11 @@ def _capabilities(
     *,
     version: str | None = "2.0.0",
     formats: dict[str, list[str]] | None = None,
+    extra: str = "",
 ) -> str:
     """A WFS capabilities document advertising *names*, on this origin;
-    ``formats`` adds an ``OutputFormats`` list to the named types."""
+    ``formats`` adds an ``OutputFormats`` list to the named types and
+    ``extra`` is placed after the ``FeatureTypeList``."""
     version_attr = "" if version is None else f' version="{version}"'
 
     def outputs(name: str) -> str:
@@ -81,7 +83,7 @@ def _capabilities(
     <ows:Operation name="GetFeature"><ows:DCP><ows:HTTP>
       <ows:Get xlink:href="{_SVC_WFS}"/></ows:HTTP></ows:DCP></ows:Operation>
   </ows:OperationsMetadata>
-  <FeatureTypeList>{types}</FeatureTypeList>
+  <FeatureTypeList>{types}</FeatureTypeList>{extra}
 </WFS_Capabilities>"""
 
 
@@ -1652,3 +1654,40 @@ class TestTheCapabilitiesRequestIsTheDriversByteForByte:
         assert str(capabilities[0].url) == (
             f"{_SVC_WFS}?foo=bar&SERVICE=WFS&REQUEST=GetCapabilities"
         )
+
+
+class TestOnlyTheDriversFeatureTypesAreLayers:
+    """The driver lists the direct `FeatureType` children of the first direct
+    `FeatureTypeList` of the capabilities node it finds as `WFSFindNode` does;
+    the check enumerates the same nodes and no others."""
+
+    uses_the_real_endpoint_check = True
+
+    async def test_a_feature_type_outside_the_list_is_not_batched(
+        self, monkeypatch
+    ) -> None:
+        stray = (
+            "<Extension><FeatureType><Name>topp:stray</Name></FeatureType>"
+            "</Extension><FeatureTypeList><FeatureType><Name>topp:second</Name>"
+            "</FeatureType></FeatureTypeList>"
+        )
+        handler = _wfs(
+            _capabilities([_LAYER, "topp:roads"], extra=stray),
+            lambda names: _schema(names),
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert _described(recorded) == [[_LAYER, "topp:roads"], [_LAYER]]
+
+    async def test_a_capabilities_node_under_a_wrapper_root_is_found(
+        self, monkeypatch
+    ) -> None:
+        document = _capabilities([_LAYER, "topp:roads"])
+        body, capabilities = document.split("\n", 1)
+        wrapped = f"{body}\n<Wrapper>{capabilities}</Wrapper>"
+        handler = _wfs(wrapped, lambda names: _schema(names))
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert _described(recorded) == [[_LAYER, "topp:roads"], [_LAYER]]

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -1,0 +1,791 @@
+"""fix(#1828): a credentialed WFS whose DescribeFeatureType schema includes a
+location on another origin is refused before GDAL is handed the source.
+
+The WFS driver resolves every ``xs:include`` of the schema it is given, with
+the credential header attached, before any GetFeature. No GDAL option turns
+that off, so `_check_wfs` reads every DescribeFeatureType the driver would
+read, on the submitted origin, and refuses the first include the driver would
+fetch from another origin or open as a path. The import path is not refused:
+GDAL only fetches ``xs:import`` locations under a config value the vector envs
+pin off (`test_gdal_env.py`), and a real schema imports GML from another
+origin.
+
+Every credential value is generated per test, so an assertion that a value
+never reached a host cannot pass by coincidence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.platform import security
+from app.platform.service_endpoints import (
+    CrossOriginEndpointError,
+    EndpointCheckFailedError,
+    assert_endpoints_stay_on_origin,
+)
+
+pytestmark = pytest.mark.anyio
+
+_SVC_ORIGIN = "https://service.example"
+_SVC_WFS = f"{_SVC_ORIGIN}/geoserver/wfs"
+_FOREIGN = "https://collector.example"
+_XS = "http://www.w3.org/2001/XMLSchema"
+
+
+def _value() -> str:
+    return uuid.uuid4().hex
+
+
+def _capabilities(names: list[str], *, version: str | None = "2.0.0") -> str:
+    """A WFS capabilities document advertising *names*, on this origin."""
+    version_attr = "" if version is None else f' version="{version}"'
+    types = "".join(
+        f"<FeatureType><Name>{name}</Name><Title>{name}</Title></FeatureType>"
+        for name in names
+    )
+    return f"""<?xml version="1.0"?>
+<WFS_Capabilities{version_attr}
+    xmlns="http://www.opengis.net/wfs/2.0"
+    xmlns:ows="http://www.opengis.net/ows/1.1"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+  <ows:OperationsMetadata>
+    <ows:Operation name="DescribeFeatureType"><ows:DCP><ows:HTTP>
+      <ows:Get xlink:href="{_SVC_WFS}"/></ows:HTTP></ows:DCP></ows:Operation>
+    <ows:Operation name="GetFeature"><ows:DCP><ows:HTTP>
+      <ows:Get xlink:href="{_SVC_WFS}"/></ows:HTTP></ows:DCP></ows:Operation>
+  </ows:OperationsMetadata>
+  <FeatureTypeList>{types}</FeatureTypeList>
+</WFS_Capabilities>"""
+
+
+def _schema(
+    names: list[str] | None = None,
+    *,
+    include: str | None = None,
+    extra: str = "",
+) -> str:
+    """A DescribeFeatureType answer declaring *names*, with the ordinary
+    off-origin GML import every real schema carries."""
+    declared = "".join(
+        f'<xs:element name="{n.split(":", 1)[-1]}" type="topp:{n.split(":", 1)[-1]}Type"'
+        ' substitutionGroup="gml:AbstractFeature"/>'
+        for n in names or ["topp:parcels"]
+    )
+    included = "" if include is None else f'<xs:include schemaLocation="{include}"/>'
+    return f"""<?xml version="1.0"?>
+<xs:schema xmlns:xs="{_XS}" xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:topp="http://example.test/topp"
+    targetNamespace="http://example.test/topp" elementFormDefault="qualified">
+  <xs:import namespace="http://www.opengis.net/gml/3.2"
+      schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+  {included}{extra}
+  {declared}
+</xs:schema>"""
+
+
+def _exception_report() -> str:
+    return """<?xml version="1.0"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0">
+  <ows:Exception exceptionCode="InvalidParameterValue" locator="typeName">
+    <ows:ExceptionText>unknown type</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>"""
+
+
+def _as_stream(response: httpx.Response, *, chunk: int = 64) -> httpx.Response:
+    """A double that streams, so the bounded read under test really runs."""
+    if not response.is_stream_consumed:
+        return response
+    raw = response.content
+
+    async def _chunks():
+        for start in range(0, len(raw), chunk):
+            yield raw[start : start + chunk]
+
+    return httpx.Response(
+        response.status_code, headers=response.headers, content=_chunks()
+    )
+
+
+def _params(request: httpx.Request) -> dict[str, str]:
+    return {key.lower(): value for key, value in request.url.params.items()}
+
+
+def _wfs(capabilities: str, describe, *, files: dict[str, str] | None = None):
+    """A WFS double. ``describe(names)`` answers a DescribeFeatureType for the
+    comma-separated ``TYPENAME`` it received, as text or as a response; any
+    other path is looked up in ``files``."""
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        params = _params(request)
+        operation = params.get("request", "").lower()
+        if operation == "getcapabilities":
+            return httpx.Response(200, text=capabilities)
+        if operation == "describefeaturetype":
+            answer = describe(params.get("typename", "").split(","))
+            if isinstance(answer, httpx.Response):
+                return answer
+            return httpx.Response(200, text=answer)
+        if files is not None and request.url.path in files:
+            return httpx.Response(200, text=files[request.url.path])
+        return httpx.Response(404)
+
+    return handle
+
+
+def _transport(monkeypatch, handler) -> list[httpx.Request]:
+    recorded: list[httpx.Request] = []
+
+    def _handle(request: httpx.Request) -> httpx.Response:
+        recorded.append(request)
+        return _as_stream(handler(request))
+
+    monkeypatch.setattr(
+        security, "make_safe_transport", lambda: httpx.MockTransport(_handle)
+    )
+    monkeypatch.setattr(security, "validate_url_for_ssrf", AsyncMock())
+    monkeypatch.setattr(
+        "app.platform.service_endpoints.validate_url_for_ssrf", AsyncMock()
+    )
+    return recorded
+
+
+async def _check(
+    monkeypatch,
+    handler,
+    *,
+    url: str = _SVC_WFS,
+    collection: str | None = None,
+) -> tuple[list[httpx.Request], str]:
+    """Run the credentialed check; the recorded requests and the credential."""
+    recorded = _transport(monkeypatch, handler)
+    value = _value()
+    await assert_endpoints_stay_on_origin(
+        url,
+        service_format="wfs",
+        credential_line=f"X-Api-Key: {value}",
+        collection=collection,
+        deadline=None,
+    )
+    return recorded, value
+
+
+def _described(recorded: list[httpx.Request]) -> list[list[str]]:
+    """The type names of every DescribeFeatureType request, in order."""
+    return [
+        _params(request)["typename"].split(",")
+        for request in recorded
+        if _params(request).get("request") == "DescribeFeatureType"
+    ]
+
+
+def _hosts(recorded: list[httpx.Request]) -> set[str]:
+    return {request.url.host for request in recorded}
+
+
+class TestAnIncludeOffTheOriginIsRefused:
+    uses_the_real_endpoint_check = True
+
+    async def test_an_absolute_include_on_another_origin_is_refused_naming_it(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, include=f"{_FOREIGN}/inc.xsd"),
+        )
+        recorded = _transport(monkeypatch, handler)
+        value = _value()
+
+        with pytest.raises(CrossOriginEndpointError) as raised:
+            await assert_endpoints_stay_on_origin(
+                _SVC_WFS,
+                service_format="wfs",
+                credential_line=f"X-Api-Key: {value}",
+                deadline=None,
+            )
+
+        assert raised.value.code == "cross_origin_endpoint"
+        assert raised.value.field == "url"
+        assert raised.value.origin == _FOREIGN
+        assert value not in str(raised.value)
+        # The check itself read the schema on the submitted origin and nothing
+        # else: the other origin was never contacted.
+        assert _hosts(recorded) == {"service.example"}
+        assert _described(recorded) == [["topp:parcels"]]
+
+    async def test_every_read_carries_the_credential_to_the_submitted_origin_only(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, include=f"{_SVC_ORIGIN}/inc.xsd"),
+            files={"/inc.xsd": _schema()},
+        )
+
+        recorded, value = await _check(monkeypatch, handler)
+
+        assert [request.url.path for request in recorded] == [
+            "/geoserver/wfs",
+            "/geoserver/wfs",
+            "/inc.xsd",
+        ]
+        for request in recorded:
+            assert request.url.host == "service.example"
+            assert request.headers["X-Api-Key"] == value
+
+    @pytest.mark.parametrize(
+        "spelling",
+        [
+            f'<xs:INCLUDE SCHEMALOCATION="{_FOREIGN}/inc.xsd"/>',
+            f'<xs:include xs:schemaLocation="{_FOREIGN}/inc.xsd"/>',
+            f"<xs:include><xs:schemaLocation>{_FOREIGN}/inc.xsd"
+            "</xs:schemaLocation></xs:include>",
+        ],
+        ids=["upper_cased", "prefixed_attribute", "child_element"],
+    )
+    async def test_the_spellings_the_driver_reads_are_all_read(
+        self, monkeypatch, spelling
+    ) -> None:
+        """GDAL matches the element and the attribute case-insensitively, after
+        stripping any namespace prefix, and `CPLGetXMLValue` also answers a
+        text-only child element by that name."""
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, extra=spelling),
+        )
+
+        with pytest.raises(CrossOriginEndpointError) as raised:
+            await _check(monkeypatch, handler)
+
+        assert raised.value.origin == _FOREIGN
+
+    async def test_an_include_under_redefine_is_refused(self, monkeypatch) -> None:
+        nested = (
+            f'<xs:redefine schemaLocation="local.xsd">'
+            f'<xs:include schemaLocation="{_FOREIGN}/inc.xsd"/></xs:redefine>'
+        )
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, extra=nested),
+        )
+
+        with pytest.raises(CrossOriginEndpointError) as raised:
+            await _check(monkeypatch, handler)
+
+        assert raised.value.origin == _FOREIGN
+
+    @pytest.mark.parametrize(
+        ("location", "named"),
+        [
+            ("//collector.example/inc.xsd", "://collector.example"),
+            (f"/vsicurl/{_FOREIGN}/inc.xsd", "a local path"),
+            ("\\\\collector.example\\inc.xsd", "a local path"),
+            ("C:/inc.xsd", "a local path"),
+            ("ftp://collector.example/inc.xsd", "ftp://collector.example"),
+            (f"vsicurl/{_FOREIGN}/inc.xsd", "a local path"),
+            ("HTTP://collector.example/inc.xsd", "http://collector.example"),
+        ],
+        ids=[
+            "scheme_relative",
+            "vsi_path",
+            "unc_path",
+            "drive_path",
+            "other_scheme",
+            "embedded_scheme",
+            "upper_cased_scheme",
+        ],
+    )
+    async def test_a_location_the_driver_opens_as_a_path_is_refused(
+        self, monkeypatch, location, named
+    ) -> None:
+        """Only a relative location stays inside the process: GDAL resolves it
+        under its in-memory directory. Everything `CPLIsFilenameRelative`
+        rejects is opened as a VSI path, and a VSI path can reach the network
+        or the worker's own storage, so it is refused with the same outcome."""
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, include=location),
+        )
+        recorded = _transport(monkeypatch, handler)
+
+        with pytest.raises(CrossOriginEndpointError) as raised:
+            await assert_endpoints_stay_on_origin(
+                _SVC_WFS,
+                service_format="wfs",
+                credential_line=f"X-Api-Key: {_value()}",
+                deadline=None,
+            )
+
+        assert raised.value.origin == named
+        assert _hosts(recorded) == {"service.example"}
+
+    async def test_a_same_origin_include_that_includes_another_origin_is_refused(
+        self, monkeypatch
+    ) -> None:
+        """The driver splices an included schema in and resolves its includes
+        too, so a same-origin include is read the way the driver reads it."""
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, include=f"{_SVC_ORIGIN}/first.xsd"),
+            files={"/first.xsd": _schema(include=f"{_FOREIGN}/second.xsd")},
+        )
+        recorded = _transport(monkeypatch, handler)
+
+        with pytest.raises(CrossOriginEndpointError) as raised:
+            await assert_endpoints_stay_on_origin(
+                _SVC_WFS,
+                service_format="wfs",
+                credential_line=f"X-Api-Key: {_value()}",
+                deadline=None,
+            )
+
+        assert raised.value.origin == _FOREIGN
+        assert [r.url.path for r in recorded][-1] == "/first.xsd"
+        assert _hosts(recorded) == {"service.example"}
+
+
+class TestAnOrdinarySchemaPasses:
+    uses_the_real_endpoint_check = True
+
+    async def test_a_relative_include_passes(self, monkeypatch) -> None:
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, include="types/parcels.xsd"),
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert _described(recorded) == [["topp:parcels"]]
+        assert len(recorded) == 2
+
+    async def test_an_import_on_another_origin_passes(self, monkeypatch) -> None:
+        """Imports are not fetched by the driver: the WFS driver passes
+        `bUseSchemaImports=false` and the GML driver reads a config value the
+        vector envs pin to NO. Refusing them would refuse every real schema."""
+        imported = (
+            '<xs:import namespace="http://example.test/other"'
+            f' schemaLocation="{_FOREIGN}/other.xsd"/>'
+        )
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, extra=imported),
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert _hosts(recorded) == {"service.example"}
+
+    async def test_a_same_origin_absolute_include_is_read_once_and_passes(
+        self, monkeypatch
+    ) -> None:
+        twice = (
+            f'<xs:include schemaLocation="{_SVC_ORIGIN}/inc.xsd"/>'
+            f'<xs:include schemaLocation="{_SVC_ORIGIN}/inc.xsd"/>'
+        )
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, extra=twice),
+            files={"/inc.xsd": _schema(include="nested-relative.xsd")},
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert [r.url.path for r in recorded].count("/inc.xsd") == 1
+
+    async def test_no_advertised_feature_type_means_no_second_request(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(_capabilities([]), lambda names: _schema(names))
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert len(recorded) == 1
+        assert _described(recorded) == []
+
+    async def test_the_request_is_built_the_way_the_driver_builds_it(
+        self, monkeypatch
+    ) -> None:
+        """The caller's own parameters survive; the operation parameters are
+        replaced whatever their case; VERSION is the capabilities' own."""
+        handler = _wfs(
+            _capabilities(["topp:parcels"], version="1.1.0"),
+            lambda names: _schema(names),
+        )
+        submitted = (
+            f"{_SVC_WFS}?request=GetCapabilities&service=wfs&Version=2.0.0&map=x"
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler, url=submitted)
+
+        describe = [
+            r for r in recorded if _params(r).get("request") == "DescribeFeatureType"
+        ]
+        assert len(describe) == 1
+        pairs = describe[0].url.params.multi_items()
+        assert sorted(pairs) == sorted(
+            [
+                ("map", "x"),
+                ("SERVICE", "WFS"),
+                ("VERSION", "1.1.0"),
+                ("REQUEST", "DescribeFeatureType"),
+                ("TYPENAME", "topp:parcels"),
+            ]
+        )
+        assert describe[0].url.path == "/geoserver/wfs"
+
+    async def test_a_version_the_capabilities_do_not_state_is_the_drivers_default(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(
+            _capabilities(["topp:parcels"], version=None),
+            lambda names: _schema(names),
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert _params(recorded[-1])["version"] == "1.0.0"
+
+
+class TestEveryReadTheDriverMakesIsChecked:
+    """The driver asks for every type of a prefix in one DescribeFeatureType,
+    fifty at most, and then for a type alone whenever that answer does not
+    cover it. A schema that is clean for the batch and not for the single
+    request is the shape this class exists to catch."""
+
+    uses_the_real_endpoint_check = True
+
+    async def test_one_request_names_every_type_and_a_sibling_include_is_found(
+        self, monkeypatch
+    ) -> None:
+        def describe(names: list[str]) -> str:
+            include = f"{_FOREIGN}/inc.xsd" if "topp:roads" in names else None
+            return _schema(names, include=include)
+
+        handler = _wfs(_capabilities(["topp:parcels", "topp:roads"]), describe)
+        recorded = _transport(monkeypatch, handler)
+
+        with pytest.raises(CrossOriginEndpointError):
+            await assert_endpoints_stay_on_origin(
+                _SVC_WFS,
+                service_format="wfs",
+                credential_line=f"X-Api-Key: {_value()}",
+                deadline=None,
+            )
+
+        assert _described(recorded) == [["topp:parcels", "topp:roads"]]
+
+    async def test_types_are_batched_by_prefix_fifty_at_a_time(
+        self, monkeypatch
+    ) -> None:
+        names = [f"a:t{n}" for n in range(1, 121)] + [f"b:t{n}" for n in range(1, 4)]
+        handler = _wfs(_capabilities(names), lambda batch: _schema(batch))
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert _described(recorded) == [
+            names[0:50],
+            names[50:100],
+            names[100:120],
+            names[120:123],
+        ]
+
+    async def test_a_batch_answered_with_an_exception_report_falls_back_per_type(
+        self, monkeypatch
+    ) -> None:
+        def describe(names: list[str]) -> str:
+            if len(names) > 1:
+                return _exception_report()
+            include = f"{_FOREIGN}/inc.xsd" if names == ["topp:roads"] else None
+            return _schema(names, include=include)
+
+        handler = _wfs(_capabilities(["topp:parcels", "topp:roads"]), describe)
+        recorded = _transport(monkeypatch, handler)
+
+        with pytest.raises(CrossOriginEndpointError):
+            await assert_endpoints_stay_on_origin(
+                _SVC_WFS,
+                service_format="wfs",
+                credential_line=f"X-Api-Key: {_value()}",
+                deadline=None,
+            )
+
+        assert _described(recorded) == [
+            ["topp:parcels", "topp:roads"],
+            ["topp:parcels"],
+            ["topp:roads"],
+        ]
+
+    async def test_after_a_rejected_batch_every_remaining_type_is_read_alone(
+        self, monkeypatch
+    ) -> None:
+        """The driver stops batching for the rest of the open after one batch
+        it cannot use, so the other prefix is read one type at a time too."""
+
+        def describe(names: list[str]) -> str:
+            return _exception_report() if len(names) > 1 else _schema(names)
+
+        names = ["a:one", "a:two", "b:one", "b:two"]
+        handler = _wfs(_capabilities(names), describe)
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert _described(recorded) == [
+            ["a:one", "a:two"],
+            ["a:one"],
+            ["a:two"],
+            ["b:one"],
+            ["b:two"],
+        ]
+
+    async def test_a_named_layer_reads_its_batch_and_then_itself(
+        self, monkeypatch
+    ) -> None:
+        """A server that answers the batch cleanly and the single request with
+        an include is refused: the driver reads both."""
+
+        def describe(names: list[str]) -> str:
+            include = f"{_FOREIGN}/inc.xsd" if names == ["topp:roads"] else None
+            return _schema(names, include=include)
+
+        handler = _wfs(_capabilities(["topp:parcels", "topp:roads", "sf:x"]), describe)
+        recorded = _transport(monkeypatch, handler)
+
+        with pytest.raises(CrossOriginEndpointError):
+            await assert_endpoints_stay_on_origin(
+                _SVC_WFS,
+                service_format="wfs",
+                credential_line=f"X-Api-Key: {_value()}",
+                collection="topp:roads",
+                deadline=None,
+            )
+
+        assert _described(recorded) == [["topp:roads", "topp:parcels"], ["topp:roads"]]
+
+    async def test_a_named_layer_alone_in_its_prefix_is_read_once(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(_capabilities(["topp:parcels"]), lambda names: _schema(names))
+
+        recorded, _value_ = await _check(
+            monkeypatch, handler, collection="topp:parcels"
+        )
+
+        assert _described(recorded) == [["topp:parcels"]]
+
+    @pytest.mark.parametrize("requested", ["TOPP:ROADS", "roads", "Roads"])
+    async def test_a_named_layer_is_resolved_the_way_the_driver_resolves_it(
+        self, monkeypatch, requested
+    ) -> None:
+        """`GetLayerByName`: exact, then case-insensitive, then the part after
+        the prefix. The request names the advertised spelling, which is what
+        the driver puts in its own TYPENAME."""
+        handler = _wfs(
+            _capabilities(["topp:parcels", "topp:roads"]),
+            lambda names: _schema(names),
+        )
+
+        recorded, _value_ = await _check(monkeypatch, handler, collection=requested)
+
+        assert _described(recorded) == [["topp:roads", "topp:parcels"], ["topp:roads"]]
+
+    @pytest.mark.parametrize(
+        ("names", "requested"),
+        [
+            (["topp:roads", "sf:roads"], "roads"),
+            (["topp:parcels"], "topp:nothing"),
+        ],
+        ids=["short_name_two_prefixes_share", "not_advertised"],
+    )
+    async def test_a_layer_the_driver_would_not_resolve_is_walked_like_no_layer(
+        self, monkeypatch, names, requested
+    ) -> None:
+        handler = _wfs(_capabilities(names), lambda batch: _schema(batch))
+
+        recorded, _value_ = await _check(monkeypatch, handler, collection=requested)
+
+        assert _described(recorded) == [[name] for name in names]
+
+
+class TestAnUnreadableSchemaFailsClosed:
+    uses_the_real_endpoint_check = True
+
+    async def _refused(self, monkeypatch, handler, **kwargs) -> list[httpx.Request]:
+        recorded = _transport(monkeypatch, handler)
+        with pytest.raises(EndpointCheckFailedError) as raised:
+            await assert_endpoints_stay_on_origin(
+                _SVC_WFS,
+                service_format="wfs",
+                credential_line=f"X-Api-Key: {_value()}",
+                deadline=None,
+                **kwargs,
+            )
+        assert raised.value.code == "endpoint_check_failed"
+        return recorded
+
+    async def test_a_body_that_is_not_xml_refuses(self, monkeypatch) -> None:
+        handler = _wfs(_capabilities(["topp:parcels"]), lambda names: "<not xml")
+
+        await self._refused(monkeypatch, handler)
+
+    async def test_a_batch_that_does_not_parse_refuses_without_falling_back(
+        self, monkeypatch
+    ) -> None:
+        """The driver's own parser is more lenient than this one, so a body
+        that does not parse here may still be a schema the driver resolves.
+        Not knowing what it would read is a refusal, not a fallback."""
+
+        def describe(names: list[str]) -> str:
+            return "<not xml" if len(names) > 1 else _schema(names)
+
+        handler = _wfs(_capabilities(["topp:parcels", "topp:roads"]), describe)
+
+        recorded = await self._refused(monkeypatch, handler)
+
+        assert _described(recorded) == [["topp:parcels", "topp:roads"]]
+
+    async def test_a_document_carrying_a_doctype_refuses(self, monkeypatch) -> None:
+        with_doctype = (
+            '<?xml version="1.0"?><!DOCTYPE schema>' + _schema().split("?>", 1)[1]
+        )
+        handler = _wfs(_capabilities(["topp:parcels"]), lambda names: with_doctype)
+
+        await self._refused(monkeypatch, handler)
+
+    async def test_an_exception_report_for_a_single_type_refuses(
+        self, monkeypatch
+    ) -> None:
+        handler = _wfs(
+            _capabilities(["topp:parcels"]), lambda names: _exception_report()
+        )
+
+        recorded = await self._refused(monkeypatch, handler)
+
+        assert _described(recorded) == [["topp:parcels"], ["topp:parcels"]]
+
+    async def test_an_http_error_on_a_batch_refuses(self, monkeypatch) -> None:
+        def describe(names: list[str]):
+            return httpx.Response(500) if len(names) > 1 else _schema(names)
+
+        handler = _wfs(_capabilities(["topp:parcels", "topp:roads"]), describe)
+
+        recorded = await self._refused(monkeypatch, handler)
+
+        assert _described(recorded) == [["topp:parcels", "topp:roads"]]
+
+    async def test_an_unreadable_same_origin_include_refuses(self, monkeypatch) -> None:
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, include=f"{_SVC_ORIGIN}/inc.xsd"),
+        )
+
+        recorded = await self._refused(monkeypatch, handler)
+
+        assert recorded[-1].url.path == "/inc.xsd"
+
+    async def test_reads_past_the_budget_refuse(self, monkeypatch) -> None:
+        """Sixty types, a batch the server rejects, and clean single answers:
+        the fiftieth read is the last one made."""
+        from app.platform.service_endpoints import _MAX_WFS_SCHEMA_READS
+
+        def describe(names: list[str]) -> str:
+            return _exception_report() if len(names) > 1 else _schema(names)
+
+        names = [f"a:t{n}" for n in range(1, 61)]
+        handler = _wfs(_capabilities(names), describe)
+
+        recorded = await self._refused(monkeypatch, handler)
+
+        assert len(_described(recorded)) == _MAX_WFS_SCHEMA_READS
+
+
+class TestTheDoorsRefuseBeforeGdalRuns:
+    """The three doors share `assert_endpoints_stay_on_origin`, so the schema
+    check reaches the probe, the preview and the worker without edits. The
+    probe is the first door a caller meets; the worker is the one that spends
+    the credential."""
+
+    uses_the_real_endpoint_check = True
+
+    async def test_the_probe_refuses_with_the_coded_outcome(
+        self, client, admin_auth_header: dict
+    ) -> None:
+        recorded: list[httpx.Request] = []
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, include=f"{_FOREIGN}/inc.xsd"),
+        )
+
+        def _handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return _as_stream(handler(request))
+
+        value = _value()
+        with (
+            patch.object(
+                security, "make_safe_transport", lambda: httpx.MockTransport(_handle)
+            ),
+            patch.object(security, "validate_url_for_ssrf", AsyncMock()),
+            patch(
+                "app.modules.catalog.sources.router.validate_url_for_ssrf",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "app.platform.service_endpoints.validate_url_for_ssrf",
+                new_callable=AsyncMock,
+            ),
+        ):
+            resp = await client.post(
+                "/services/probe",
+                json={
+                    "url": _SVC_WFS,
+                    "auth": {
+                        "method": "header",
+                        "header_name": "X-Api-Key",
+                        "header_value": value,
+                    },
+                },
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["code"] == "cross_origin_endpoint"
+        assert value not in resp.text
+        assert _hosts(recorded) == {"service.example"}
+
+    async def test_the_worker_refuses_before_spawning_ogr2ogr(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from app.core.config import settings
+        from app.processing.ingest.ogr import run_ogr2ogr_service
+
+        monkeypatch.setattr(settings, "upload_staging_dir", str(tmp_path / "staging"))
+        handler = _wfs(
+            _capabilities(["topp:parcels"]),
+            lambda names: _schema(names, include=f"{_FOREIGN}/inc.xsd"),
+        )
+        recorded = _transport(monkeypatch, handler)
+
+        async def _fake_exec(*cmd, **kwargs):
+            raise AssertionError("ogr2ogr must not run for a refused source")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+        with pytest.raises(CrossOriginEndpointError) as raised:
+            await run_ogr2ogr_service(
+                gdal_source=f"WFS:{_SVC_WFS}",
+                layer_name="topp:parcels",
+                table_name="t",
+                db_conn_str="PG:dummy",
+                service_type="wfs",
+                token=f"X-Api-Key: {_value()}",
+                schema="data",
+            )
+
+        assert raised.value.origin == _FOREIGN
+        assert _hosts(recorded) == {"service.example"}

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -1564,3 +1564,48 @@ class TestTheDriverNegotiatesAsTheCheckDoes:
             ),
         }
         assert gdal_transport_env("oapif") == {"GDAL_HTTP_USERAGENT": "GeoLens"}
+
+
+class TestTheLayerAloneIsReadWheneverItIsADifferentRequest:
+    """A batch that names only the layer still differs from the single request
+    when the submitted URL carries a `COUNT` (or a WFS 2 `MAXFEATURES`), which
+    the single request drops; the driver retries that request when the batch
+    answer does not cover the layer, so the check reads it too."""
+
+    uses_the_real_endpoint_check = True
+
+    async def test_a_count_less_retry_with_an_include_is_refused(
+        self, monkeypatch
+    ) -> None:
+        def describe(names: list[str]) -> str:
+            return _schema(names)
+
+        recorded_urls: list[str] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            params = _params(request)
+            if params.get("request") == "DescribeFeatureType":
+                recorded_urls.append(str(request.url))
+                include = None if "count" in params else f"{_FOREIGN}/inc.xsd"
+                return httpx.Response(200, text=_schema([_LAYER], include=include))
+            return _wfs(_capabilities([_LAYER]), describe)(request)
+
+        recorded = _transport(monkeypatch, handle)
+        with pytest.raises(CrossOriginEndpointError):
+            await assert_endpoints_stay_on_origin(
+                f"{_SVC_WFS}?MAXFEATURES=7",
+                service_format="wfs",
+                credential_line=f"X-Api-Key: {_value()}",
+                collection=_LAYER,
+                deadline=None,
+            )
+
+        assert _described(recorded) == [[_LAYER], [_LAYER]]
+        assert "COUNT=7" in recorded_urls[0] and "COUNT" not in recorded_urls[1]
+
+    async def test_an_identical_request_is_read_once(self, monkeypatch) -> None:
+        handler = _wfs(_capabilities([_LAYER]), lambda names: _schema(names))
+
+        recorded, _value_ = await _check(monkeypatch, handler)
+
+        assert _described(recorded) == [[_LAYER]]

--- a/backend/tests/test_wfs_schema_include_1828.py
+++ b/backend/tests/test_wfs_schema_include_1828.py
@@ -1378,6 +1378,36 @@ def _output_formats(recorded: list[httpx.Request]) -> list[str | None]:
     ]
 
 
+class TestTheVersionIsComparedAsTheDriverComparesIt:
+    """``atoi`` on the version decides the ``COUNT`` rewrite; a version of any
+    length, sign or leading zeros is compared without an integer conversion."""
+
+    uses_the_real_endpoint_check = True
+
+    @pytest.mark.parametrize(
+        ("version", "rewritten"),
+        [
+            ("2.0.0", True),
+            ("1.1.0", False),
+            ("+2", True),
+            ("-2", False),
+            ("0002.0.0", True),
+            ("10", True),
+            ("0" * 5000 + "1.0", False),
+            ("9" * 5000, True),
+            ("", False),
+            ("x", False),
+        ],
+    )
+    def test_the_count_rewrite_follows_the_leading_integer(
+        self, version: str, rewritten: bool
+    ) -> None:
+        from app.platform.service_endpoints import _wfs_base_url
+
+        base = _wfs_base_url("https://s.example/wfs?MAXFEATURES=5", version)
+        assert ("COUNT=5" in base) is rewritten
+
+
 class TestTheRequiredOutputFormatIsMirrored:
     """On WFS 1.1.0 the driver adds the first advertised ``Format`` of a type
     whose formats never mention GML 3.1 as ``OUTPUTFORMAT`` on both schema


### PR DESCRIPTION
## What changed

A credentialed WFS whose DescribeFeatureType schema includes a location on another origin is now refused before GDAL is handed the source, and the two schema fetches the GML driver can make on its own stay off by value.

Measured on the pinned GDAL (3.10.3, the worker image): the WFS driver resolves every `xs:include` of the DescribeFeatureType schema through its plain HTTP fetch, which carries the whole header file to whichever host the include names, at schema-parse time and before any GetFeature. `GML_SKIP_RESOLVE_ELEMS`, `GML_DOWNLOAD_SCHEMA`, `CPL_VSIL_CURL_ALLOWED_EXTENSIONS` and `GDAL_SKIP` do not apply to that fetch, and GDAL has no option that disables include resolution. The existing same-origin check read GetCapabilities only, so this document was outside it. Tracked in #1828.

### Part 1: `_check_wfs` reads the schema the driver reads for the layer

`backend/app/platform/service_endpoints.py`. After the capabilities pass, the check collects the advertised feature type names and the capabilities version, then reads DescribeFeatureType the way the driver does for the layer the door is about to open, per the GDAL 3.10.3 source:

- One request naming the layer first and then the other members of its prefix, fifty at most, followed by one request naming the layer alone. The driver issues that second request whenever the batch answer does not cover the layer, and whether it covers the layer depends on the driver's own feature-class parser, so the check reads both rather than guessing. A server that answers the batch cleanly and the single request with an include is refused.
- The preview and the worker pass the layer they open (`collection=layer_name`). With no layer the check is the capabilities check alone, as before, and a credentialed WFS never reaches GDAL without a layer: `run_service_preview` and `run_ogr2ogr_service` refuse one that names no layer before the process starts, through `require_wfs_layer`, with the coded `layer_required` refusal in the same shape as the origin check (a 422 naming the `layer_name` field at the preview, the same job failure at the worker). The SPA always names the layer it previews or imports, so no door changed. A structural test pins that every spawn point that passes a `collection` to the check calls the refusal first, and the set of those spawn points is exact. The probe names no layer and runs no GDAL.
- The layer name is resolved the way `GetLayerByName` resolves it (exact, then case-insensitive, then the short name after the prefix when no two short names collide), so the request names the advertised spelling the driver would put in its own TYPENAME.
- The check's requests carry the submitted URL's parameters exactly as the driver's do. Both requests are built byte for byte the way the driver builds them, through ports of `CPLURLAddKVP`, `CPLURLGetValue` and `WFS_EscapeURL`: the driver's own keys (`SERVICE`, `VERSION`, `REQUEST`, `TYPENAME`) replace the first case-insensitive match in place with the driver's spelling or are appended when absent, the keys the driver removes (`PROPERTYNAME`, `MAXFEATURES`, `FILTER`, `OUTPUTFORMAT`, and `COUNT` on the single-layer request only) are removed the same way, a WFS 2 `MAXFEATURES` with no `COUNT` beside it becomes `COUNT` as the driver rewrites its base URL, and every other parameter, `TYPENAMES` included, stays in place and in order. `VERSION` is the capabilities document's own, 1.0.0 when absent and sent empty when the attribute is empty, as the driver sends it.
- Every read goes through the existing `_fetch` and `make_safe_client`, with the credential, `WFS_XML_ACCEPT`, the byte, element, attribute, depth and text budgets, SSRF revalidation, and the caller's deadline. Every read counts against a budget of fifty schema reads per check; past it the check refuses with `endpoint_check_failed`. A real schema costs two.
- Every element with local name `include` contributes its location. Both the element name and the attribute name are matched case-insensitively after stripping any namespace prefix, and a text-only `schemaLocation` child element counts as well, because that is how `CPLGetXMLValue` reads it. The driver resolves only the direct children of the schema element; the walk covers the whole tree, which over-refuses on a shape no real schema has. `import` elements are not refused: the driver passes `bUseSchemaImports=false`, the GML driver reads a config value part 2 pins off, and a real schema imports GML from another origin.
- A location is classified the way `CPLIsFilenameRelative` classifies it. A relative location resolves under the driver's in-memory directory and never leaves the process, so it passes. An absolute `http://` or `https://` location on the submitted origin is read once, with the credential, and walked the same way, because the driver splices an included schema in and resolves its includes too. An absolute location on another origin raises `CrossOriginEndpointError` naming that origin. Anything else the driver would open as a VSI path (a scheme-relative `//host/...`, an absolute or UNC or drive path, any other scheme, a scheme embedded after the first character) raises `CrossOriginEndpointError` as well: a VSI path can reach the network or the worker's own storage.
- An unreadable schema fails closed with `EndpointCheckFailedError`: a body that does not parse under defusedxml (the driver's parser is more lenient, so what it would read is unknown), an HTTP error, a document over budget, an exception report for the single-type request, an unreadable same-origin include, or a URL over the advertised-href length cap. Only a well-formed answer that carries no schema triggers the single-type fallback, which is the case the driver itself falls back on.
- A capabilities document advertising no feature type makes no second request.

What still differs from the driver's request: the User-Agent and Accept headers, the `OUTPUTFORMAT` the driver adds for a 1.1.0 type with a required output format, and timing. A server keyed on those can answer the check and the driver differently, which is the limitation the capabilities check already has. The invariant is that a server cannot answer the two differently by URL or by document shape.

The capabilities root is now parsed once and handed to both walks; `_wfs_operation_hrefs(bytes)` keeps its signature as a wrapper. The three doors (`sources/router.py` `/probe`, `sources/preview.py`, `processing/ingest/ogr.py`) call `assert_endpoints_stay_on_origin`; the two that spawn GDAL gained the layer refusal beside that call and nothing else changed in them.

### Part 2: the two GML-driver schema fetches stay off by value

`backend/app/platform/gdal_env.py`. Both `gdal_vector_safe_env()` and `gdal_service_safe_env()` set `GML_USE_SCHEMA_IMPORT=NO` and `GML_DOWNLOAD_SCHEMA=NO` explicitly. At YES the GML driver fetches every `xs:import` location of a schema, and the schema a GetFeature response points at, with the header attached. Both are values, so an operator's process env cannot flip either on, and a tree walk with a positive control pins that nothing under `backend/app` sets either to anything else. No GDAL argv changed.

### Choices a reviewer should check

- The attribute and element names are matched case-insensitively. GDAL's `CPLGetXMLNode` and its element match both use `EQUAL`, so a case-sensitive check would pass a spelling the driver resolves.
- The batch is fifty per prefix, not one request naming every type. That is the request the driver sends, so it is the one real servers already answer.
- The named layer always gets the single-type read as well as the batch, for the coverage reason above.
- A same-origin absolute include is read and walked instead of passed on sight, because the driver splices it in and resolves its includes too.
- A URL over the length cap or an HTTP error on a batch fails closed instead of falling back. The driver would have read that answer and the check cannot.

## Schema, API and config impact

None. No request or response schema changed, no migration, no new setting. The subprocess env gains two fixed values.

## Verification

Run from the worktree with Postgres at localhost:5434.

```
cd backend && uv run pytest tests/test_wfs_schema_include_1828.py tests/test_gdal_env.py tests/test_gdal_driver_clamp_1846.py tests/test_service_auth_transport_1746.py tests/test_arcgis_auth.py tests/test_credential_policy.py tests/test_door_token_policy_1746.py tests/test_ingest_ogr_pure.py tests/test_preview_token_sec021.py tests/test_reupload.py tests/test_service_auth_contract_1746.py tests/test_service_refresh_1220.py tests/test_services_wfs_pure.py tests/test_source_health_1222.py tests/test_ogr_subprocess_env.py -q
1226 passed

cd backend && uv run pytest tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q
165 passed

cd backend && uv run ruff check . && uv run ruff format --check .
All checks passed, 1177 files already formatted
```

Counterfactual: with only the `_check_wfs_schemas` call removed from `_check_wfs` and every test kept, `tests/test_wfs_schema_include_1828.py` reports `39 failed, 25 passed`. The tests that still pass are the ones that assert nothing about the schema read (the import-passes, no-feature-type, unresolved-name, no-layer and probe cases, the layer-requirement cases, and the pure URL-builder cases). The first failures:

```
FAILED TestAnIncludeOffTheOriginIsRefused::test_an_absolute_include_on_another_origin_is_refused_naming_it
FAILED TestAnIncludeOffTheOriginIsRefused::test_every_read_carries_the_credential_to_the_submitted_origin_only
FAILED TestAnIncludeOffTheOriginIsRefused::test_the_spellings_the_driver_reads_are_all_read[upper_cased]
FAILED TestTheReadsTheDriverMakesForTheLayerAreChecked::test_a_named_layer_reads_its_batch_and_then_itself
FAILED TestAnUnreadableSchemaFailsClosed::test_an_unreadable_same_origin_include_refuses
FAILED TestTheDoorsRefuseBeforeGdalRuns::test_the_preview_refuses_before_spawning_ogrinfo
FAILED TestTheDoorsRefuseBeforeGdalRuns::test_the_worker_refuses_before_spawning_ogr2ogr
```

`_MODULE_LOC_CAPS`: `backend/app/platform/service_endpoints.py` 1330 to 1726 and `backend/app/processing/ingest/ogr.py` 1433 to 1439, exact, each with an anchored comment.

## Noticed and left alone

- Eleven existing doubles in `test_service_auth_transport_1746.py` answered every request with the capabilities document or a 404; they now answer a DescribeFeatureType with a plain schema through one shared helper. No assertion in those tests changed.
- `test_gdal_driver_clamp_1846.py::test_vector_env_does_not_disturb_the_rest_of_the_environment` iterates the host environment and now skips the two pinned keys as it already skipped `GDAL_SKIP`.
- The `OGC API - Features` path is unaffected: that driver reads JSON and has no schema location to resolve.
- AGENTS.md rule 2 does not yet mention include resolution or the two GML clamps; left for a docs follow-up rather than growing this PR.

## Round 5 (codex)

The check now holds one aggregate budget over every document it parses, bytes and elements together, at twice the per-document limits, and walks includes depth first so at most one included tree is alive beside the root; past any budget it refuses. A schema location whose scheme is spelled in any case is classified as the driver classifies it. At 30c653c1e: `tests/test_wfs_schema_include_1828.py` 71 passed alone; with `test_layering.py`, `test_rule1_structural.py` and `test_rule2_structural.py` 236 passed; ruff check and format clean. `service_endpoints.py` cap 1726 to 1755, exact.

## Round 6 (codex)

The check now adds the required `OUTPUTFORMAT` exactly as the driver does: on WFS 1.1.0 only, the first `Format` under a feature type's `OutputFormats` when none of them mentions GML 3.1, escaped with the driver's escaper, on the batch and the single request, and the batch holds only the prefix siblings that share that format. Every other case removes the key as before. At 0fc32ad6f: `tests/test_wfs_schema_include_1828.py` 78 passed; with the three structural gates 243 passed; ruff clean; `service_endpoints.py` cap to 1831, exact.

## Round 7 (codex)

The `COUNT` rewrite decides `atoi(version) >= 2` from the digits themselves, so a version of any length is compared without an integer conversion; a ten-case matrix pins it. At b6b3580fb: 253 passed with the three gates; ruff clean; cap 1843, exact.

## Round 8 (codex)

The leading-integer pattern is compiled with `re.ASCII`, so a version beginning with a non-ASCII digit or whitespace is 0 to the check as it is to the driver's `atoi`; four cases join the matrix. At 9282a2218: 257 passed with the three gates; ruff clean.

## Round 9 (codex)

`_c_atoi` reproduces the worker's `atoi`: ASCII whitespace and sign, the digit run saturated to a 64-bit `long`, then truncated to a signed 32-bit `int`; the WFS 2 test is `_c_atoi(version) >= 2`, as `ogrwfsdatasource.cpp` tests it. The expected values were measured with the C library on the host and, through ctypes, in the worker image (`2147483648.0` gives -2147483648, `4294967298` gives 2, a 23-digit run gives -1, `-8589934590` gives 2). At c67c4bee7: 266 passed with the three gates; ruff clean; cap 1858, exact.

At b353beac7 the matrix entry for a 5000-digit version expects no rewrite, which is what the measured `atoi` gives (-1); 266 passed with the three gates.

## Round 10 (codex)

The driver now negotiates as the check's reads do. Both spawn points set `GDAL_HTTP_USERAGENT` to the value every read here sends, and for a WFS `GDAL_HTTP_HEADERS` to the same `Accept` and `Accept-Encoding: identity` the reads send; the credential stays alone in the 0600 header file, and the GDAL 3.10.3 HTTP layer appends both sources to one header list (`port/cpl_http.cpp`, header file lines verbatim, `GDAL_HTTP_HEADERS` split on CRLF). What remains different is what neither side exposes: libcurl's and httpx's connection-level headers. Tests pin every read's three headers, the env both spawn points produce, and that no env value carries the credential. At ee05b8758: 906 passed across the transport, header-file, env, clamp and structural suites; ruff clean; caps `service_endpoints.py` 1871 and `ogr.py` 1441, exact.

## Round 11 (codex)

The layer-alone DescribeFeatureType is read whenever it is a different request from the batch, not only when the batch named more than the layer: with a `COUNT` on the submitted URL (or a WFS 2 `MAXFEATURES` the driver rewrites to one) the single request drops it, and the driver issues that request whenever the batch answer does not cover the layer, which the check does not try to decide. An identical request is still read once. At 7de68693a: 270 passed with the three gates; ruff clean; cap 1880, exact.

## Round 12 (codex)

The capabilities request is built with the same in-place, case-insensitive first-match replacement as the schema requests (`Open`'s chain: `SERVICE`, `REQUEST`, then `TYPENAME`, `TYPENAMES`, `FILTER`, `PROPERTYNAME`, `MAXFEATURES` and `OUTPUTFORMAT` removed, everything else kept), so the capabilities the check reads are the ones the driver reads; the `parse_qs` rebuild is gone. The probe adapter's own capabilities URL is unchanged, since it is not the driver's request. At f5b4c0849: 531 passed across the schema, transport and layering suites; ruff clean; cap 1863, exact.

## Round 13 (codex)

The feature types come from the nodes the driver turns into layers and no others: the capabilities node is the root or its first direct child named `WFS_Capabilities` (`WFSFindNode`), and the types are the direct `FeatureType` children of its first direct `FeatureTypeList`; the version and the required output formats are read from the same nodes. A `FeatureType` anywhere else no longer joins the batch or supplies a format. At 6a8f02f4a: 648 passed across the schema, transport and structural suites; ruff clean; cap 1881, exact.
