### PR TITLE
fix(scripts): refuse a .env that docker compose cannot load, by line (#1899)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,7 +84,7 @@ needs the `upload` and `export` capabilities on the seeding account.
 | Script | Purpose |
 |--------|---------|
 | `install.sh` | First-run installer (see below) |
-| `preflight-env.sh` | Validate the boot-required settings (JWT secret, admin creds, encryption key shape) as Compose will resolve them, shell environment first and then `.env`, via `make preflight` / `make dev` |
+| `preflight-env.sh` | Refuse a `.env` line Compose cannot load, then validate the boot-required settings (JWT secret, admin creds, encryption key shape) as Compose will resolve them, shell environment first and then `.env`, via `make preflight` / `make dev` |
 | `check-env.sh` | Probe the running stack's env, DB connectivity, and GDAL via `make doctor` (requires the stack up) |
 | `init-db.sh` | Initialize the PostGIS database schema (mounted into the db container's init) |
 | `init-test-db.sh` | Initialize a host-accessible `geolens_test` database (extensions, schemas, roles) for local `psql` debugging. Not used by CI. CI and pytest each bootstrap their own test databases. |

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1582,8 +1582,12 @@ get_env_value() {
   # blind to `export`/bare-key/CRLF/whitespace-around-`=` lines (P2 #2 and
   # the rest of this round's grammar sweep — see _env_tokenize's own doc
   # comment for the full list, each verified against the oracle).
-  _gev_records="$(_env_tokenize "$file")" || return 1
-  _env_select_record "$_gev_records" "$key" 0
+  # fix(#1899): BEFORE ($3, default 0) keeps only records that start before
+  # that line, as _env_select_record does; RECORDS ($4) is _env_tokenize's
+  # stream for FILE when the caller already holds it, so FILE is read once.
+  _gev_records="${4:-}"
+  [ -n "$_gev_records" ] || _gev_records="$(_env_tokenize "$file")" || return 1
+  _env_select_record "$_gev_records" "$key" "${3:-0}"
   case "$_esr_found" in
     0) return 1 ;;
     2) return 1 ;;
@@ -1795,6 +1799,83 @@ effective_env_value_into() {
     return 0
   fi
   [ "$_eevi_in_file" -eq 1 ]
+}
+
+# fix(#1899): prints "LINE KEY REASON" for the first line of FILE that Compose
+# refuses to load (whitespace-in-key, unexpected-character, unterminated-quote
+# or unresolvable) with rc 0; rc 1 and no output when every line loads.
+env_file_first_refused_line() {
+  _efrl_file="$1"
+  [ -f "$_efrl_file" ] || return 1
+  _efrl_records="$(_env_tokenize "$_efrl_file")" || return 1
+
+  # Compose's parse phase: a key ends at `=` or `:`, holds letters, digits,
+  # `_.-[]` or a tab, never a space; a multiline value's continuation lines
+  # are exempt; bytes above 0x7f pass. ENVIRON carries the records, -v cannot.
+  _efrl_hit="$(_EFRL_RECORDS="$_efrl_records" LC_ALL=C awk '
+    BEGIN {
+      n = split(ENVIRON["_EFRL_RECORDS"], r, "\n")
+      for (i = 1; i <= n; i++) {
+        split(r[i], f, " ")
+        if (f[1] != "" && f[1] != "B" && f[3] > f[2]) { m++; lo[m] = f[2] + 1; hi[m] = f[3] }
+      }
+    }
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      if (NR == 1 && substr(line, 1, 3) == "\357\273\277") line = substr(line, 4)
+      sub(/^[ \t]+/, "", line)
+      if (line == "" || substr(line, 1, 1) == "#") next
+      for (i = 1; i <= m; i++) if (NR >= lo[i] && NR <= hi[i]) next
+      sub(/^export[ \t]+/, "", line)
+      key = line
+      if (match(key, /[=:]/)) key = substr(key, 1, RSTART - 1)
+      sub(/[ \t]+$/, "", key)
+      name = key
+      sub("[ \t#\"$].*$", "", name)
+      if (name == "") name = "?"
+      if (index(key, " ") > 0) { print NR, name, "whitespace-in-key"; exit }
+      bad = key
+      gsub(/[]A-Za-z0-9_.[\t-]/, "", bad)
+      for (j = 1; j <= length(bad); j++) {
+        if (substr(bad, j, 1) < "\200") { print NR, name, "unexpected-character"; exit }
+      }
+    }' "$_efrl_file")" || fail "env_file_first_refused_line: could not scan $_efrl_file"
+  if [ -n "$_efrl_hit" ]; then
+    printf '%s' "$_efrl_hit"
+    return 0
+  fi
+
+  _efrl_hit="$(printf '%s' "$_efrl_records" | awk '$1 == "U" { print $2, $4, "unterminated-quote"; exit }')" \
+    || fail "env_file_first_refused_line: could not scan the records of $_efrl_file"
+  if [ -n "$_efrl_hit" ]; then
+    printf '%s' "$_efrl_hit"
+    return 0
+  fi
+
+  # Compose's interpolation phase. Only a value holding `$` can fail it, so
+  # only those records are resolved, each bounded by its own start line.
+  _efrl_list="$(_EFRL_RECORDS="$_efrl_records" LC_ALL=C awk '
+    BEGIN {
+      n = split(ENVIRON["_EFRL_RECORDS"], r, "\n")
+      for (i = 1; i <= n; i++) {
+        split(r[i], f, " ")
+        if (f[1] == "A") { m++; lo[m] = f[2]; hi[m] = f[3]; key[m] = f[4] }
+      }
+    }
+    index($0, "$") > 0 { for (i = 1; i <= m; i++) if (NR >= lo[i] && NR <= hi[i]) seen[i] = 1 }
+    END { for (i = 1; i <= m; i++) if (seen[i]) print lo[i], key[i] }' "$_efrl_file")" \
+    || fail "env_file_first_refused_line: could not scan the values of $_efrl_file"
+  _efrl_hit="$(printf '%s\n' "$_efrl_list" | while read -r _efrl_start _efrl_key; do
+      [ -n "$_efrl_start" ] || continue
+      get_env_value "$_efrl_key" "$_efrl_file" "$((_efrl_start + 1))" "$_efrl_records" >/dev/null 2>&1 \
+        || { printf '%s %s unresolvable' "$_efrl_start" "$_efrl_key"; break; }
+    done)"
+  if [ -n "$_efrl_hit" ]; then
+    printf '%s' "$_efrl_hit"
+    return 0
+  fi
+  return 1
 }
 
 # Replace `KEY=...` in .env (or append if missing). Pass the value via ENVIRON

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -618,9 +618,11 @@ _env_parse_assignment_line() {
       ;;
   esac
 
+  # fix(#1899): Compose's key grammar: letters, digits and `_.-[]`, ended by
+  # `=` or `:`; whitespace ends the scan too and the parse phase judges it.
   _epa_first="${_epa_s%"${_epa_s#?}"}"
   case "$_epa_first" in
-    [A-Za-z_]) : ;;
+    []A-Za-z0-9_.[-]) : ;;
     *) return 0 ;;
   esac
 
