### PR TITLE
fix(catalog): bump tile_cache_version at write time on the request side (#1826) (#1902)

### DIFF
--- a/backend/app/modules/catalog/datasets/api/router.py
+++ b/backend/app/modules/catalog/datasets/api/router.py
@@ -22,6 +22,7 @@ from app.core.db.sqlstate import is_lock_conflict
 from app.platform.catalog_locks import (
     CATALOG_LOCK_CONFLICT_CODE,
     CatalogLockConflict,
+    bump_tile_cache_version_on,
 )
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.audit.schemas import AuditLogListResponse, AuditLogResponse
@@ -399,17 +400,16 @@ async def update_dataset_metadata(
             ip_address=request.client.host if request.client else None,
         ),
     )
-    # fix(#525 B-038): a tile_columns change alters the attribute set embedded
-    # in vector tiles — roll the _v= URL cache-buster in the same transaction
-    # (the post-commit Valkey purge cannot reach CDN/browser caches).
-    # fix(#458 E-48): only when the value actually changed — a no-op echo used
-    # to purge every cached tile for the table.
+    # fix(#458 E-48): only when the value actually changed; a no-op echo must
+    # not purge every cached tile for the table.
     tile_columns_changed = (
         "tile_columns" in meta.model_fields_set
         and dataset.tile_columns != tile_columns_before
     )
     if tile_columns_changed:
-        dataset.bump_tile_cache_version()
+        # fix(#1902): evaluated at write time, so a counter read before the
+        # lock wait is never written back over a peer's commit.
+        await bump_tile_cache_version_on(db, dataset)
     await db.commit()
     await db.refresh(dataset)
     await db.refresh(dataset.record)

--- a/backend/app/modules/catalog/datasets/domain/models.py
+++ b/backend/app/modules/catalog/datasets/domain/models.py
@@ -618,14 +618,14 @@ class Dataset(Base):
     def bump_tile_cache_version(self) -> None:
         """Roll the `_v=` tile-URL cache-buster after a tile-content mutation.
 
-        Call in the same transaction as any change to the dataset's tile
-        content (feature edits, column DDL, tile_columns, reupload) — the
-        post-commit Valkey purge cannot reach CDN/browser caches keyed on the
-        tile URL. fix(#525 B-038)
+        Call in the same transaction as the change to the dataset's tile
+        content; the post-commit Valkey purge cannot reach CDN or browser
+        caches keyed on the tile URL.
 
         Writes an ABSOLUTE value read off this instance, so it is correct only
-        while the caller holds this row; one that does not must use
-        ``bump_tile_cache_version_atomic`` (ingest/tasks_common). #1738 r1
+        for a caller that loaded this row under a lock it still holds. A
+        request handler loads before it waits and must use
+        ``bump_tile_cache_version_on`` (platform/catalog_locks) instead.
         """
         self.tile_cache_version = (self.tile_cache_version or 1) + 1
 

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -28,7 +28,10 @@ from app.core.db.sqlstate import (
     sqlstate,
 )
 from app.core.identity import Identity
-from app.platform.catalog_locks import CatalogLockConflict
+from app.platform.catalog_locks import (
+    CatalogLockConflict,
+    bump_tile_cache_version_on,
+)
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 from app.modules.auth.dependencies import (
     get_current_active_user,
@@ -667,9 +670,9 @@ async def create_feature(
             },
         ),
     )
-    # fix(#525 B-038): roll the _v= URL cache-buster in the same transaction —
-    # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
-    dataset.bump_tile_cache_version()
+    # fix(#1902): evaluated at write time, so a counter read before the lock
+    # wait is never written back over a peer's commit.
+    tile_version = await bump_tile_cache_version_on(db, dataset)
     await db.commit()
 
     # Invalidate cached tiles so the new feature appears immediately
@@ -680,6 +683,7 @@ async def create_feature(
     logger.info(
         "feature.insert",
         dataset_id=str(dataset_id),
+        tile_cache_version=tile_version,
         gid=row["gid"],
         user_id=str(user.id),
     )
@@ -786,8 +790,9 @@ async def replace_single_feature(
             },
         ),
     )
