### PR TITLE
fix(sources): arbitrate the sign-in settle row on a unique partial index (#1889)

### DIFF
--- a/backend/alembic/versions/0059_arcgis_signin_settle_index.py
+++ b/backend/alembic/versions/0059_arcgis_signin_settle_index.py
@@ -1,8 +1,7 @@
 """Let PostgreSQL enforce one settled audit row per ArcGIS sign-in attempt.
 
-fix(#1889). The sign-in settle finaliser deduplicated on ``attempt_id`` with a
-SELECT before its INSERT, and a commit the cancellation interrupted can become
-visible between the two. The invariant belongs in the schema, as in 0051.
+fix(#1889): one settled row per ``attempt_id`` is a schema invariant, as in
+0051, not a read-then-write in the finaliser.
 
 The predicate pins ``action = 'arcgis_signin'`` and a present ``attempt_id``,
 so no other audit action is constrained, and rows written before #1887 carry

--- a/backend/alembic/versions/0059_arcgis_signin_settle_index.py
+++ b/backend/alembic/versions/0059_arcgis_signin_settle_index.py
@@ -9,10 +9,10 @@ so no other audit action is constrained, and rows written before #1887 carry
 no ``attempt_id`` and sit outside it. The finaliser's INSERT names this index
 in its ``ON CONFLICT`` clause; the model mirrors it for ``alembic check``.
 
-Plain rather than ``CONCURRENTLY``: ``env.py`` runs the upgrade as one
-transaction, which a concurrent build cannot join, and a failed concurrent
-build leaves an INVALID index behind. No tagged release writes ``attempt_id``
-yet, so no upgraded instance holds a row this index covers.
+Plain, as 0051 built its index on this table. An instance already holding
+two settle rows for one attempt fails this build, and that is the loud and
+correct outcome: it is the state the index exists to prevent, and an operator
+settles the duplicates first.
 
 Revision ID: 0059_arcgis_signin_settle_index
 Revises: 0058_arcgis_signin_user_scope

--- a/backend/alembic/versions/0059_arcgis_signin_settle_index.py
+++ b/backend/alembic/versions/0059_arcgis_signin_settle_index.py
@@ -1,0 +1,49 @@
+"""Let PostgreSQL enforce one settled audit row per ArcGIS sign-in attempt.
+
+fix(#1889). The sign-in settle finaliser deduplicated on ``attempt_id`` with a
+SELECT before its INSERT, and a commit the cancellation interrupted can become
+visible between the two. The invariant belongs in the schema, as in 0051.
+
+The predicate pins ``action = 'arcgis_signin'`` and a present ``attempt_id``,
+so no other audit action is constrained, and rows written before #1887 carry
+no ``attempt_id`` and sit outside it. The finaliser's INSERT names this index
+in its ``ON CONFLICT`` clause; the model mirrors it for ``alembic check``.
+
+Plain rather than ``CONCURRENTLY``: ``env.py`` runs the upgrade as one
+transaction, which a concurrent build cannot join, and a failed concurrent
+build leaves an INVALID index behind. No tagged release writes ``attempt_id``
+yet, so no upgraded instance holds a row this index covers.
+
+Revision ID: 0059_arcgis_signin_settle_index
+Revises: 0058_arcgis_signin_user_scope
+Create Date: 2026-09-05
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0059_arcgis_signin_settle_index"
+down_revision: Union[str, None] = "0058_arcgis_signin_user_scope"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_INDEX_NAME = "uq_audit_logs_arcgis_signin_attempt"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        CREATE UNIQUE INDEX {_INDEX_NAME}
+        ON catalog.audit_logs ((details ->> 'attempt_id'))
+        WHERE (
+            action = 'arcgis_signin'
+            AND details ->> 'attempt_id' IS NOT NULL
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP INDEX IF EXISTS catalog.{_INDEX_NAME}")

--- a/backend/app/modules/audit/models.py
+++ b/backend/app/modules/audit/models.py
@@ -8,6 +8,15 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.db import Base
 
+# fix(#1889): the sign-in settle finaliser's ON CONFLICT names this index, so
+# the key and the predicate are read from here by the model and by the write.
+# Migration 0059 is the source of truth for the DDL.
+ARCGIS_SIGNIN_SETTLE_INDEX = "uq_audit_logs_arcgis_signin_attempt"
+ARCGIS_SIGNIN_SETTLE_KEY = "(details ->> 'attempt_id')"
+ARCGIS_SIGNIN_SETTLE_WHERE = (
+    "action = 'arcgis_signin' AND details ->> 'attempt_id' IS NOT NULL"
+)
+
 if TYPE_CHECKING:
     from app.modules.auth.models import User
 
@@ -55,6 +64,12 @@ class AuditLog(Base):
             postgresql_where=text(
                 "action = 'embedding.backfill' AND details ->> 'outcome' <> 'requested'"
             ),
+        ),
+        Index(
+            ARCGIS_SIGNIN_SETTLE_INDEX,
+            text(ARCGIS_SIGNIN_SETTLE_KEY),
+            unique=True,
+            postgresql_where=text(ARCGIS_SIGNIN_SETTLE_WHERE),
         ),
         {"schema": "catalog"},
     )

--- a/backend/app/modules/audit/service.py
+++ b/backend/app/modules/audit/service.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import aliased, joinedload
 from app.platform.audit import (
     AuditEvent,
     audit_emit,
+    extension_audit_sinks,
 )  # re-exported for ergonomic single-import
 from app.modules.audit.models import AuditLog
 from app.core.text import escape_ilike
@@ -20,6 +21,7 @@ __all__ = [
     "AuditEvent",
     "audit_emit",
     "audit_emit_durable",
+    "extension_audit_sinks",
     "log_action",
     "query_audit_logs",
     "query_column_ddl_history",

--- a/backend/app/modules/catalog/sources/signin_guard.py
+++ b/backend/app/modules/catalog/sources/signin_guard.py
@@ -37,9 +37,14 @@ from typing import NoReturn
 import structlog
 from fastapi import HTTPException, status
 from sqlalchemy import delete, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.modules.audit.models import AuditLog
+from app.modules.audit.models import (
+    ARCGIS_SIGNIN_SETTLE_KEY,
+    ARCGIS_SIGNIN_SETTLE_WHERE,
+    AuditLog,
+)
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.modules.catalog.sources.arcgis_signin import (
     AUDIT_CONCURRENT,
@@ -101,6 +106,44 @@ def signin_target(user_id: uuid.UUID, host: str, username: str) -> SignInTarget:
     )
 
 
+def _signin_event(
+    user_id: uuid.UUID,
+    target: SignInTarget,
+    result: str,
+    note: str | None = None,
+    *,
+    attempt_id: uuid.UUID | None = None,
+) -> AuditEvent:
+    """The audit event for one sign-in outcome, the same row from every writer.
+
+    The token-service HOST rather than the portal URL, and a keyed digest
+    rather than the username: an audit row is read by an operator looking for
+    someone walking accounts, and the host, the digest and the outcome are the
+    whole of that signal. ``result`` carries the distinction the caller-facing
+    message deliberately collapses.
+    """
+    return AuditEvent(
+        user_id=user_id,
+        action="arcgis_signin",
+        resource_type="service_url",
+        details={
+            # fix(#1758): the DESTINATION host from authInfo.tokenServicesUrl,
+            # which the limits are keyed on, never the address the caller typed.
+            "token_service_host": target.host,
+            "result": result,
+            # fix(#1758): a keyed digest of the target account, never the
+            # username; the only trace of which account was addressed.
+            "account_key": target.account_key,
+            # fix(#1825): the reservation this outcome settles; nothing else
+            # tells a retry of one attempt from a second attempt.
+            **({"attempt_id": str(attempt_id)} if attempt_id else {}),
+            # fix(#1758): present only when discovery turned up something an
+            # operator should see, so the common row keeps its shape.
+            **({"discovery_note": note} if note else {}),
+        },
+    )
+
+
 async def _signin_audit(
     db: AsyncSession,
     user_id: uuid.UUID,
@@ -111,13 +154,7 @@ async def _signin_audit(
     reserved: bool = False,
     attempt_id: uuid.UUID | None = None,
 ) -> None:
-    """Record one sign-in attempt: who, which portal, which account, what happened.
-
-    The token-service HOST rather than the portal URL, and a keyed digest
-    rather than the username: an audit row is read by an operator looking for someone walking
-    accounts, and the host, the digest and the outcome are the whole of that
-    signal. ``result`` carries the distinction the caller-facing message
-    deliberately collapses.
+    """Record one sign-in attempt on the caller's session and commit it.
 
     fix(#1775): ``reserved`` says the ledger row for this attempt was already
     committed by :func:`_signin_reserve` before the credential POST, so this
@@ -128,33 +165,7 @@ async def _signin_audit(
     "a new outcome counts until somebody decides otherwise" property.
     """
     await audit_emit(
-        db,
-        AuditEvent(
-            user_id=user_id,
-            action="arcgis_signin",
-            resource_type="service_url",
-            details={
-                # fix(#1758 codex r7): the DESTINATION host, resolved from
-                # authInfo.tokenServicesUrl, not the address the caller typed.
-                # That is what the limits are keyed on, so that is what an
-                # operator reading this row needs to see.
-                "token_service_host": target.host,
-                "result": result,
-                # fix(#1758 codex r3): a keyed digest of the target account,
-                # never the username. It is what both budgets below are
-                # counted on, and it is the only trace of which ArcGIS account
-                # was addressed that survives the request.
-                "account_key": target.account_key,
-                # fix(#1825 codex r1): the reservation this outcome settles.
-                # Nothing else links the two, so nothing else can tell a
-                # retry of one attempt from a second attempt.
-                **({"attempt_id": str(attempt_id)} if attempt_id else {}),
-                # fix(#1758 codex r9): present only when discovery turned up
-                # something an operator should see, so the common row keeps
-                # its shape.
-                **({"discovery_note": note} if note else {}),
-            },
-        ),
+        db, _signin_event(user_id, target, result, note, attempt_id=attempt_id)
     )
     if not reserved and result not in UNCOUNTED_SIGNIN_RESULTS:
         # fix(#1758 codex r4): both budgets' own copy, in the one table that is
@@ -350,23 +361,6 @@ async def _signin_reserve(
     return reservation_id
 
 
-async def _settled_already(session: AsyncSession, attempt_id: uuid.UUID) -> bool:
-    """Whether this reservation already has its audit row.
-
-    fix(#1825): an interrupted commit is ambiguous, so the finaliser looks
-    before it writes or one attempt ends up with two rows.
-    """
-    found = await session.scalar(
-        select(AuditLog.id)
-        .where(
-            AuditLog.action == "arcgis_signin",
-            AuditLog.details["attempt_id"].astext == str(attempt_id),
-        )
-        .limit(1)
-    )
-    return found is not None
-
-
 async def _write_settled_outcome(
     user_id: uuid.UUID,
     target: SignInTarget,
@@ -374,32 +368,45 @@ async def _write_settled_outcome(
     note: str | None = None,
     attempt_id: uuid.UUID | None = None,
 ) -> None:
-    """Write one settled attempt's audit row on a session of its OWN.
+    """Write one settled attempt's audit row on a session of its OWN, at most once.
 
-    fix(#1775 audit): NOT the request's session. The caller below stops
-    waiting at a deadline and the route then re-raises, so FastAPI runs
-    ``get_db``'s teardown and closes the request session — which, if this
-    write were still in flight on it, closes the connection out from under a
-    live statement and turns a lost audit row into an ``InterfaceError`` or a
-    greenlet error on a shutting-down worker. A session this coroutine opens
-    and closes in its own frame cannot be closed by anybody else, so the
-    abandoned case is a task that finishes quietly rather than one that
-    faults.
+    fix(#1775 audit): NOT the request's session. The caller stops waiting at a
+    deadline and the route then re-raises, so FastAPI closes the request
+    session, which would close a connection under a statement still running.
+
+    fix(#1889): one INSERT, arbitrated by ``uq_audit_logs_arcgis_signin_attempt``,
+    that does nothing when a row already carries this ``attempt_id``. A commit
+    the cancellation interrupted can land at any point without a second row.
+
+    Only the ``audit_logs`` row is recovered. No other audit sink is dispatched
+    again: every sink ran before the commit was interrupted.
 
     Late-bound import, per the rule ``test_layering.py`` enforces (fix(#909)):
     a module-scope binding snapshots the dev-DB factory before the test
     fixture rebinds ``app.core.db.async_session``.
     """
+    # `text` is imported here for the reason `_signin_locks` gives.
+    from sqlalchemy import text
+
     from app.core.db import async_session
 
-    async with async_session() as session:
-        if attempt_id is not None and await _settled_already(session, attempt_id):
-            return
-        # `reserved=True` unconditionally: every caller of this reaches it
-        # after `_signin_reserve` committed, so the ledger row already exists.
-        await _signin_audit(
-            session, user_id, target, result, note, reserved=True, attempt_id=attempt_id
+    event = _signin_event(user_id, target, result, note, attempt_id=attempt_id)
+    settle = (
+        pg_insert(AuditLog)
+        .values(
+            user_id=event.user_id,
+            action=event.action,
+            resource_type=event.resource_type,
+            details=event.details,
         )
+        .on_conflict_do_nothing(
+            index_elements=[text(ARCGIS_SIGNIN_SETTLE_KEY)],
+            index_where=text(ARCGIS_SIGNIN_SETTLE_WHERE),
+        )
+    )
+    async with async_session() as session:
+        await session.execute(settle)
+        await session.commit()
 
 
 def _settle_failure(settle: asyncio.Future) -> str | None:

--- a/backend/app/modules/catalog/sources/signin_guard.py
+++ b/backend/app/modules/catalog/sources/signin_guard.py
@@ -36,7 +36,7 @@ from typing import NoReturn
 
 import structlog
 from fastapi import HTTPException, status
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -45,7 +45,7 @@ from app.modules.audit.models import (
     ARCGIS_SIGNIN_SETTLE_WHERE,
     AuditLog,
 )
-from app.modules.audit.service import AuditEvent, audit_emit
+from app.modules.audit.service import AuditEvent, audit_emit, extension_audit_sinks
 from app.modules.catalog.sources.arcgis_signin import (
     AUDIT_CONCURRENT,
     AUDIT_RATE_LIMITED,
@@ -367,8 +367,11 @@ async def _write_settled_outcome(
     result: str,
     note: str | None = None,
     attempt_id: uuid.UUID | None = None,
-) -> None:
+) -> AuditEvent | None:
     """Write one settled attempt's audit row on a session of its OWN, at most once.
+
+    Returns the event when this call wrote the row, and ``None`` when a row
+    already carried this ``attempt_id``: the interrupted commit had landed.
 
     fix(#1775 audit): NOT the request's session. The caller stops waiting at a
     deadline and the route then re-raises, so FastAPI closes the request
@@ -378,16 +381,13 @@ async def _write_settled_outcome(
     that does nothing when a row already carries this ``attempt_id``. A commit
     the cancellation interrupted can land at any point without a second row.
 
-    Only the ``audit_logs`` row is recovered. No other audit sink is dispatched
-    again: every sink ran before the commit was interrupted.
+    Only the ``audit_logs`` row is written here. A written outcome still has to
+    reach every other registered sink; :func:`_forward_settled_outcome` does.
 
     Late-bound import, per the rule ``test_layering.py`` enforces (fix(#909)):
     a module-scope binding snapshots the dev-DB factory before the test
     fixture rebinds ``app.core.db.async_session``.
     """
-    # `text` is imported here for the reason `_signin_locks` gives.
-    from sqlalchemy import text
-
     from app.core.db import async_session
 
     event = _signin_event(user_id, target, result, note, attempt_id=attempt_id)
@@ -405,7 +405,24 @@ async def _write_settled_outcome(
         )
     )
     async with async_session() as session:
-        await session.execute(settle)
+        inserted = (await session.execute(settle)).rowcount == 1
+        await session.commit()
+    return event if inserted else None
+
+
+async def _forward_settled_outcome(event: AuditEvent, sinks: list) -> None:
+    """Hand a written outcome to every registered sink except the ``audit_logs`` one.
+
+    fix(#1889): a cancel can land while the ``audit_logs`` sink is still on its
+    round trips and before a later sink ran, so a written row is no proof the
+    others heard it. At-least-once for them, keyed on ``attempt_id``.
+
+    Late-bound import, for the reason :func:`_write_settled_outcome` gives.
+    """
+    from app.core.db import async_session
+
+    async with async_session() as session:
+        await audit_emit(session, event, sinks=sinks)
         await session.commit()
 
 
@@ -475,10 +492,12 @@ async def _signin_settle_shielded(
     *release* is the request's session, rolled back first so this write does
     not queue behind a connection FastAPI has not torn down yet. *attempt_id*
     is the reservation, and a row already carrying it means an interrupted
-    commit landed after all, so nothing is written.
+    commit landed after all, so nothing is written. A row written here is
+    then handed to every other registered sink.
 
     Everything runs under one ceiling. A rollback that cannot finish spends
-    it, and the write is then abandoned with a warning.
+    it, and the write is then abandoned with a warning; a sink that cannot
+    finish is cut off with the row already durable, and says so.
     """
     loop = asyncio.get_running_loop()
     deadline = loop.time() + _SETTLE_DRAIN_SECONDS
@@ -499,6 +518,19 @@ async def _signin_settle_shielded(
         # hold a request whose encoded body is the password.
         logger.warning(
             "ArcGIS sign-in cancelled before its outcome could be recorded",
+            token_service_host=target.host,
+            error_type=failure,
+        )
+        return
+    written = settle.result()
+    sinks = extension_audit_sinks()
+    if written is None or not sinks:
+        return
+    forward = await _drain_shielded(_forward_settled_outcome(written, sinks), deadline)
+    failure = _settle_failure(forward)
+    if failure is not None:
+        logger.warning(
+            "ArcGIS sign-in outcome recorded but not forwarded to every audit sink",
             token_service_host=target.host,
             error_type=failure,
         )
@@ -542,11 +574,6 @@ async def _signin_locks(
     Both are TRY-locks: a busy scope answers immediately rather than queuing,
     so a caller never waits on another caller's portal round trip.
     """
-    # Imported here rather than at module scope: `_is_sensitive_connector_key`
-    # in router.py binds `text` as a local name, and a module-level import of
-    # the same word reads like a shadowing bug to everyone who meets it later.
-    from sqlalchemy import text
-
     for scope in (user_scope, account_scope):
         held = await db.execute(
             text("SELECT pg_try_advisory_xact_lock(hashtextextended(:lock_key, 0))"),

--- a/backend/app/platform/audit.py
+++ b/backend/app/platform/audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging_config import redact_nested
 from app.platform.extensions import get_audit_sinks
+from app.platform.extensions.defaults_extensions import DefaultAuditSink
 
 if TYPE_CHECKING:
     from app.platform.extensions.protocols import AuditSink
@@ -73,8 +75,27 @@ def _event_fields(event: AuditEvent) -> dict:
     }
 
 
-async def audit_emit(session: AsyncSession, event: AuditEvent) -> None:
+def extension_audit_sinks() -> list["AuditSink"]:
+    """Every registered sink except the one that writes ``audit_logs``.
+
+    For a caller that has written that row itself and needs the other sinks
+    to receive the same event.
+    """
+    return [
+        sink for sink in get_audit_sinks() if not isinstance(sink, DefaultAuditSink)
+    ]
+
+
+async def audit_emit(
+    session: AsyncSession,
+    event: AuditEvent,
+    *,
+    sinks: Sequence["AuditSink"] | None = None,
+) -> None:
     """Dispatch an audit event to every registered sink with failure isolation.
+
+    ``sinks`` narrows the dispatch to the given sinks; by default every
+    registered sink receives the event.
 
     AUDIT-03's contract is that an audit sink must never break the operation it
     records. The try/except below is only half of that: the default sink's
@@ -97,7 +118,7 @@ async def audit_emit(session: AsyncSession, event: AuditEvent) -> None:
     * Each event costs a SAVEPOINT / INSERT / RELEASE round trip that used to
       ride along with the caller's commit.
     """
-    sinks = get_audit_sinks()
+    sinks = get_audit_sinks() if sinks is None else list(sinks)
     if not sinks:
         return
 

--- a/backend/tests/test_arcgis_signin.py
+++ b/backend/tests/test_arcgis_signin.py
@@ -3164,12 +3164,13 @@ class _ListHandler(logging.Handler):
         self.lines.append(self.format(record))
 
 
-async def _post_with_captured_logs(client, headers, body) -> tuple[object, list[str]]:
-    """Run one sign-in through the real logging pipeline and keep every line.
+@contextlib.contextmanager
+def _captured_lines():
+    """Every rendered log line emitted inside the block.
 
-    ``caplog`` sees zero structlog records in this repo, so this attaches an
-    explicit handler to the stdlib root logger and gives it the formatter
-    ``setup_logging()`` installed, exactly as the #1746 redaction tests do.
+    ``caplog`` sees zero structlog records in this repo, so this attaches a
+    handler to the stdlib root logger with the formatter ``setup_logging()``
+    installed.
     """
     with configured_logging(json_logs=True, log_level="DEBUG", production=True):
         root = logging.getLogger()
@@ -3177,10 +3178,16 @@ async def _post_with_captured_logs(client, headers, body) -> tuple[object, list[
         capture.setFormatter(root.handlers[0].formatter)
         root.addHandler(capture)
         try:
-            resp = await client.post(SIGNIN_URL, json=body, headers=headers)
+            yield capture.lines
         finally:
             root.removeHandler(capture)
-    return resp, capture.lines
+
+
+async def _post_with_captured_logs(client, headers, body) -> tuple[object, list[str]]:
+    """Run one sign-in with every rendered log line kept."""
+    with _captured_lines() as lines:
+        resp = await client.post(SIGNIN_URL, json=body, headers=headers)
+    return resp, lines
 
 
 async def test_a_successful_signin_leaks_nothing_into_logs_or_the_audit_row(
@@ -3608,20 +3615,6 @@ async def test_a_flush_cancelled_before_its_commit_is_written_once(
     await _assert_one_row(test_db_session, result)
 
 
-@contextlib.contextmanager
-def _captured_lines():
-    """Every rendered log line emitted inside the block; see ``_ListHandler``."""
-    with configured_logging(json_logs=True, log_level="DEBUG", production=True):
-        root = logging.getLogger()
-        capture = _ListHandler()
-        capture.setFormatter(root.handlers[0].formatter)
-        root.addHandler(capture)
-        try:
-            yield capture.lines
-        finally:
-            root.removeHandler(capture)
-
-
 @pytest.mark.parametrize("result", ["success", "invalid_credentials"])
 async def test_a_commit_landing_during_the_finaliser_leaves_one_row(
     client: AsyncClient,
@@ -3685,3 +3678,79 @@ async def test_a_commit_landing_during_the_finaliser_leaves_one_row(
     assert lines, "the capture handler saw nothing, so it proves nothing"
     refused = [line for line in lines if "Audit sink raised" in line]
     assert refused == [], "the finaliser's write was refused rather than a no-op"
+
+
+class _RecordingSink:
+    """An audit sink that keeps every event it is handed."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    async def emit(self, session, event) -> None:
+        self.events.append(event)
+
+
+@contextlib.contextmanager
+def _registered_sinks(*sinks):
+    """Swap the registered audit sinks for the block."""
+    from app.platform.extensions import _extensions
+
+    saved = _extensions.get("audit_sinks")
+    _extensions["audit_sinks"] = list(sinks)
+    try:
+        yield
+    finally:
+        if saved is None:
+            _extensions.pop("audit_sinks", None)
+        else:
+            _extensions["audit_sinks"] = saved
+
+
+@pytest.mark.parametrize("landed", [True, False], ids=["landed", "unlanded"])
+async def test_every_other_sink_hears_a_recovered_outcome_exactly_once(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    allow_ssrf,
+    test_db_session,
+    monkeypatch,
+    landed: bool,
+):
+    """fix(#1889): a registered sink beyond ``audit_logs`` sees the outcome once.
+
+    Landed: the request committed through every sink, so the finaliser must
+    not forward. Unlanded: the cancel arrived after the ``audit_logs`` sink
+    flushed and before the next sink ran, so the finaliser must.
+    """
+    from app.platform.extensions.defaults import DefaultAuditSink
+
+    real_audit = signin_guard._signin_audit
+    entered = asyncio.Event()
+    never = asyncio.Event()
+    calls: list[int] = []
+
+    async def _first_write(db, user_id, target, outcome, note=None, **kwargs):
+        calls.append(1)
+        if len(calls) > 1:
+            return await real_audit(db, user_id, target, outcome, note, **kwargs)
+        if landed:
+            await real_audit(db, user_id, target, outcome, note, **kwargs)
+        else:
+            event = signin_guard._signin_event(
+                user_id, target, outcome, note, attempt_id=kwargs["attempt_id"]
+            )
+            await signin_guard.audit_emit(db, event, sinks=[DefaultAuditSink()])
+        entered.set()
+        await never.wait()
+        raise AssertionError("unreachable: the wait above is never released")
+
+    monkeypatch.setattr(signin_guard, "_signin_audit", _first_write)
+    monkeypatch.setattr(sources_router, "_signin_audit", _first_write)
+    sink = _RecordingSink()
+    with _registered_sinks(DefaultAuditSink(), sink):
+        await _drive_and_cancel(
+            client, admin_auth_header, _settle_exchange("success"), entered
+        )
+
+    await _assert_one_row(test_db_session, "success")
+    (row,) = await _audit_rows(test_db_session)
+    assert [event.details for event in sink.events] == [row.details]

--- a/backend/tests/test_arcgis_signin.py
+++ b/backend/tests/test_arcgis_signin.py
@@ -2389,12 +2389,11 @@ async def test_a_settle_that_outruns_the_drain_still_leaves_cancellederror(
         await never.wait()
         raise AssertionError("unreachable: the wait above is never released")
 
-    async def _hanging_audit(*_args, **_kwargs):
-        # Far longer than the ceiling, and on the settle's OWN session, so
-        # abandoning it cannot fault against the request session.
+    async def _hanging_write(*_args, **_kwargs):
+        # Far longer than the ceiling: the settle write has stopped answering.
         await asyncio.sleep(30)
 
-    monkeypatch.setattr(signin_guard, "_signin_audit", _hanging_audit)
+    monkeypatch.setattr(signin_guard, "_write_settled_outcome", _hanging_write)
 
     exchange = _Exchange(
         {
@@ -3330,7 +3329,7 @@ async def test_a_portal_url_carrying_credentials_is_refused(
 
 
 async def _cancel_the_first_audit(monkeypatch, entered, never):
-    """Hang the first settle write; delegate the finaliser's own to the real one.
+    """Hang the first settle write; any later call reaches the real one.
 
     Both bindings: the success settle reaches the helper through the router's
     import, the refusal settle through signin_guard's own global.
@@ -3548,7 +3547,7 @@ async def test_a_commit_that_landed_before_the_cancellation_is_not_written_twice
     """fix(#1825): an interrupted commit is ambiguous, not failed.
 
     PostgreSQL can apply the commit while the client sees `CancelledError`, so
-    the finaliser looks for this reservation before writing.
+    the finaliser's write is arbitrated on this reservation and does nothing.
     """
     real_audit = signin_guard._signin_audit
     committed = asyncio.Event()
@@ -3607,3 +3606,82 @@ async def test_a_flush_cancelled_before_its_commit_is_written_once(
         client, admin_auth_header, _settle_exchange(result), flushed
     )
     await _assert_one_row(test_db_session, result)
+
+
+@contextlib.contextmanager
+def _captured_lines():
+    """Every rendered log line emitted inside the block; see ``_ListHandler``."""
+    with configured_logging(json_logs=True, log_level="DEBUG", production=True):
+        root = logging.getLogger()
+        capture = _ListHandler()
+        capture.setFormatter(root.handlers[0].formatter)
+        root.addHandler(capture)
+        try:
+            yield capture.lines
+        finally:
+            root.removeHandler(capture)
+
+
+@pytest.mark.parametrize("result", ["success", "invalid_credentials"])
+async def test_a_commit_landing_during_the_finaliser_leaves_one_row(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    allow_ssrf,
+    test_db_session,
+    monkeypatch,
+    result: str,
+):
+    """fix(#1889): one row when the interrupted commit lands during the finaliser.
+
+    The request's row is staged on a connection of its own and committed the
+    moment the finaliser's INSERT goes on the wire: visible after any read the
+    finaliser could have done, and before its write is decided.
+    """
+    import app.core.db as core_db
+    from sqlalchemy import event as sa_event
+
+    real_audit = signin_guard._signin_audit
+    late = core_db.async_session()
+    staged = asyncio.Event()
+    never = asyncio.Event()
+    calls: list[int] = []
+    armed: list[bool] = []
+    landing: list[asyncio.Future] = []
+
+    async def _stage_elsewhere(db, user_id, target, outcome, note=None, **kwargs):
+        calls.append(1)
+        if len(calls) > 1:
+            return await real_audit(db, user_id, target, outcome, note, **kwargs)
+        event = signin_guard._signin_event(
+            user_id, target, outcome, note, attempt_id=kwargs["attempt_id"]
+        )
+        await signin_guard.audit_emit(late, event)
+        armed.append(True)
+        staged.set()
+        await never.wait()
+        raise AssertionError("unreachable: the wait above is never released")
+
+    def _land_on_insert(conn, cursor, statement, parameters, context, executemany):
+        if armed and statement.startswith("INSERT INTO catalog.audit_logs"):
+            armed.clear()
+            landing.append(asyncio.ensure_future(late.commit()))
+
+    monkeypatch.setattr(signin_guard, "_signin_audit", _stage_elsewhere)
+    monkeypatch.setattr(sources_router, "_signin_audit", _stage_elsewhere)
+    sync_engine = late.get_bind()
+    sa_event.listen(sync_engine, "before_cursor_execute", _land_on_insert)
+    try:
+        with _captured_lines() as lines:
+            await _drive_and_cancel(
+                client, admin_auth_header, _settle_exchange(result), staged
+            )
+        assert landing, "the finaliser never put its INSERT on the wire"
+        await landing[0]
+    finally:
+        sa_event.remove(sync_engine, "before_cursor_execute", _land_on_insert)
+        await late.close()
+
+    await _assert_one_row(test_db_session, result)
+    assert lines, "the capture handler saw nothing, so it proves nothing"
+    refused = [line for line in lines if "Audit sink raised" in line]
+    assert refused == [], "the finaliser's write was refused rather than a no-op"


### PR DESCRIPTION
Fixes the window filed as #1889 off #1887's review round 2. Reproduced on `origin/main` at 56aa03abe before anything changed: the finaliser deduplicated with a read, and nothing in the schema enforced the fact it was reading.

## The window

`_write_settled_outcome` in `signin_guard.py` deduplicated on `details ->> 'attempt_id'` with a SELECT before its INSERT. When a cancellation interrupts an in-flight COMMIT, PostgreSQL can still apply it, and it can become visible after that SELECT finds nothing and before the finaliser commits its own row. `AuditLog.__table_args__` carried no uniqueness on that expression, so both inserts succeeded and one attempt produced two audit rows. #1887's tests cover a commit that had already landed and one that never started, not one landing between the check and the insert.

## The fix

Migration `0059_arcgis_signin_settle_index` adds `uq_audit_logs_arcgis_signin_attempt`, a unique partial index on `catalog.audit_logs ((details ->> 'attempt_id'))` where `action = 'arcgis_signin' AND details ->> 'attempt_id' IS NOT NULL`. That is the discriminator `_signin_audit` writes (`action="arcgis_signin"`, `resource_type="service_url"`); pinning the action means no other audit action is constrained. `attempt_id` is the ledger row's random uuid, so the index needs no tenant column. `AuditLog.__table_args__` mirrors it, and the key expression and the predicate live once, as `ARCGIS_SIGNIN_SETTLE_KEY` and `ARCGIS_SIGNIN_SETTLE_WHERE` on the model module, read by the ORM mirror and by the finaliser's insert.

The finaliser now issues one `INSERT ... ON CONFLICT ((details ->> 'attempt_id')) WHERE <predicate> DO NOTHING` through `sqlalchemy.dialects.postgresql.insert`, and the pre-read `_settled_already` is deleted. A no-op insert means the interrupted commit landed after all, and the finaliser stays silent about it, as it did before. Measured on the dedicated database rather than reasoned: against a conflicting row that is still uncommitted in another transaction, the arbitrated insert blocks until that transaction ends and then returns `INSERT 0 0`; a plain insert blocks the same way and then raises the unique violation.

The audit event a settle writes is built by one helper, `_signin_event`, used by `_signin_audit` and by the finaliser, so the two writers cannot drift on the details they record.

The finaliser writes the `audit_logs` row directly, so the other registered sinks need their own path. A cancel can land while the `audit_logs` sink is still on its round trips (SAVEPOINT, INSERT, RELEASE) and before a later sink such as a SIEM collector has run, so a written row is no proof the others heard the outcome. `_write_settled_outcome` therefore returns the event when it inserted (`rowcount == 1`) and `None` on the no-op, and `_signin_settle_shielded` then drains a second step, `_forward_settled_outcome`, which dispatches that event to every registered sink except `DefaultAuditSink` through `audit_emit`'s new `sinks=` parameter, on a session of its own, after the row is committed, under what is left of the same ceiling. The set of sinks comes from `extension_audit_sinks()` in `platform/audit.py`, and nothing outside that module touches `_emit_isolated`. A sink that cannot finish inside the ceiling is cut off with the row already durable and logged as recorded-but-not-forwarded, a different line from the one that says the row was lost. The result is exactly-once for the `audit_logs` row and at-least-once for the other sinks; a duplicate there carries the same `attempt_id` in `details`, and a missing outcome was the defect. In the community edition the sink list is empty and the step is skipped without opening a session.

## Schema impact

One unique partial index on `catalog.audit_logs`, created plain, following `0051_one_terminal_backfill_audit` on the same table. A plain build takes a SHARE lock on `audit_logs` for one scan of the table; in the compose stack the migrate service completes before the API starts, and on a rolling deploy an audit write from a replica still serving waits for that scan. An instance already holding two settle rows for one attempt fails the build, and that is the loud and correct outcome: it is the state the index exists to prevent, and an operator settles the duplicates first. Main has written `attempt_id` since #1887 merged, so a dev or demo instance that hit the #1887 window before this lands is the one place that can happen; no tagged release writes it. Downgrade drops the index.

No API, config or request/response change; `scripts/dump_openapi.py --check` exits 0.

## Tests

`test_a_commit_landing_during_the_finaliser_leaves_one_row`, parametrised over the success and the refusal path. The row the request was committing is staged on a session of its own and left uncommitted, and the finaliser is driven by cancelling the request from outside. A `before_cursor_execute` listener commits that staged row the moment the finaliser's INSERT goes on the wire, so it becomes visible after any read the finaliser could have done and before its write is decided. The test asserts one audit row, one ledger row, and that no `Audit sink raised; suppressed per AUDIT-03` line was logged, with a liveness half that the capture saw output at all.

That last assertion is the one the counterfactual needs. With the index in place a second row is impossible, so what the old code does on this window is have its INSERT refused by the index inside the audit sink's savepoint, swallowed under AUDIT-03 and logged at error, leaving the settle looking healthy on the return path while the log says the write failed.

`test_every_other_sink_hears_a_recovered_outcome_exactly_once`, parametrised over landed and unlanded. It registers a recording sink after `DefaultAuditSink` in the registry slot. On the landed path the request commits through every sink before the cancel, so the finaliser's no-op must forward nothing; on the unlanded path the request's write is cancelled after the `audit_logs` sink flushed and before the next sink ran, so the finaliser must forward. Both assert one row and that the recording sink holds exactly the row's details once. The unlanded case also pins the `rowcount` gate: had the no-op reported a row, the landed case would see the sink twice.

The drain-outrun test from #1775 hung the write by patching `_signin_audit`, which the finaliser no longer calls; it now hangs `_write_settled_outcome`. Two #1887 test docstrings that described the look-before-write say what the finaliser now does. The two log-capture helpers share one body. Every other test is untouched.

`sqlalchemy.text` is imported at module scope in `signin_guard.py`; the function-scope import carried a pointer to a reason about a local name in `router.py`, which is not this module.

## Verification

From the worktree, against a dedicated database `geolens_m1889` on localhost:5434 created, bootstrapped and migrated for this branch. The shared dev database was not migrated.

```
python -m alembic upgrade head            0058 -> 0059; 0059 -> 0058 -> 0059 round trip clean
python -m alembic check                   No new upgrade operations detected (before and after)
tests/test_arcgis_signin.py -n 4          189 passed
tests/test_layering.py + rule1 + rule2    165 passed
ruff check .                              All checks passed
ruff format --check .                     1177 files already formatted
scripts/dump_openapi.py --check           exit 0
```

Counterfactual, reverting only the conflict-safe insert (pre-read and `_signin_audit` call restored; index, helper and test kept), both parametrised cases:

```
AssertionError: the finaliser's write was refused rather than a no-op
assert ['{"sink": "DefaultAuditSink", ... "event": "Audit sink raised; suppressed per AUDIT-03", ...
        UniqueViolationError: duplicate key value violates unique constraint "uq_audit_logs_arcgis_signin_attempt" ...'] == []
```

Counterfactual for the sink test, disabling only the forward step (index, arbitrated insert and both tests kept):

```
FAILED test_every_other_sink_hears_a_recovered_outcome_exactly_once[unlanded]
AssertionError: assert [] == [{'result': 'success', 'attempt_id': '95b8c3fc-...', ...}]
PASSED test_every_other_sink_hears_a_recovered_outcome_exactly_once[landed]
```

No LOC cap moved: `signin_guard.py` and `test_arcgis_signin.py` are not in `_MODULE_LOC_CAPS`, and `router.py` is untouched.