@@ -628,15 +630,15 @@ _env_parse_assignment_line() {
   while [ -n "$_epa_scan" ]; do
     _epa_c="${_epa_scan%"${_epa_scan#?}"}"
     case "$_epa_c" in
-      [A-Za-z0-9_]) _epa_key="${_epa_key}${_epa_c}"; _epa_scan="${_epa_scan#?}" ;;
+      []A-Za-z0-9_.[-]) _epa_key="${_epa_key}${_epa_c}"; _epa_scan="${_epa_scan#?}" ;;
       *) break ;;
     esac
   done
 
   _epa_scan="$(_env_lstrip_ws "$_epa_scan")"
   case "$_epa_scan" in
-    "="*)
-      _epa_value="$(_env_lstrip_ws "${_epa_scan#=}")"
+    "="*|":"*)
+      _epa_value="$(_env_lstrip_ws "${_epa_scan#?}")"
       _epa_bare=0
       ;;
     *)
@@ -771,15 +773,14 @@ _env_select_record() {
         ;;
     esac
     [ -n "$_esr_rec" ] || continue
-    # shellcheck disable=SC2086  # deliberate word-splitting: _esr_rec is
-    # this function's own machine-generated "TYPE START END KEY" record
-    # (from _env_tokenize), never glob-special, exactly 4 space-separated
-    # fields -- quoting it would parse it as ONE field instead of four.
-    set -- $_esr_rec
-    _esr_rtype="$1"
-    _esr_rstart="$2"
-    _esr_rend="$3"
-    _esr_rkey="$4"
+    # fix(#1899): a key may hold `[` or `]`, which glob under an unquoted
+    # expansion, so the "TYPE START END KEY" record is split by expansion.
+    _esr_rtype="${_esr_rec%% *}"
+    _esr_rest="${_esr_rec#* }"
+    _esr_rstart="${_esr_rest%% *}"
+    _esr_rest="${_esr_rest#* }"
+    _esr_rend="${_esr_rest%% *}"
+    _esr_rkey="${_esr_rest#* }"
     if [ "$_esr_rkey" = "$_esr_key" ] && { [ "$_esr_before" = "0" ] || [ "$_esr_rstart" -lt "$_esr_before" ]; }; then
       _esr_type="$_esr_rtype"
       _esr_start="$_esr_rstart"

--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -18,6 +18,9 @@
 # Each value is read the way Compose resolves it: from the exported
 # environment when that sets the name (even to an empty string), else .env.
 #
+# The whole file is checked first: a line Compose cannot load stops
+# `docker compose up` whatever key it holds, so it is refused here by line.
+#
 # Run automatically by `make dev` unless SKIP_PREFLIGHT=1.
 
 set -euo pipefail
@@ -57,29 +60,41 @@ value_source() {
     fi
 }
 
-# fix(#1886): a line Compose cannot load stops `docker compose up` before any
-# override applies, so it is refused here whether or not $1 is exported.
-refuse_unloadable_line() {
+# fix(#1899): Compose loads every line of .env before anything else, so the
+# whole file is checked first and the first line it would refuse is named.
+check_env_file() {
+    local hit why
+    hit="$(env_file_first_refused_line "$ENV_FILE")" || return 0
+    # shellcheck disable=SC2086  # "LINE KEY REASON", none of which holds whitespace
+    set -- $hit
+    case "$3" in
+        whitespace-in-key) why="its key contains a space" ;;
+        unexpected-character) why="its key contains a character docker compose does not allow" ;;
+        unterminated-quote) why="its quoted value never closes" ;;
+        *) why="a \${NAME:?message} reference names a NAME that is not set, or a \${ never closes" ;;
+    esac
     cat >&2 <<EOF
