### PR TITLE
fix(ingest): reap the staged copy once a manifest entry settles to failed (#1888)

### DIFF
--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -844,6 +844,14 @@ async def _fail_reservation(
     await _settle_under_reset(db, job, _release, job_id=job_id)
 
 
+async def _settled_failed(db: AsyncSession, job_id: uuid.UUID) -> bool:
+    """Does the row for ``job_id`` read ``failed`` on this transaction?"""
+    row = (
+        await db.execute(select(IngestJob.status).where(IngestJob.id == job_id))
+    ).one_or_none()
+    return row is not None and row.status == "failed"
+
+
 async def _settle_staged_entry(
     db: AsyncSession,
     job: IngestJob,
@@ -852,7 +860,7 @@ async def _settle_staged_entry(
     prepared: ManifestPreparedSource,
     file_path: str,
 ) -> None:
-    """Settle an entry that failed after its source was staged.
+    """Settle an entry that failed after its source was staged, then reap the copy.
 
     fix(#1814): the row decides, not the exception. The two settlements fence on
     disjoint states, and read and settlement share one body.
@@ -861,9 +869,10 @@ async def _settle_staged_entry(
     # The safe default if neither attempt can read: keep the bytes, because
     # orphaned ones are reclaimable and ones a durable row names are not.
     referenced = True
+    failed = False
 
     async def _decide_and_settle() -> None:
-        nonlocal referenced
+        nonlocal referenced, failed
         referenced = await staged_source_is_referenced(db, job_id, file_path=file_path)
         if not await release_manifest_reservation(
             db, job, f"Failed to stage manifest source: {exc}"
@@ -871,12 +880,17 @@ async def _settle_staged_entry(
             await settle_ingest_job_failed(
                 job, exc, message_prefix="Failed to queue manifest job"
             )
+        failed = await _settled_failed(db, job_id)
 
     await _settle_under_reset(db, job, _decide_and_settle, job_id=job_id)
     # Outside the retry: the filesystem is not part of the transaction, and an
     # HTTP download is owned by this attempt while a raw operator seed is not.
-    if not referenced:
-        _cleanup_downloaded_source(prepared, file_path)
+    # fix(#1888): a failed manifest row has no retry, so its copy has no consumer.
+    if failed or not referenced:
+        try:
+            _cleanup_downloaded_source(prepared, file_path)
+        except OSError:
+            log.warning("Could not reap a staged manifest source", job_id=str(job_id))
 
 
 async def _finalize_reserved_entry(

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -805,11 +805,12 @@ async def _settle_under_reset(
     body: Callable[[], Awaitable[None]],
     *,
     job_id: uuid.UUID,
-) -> None:
+) -> bool:
     """Run every statement of one settlement on a session that was just reset.
 
-    fix(#1814): any statement in a settlement can find the transaction unusable.
-    The body is fenced, so one reset-and-retry lands nothing twice.
+    Returns whether an attempt committed. fix(#1814): any statement in a
+    settlement can find the transaction unusable. The body is fenced, so one
+    reset-and-retry lands nothing twice.
     """
     # fix(#1814): pinned once, never re-read. A retry can rotate the token
     # between the two attempts, and a reset reloads the new one, so the retry
@@ -822,11 +823,12 @@ async def _settle_under_reset(
         try:
             await body()
             await db.commit()
-            return
+            return True
         except Exception:  # broad: any database error is a reset-and-retry
             if attempt == 2:
                 log.exception("Could not settle a manifest job", job_id=str(job_id))
                 await db.rollback()
+    return False
 
 
 async def _fail_reservation(
@@ -882,11 +884,11 @@ async def _settle_staged_entry(
             )
         failed = await _settled_failed(db, job_id)
 
-    await _settle_under_reset(db, job, _decide_and_settle, job_id=job_id)
+    committed = await _settle_under_reset(db, job, _decide_and_settle, job_id=job_id)
     # Outside the retry: the filesystem is not part of the transaction, and an
     # HTTP download is owned by this attempt while a raw operator seed is not.
-    # fix(#1888): a failed manifest row has no retry, so its copy has no consumer.
-    if failed or not referenced:
+    # fix(#1888): only a committed settlement may reap; a failed row has no retry.
+    if committed and (failed or not referenced):
         try:
             _cleanup_downloaded_source(prepared, file_path)
         except OSError:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2534,10 +2534,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1814): first entry. The lines bought the reserve/stage/bind split of
     # one create-and-queue function, its two fenced settlement exits, the quota
     # preflight, the staging deadline, and the reset-and-retry settlement.
-    # fix(#1888): +14. The staged-entry settlement reads the row's status on
-    # its own transaction and reaps the staged copy once the row is failed,
-    # best effort, after the commit. Cap 1130 -> 1144, exact.
-    "backend/app/processing/ingest/manifest_service.py": 1144,
+    # fix(#1888): +16. The staged-entry settlement reads the row's status on
+    # its own transaction and reaps the staged copy once a committed attempt
+    # left the row failed, best effort. Cap 1130 -> 1146, exact.
+    "backend/app/processing/ingest/manifest_service.py": 1146,
     # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
     # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
     # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2534,7 +2534,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1814): first entry. The lines bought the reserve/stage/bind split of
     # one create-and-queue function, its two fenced settlement exits, the quota
     # preflight, the staging deadline, and the reset-and-retry settlement.
-    "backend/app/processing/ingest/manifest_service.py": 1130,
+    # fix(#1888): +14. The staged-entry settlement reads the row's status on
+    # its own transaction and reaps the staged copy once the row is failed,
+    # best effort, after the commit. Cap 1130 -> 1144, exact.
+    "backend/app/processing/ingest/manifest_service.py": 1144,
     # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
     # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
     # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -628,14 +628,11 @@ class TestReservationFailureReleasesTheKey:
         assert retried.results[0].action == "create"
         queue.assert_awaited_once()
 
-    async def test_a_durable_bind_whose_commit_raises_keeps_its_bytes(
+    async def test_a_durable_bind_whose_commit_raises_reaps_its_bytes(
         self, test_db_session, clean_tables
     ):
-        """fix(#1814): the row decides the cleanup, not the exception.
-
-        Deciding from the exception deleted the staged source and left a
-        pending row pointing at nothing, with no queued task.
-        """
+        """fix(#1888): the row settles to failed and nothing can retry a
+        manifest-keyed row, so the staged copy it still names is reaped."""
         request = _request(
             _manifest_dataset(
                 key="manifest-1814-ambiguous",
@@ -673,8 +670,8 @@ class TestReservationFailureReleasesTheKey:
         assert response.results[0].action == "error"
         assert "acknowledgement lost" in response.results[0].message
         queue.assert_not_awaited()
-        # The bind landed, so the bytes are what /jobs/{id}/retry needs.
-        assert staged.exists()
+        # fix(#1888): the bind landed, but a failed manifest row has no retry.
+        assert not staged.exists()
 
         settled = await _jobs_for_key(test_db_session, "manifest-1814-ambiguous")
         assert len(settled) == 1
@@ -684,6 +681,79 @@ class TestReservationFailureReleasesTheKey:
 
         # And the key is free: a re-apply does not attach to the dead job.
         retry_staged = _staged_bytes("manifest_1814_ambiguous_retry.geojson")
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(retry_staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            retried = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert retried.results[0].action == "create"
+        assert retried.results[0].job_id != settled[0].id
+        queue.assert_awaited_once()
+
+    async def test_a_failed_dispatch_reaps_the_staged_copy(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1888): a terminal manifest failure leaves no staged object behind,
+        including when the orphan guard has already settled the row before the
+        entry's own settlement reads it."""
+        request = _request(
+            _manifest_dataset(
+                key="manifest-1888-dispatch-failed",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+        staged = _staged_bytes("manifest_1888_dispatch_failed.geojson")
+
+        async def _refuse_after_settling(job, user_id, *, db, **_kwargs) -> None:
+            exc = RuntimeError("queue unreachable")
+            assert await settle_ingest_job_failed(
+                job, exc, message_prefix="Failed to queue ingest task"
+            )
+            await db.commit()
+            raise exc
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=_refuse_after_settling,
+            ),
+        ):
+            response = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert response.results[0].action == "error"
+        assert "queue unreachable" in response.results[0].message
+        assert not staged.exists()
+
+        settled = await _jobs_for_key(test_db_session, "manifest-1888-dispatch-failed")
+        assert len(settled) == 1
+        assert settled[0].status == "failed"
+        assert settled[0].file_path == str(staged)
+        assert MANIFEST_STAGE_METADATA_KEY not in settled[0].user_metadata
+
+        retry_staged = _staged_bytes("manifest_1888_dispatch_failed_retry.geojson")
         with (
             patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
             patch(

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -776,6 +776,75 @@ class TestReservationFailureReleasesTheKey:
         assert retried.results[0].job_id != settled[0].id
         queue.assert_awaited_once()
 
+    async def test_a_settlement_that_never_commits_keeps_its_bytes(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#1888): the reap follows the commit that made the decision. A first
+        attempt whose commit is lost non-durably and a second that errors before
+        deciding leave the durable pending row and the bytes it names alone."""
+        request = _request(
+            _manifest_dataset(
+                key="manifest-1888-uncommitted",
+                uri="https://data.example.test/roads.geojson",
+            )
+        )
+        staged = _staged_bytes("manifest_1888_uncommitted.geojson")
+        real_commit = test_db_session.commit
+        real_read = manifest_service.staged_source_is_referenced
+        state = {"armed": False, "commits_lost": 0, "reads": 0}
+
+        async def _refuse_dispatch(job, user_id, *, db, **_kwargs) -> None:
+            state["armed"] = True
+            raise RuntimeError("queue unreachable")
+
+        async def _lose_the_first_settlement_commit() -> None:
+            if state["armed"] and state["commits_lost"] == 0:
+                state["commits_lost"] += 1
+                await test_db_session.rollback()
+                raise RuntimeError("commit lost")
+            await real_commit()
+
+        async def _error_on_the_retry_read(db, job_id, *, file_path: str) -> bool:
+            state["reads"] += 1
+            if state["reads"] == 2:
+                raise RuntimeError("read failed")
+            return await real_read(db, job_id, file_path=file_path)
+
+        with (
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=_refuse_dispatch,
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.staged_source_is_referenced",
+                new=_error_on_the_retry_read,
+            ),
+            patch.object(
+                test_db_session, "commit", new=_lose_the_first_settlement_commit
+            ),
+        ):
+            response = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert response.results[0].action == "error"
+        assert state == {"armed": True, "commits_lost": 1, "reads": 2}
+        assert staged.exists()
+
+        rows = await _jobs_for_key(test_db_session, "manifest-1888-uncommitted")
+        assert len(rows) == 1
+        assert rows[0].status == "pending"
+        assert rows[0].file_path == str(staged)
+        assert MANIFEST_STAGE_METADATA_KEY not in rows[0].user_metadata
+
     async def test_a_poisoned_reconciliation_read_still_settles(
         self, test_db_session, clean_tables
     ):


### PR DESCRIPTION
Issue: #1888, follow-up from #1885 review round 7. Option taken: reap on terminal failure, the first of the two the issue lists.

## Defect

`_settle_staged_entry` in `backend/app/processing/ingest/manifest_service.py` settles an entry that failed after its source was staged. It read whether the row still named the staged bytes and kept them when it did, because `/jobs/{id}/retry` was going to consume them. #1885 made `_retry_capability` refuse every manifest-keyed row, and a re-apply takes a new reservation and downloads a fresh copy, so the retained bytes have no consumer. They sat in staging until the retention purge, or indefinitely with retention off, and each repeated queue failure added one copy.

Reproduced on main at 56aa03abe by the first two tests below: after an ambiguous bind commit and after a queue failure, the row reads `failed`, still names the staged file, and the file is still on disk.

## Fix

The settlement body reads the row's status on its own transaction after the two fenced writes (`_settled_failed`, a single `SELECT status WHERE id`). `_settle_under_reset` now returns whether one of its attempts committed, and the reap runs only when it did and the committed attempt saw the row `failed`, or saw that nothing names the bytes. The order is the one `delete_dataset` and its router use: the fenced status write commits first, then the bytes go.

Reading the row rather than trusting which fenced write landed is what makes the queue-failure case work. `queue_ingest_job` dispatches through `defer_with_orphan_guard`, which has usually already settled the row from `pending` to `failed` before this settlement runs, so neither `release_manifest_reservation` nor `settle_ingest_job_failed` matches anything. The same read also covers the lost-acknowledgement replay, where the first attempt's writes were durable and the retry matches nothing.

Gating on the return value rather than on the flag alone is the round 1 fix. The flag is set inside the attempt, before its commit. A first attempt that flipped the row to `failed` and then lost its commit non-durably, followed by a second attempt that errored before overwriting the flag, had the wrapper log and return while the reap still ran, leaving a durable pending row naming bytes that were gone. The flag is overwritten by whichever attempt reaches the commit, so with the gate the decision honoured is always the committed attempt's, and a settlement that never lands reaps nothing.

The reap is best effort: `_cleanup_downloaded_source` is wrapped so an `OSError` is logged and the entry's original error still propagates, where before it would have replaced it. Nothing the operator owns is touched: that helper unlinks only an HTTP download or the owned copy of a local seed, and leaves a storage key or a raw operator path alone, exactly as before.

`file_path` stays on the row. The existing assertions read it (`settled[0].file_path == str(staged)`), it keeps the audit trail saying what was staged, and nothing consults it on a failed manifest row: `_retry_capability` refuses on `manifest_key` before it reaches the import-copy branch that reads `file_path`.

Not touched, per the brief: `_retry_capability`, the sweep, the retention purge.

## Tests

In `backend/tests/test_manifest_reservation_1814.py`, next to the other staged-settlement tests:

The existing ambiguous-bind test asserted `staged.exists()` with the comment that the bytes are what retry needs. That assertion is the defect, so it is flipped to `not staged.exists()` and the test is renamed `test_a_durable_bind_whose_commit_raises_reaps_its_bytes`. Its other assertions (row `failed`, `file_path` still set, stage marker gone, re-apply creates a new job) are unchanged.

`test_a_failed_dispatch_reaps_the_staged_copy`: the bind commits for real, then the patched `queue_ingest_job` settles the row through `settle_ingest_job_failed`, commits, and raises, the way the orphan guard does. The entry's own settlement then finds a row that is already `failed`, and the copy must still be reaped. Asserts the error result, no staged object on disk, the row `failed` with `file_path` set and no stage marker, and a re-apply that creates a new job.

`test_a_settlement_that_never_commits_keeps_its_bytes` (round 1): the bind commits for real, the queue raises without settling, the session's `commit` is patched so the first settlement commit rolls back and raises, and `staged_source_is_referenced` raises on its second call so the retry errors before deciding. Asserts the staged object survives, the row reads `pending` with `file_path` set, and that exactly one commit was lost and two reads were made.

Counterfactual for the first two, tests in place and `manifest_service.py` at main, so only the reap is missing:

```
E       AssertionError: assert not True
E        +  where True = exists()
E        +    where exists = PosixPath('.../staging/manifest_1814_ambiguous.geojson').exists
tests/test_manifest_reservation_1814.py:674: AssertionError
E       AssertionError: assert not True
E        +  where True = exists()
E        +    where exists = PosixPath('.../staging/manifest_1888_dispatch_failed.geojson').exists
tests/test_manifest_reservation_1814.py:748: AssertionError
FAILED tests/test_manifest_reservation_1814.py::TestReservationFailureReleasesTheKey::test_a_durable_bind_whose_commit_raises_reaps_its_bytes
FAILED tests/test_manifest_reservation_1814.py::TestReservationFailureReleasesTheKey::test_a_failed_dispatch_reaps_the_staged_copy
2 failed, 22 deselected
```

Counterfactual for the third, against the round 0 head 6e860d69b, so the reap gates on the flag alone:

```
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('.../staging/manifest_1888_uncommitted.geojson').exists
tests/test_manifest_reservation_1814.py:840: AssertionError
ERROR ... 'event': 'Could not settle a manifest job' ... RuntimeError: commit lost ... RuntimeError: read failed
```

No mock-mirror suite counts storage calls on this path. The poisoned-read test counts calls to `staged_source_is_referenced` only, and that call is unchanged. `TestFencedWritesAreSingleStatements` counts the bind and release statements, not the settlement body.

## Impact

No request or response schema change, no migration, no new setting. `manifest_service.py` sat at its cap of 1130 with zero headroom; the status read, the flag, the committed return, the reap guard and its comment add sixteen lines, so `_MODULE_LOC_CAPS` moves to 1146, exact, with an anchored comment.

## Verification

Run on the host from the worktree, Postgres at localhost:5434.

```
cd backend && set -a && source ../.env.test && set +a
uv run pytest tests/test_manifest_reservation_1814.py -q                                                          # 25 passed
uv run pytest tests/test_manifest_apply_api.py tests/test_manifest_apply_roundtrip.py tests/test_manifest_apply_service.py tests/test_manifest_apply_vrt.py tests/test_commit_attempted_marker_doors.py tests/test_defer_orphan_guard.py -q   # 122 passed
uv run pytest tests/test_layering.py -q                                                                           # 50 passed
uv run pytest tests/test_rule1_structural.py tests/test_rule2_structural.py -q                                    # 118 passed
uv run ruff check . && uv run ruff format --check .                                                               # clean
```

## Left alone

The second option in the issue, adopting a retained copy on re-apply, is not taken; it needs a lookup keyed on source and key and a liveness check on the file, for bytes that a fresh download replaces in the same request. The sweep still does not unlink local staged files for rows it reaps itself; that is a separate path and was not in scope.