-    # fix(#525 B-038): roll the _v= URL cache-buster (see feature.insert above).
-    dataset.bump_tile_cache_version()
+    # fix(#1902): evaluated at write time, so a counter read before the lock
+    # wait is never written back over a peer's commit.
+    await bump_tile_cache_version_on(db, dataset)
     await db.commit()
 
     # Invalidate cached tiles so the replaced feature renders correctly
@@ -901,8 +906,9 @@ async def patch_single_feature(
             },
         ),
     )
-    # fix(#525 B-038): roll the _v= URL cache-buster (see feature.insert above).
-    dataset.bump_tile_cache_version()
+    # fix(#1902): evaluated at write time, so a counter read before the lock
+    # wait is never written back over a peer's commit.
+    await bump_tile_cache_version_on(db, dataset)
     await db.commit()
 
     # Invalidate cached tiles so the updated feature renders correctly
@@ -978,8 +984,9 @@ async def delete_single_feature(
             details={"gid": gid},
         ),
     )
-    # fix(#525 B-038): roll the _v= URL cache-buster (see feature.insert above).
-    dataset.bump_tile_cache_version()
+    # fix(#1902): evaluated at write time, so a counter read before the lock
+    # wait is never written back over a peer's commit.
+    tile_version = await bump_tile_cache_version_on(db, dataset)
     await db.commit()
 
     # Invalidate cached tiles so the deleted feature disappears immediately
@@ -990,6 +997,7 @@ async def delete_single_feature(
     logger.info(
         "feature.delete",
         dataset_id=str(dataset_id),
+        tile_cache_version=tile_version,
         gid=gid,
         user_id=str(user.id),
     )

--- a/backend/app/modules/catalog/layers/router.py
+++ b/backend/app/modules/catalog/layers/router.py
@@ -35,6 +35,7 @@ from app.modules.catalog.layers.service import (
     rename_column,
 )
 from app.platform.cache.provider import get_tile_cache
+from app.platform.catalog_locks import bump_tile_cache_version_on
 from app.standards.ogc.errors import ERROR_RESPONSES_WRITE
 
 
@@ -187,9 +188,9 @@ async def add_column_endpoint(
             },
         ),
     )
-    # fix(#525 B-038): roll the _v= URL cache-buster in the same transaction —
-    # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
-    dataset.bump_tile_cache_version()
+    # fix(#1902): evaluated at write time, so a counter read before the lock
+    # wait is never written back over a peer's commit.
+    await bump_tile_cache_version_on(db, dataset)
     await db.commit()
     await _invalidate_tiles(dataset.table_name)
 
@@ -246,9 +247,9 @@ async def rename_column_endpoint(
             details={"old_name": column_name, "new_name": body.new_name},
         ),
     )
-    # fix(#525 B-038): roll the _v= URL cache-buster in the same transaction —
-    # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
-    dataset.bump_tile_cache_version()
+    # fix(#1902): evaluated at write time, so a counter read before the lock
+    # wait is never written back over a peer's commit.
+    await bump_tile_cache_version_on(db, dataset)
     await db.commit()
     await _invalidate_tiles(dataset.table_name)
     return ColumnListResponse(columns=columns)
@@ -311,9 +312,9 @@ async def alter_column_type_endpoint(
             details={"column_name": column_name, "new_type": body.new_type},
         ),
     )
-    # fix(#525 B-038): roll the _v= URL cache-buster in the same transaction —
-    # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
-    dataset.bump_tile_cache_version()
+    # fix(#1902): evaluated at write time, so a counter read before the lock
+    # wait is never written back over a peer's commit.
+    await bump_tile_cache_version_on(db, dataset)
     await db.commit()
     await _invalidate_tiles(dataset.table_name)
     return ColumnListResponse(columns=columns)
@@ -367,9 +368,9 @@ async def drop_column_endpoint(
             details={"column_name": column_name},
         ),
     )