-Pre-flight: the $1 line in .env cannot be loaded by docker compose.
+Pre-flight: .env line $1 ($2) cannot be loaded by docker compose: $why.
 
 Compose reads every line of .env before it applies your shell environment, so
-an unterminated quote, or a \${NAME:?message} reference to a NAME that is not
-set, stops \`docker compose up\` on this line even when $1 is exported. Fix or
-remove the line in .env.
+\`docker compose up\` stops on this line even if the key is not one GeoLens
+reads. Fix or remove the line in .env.
 EOF
     exit 1
 }
 
-# Sets \`value\` to what Compose will pass for $1, or refuses the .env line.
+# Sets \`value\` to what Compose will pass for $1. rc 2 (a line Compose
+# refuses) cannot occur once check_env_file has passed; it re-runs the check.
 read_effective() {
     value=""
     rc=0
     effective_env_value_into value "$1" "$ENV_FILE" || rc=$?
     if [ "$rc" -eq 2 ]; then
-        refuse_unloadable_line "$1"
+        check_env_file
     fi
 }
+
+check_env_file
 
 REQUIRED=(JWT_SECRET_KEY GEOLENS_ADMIN_USERNAME GEOLENS_ADMIN_PASSWORD)
 MISSING=()

--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -63,18 +63,21 @@ value_source() {
 # fix(#1899): Compose loads every line of .env before anything else, so the
 # whole file is checked first and the first line it would refuse is named.
 check_env_file() {
-    local hit why
+    local hit line key reason why
     hit="$(env_file_first_refused_line "$ENV_FILE")" || return 0
-    # shellcheck disable=SC2086  # "LINE KEY REASON", none of which holds whitespace
-    set -- $hit
-    case "$3" in
+    # "LINE KEY REASON", split by expansion: a key may hold `[`, which globs.
+    line="${hit%% *}"
+    reason="${hit##* }"
+    key="${hit#* }"
+    key="${key% *}"
+    case "$reason" in
         whitespace-in-key) why="its key contains a space" ;;
         unexpected-character) why="its key contains a character docker compose does not allow" ;;
         unterminated-quote) why="its quoted value never closes" ;;
         *) why="a \${NAME:?message} reference names a NAME that is not set, or a \${ never closes" ;;
     esac
     cat >&2 <<EOF
-Pre-flight: .env line $1 ($2) cannot be loaded by docker compose: $why.
+Pre-flight: .env line $line ($key) cannot be loaded by docker compose: $why.
 
 Compose reads every line of .env before it applies your shell environment, so
 \`docker compose up\` stops on this line even if the key is not one GeoLens

--- a/scripts/tests/test-env-file-compose-oracle.sh
+++ b/scripts/tests/test-env-file-compose-oracle.sh
@@ -615,6 +615,38 @@ _assert_file_like_compose "$FILE_DIR/unclosed-ref" "an unclosed \${ reference"
 printf 'CONTROL=ok\nFOO="a\nb c\n"\nBAR # after\n' > "$FILE_DIR/continuation"
 _assert_file_like_compose "$FILE_DIR/continuation" "a spaced continuation line is exempt and the key error after it is the one named"
 
+# fix(#1899 codex r1): a key outside the shell-identifier charset is a record
+# too, so its value is interpolated where Compose interpolates it.
+printf 'CONTROL=ok\nODD-KEY=${MISSING:?boom}\n' > "$FILE_DIR/odd-hyphen"
+_assert_file_like_compose "$FILE_DIR/odd-hyphen" "a hyphenated key whose value Compose refuses"
+
+printf 'CONTROL=ok\nDOTTED.KEY=${X\n' > "$FILE_DIR/odd-dotted"
+_assert_file_like_compose "$FILE_DIR/odd-dotted" "a dotted key with an unclosed \${"
+
+printf 'CONTROL=ok\nCOLON: ${MISSING:?boom}\n' > "$FILE_DIR/odd-colon"
+_assert_file_like_compose "$FILE_DIR/odd-colon" "a colon-terminated key whose value Compose refuses"
+
+printf 'CONTROL=ok\n1ODD=${MISSING:?boom}\n' > "$FILE_DIR/odd-digit"
+_assert_file_like_compose "$FILE_DIR/odd-digit" "a digit-leading key whose value Compose refuses"
+
+printf 'CONTROL=ok\nBRACKET[0]=${MISSING:?boom}\n' > "$FILE_DIR/odd-bracket"
+touch "$FILE_DIR/BRACKET0"
+_afl_pwd="$PWD"
+cd "$FILE_DIR" || bad "could not cd into $FILE_DIR"
+_assert_file_like_compose "$FILE_DIR/odd-bracket" "a bracketed key whose value Compose refuses, beside a file its brackets would glob to"
+cd "$_afl_pwd" || bad "could not cd back to $_afl_pwd"
+if [ "${_afl_ours%% *}" = "2" ] && [ "${_afl_ours#* }" = "BRACKET[0] unresolvable" ]; then
+  ok "the refused key is reported by its own name, not the file its brackets glob to"
+else
+  bad "the refused key was reported as [$_afl_ours]"
+fi
+
+printf 'CONTROL=ok\nODD-KEY="a\nb c\n"\n' > "$FILE_DIR/odd-multiline"
+_assert_file_like_compose "$FILE_DIR/odd-multiline" "a multiline value under a hyphenated key keeps its continuation lines exempt"
+
+printf 'COLON: sep value\n' > "$FILE_DIR/colon-value"
+_assert_matches_compose COLON "$FILE_DIR/colon-value" "a colon ends the key and the value after it is what Compose reads"
+
 
 # ============================================================================
 # Round 14 (review 5104197320) — closes the WHOLE Compose interpolation

--- a/scripts/tests/test-env-file-compose-oracle.sh
+++ b/scripts/tests/test-env-file-compose-oracle.sh
@@ -121,6 +121,61 @@ _our_effective_value() {
   ( . "$REPO_ROOT/lib/common.sh" && effective_env_value_into _test_effective "$1" "$2" && printf '%s' "$_test_effective" )
 }
 
+# Loads FILE through real Compose with CONTROL as the probed key; Compose's
+# own rc, first stderr line on stdout.
+_compose_file_load() {
+  cat > "$COMPOSE_YML" <<YML
+services:
+  svc:
+    image: busybox
+    environment:
+      X: \${CONTROL}
+YML
+  docker compose -f "$COMPOSE_YML" --env-file "$1" config --format json >/dev/null 2>"$WORK/file-load.err"
+  _cfl_rc=$?
+  head -1 "$WORK/file-load.err"
+  return "$_cfl_rc"
+}
+
+# fix(#1899): whole-file loadability, env_file_first_refused_line against
+# Compose. Both must agree, and when Compose names the line of a key error
+# ours must name the same line.
+_assert_file_like_compose() {
+  _afl_file="$1"
+  _afl_desc="$2"
+  _afl_ours="$( ( . "$REPO_ROOT/lib/common.sh" && env_file_first_refused_line "$_afl_file" ) 2>"$WORK/file-ours.err" )"
+  _afl_ours_rc=$?
+  if [ -s "$WORK/file-ours.err" ]; then
+    bad "$_afl_desc (env_file_first_refused_line wrote to stderr: $(head -1 "$WORK/file-ours.err"))"
+    return
+  fi
+  _afl_err="$(_compose_file_load "$_afl_file")"
+  _afl_compose_rc=$?
+
+  if [ "$_afl_compose_rc" -eq 0 ] && [ "$_afl_ours_rc" -ne 0 ]; then
+    ok "$_afl_desc (both load the file)"
+    return
+  fi
+  if [ "$_afl_compose_rc" -eq 0 ]; then
+    bad "$_afl_desc (Compose loads the file, ours refuses it: [$_afl_ours])"
+    return
+  fi
+  if [ "$_afl_ours_rc" -ne 0 ]; then
+    bad "$_afl_desc (Compose refuses the file: [$_afl_err]; ours loads it)"
+    return
+  fi
+  case "$_afl_err" in
+    *"key cannot contain a space"*|*"unexpected character"*)
+      _afl_line="$(printf '%s' "$_afl_err" | sed -n 's/.*line \([0-9][0-9]*\):.*/\1/p')"
+      if [ -n "$_afl_line" ] && [ "$_afl_line" != "${_afl_ours%% *}" ]; then
+        bad "$_afl_desc (Compose names line $_afl_line, ours names [$_afl_ours])"
+        return
+      fi
+      ;;
+  esac
+  ok "$_afl_desc (both refuse: ours [$_afl_ours])"
+}
+
 # fix(#1886): a top-level ${KEY} resolves from the process environment first,
 # so this compares effective_env_value_into against the oracle (get_env_value
 # keeps its file-only contract and is not what preflight-env.sh reads).
@@ -511,6 +566,54 @@ printf 'TARGETVAR\n' > "$BARE_ENV"
 export TARGETVAR=fromenv
 _assert_effective_matches_compose TARGETVAR "$BARE_ENV"   "env set (fromenv) + a bare TARGETVAR line: the line inherits the export and is not refused"
 unset TARGETVAR
+
+# ============================================================================
+# fix(#1899): whole-file loadability, each shape judged by Compose and by ours.
+# ============================================================================
+FILE_DIR="$WORK/files"
+mkdir -p "$FILE_DIR"
+
+printf 'CONTROL=ok\nUNRELATED=${MISSING:?boom}\n' > "$FILE_DIR/unrelated"
+_assert_file_like_compose "$FILE_DIR/unrelated" "an unrelated line with \${MISSING:?boom} beside a valid key"
+
+printf 'CONTROL=${MISSING:?boom}\nCONTROL=ok\n' > "$FILE_DIR/earlier-dup"
+_assert_file_like_compose "$FILE_DIR/earlier-dup" "an earlier invalid duplicate of a key whose last definition is valid"
+
+printf '# comment\nCONTROL=ok\n\nexport EXPORTED=1\nQUOTED="with # hash" # note\nSINGLE='"'"'lit $x'"'"'\nBARE\nSPACED = value\nREF=${CONTROL}\nODD-KEY=x\n1ODD=x\nDOTTED.KEY=x\nBRACKET[0]=x\nCOLON:sep value\nTAB\t=x\nDOLLAR=$5\nJUNK="a"b\nMULTI="a\nb c\n"\n' > "$FILE_DIR/mixed-valid"
+_assert_file_like_compose "$FILE_DIR/mixed-valid" "a file of comments, export, quotes, a bare key, odd keys, a colon key, a ref, a bare \$ and a multiline value"
+
+printf '\357\273\277# bom\nCONTROL=ok\n' > "$FILE_DIR/bom"
+_assert_file_like_compose "$FILE_DIR/bom" "a BOM before a first-line comment"
+
+printf 'CONTROL=ok\nFOO # comment\n' > "$FILE_DIR/bare-comment"
+_assert_file_like_compose "$FILE_DIR/bare-comment" "a bare key followed by a comment"
+
+printf 'CONTROL=ok\nFOO BAR=x\n' > "$FILE_DIR/space-key"
+_assert_file_like_compose "$FILE_DIR/space-key" "a space inside a key"
+
+printf 'CONTROL=ok\ngarbage line\n' > "$FILE_DIR/garbage"
+_assert_file_like_compose "$FILE_DIR/garbage" "a line with a space and no ="
+
+printf 'CONTROL=ok\n- x=y\n' > "$FILE_DIR/odd-space"
+_assert_file_like_compose "$FILE_DIR/odd-space" "a space inside a key the tokenizer does not recognise"
+
+printf 'CONTROL=ok\nFOO#BAR=x\n' > "$FILE_DIR/hash-key"
+_assert_file_like_compose "$FILE_DIR/hash-key" "a # inside a key"
+
+printf 'CONTROL=ok\nFOO$=x\n' > "$FILE_DIR/dollar-key"
+_assert_file_like_compose "$FILE_DIR/dollar-key" "a \$ inside a key"
+
+printf 'CONTROL=ok\n"FOO"=x\n' > "$FILE_DIR/quoted-key"
+_assert_file_like_compose "$FILE_DIR/quoted-key" "a key wrapped in quotes"
+
+printf 'CONTROL=ok\nFOO="unterminated\nFOO=ok\n' > "$FILE_DIR/unterminated"
+_assert_file_like_compose "$FILE_DIR/unterminated" "an unterminated quote that swallows the rest of the file"
+
+printf 'CONTROL=ok\nFOO=${X\n' > "$FILE_DIR/unclosed-ref"
+_assert_file_like_compose "$FILE_DIR/unclosed-ref" "an unclosed \${ reference"
+
+printf 'CONTROL=ok\nFOO="a\nb c\n"\nBAR # after\n' > "$FILE_DIR/continuation"
+_assert_file_like_compose "$FILE_DIR/continuation" "a spaced continuation line is exempt and the key error after it is the one named"
 
 
 # ============================================================================

--- a/scripts/tests/test-preflight-env.sh
+++ b/scripts/tests/test-preflight-env.sh
@@ -263,21 +263,21 @@ GEOLENS_ADMIN_PASSWORD=$NONEMPTY"
 # CASE 7 (fix(#1886)): a line Compose refuses to load is refused, exported or not.
 # ============================================================================
 run_preflight_env SECRET_ENCRYPTION_KEY "$VALID_KEY" 'SECRET_ENCRYPTION_KEY=${NO_SUCH_VAR:?boom}'
-if [ "$STATUS" -ne 0 ] && grep -q "SECRET_ENCRYPTION_KEY line in .env" "$WORK/out.txt"; then
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (SECRET_ENCRYPTION_KEY)" "$WORK/out.txt"; then
     ok "a valid exported key over a line Compose refuses is refused, naming the .env line"
 else
     bad "a valid exported key masked a line Compose refuses (exit $STATUS): $(cat "$WORK/out.txt")"
 fi
 
 run_preflight 'SECRET_ENCRYPTION_KEY=${NO_SUCH_VAR:?boom}'
-if [ "$STATUS" -ne 0 ] && grep -q "SECRET_ENCRYPTION_KEY line in .env" "$WORK/out.txt"; then
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (SECRET_ENCRYPTION_KEY)" "$WORK/out.txt"; then
     ok "the same line is refused with nothing exported"
 else
     bad "a line Compose refuses passed with nothing exported (exit $STATUS): $(cat "$WORK/out.txt")"
 fi
 
 run_preflight_env SECRET_ENCRYPTION_KEY "$VALID_KEY" 'SECRET_ENCRYPTION_KEY="unterminated'
-if [ "$STATUS" -ne 0 ] && grep -q "SECRET_ENCRYPTION_KEY line in .env" "$WORK/out.txt"; then
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (SECRET_ENCRYPTION_KEY)" "$WORK/out.txt"; then
     ok "an unterminated quote is refused under a valid exported key too"
 else
     bad "a valid exported key masked an unterminated quote (exit $STATUS): $(cat "$WORK/out.txt")"
@@ -295,6 +295,80 @@ if [ "$STATUS" -eq 0 ]; then
     ok "a bare KEY line with nothing exported reads as unset and passes"
 else
     bad "a bare KEY line with nothing exported was refused: $(cat "$WORK/out.txt")"
+fi
+
+# ============================================================================
+# CASE 8 (fix(#1899)): the whole file is checked as Compose loads it, by line.
+# ============================================================================
+run_preflight 'UNRELATED=${MISSING:?boom}'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (UNRELATED)" "$WORK/out.txt"; then
+    ok "an unrelated line Compose refuses is refused, naming line and key"
+else
+    bad "an unrelated line Compose refuses passed (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+if ! grep -q "boom" "$WORK/out.txt" && ! grep -q "MISSING" "$WORK/out.txt"; then
+    ok "the refusal never prints the line's value"
+else
+    bad "the refusal printed the line's value: $(cat "$WORK/out.txt")"
+fi
+
+DUPLICATE="$(printf 'SECRET_ENCRYPTION_KEY=${MISSING:?boom}\nSECRET_ENCRYPTION_KEY=%s' "$VALID_KEY")"
+run_preflight "$DUPLICATE"
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (SECRET_ENCRYPTION_KEY)" "$WORK/out.txt"; then
+    ok "an earlier invalid duplicate of a checked key is refused although the last definition is valid"
+else
+    bad "an earlier invalid duplicate was masked by the last definition (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+MIXED_VALID="$(printf '# comment\n\nexport EXPORTED=1\nQUOTED="with # hash" # note\nSINGLE='"'"'lit $x'"'"'\nBARE\nSPACED = value\nREF=${JWT_SECRET_KEY}\nODD-KEY=x\n1ODD=x\nDOTTED.KEY=x\nCOLON:sep value\nTAB\t=x\nDOLLAR=$5\nJUNK="a"b\nMULTI="a\nb c\n"')"
+run_preflight "$MIXED_VALID"
+if [ "$STATUS" -eq 0 ]; then
+    ok "a file of lines Compose loads still passes (comments, export, quotes, bare, odd keys, refs, multiline)"
+else
+    bad "a valid file was refused by the whole-file check: $(cat "$WORK/out.txt")"
+fi
+
+run_preflight 'FOO # comment'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (FOO)" "$WORK/out.txt"; then
+    ok "a bare key followed by a comment is refused like Compose does"
+else
+    bad "a bare key followed by a comment passed (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight 'garbage line'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (garbage)" "$WORK/out.txt"; then
+    ok "a line with a space and no = is refused"
+else
+    bad "a line with a space and no = passed (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight 'FOO#BAR=x'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (FOO)" "$WORK/out.txt"; then
+    ok "a key holding a character Compose rejects is refused"
+else
+    bad "a key holding # passed (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight 'FOO="unterminated'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (FOO)" "$WORK/out.txt"; then
+    ok "an unterminated quote on an unrelated key is refused, naming its opening line"
+else
+    bad "an unterminated quote on an unrelated key passed (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight 'FOO=${X'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (FOO)" "$WORK/out.txt"; then
+    ok "an unclosed \${ on an unrelated key is refused"
+else
+    bad "an unclosed \${ on an unrelated key passed (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+CONTINUATION="$(printf 'FOO="a\nb c\n"\nBAR # after')"
+run_preflight "$CONTINUATION"
+if [ "$STATUS" -ne 0 ] && grep -q "line 7 (BAR)" "$WORK/out.txt"; then
+    ok "a spaced continuation line of a multiline value is exempt and the refusal names the real line after it"
+else
+    bad "a multiline value's continuation was misjudged (exit $STATUS): $(cat "$WORK/out.txt")"
 fi
 
 echo "1..$((PASS + FAIL))"

--- a/scripts/tests/test-preflight-env.sh
+++ b/scripts/tests/test-preflight-env.sh
@@ -371,6 +371,55 @@ else
     bad "a multiline value's continuation was misjudged (exit $STATUS): $(cat "$WORK/out.txt")"
 fi
 
+# fix(#1899 codex r1): a key outside the shell-identifier charset is a record
+# too, so its value is interpolated where Compose interpolates it.
+run_preflight 'ODD-KEY=${MISSING:?boom}'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (ODD-KEY)" "$WORK/out.txt"; then
+    ok "a hyphenated key with a value Compose refuses is refused"
+else
+    bad "a hyphenated key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight 'DOTTED.KEY=${X'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (DOTTED.KEY)" "$WORK/out.txt"; then
+    ok "a dotted key with an unclosed \${ is refused"
+else
+    bad "a dotted key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight 'COLON: ${MISSING:?boom}'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (COLON)" "$WORK/out.txt"; then
+    ok "a colon-terminated key with a value Compose refuses is refused"
+else
+    bad "a colon-terminated key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight '1ODD=${MISSING:?boom}'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (1ODD)" "$WORK/out.txt"; then
+    ok "a digit-leading key with a value Compose refuses is refused"
+else
+    bad "a digit-leading key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+printf '%s\n' "$REQUIRED_LINES" > "$FAKE/.env"
+printf 'BRACKET[0]=${MISSING:?boom}\n' >> "$FAKE/.env"
+touch "$WORK/BRACKET0"
+( cd "$WORK" && bash "$FAKE/scripts/preflight-env.sh" > "$WORK/out.txt" 2>&1 )
+STATUS=$?
+if [ "$STATUS" -ne 0 ] && grep -qF "line 4 (BRACKET[0])" "$WORK/out.txt"; then
+    ok "a bracketed key is refused by its own name even beside a file its brackets would glob to"
+else
+    bad "a bracketed key was mishandled (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+ODD_MULTI="$(printf 'ODD-KEY="a\nb c\n"')"
+run_preflight "$ODD_MULTI"
+if [ "$STATUS" -eq 0 ]; then
+    ok "a multiline value under a hyphenated key keeps its continuation lines exempt"
+else
+    bad "a multiline value under a hyphenated key was refused: $(cat "$WORK/out.txt")"
+fi
+
 echo "1..$((PASS + FAIL))"
 echo "# ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Tracked in #1899, follow-up to #1896 (codex round 2).

## Defect

Compose parses every line of `.env` and interpolates every value before it looks up a single key. Preflight validated only the records it asked for, so an unrelated line Compose refuses (`UNRELATED=${MISSING:?boom}` beside valid required settings) or an earlier invalid duplicate of a checked key (the selector keeps the last definition) passed preflight and then aborted `make dev` at `docker compose up`. This was true on main before #1896 too.

Before writing the check I measured what Compose v5.1.2 actually refuses, since the oracle only pinned value and interpolation rules until now. A key ends at `=` or `:` and may hold letters, digits, `_ . - [ ]` and a tab. A space inside the key, or a `#`, `"` or `$` in it, is refused with a line number. `1FOO=x`, `-x=y`, `FOO.BAR=x`, `=x` and `FOO="a"b` all load. An unterminated quote and an unclosed `${` are refused. Interpolation failures are refused without a line number, after the whole file has parsed.

## Fix

`scripts/lib/common.sh` gains `env_file_first_refused_line FILE`, which prints `LINE KEY REASON` for the first line Compose would refuse (rc 0) or nothing with rc 1 when the file loads. It tokenizes once, then mirrors Compose's two phases:

1. Parse phase: one awk pass over every line outside a multiline value applying the key grammar above, then the tokenizer's unterminated-quote record. The record stream reaches awk through `ENVIRON` because macOS awk rejects a `-v` value that holds a newline (that cost one red run while writing this). Bytes above 0x7f are left alone since Compose accepts Unicode letters.
2. Interpolation phase: only a value holding `$` can fail it, so only those records are resolved, each through `get_env_value` bounded by its own start line. That is what judges an earlier duplicate where Compose judges it, instead of at the last definition.

An awk failure fails closed through `fail`, never as "the file loads".

`get_env_value` takes two optional arguments for that: `BEFORE` (records starting before that line, the same bound `_env_select_record` already has) and `RECORDS` (a stream the caller already holds, so the file is read once). The two-argument contract is unchanged, `env_value_into` and the three disaster-recovery scripts still call it that way, and their precedence is untouched.

`scripts/preflight-env.sh` runs `check_env_file` before the per-key checks and names the line by number and key, never the value, with one sentence per reason. The rc 2 branch from #1896 now re-runs the same check rather than printing its own message, so there is one refusal path. `scripts/README.md` gets a one-line update.

Not covered: two shapes sit outside the record format and are not interpolated by us, an empty key (`=x`) and a key with a tab inside it. Compose accepts both; nothing in this repo writes either. (Round 1 below widened the tokenizer to every other key form Compose accepts.)

## Cost

The walk tokenizes once and does the rest in awk, so it adds about 0.8 s in bash and 0.25 s in dash on the maintainer's 416-line `.env`. On an install.sh-sized `.env` (1146 lines, a copy of `.env.example`) it adds about 4.5 s in bash. Preflight on that file already takes 44 s in bash on main because the shell parser is quadratic in file length and each per-key lookup re-tokenizes. That is a pre-existing cost outside this issue; it deserves its own look.

## Tests

`scripts/tests/test-preflight-env.sh` CASE 8, nine cases: an unrelated refused line is refused naming line 4 and the key, and the message never prints `boom` or `MISSING`; an earlier invalid duplicate of `SECRET_ENCRYPTION_KEY` is refused although the last definition is valid; a file of comments, `export`, quotes with a `#` inside, a single-quoted `$x`, a bare key, `KEY = value`, a `${JWT_SECRET_KEY}` reference, odd keys, a colon key, a tab before `=`, a bare `$5`, junk after a closing quote and a multiline value still passes; a bare key followed by a comment, a line with a space and no `=`, a `#` in a key, an unterminated quote and an unclosed `${` on unrelated keys are each refused naming line 4; a spaced continuation line inside a multiline value is exempt and the key error after it is named as line 7. CASE 7's three greps follow the new message format.

`scripts/tests/test-env-file-compose-oracle.sh` gains `_assert_file_like_compose`, which loads a file through real `docker compose config` and through `env_file_first_refused_line`, requires both to agree, and when Compose names a line for a key error requires ours to name the same line. Fourteen shapes: the two from the issue, the mixed valid file, a BOM, the whitespace and character cases (`FOO # comment`, `FOO BAR=x`, `garbage line`, `- x=y`, `FOO#BAR=x`, `FOO$=x`, `"FOO"=x`), an unterminated quote, an unclosed `${`, and the continuation-line case where Compose reports line 5 and so do we.

## Verification

At 07d06ef96 (rebased onto 4cf8e1346; the diff against it is these five script files only):

| command | sh (macOS) | dash |
|---|---|---|
| `sh scripts/tests/test-preflight-env.sh` | 35 passed, 0 failed | 35 passed, 0 failed |
| `sh scripts/tests/test-env-file-compose-oracle.sh` | 120 passed, 0 failed | 120 passed, 0 failed |
| `sh scripts/tests/test-restore-env-sourcing-safety.sh` | 54 passed | 54 passed |
| `sh scripts/tests/test-runbook-env-value-guarded.sh` | 4 passed | |
| `sh scripts/tests/test-upgrade-order.sh` | 102 passed | |
| `sh scripts/tests/test-restore-trap-safety.sh` | 10 passed | |

The preflight suite also passes in an `ubuntu:24.04` container under `dash` with `mawk` (the default) and again with `gawk` 5.2.1, so the awk is portable across the three implementations CI or an operator host can have.

`shellcheck` adds one SC1091 info on the new sourcing line in the oracle and SC2016 info on the single-quoted `${...}` literals in tests. Both classes already exist in these files.

Counterfactual, with `scripts/lib/common.sh` and `scripts/preflight-env.sh` reset to origin/main and the tests kept:

```
$ sh scripts/tests/test-preflight-env.sh
not ok 26 - an unrelated line Compose refuses passed (exit 0): Pre-flight: required vars OK ...
not ok 28 - an earlier invalid duplicate was masked by the last definition (exit 0): Pre-flight: required vars OK ...
not ok 30 - a bare key followed by a comment passed (exit 0): ...
not ok 31 - a line with a space and no = passed (exit 0): ...
not ok 32 - a key holding # passed (exit 0): ...
not ok 33 - an unterminated quote on an unrelated key passed (exit 0): ...
not ok 34 - an unclosed ${ on an unrelated key passed (exit 0): ...
not ok 35 - a multiline value's continuation was misjudged (exit 0): ...
# 24 passed, 11 failed   (the other three are CASE 7's greps on the old message format)

$ sh scripts/tests/test-env-file-compose-oracle.sh
not ok 28 ... not ok 41 - (env_file_first_refused_line wrote to stderr: ... env_file_first_refused_line: not found)
# 106 passed, 14 failed
```

## Impact

Scripts only. No schema, API or config change. `make dev` now refuses a `.env` that `docker compose up` would refuse, before the build starts, and says which line.

## Round 1 (codex P2)

The interpolation pass only resolved records the tokenizer produced, and the tokenizer only recognised a shell-identifier key followed by `=`. So `ODD-KEY=${MISSING:?boom}`, `DOTTED.KEY=${X`, `COLON: ${MISSING:?boom}` and a digit-leading key came out as bare records or nothing, passed preflight, and died at Compose load. Fixed in ebd6dbd48 by widening `_env_parse_assignment_line` to Compose's key grammar (letters, digits, `_ . - [ ]`, ended by `=` or `:`), which is the smaller option because those records then also carry the right span, so a multiline value under such a key keeps its continuation lines exempt (the previous head false-refused `ODD-KEY="a\nb c\n"` at its second line).

A key may now hold `[` or `]`, which glob under an unquoted expansion. Two splits did that: `_env_select_record`'s `set -- $record` and preflight's split of the refusal line. Both now split by parameter expansion, and the tests plant a file named `BRACKET0` next to a `BRACKET[0]=` line so the refusal must name the key, not the file.

Tests: six preflight cases (the four shapes above, the bracketed key beside its glob target, and the multiline value under a hyphenated key passing) and eight oracle cases (the same five refusals against real Compose, the bracket name check, the multiline file loading, and `COLON: sep value` resolving to what Compose reads).

Verification at ebd6dbd48: `test-preflight-env.sh` 41 passed under macOS `sh`, `dash`, and Ubuntu `dash` with `mawk` and with `gawk`; `test-env-file-compose-oracle.sh` 128 passed under `sh` and `dash`; the four sibling suites unchanged (54, 4, 102, 10). Counterfactual with `common.sh` and `preflight-env.sh` at the previous head 07d06ef96 and the tests kept: preflight 35 passed, 6 failed (cases 36 to 41); oracle 120 passed, 8 failed (cases 42 to 49).
