### PR TITLE
test(ingest): inventory the #1857 follow-ups and pin a repetitive workbook under the ratio cap (#1857)

### DIFF
--- a/backend/tests/test_upload_validation.py
+++ b/backend/tests/test_upload_validation.py
@@ -208,6 +208,27 @@ class TestValidateZipSafety:
         with pytest.raises(ValueError, match="maximum"):
             validate_archive_safety(str(staged), "renamed-upload.xlsx")
 
+    def test_a_repetitive_workbook_clears_the_ratio_check(self, tmp_path: Path):
+        """fix(#1857 item 4): a workbook of repeated values stays an order of
+        magnitude under MAX_COMPRESSION_RATIO, because every cell reference
+        increments and breaks the run deflate would otherwise collapse."""
+        rows = "".join(
+            f'<row r="{r}"><c r="A{r}"><v>1</v></c></row>' for r in range(1, 50_001)
+        )
+        sheet = f"<worksheet><sheetData>{rows}</sheetData></worksheet>".encode()
+        staged = tmp_path / "repetitive.xlsx"
+        with zipfile.ZipFile(staged, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("[Content_Types].xml", b"<Types/>")
+            zf.writestr("xl/workbook.xml", b"<workbook/>")
+            zf.writestr("xl/worksheets/sheet1.xml", sheet)
+
+        validate_archive_safety(str(staged), "repetitive.xlsx")
+
+        with zipfile.ZipFile(staged) as zf:
+            info = zf.getinfo("xl/worksheets/sheet1.xml")
+        ratio = info.file_size / info.compress_size
+        assert 5 < ratio < validation.MAX_COMPRESSION_RATIO / 10, ratio
+
     def test_decompressed_size_over_2gb_rejected(self, tmp_path: Path):
         """ZIP with total decompressed size >2GB is rejected."""
         f = tmp_path / "huge.zip"

--- a/backend/tests/test_upload_validation.py
+++ b/backend/tests/test_upload_validation.py
@@ -209,9 +209,8 @@ class TestValidateZipSafety:
             validate_archive_safety(str(staged), "renamed-upload.xlsx")
 
     def test_a_repetitive_workbook_clears_the_ratio_check(self, tmp_path: Path):
-        """fix(#1857 item 4): a workbook of repeated values stays an order of
-        magnitude under MAX_COMPRESSION_RATIO, because every cell reference
-        increments and breaks the run deflate would otherwise collapse."""
+        """fix(#1857): a repeated-value workbook deflates an order of magnitude
+        under MAX_COMPRESSION_RATIO."""
         rows = "".join(
             f'<row r="{r}"><c r="A{r}"><v>1</v></c></row>' for r in range(1, 50_001)
         )


### PR DESCRIPTION
Tracked in #1857. Follow-up to #1868 and #1894.

## Inventory against origin/main at 4cf8e1346

Every numbered item in #1857, with what holds on current main.

1. Policy validator `KeyError` on a helper name outside its kind map. Already on main: #1868 (e66fc45f4) records the key in `unresolvable_env_helper`, skips that entry's credit check, and `test_policy_naming_an_unknown_env_helper_reports_instead_of_raising` pins the authored message and the allowed set. Re-run here: passes. I also probed the sibling field. An unknown policy `kind` reports "unknown VECTOR_CLI_DRIVER_POLICY kind 'bogus_kind' for (...)" and does not raise, so the env helper, the one field that becomes a resolution kind, was the only one that needed the skip.

2. Positional `create_subprocess_exec("ogrinfo", ...)` not matched. Already on main: #1868 added the varargs and sequence spawner tables with `test_positional_argv_is_seen_by_the_cli_env_gate`, and #1894 added the keyword-bound program and the unheaded sequence tail.

3. `run_service_preview` without the env helper. Already on main: #1868 moved `gdal_vector_safe_env`, `gdal_service_safe_env` and the shared driver tuple to `app/platform/gdal_env.py`. `modules/catalog/sources/preview.py` imports the service variant at line 21 and applies it at line 338, `GDAL_CLI_CALL_ALLOWLIST` is empty, and `test_gdal_driver_clamp_1846.py` carries the runtime test for that site.

4. `.xlsx` and `.kmz` meeting the archive checks at preview, with a note to watch for a legitimate workbook tripping the ratio check. Fixed in this PR as a measurement rather than a watch. Both extensions are in `ZIP_CONTAINER_EXTENSIONS`, so `validate_archive_safety` runs `validate_zip_safety` on them, and the per-entry check refuses a member above `MAX_COMPRESSION_RATIO`, which is 500. Measured with `zipfile` at the default deflate level:

   | member | uncompressed | ratio |
   |---|---|---|
   | 200,000-row sheet, four shared-string cells per row | 30.2 MB | 11.1:1 |
   | 200,000 identical numeric rows | 14.9 MB | 11.9:1 |
   | 200,000 rows of the same inline string in four cells | 60.6 MB | 25.2:1 |
   | 50,000 single-cell rows (the fixture) | 2.3 MB | 9.3:1 |
   | sharedStrings.xml of 300,000 identical entries | 11.4 MB | 343:1 |
   | sharedStrings.xml of 3,000,000 identical entries | 114 MB | 344:1 |

   Every worksheet shape stays an order of magnitude under the cap, because a cell reference is written on every cell and the incrementing reference breaks the run deflate would otherwise collapse. The shared-strings rows model a producer that does not deduplicate its strings, which Excel does; even that plateaus at 344:1 between 300,000 and 3,000,000 entries, so no workbook member reaches 500:1 by content alone. The new test in `backend/tests/test_upload_validation.py` builds the 50,000-row workbook, passes it through `validate_archive_safety` as an `.xlsx`, and asserts the sheet's ratio sits between 5:1 and a tenth of the cap, so lowering the cap into the range real workbooks occupy fails there. `.kmz` goes through the same check, and a KML of placemarks carries coordinates, which compress worse than repeated cells, so it is not separately fixtured.

5. CQL2 compile synchronous on the event loop. Left. `compile_feature_cql2_ast` runs inline in `get_collection_items` (`standards/ogc/router.py:871`). #1845 bounded the cost per request (the single-pass rename, the 10,000-character cap, the recursion guard and the 1,000-bind cap) and the rate (10/second per route for requests that carry `filter=`). Offloading the compile to a threadpool is a design decision: it adds a thread hop to every filtered request to save at most the 40 ms pathological case, and it changes where the slowapi limit and the request context are evaluated. It is neither a gate nor an error-shape change.

6. The `_legacy_renamed_sql` oracle asserting `n == 1`. Already on main: #1868 raises `_LegacyRenameCollision`, the equivalence test fails with a sentence pointing at the divergence test, and `test_a_queryable_named_cql2_diverges_from_the_legacy_loop` asserts the divergence directly.

7. The bind-cap and recursion 400 missing from the published API surface. Already on main: #1868 added `FILTER_BAD_REQUEST_RESPONSE` on the items route, `backend/openapi.json` carries it, and a test reads the interpolated limits back off the app's own OpenAPI.

8. `cors.py` counting a query `api_key` as credential-bearing. Left. `api/middleware/cors.py:314` still refuses the wildcard policy when `api_key` or `embed_token` is in the query string. The issue records it as the conservative direction; relaxing it is a CORS policy decision, not a gate fix.

9. `redact_nested` not walking `frozenset`, `deque` or dataclass instances. Already on main: #1868 walks `_ITERABLE_CONTAINERS` and dataclass instances through `dataclasses.fields`, and the processor that decides whether to walk reads the same tuple.

10. No structural gate on credential secret registration. Already on main: #1868 added `backend/tests/test_credential_secret_registration_1857.py`, which enumerates every producer by shape, resolves aliased imports, and refuses a parameter reassigned before the call.

11. `tasks_common.py` and `ingest/router.py` size. Left. They stand at 2,581 and 2,616 lines; #1755 and #1711 are open and track the splits.

## Counterfactual

With `MAX_COMPRESSION_RATIO` patched to 8, the fixture's workbook is refused by the check the test exists to measure:

```
ValueError: ZIP entry 'xl/worksheets/sheet1.xml' has suspicious compression ratio (9:1). Maximum allowed is 8:1.
```

## Verification

From the worktree with `.env.test` sourced, Postgres at localhost:5434, on the rebased head:

```
uv run pytest tests/test_upload_validation.py tests/test_rule2_structural.py \
    tests/test_rule1_structural.py tests/test_layering.py -q
  190 passed
uv run ruff check . && uv run ruff format --check .
  All checks passed! 1176 files already formatted
```

Schema, API and config impact: none. Nothing under `backend/app` changed, so no LOC cap moved.