-    # fix(#525 B-038): roll the _v= URL cache-buster in the same transaction —
-    # the post-commit Valkey purge cannot reach CDN/browser caches keyed on the URL.
-    dataset.bump_tile_cache_version()
+    # fix(#1902): evaluated at write time, so a counter read before the lock
+    # wait is never written back over a peer's commit.
+    await bump_tile_cache_version_on(db, dataset)
     await db.commit()
     await _invalidate_tiles(dataset.table_name)
 

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 from contextvars import ContextVar
 from typing import Any
 
-from sqlalchemy import select, text
+from sqlalchemy import func, select, text, update
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import set_committed_value
 
 from app.core.db.sqlstate import is_lock_conflict
 
@@ -148,3 +149,38 @@ async def _raise_rolled_back_conflict(session: AsyncSession, exc: DBAPIError) ->
     raise CatalogLockConflict(
         "Another operation is updating this dataset's catalog entry."
     ) from exc
+
+
+async def bump_tile_cache_version_atomic(
+    session: AsyncSession, *, dataset_cls: Any, dataset_id: Any
+) -> int | None:
+    """Roll ``tile_cache_version`` in the database and return the new value.
+
+    ``coalesce(tile_cache_version, 1) + 1``, evaluated against the row at
+    write time, so a counter read before a lock wait is never written back
+    over a peer's commit. Call it in the same transaction as the tile-content
+    change it describes. None when the row no longer exists.
+    """
+    return await session.scalar(
+        update(dataset_cls)
+        .where(dataset_cls.id == dataset_id)
+        .values(tile_cache_version=func.coalesce(dataset_cls.tile_cache_version, 1) + 1)
+        .returning(dataset_cls.tile_cache_version)
+        .execution_options(synchronize_session=False)
+    )
+
+
+async def bump_tile_cache_version_on(session: AsyncSession, dataset: Any) -> int | None:
+    """:func:`bump_tile_cache_version_atomic` for a loaded ``Dataset`` instance.
+
+    The instance's ``tile_cache_version`` is set to the returned value without
+    marking it dirty, so a later reader sees what was published and the flush
+    does not write it back. The one spelling for a request handler, whose
+    instance was loaded before it waited for the row.
+    """
+    version = await bump_tile_cache_version_atomic(
+        session, dataset_cls=type(dataset), dataset_id=dataset.id
+    )
+    if version is not None:
+        set_committed_value(dataset, "tile_cache_version", version)
+    return version

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2075,43 +2075,6 @@ async def invalidate_tile_cache_for_table(table_name: str) -> None:
         await tile_cache.invalidate_table(table_name)
 
 
-async def bump_tile_cache_version_atomic(
-    session: "AsyncSession", Dataset: Any, dataset_id: uuid.UUID
-) -> int | None:
-    """Roll the ``_v=`` cache-buster from a writer that holds no row lock.
-
-    fix(#1738 round 1): the sibling of ``Dataset.bump_tile_cache_version``,
-    for the one case that helper cannot serve. That helper reads the counter
-    off a loaded instance and writes back an absolute value, which is correct
-    only while the caller holds the datasets row — the way
-    ``refresh_postgis``'s phase 3 does, under the ``FOR UPDATE`` it takes for
-    its superseded guard.
-
-    A writer without that lock cannot use it, and taking the lock would not
-    help: the feature-edit routers (``features/router.py``) bump through a
-    plain read-modify-write, so an absolute write computed from a read they
-    took earlier lands on top of anything committed in between. One side
-    locking does not serialize a race the other side is not playing.
-    ``tile_cache_version = tile_cache_version + 1`` in the database does,
-    because the increment is evaluated against the row as it is at write time.
-
-    Returns the new value, so the caller reports and logs the version it
-    actually published rather than the one it hoped for. Still called in the
-    same transaction as the tile-content change it describes, which is the
-    contract on both spellings.
-    """
-    from sqlalchemy import func as sa_func
-    from sqlalchemy import update as sa_update
-
-    return await session.scalar(
-        sa_update(Dataset)
-        .where(Dataset.id == dataset_id)
-        .values(tile_cache_version=sa_func.coalesce(Dataset.tile_cache_version, 1) + 1)
-        .returning(Dataset.tile_cache_version)
-        .execution_options(synchronize_session=False)
-    )
-
-
 # What PostGIS records in ``geometry_columns.type`` for an untyped column.
 # A specific value ("POLYGON", "MULTILINESTRING", ...) describes what the
 # column will accept; this one describes nothing.

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -46,6 +46,7 @@ from sqlalchemy.exc import DBAPIError
 from app.core.db.sqlstate import sqlstate
 from app.core.db.tenant_session import tenant_task
 from app.platform.cache.tiles import invalidate_catalog_cache
+from app.platform.catalog_locks import bump_tile_cache_version_atomic
 from app.platform.jobs.heartbeat import (
     claim_job_attempt_and_start_heartbeat,
     require_ingest_job_update,
@@ -67,7 +68,6 @@ from app.processing.ingest.tasks_common import (
     _derived_record_type,
     _effective_geometry_type,
     _retire_geometry_attribute_row,
-    bump_tile_cache_version_atomic,
     invalidate_tile_cache_for_table,
     stamp_failed_origin_health,
     task_app,
@@ -528,14 +528,10 @@ async def _repair_geom_4326(
                 # would bust every cached tile of every registered dataset on
                 # the first refresh after this ships.
                 #
-                # fix(#1738 round 1): the ATOMIC spelling, because this
-                # transaction holds no lock on the datasets row and the
-                # feature-edit routers write the counter without one either —
-                # see `bump_tile_cache_version_atomic`. It busts browser and
-                # CDN copies through the `_v=` parameter, which the
-                # server-side purge below cannot reach.
+                # fix(#1738): the atomic spelling, because this transaction
+                # holds no lock on the datasets row.
                 tile_version = await bump_tile_cache_version_atomic(
-                    session, Dataset, dataset_uuid
+                    session, dataset_cls=Dataset, dataset_id=dataset_uuid
                 )
                 purge_table = table_name
             await session.commit()

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -3174,3 +3174,231 @@ class TestTheGateRejectsWhatItExistsToCatch:
         tree = ast.parse("async def probe(record):\n    record.title = 'x'\n")
         fn = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
         assert _direct_writes(fn) == {"record"}
+
+
+async def _published_version(dataset_id: uuid.UUID) -> int:
+    import app.core.db as db_module
+
+    async with db_module.async_session() as check:
+        return await check.scalar(
+            select(Dataset.tile_cache_version).where(Dataset.id == dataset_id)
+        )
+
+
+class TestOverlappingEditsEachPublishAVersion:
+    """Two edits of one dataset publish N+1 and then N+2 (#1826, #1902).
+
+    The holder stands in for the first edit: it holds the datasets row, rolls
+    the counter and commits while the request is parked behind it. The request
+    loaded its instance before it waited, so an absolute write from that
+    instance would publish N+1 a second time and serve the second edit's tiles
+    under the first edit's URL.
+    """
+
+    async def _overlap(self, holder, probe, dataset_id, request_coro):
+        """Hold the row, park the request, bump, commit, then let it finish."""
+        before = await holder.scalar(
+            select(Dataset.tile_cache_version)
+            .where(Dataset.id == dataset_id)
+            .with_for_update()
+        )
+        holder_xid = await holder.scalar(text("SELECT pg_current_xact_id()::text"))
+        task = asyncio.create_task(request_coro)
+        try:
+            await _await_waiter_on(probe, holder_xid)
+            first = await holder.scalar(
+                text(
+                    "UPDATE catalog.datasets SET tile_cache_version = "
+                    "tile_cache_version + 1 WHERE id = :d RETURNING tile_cache_version"
+                ),
+                {"d": dataset_id},
+            )
+            await holder.commit()
+        except BaseException:
+            await holder.rollback()
+            raise
+        response = await task
+        assert first == before + 1
+        return before, response
+
+    def _message(self, before: int, published: int) -> str:
+        return (
+            f"the second commit published {published}. The first edit committed "
+            f"{before + 1} while this request was parked, so the second must "
+            f"publish {before + 2}: an absolute write from the instance loaded "
+            "before the wait re-publishes the first edit's version."
+        )
+
+    async def test_a_feature_insert_publishes_the_next_version(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            before, response = await self._overlap(
+                holder,
+                probe,
+                locked_dataset.id,
+                client.post(
+                    f"/datasets/{locked_dataset.id}/features/",
+                    json={
+                        "geometry": {"type": "Point", "coordinates": [-73.96, 40.74]},
+                        "properties": {"name": "second"},
+                    },
+                    headers=admin_auth_header,
+                ),
+            )
+        assert response.status_code == 201, response.text
+        published = await _published_version(locked_dataset.id)
+        assert published == before + 2, self._message(before, published)
+
+    async def test_a_column_add_publishes_the_next_version(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            before, response = await self._overlap(
+                holder,
+                probe,
+                locked_dataset.id,
+                client.post(
+                    f"/layers/{locked_dataset.id}/columns/",
+                    json={"column": {"name": "note_v", "type": "text"}},
+                    headers=admin_auth_header,
+                ),
+            )
+        assert response.status_code == 201, response.text
+        published = await _published_version(locked_dataset.id)
+        assert published == before + 2, self._message(before, published)
+
+    async def test_a_tile_columns_patch_publishes_the_next_version(
+        self, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            before, response = await self._overlap(
+                holder,
+                probe,
+                locked_dataset.id,
+                client.patch(
+                    f"/datasets/{locked_dataset.id}",
+                    json={"title": "Renamed", "tile_columns": ["name"]},
+                    headers=admin_auth_header,
+                ),
+            )
+        assert response.status_code == 200, response.text
+        published = await _published_version(locked_dataset.id)
+        assert published == before + 2, self._message(before, published)
+
+
+class TestTheAtomicBumpReportsWhatItPublished:
+    """The instance carries the returned value and stays clean (#1902)."""
+
+    async def test_the_instance_is_updated_without_being_dirtied(
+        self, locked_dataset, test_db_session
+    ):
+        from sqlalchemy import inspect as sa_inspect
+
+        dataset = await test_db_session.get(Dataset, locked_dataset.id)
+        before = dataset.tile_cache_version
+        version = await catalog_locks.bump_tile_cache_version_on(
+            test_db_session, dataset
+        )
+        assert version == before + 1
+        assert dataset.tile_cache_version == version
+        assert not sa_inspect(dataset).modified, (
+            "the instance is dirty after the atomic bump, so the flush would "
+            "write the value back as an absolute assignment"
+        )
+        await test_db_session.commit()
+        assert await _published_version(locked_dataset.id) == version
+
+    async def test_a_missing_row_answers_none(self, test_db_session):
+        version = await catalog_locks.bump_tile_cache_version_atomic(
+            test_db_session, dataset_cls=Dataset, dataset_id=uuid.uuid4()
+        )
+        assert version is None
+
+
+class TestNoCatalogModuleWritesAnAbsoluteTileVersion:
+    """Nothing under modules/catalog/ calls ``bump_tile_cache_version()``.
+
+    A request handler's instance was loaded before it waited for the row, so
+    the absolute spelling there writes a stale counter (#1902). The atomic
+    spelling is the only one a catalog module may use.
+    """
+
+    CATALOG = Path(__file__).resolve().parents[1] / "app/modules/catalog"
+    ATOMIC = "bump_tile_cache_version_on"
+    ABSOLUTE = "bump_tile_cache_version"
+
+    @staticmethod
+    def _calls_named(tree, name: str) -> list[int]:
+        out = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            called = (
+                func.attr
+                if isinstance(func, ast.Attribute)
+                else func.id
+                if isinstance(func, ast.Name)
+                else None
+            )
+            if called == name:
+                out.append(node.lineno)
+        return out
+
+    def _sites(self, name: str) -> dict[str, int]:
+        sites: dict[str, int] = {}
+        for path in sorted(self.CATALOG.rglob("*.py")):
+            for lineno in self._calls_named(ast.parse(path.read_text()), name):
+                rel = str(path.relative_to(self.CATALOG))
+                sites[f"{rel}:{lineno}"] = lineno
+        return sites
+
+    def test_no_catalog_module_calls_the_absolute_bump(self):
+        offenders = sorted(self._sites(self.ABSOLUTE))
+        assert not offenders, (
+            "absolute tile-version writes under modules/catalog/: "
+            f"{offenders}. Use bump_tile_cache_version_on (platform/catalog_locks), "
+            "which increments the row at write time."
+        )
+
+    def test_the_scan_sees_the_known_request_sites(self):
+        by_file: dict[str, int] = {}
+        for site in self._sites(self.ATOMIC):
+            rel = site.rsplit(":", 1)[0]
+            by_file[rel] = by_file.get(rel, 0) + 1
+        assert by_file == {
+            "features/router.py": 4,
+            "layers/router.py": 4,
+            "datasets/api/router.py": 1,
+        }, by_file
+
+    def test_the_scan_catches_the_absolute_spelling(self):
+        tree = ast.parse(
+            "async def handler(db, dataset):\n"
+            "    dataset.bump_tile_cache_version()\n"
+            "    await db.commit()\n"
+        )
+        assert self._calls_named(tree, self.ABSOLUTE) == [2]
+        assert self._calls_named(tree, self.ATOMIC) == []

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3592,7 +3592,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # Cap 2551 -> 2581, exact.
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 2601, exact.
     # fix(#1847): the cache-bump docstring states its contract. Cap 2601 -> 2596.
-    "backend/app/processing/ingest/tasks_common.py": 2596,
+    # fix(#1902): the atomic bump moved to platform/catalog_locks. Cap 2596 -> 2559.
+    "backend/app/processing/ingest/tasks_common.py": 2559,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -5153,7 +5154,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1134, exact.
     # fix(#1847): phase 3 takes the job row before the datasets row. Cap
     # 1134 -> 1141, exact.
-    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1141,
+    # fix(#1902): the atomic bump comment states its contract. Cap 1141 -> 1137.
+    "backend/app/processing/ingest/tasks_postgis_refresh.py": 1137,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.


### PR DESCRIPTION
Closes #1826. Closes #1902.

## The defect

`lock_catalog_rows` locks the pair by selecting one column per table, so a `Dataset` instance loaded before the wait keeps the `tile_cache_version` it had then. Every request-side writer loaded its instance at the top of the handler and called the absolute `Dataset.bump_tile_cache_version()` after the lock, so it wrote `N + 1` from a counter read before it waited. Two overlapping edits of one dataset both read `N`; the second waited for the first to commit, then wrote `N + 1` again, and its tiles were served under the first edit's `_v=` URL. #1826 is the same class against the PostGIS refresh's phase-3 atomic increment: a feature edit that loaded before the increment and flushed after it overwrote it.

Reproduced before fixing, over HTTP, on all three routers: with the first edit committing `2` while the request was parked, the second commit published `2` again.

## What changed

The increment is evaluated in the database at write time: `tile_cache_version = coalesce(tile_cache_version, 1) + 1 ... RETURNING`, the shape `bump_tile_cache_version_atomic` already had. It now lives in `platform/catalog_locks.py`, where both the catalog and the worker can reach it (`modules/catalog/` may not import `app.processing.*`), and `tasks_postgis_refresh` imports it from there. The copy in `ingest/tasks_common.py` is gone.

`bump_tile_cache_version_on(session, dataset)` is the request-side spelling. It runs the atomic increment for a loaded instance and sets the instance's `tile_cache_version` to the returned value through `set_committed_value`, so a later reader on the same session sees what was published and the flush does not write it back. A test pins that the instance is not dirty afterwards.

Nine sites go through it. The issues count seven; the layers router has four, not three, and the metadata PATCH in `datasets/api/router.py` is a ninth of the same shape (it bumps on a `tile_columns` change from an instance loaded before its acquisition).

- `modules/catalog/features/router.py`: create, replace, patch, delete. The insert and delete log lines now carry the version that was returned.
- `modules/catalog/layers/router.py`: add, rename, retype, drop column.
- `modules/catalog/datasets/api/router.py`: `update_user_metadata`, `tile_columns` branch.

The absolute method stays for the worker phases that load the row under a lock they still hold, and its docstring now says so:

- `tasks_postgis_refresh.py` phase 3 and `tasks_stac_refresh.py`: each takes the datasets row `FOR UPDATE` for its superseded-content guard and selects the `Dataset` after that, so the instance was read under the held lock.
- `tasks_vrt.py` publish: the asset `SELECT` ahead of it already holds the datasets row through its join, and the `Dataset` is selected after that.

## Noticed and left alone

Two worker doors do not re-load under their lock and are the same class from the other side: `tasks_raster_replace.py` assigns the absolute bump in `_write_swapped_fields` before its acquisition, and `_apply_reupload_swap` in `tasks_common.py` bumps an instance its caller loaded before the ACCESS EXCLUSIVE wait. A request edit committing in either window would be overwritten. Both issues scope this to the request side, and `test_reupload_swap_lock_retry.py` mirrors the swap with a stub session and a stubbed `bump_tile_cache_version`, so switching them is its own change. Flagging for a follow-up rather than widening this one.

## Tests

`tests/test_feature_lock_order_1847.py`, beside the lock-order gate:

- `TestOverlappingEditsEachPublishAVersion`: three two-session tests, one per router, over HTTP. A holder takes the datasets row, the request parks behind it (barrier on `pg_stat_activity`, as the siblings do), the holder increments and commits, and the second commit must publish `N + 2`.
- `TestTheAtomicBumpReportsWhatItPublished`: the returned value is the instance's value, the instance is not dirty, and a missing row answers `None`.
- `TestNoCatalogModuleWritesAnAbsoluteTileVersion`: an AST walk over `modules/catalog/` fails on any call to the absolute spelling, with a positive control that the walk sees the nine atomic sites and a synthetic absolute call.

Counterfactual, actually run: with the nine sites reverted to the absolute bump and everything else held, the three overlap tests fail with `the second commit published 2 ... so the second must publish 3`, the gate lists all nine sites, and the positive control sees none.

## Schema, API and config impact

None. No migration, no request or response schema change. `scripts/dump_openapi.py --check` exits 0.

## Module LOC caps

Both shrank, each re-measured with `wc -l` and set to the exact figure with the reason in the entry: `processing/ingest/tasks_common.py` 2596 to 2559, `processing/ingest/tasks_postgis_refresh.py` 1141 to 1137. The one failure in the combined run above was the postgis entry still at 1141; the layering rerun is after that fix. The three routers are under the router glob gate and stay below its ceiling.

## Verification

Run from the worktree against Postgres at localhost:5434.

```
uv run pytest tests/test_feature_lock_order_1847.py -q                    76 passed, 1 skipped
uv run pytest tests/test_features_crud.py tests/test_features_incremental_metadata.py \
  tests/test_feature_geometry_limits.py tests/test_features_unwritable_columns.py \
  tests/test_features_property_filter_types.py tests/test_layers.py \
  tests/test_layers_authz_sec_audit.py tests/test_dataset_tile_columns_metadata.py \
  tests/test_metadata_roundtrip.py tests/test_postgis_refresh_1265.py \
  tests/test_worker_tile_cache_1315.py tests/test_registered_geom_4326_rederive_1738.py \
  tests/test_refresh_gate_1269.py tests/test_reupload_swap_lock_retry.py \
  tests/test_stac_refresh_1266.py tests/test_layering.py \
  tests/test_rule1_structural.py tests/test_rule2_structural.py -q    507 passed, 3 skipped, 1 failed
uv run pytest tests/test_layering.py -q                                    50 passed
uv run ruff check . && uv run ruff format --check .                     passed
scripts/dump_openapi.py --check                                          exit 0
```
