### PR TITLE
fix(catalog): end the lock-timeout marker at commit and take the pair on every PATCH (#1890, #1881)

### DIFF
--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -129,12 +129,6 @@ _DATASET_FIELD_MAP: dict[str, str] = {
 }
 
 
-# fix(#1847): request fields that reach the `catalog.datasets` row, so a body
-# carrying one makes this a two-row write. `is_dem` is handled separately: it
-# writes `raster_assets`, which is ordered ahead of the pair, not with it.
-_DATASET_ROW_FIELDS = frozenset(_DATASET_FIELD_MAP) | {"tile_columns"}
-
-
 # Never clearable to NULL via the PATCH: records.title is NOT NULL.
 _NON_CLEARABLE_FIELDS = {"title"}
 
@@ -311,14 +305,13 @@ async def update_user_metadata(
 
     record = dataset.record
 
-    # fix(#1847): BEFORE the first assignment below, and only when the body
-    # reaches beyond the record: one row has no order to get wrong. `is_dem`
-    # writes raster_assets, so it extends the order to that child.
+    # fix(#1881): the pair, before the first write, whatever the body names:
+    # a workflow hook may write the datasets row on a record_status body.
+    # `is_dem` writes raster_assets, so it extends the order to that child.
     touches_raster = "is_dem" in meta.model_fields_set
-    if touches_raster or meta.model_fields_set & _DATASET_ROW_FIELDS:
-        await lock_catalog_rows_for_write(
-            session, dataset, with_raster_asset=touches_raster
-        )
+    await lock_catalog_rows_for_write(
+        session, dataset, with_raster_asset=touches_raster
+    )
 
     if "language" in meta.model_fields_set:
         effective_language = meta.language or "en"

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from contextvars import ContextVar
 from typing import Any
 
-from sqlalchemy import func, select, text, update
+from sqlalchemy import event, func, select, text, update
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import set_committed_value
@@ -32,11 +32,13 @@ _USE_REQUEST_DEFAULT: Any = object()
 CATALOG_LOCK_CONFLICT_CODE = "catalog_lock_conflict"
 
 
-# fix(#1847): set when THIS request installed the catalog timeout, so the
-# boundary handler does not read an unrelated 40P01 as a busy dataset.
+# fix(#1847, #1890): true from the SET LOCAL until the transaction that ran it
+# commits, so the boundary handler answers 409 only for a wait inside it.
 catalog_timeout_installed: ContextVar[bool] = ContextVar(
     "catalog_timeout_installed", default=False
 )
+
+_MARKER_LISTENER_KEY = "catalog_timeout_marker_listener"
 
 
 class CatalogLockConflict(Exception):
@@ -137,8 +139,25 @@ async def _install_lock_timeout(
         # `SET LOCAL` takes a literal; this value is a constant, never
         # request-supplied.
         await session.execute(text(f"SET LOCAL lock_timeout = '{lock_timeout}'"))
+        _clear_marker_on_commit(session)
         # Each request runs in its own task, so this cannot leak across them.
         catalog_timeout_installed.set(True)
+
+
+def _clear_marker_on_commit(session: AsyncSession) -> None:
+    """Register, once per session, the commit listener that ends the marker.
+
+    The listener runs inside ``commit()`` on the request's own task, so the
+    reset lands in the context that set the marker.
+    """
+    if session.info.get(_MARKER_LISTENER_KEY):
+        return
+    session.info[_MARKER_LISTENER_KEY] = True
+    event.listen(session.sync_session, "after_commit", _forget_lock_timeout)
+
+
+def _forget_lock_timeout(_session: Any) -> None:
+    catalog_timeout_installed.set(False)
 
 
 async def _raise_rolled_back_conflict(session: AsyncSession, exc: DBAPIError) -> None:

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -145,18 +145,17 @@ async def _install_lock_timeout(
 
 
 def _clear_marker_on_commit(session: AsyncSession) -> None:
-    """Register, once per session, the commit listener that ends the marker.
-
-    The listener runs inside ``commit()`` on the request's own task, so the
-    reset lands in the context that set the marker.
-    """
+    """Register, once per session, the listener that ends the marker at the
+    outermost commit; a savepoint release is not a commit."""
     if session.info.get(_MARKER_LISTENER_KEY):
         return
     session.info[_MARKER_LISTENER_KEY] = True
     event.listen(session.sync_session, "after_commit", _forget_lock_timeout)
 
 
-def _forget_lock_timeout(_session: Any) -> None:
+def _forget_lock_timeout(session: Any) -> None:
+    if session.in_nested_transaction():
+        return
     catalog_timeout_installed.set(False)
 
 

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -541,7 +541,11 @@ class _RecordingSession:
     """Captures the statements the lock helper emits, in order."""
 
     def __init__(self):
+        from sqlalchemy.orm import Session
+
         self.statements: list[str] = []
+        self.info: dict = {}
+        self.sync_session = Session()
 
     @property
     def no_autoflush(self):
@@ -861,6 +865,90 @@ class TestMetadataPatchTakesThePairToo:
 
         assert response.status_code == 200, response.text
         assert response.json()["title"] == "Renamed by the metadata patch"
+
+
+class TestTheMetadataPatchTakesThePairOnEveryBody:
+    """fix(#1881): the body does not decide the order.
+
+    A workflow hook runs on a `record_status` body with the dataset in its
+    context, so a PATCH that names no dataset field can still write the
+    datasets row. Every PATCH takes the pair, before its first write.
+    """
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param({"summary": "A record field alone"}, id="record-field"),
+            pytest.param({"record_status": "internal"}, id="record-status"),
+        ],
+    )
+    async def test_a_record_only_patch_waits_for_the_datasets_row_holding_nothing(
+        self, body, locked_dataset, client: AsyncClient, admin_auth_header, monkeypatch
+    ):
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "60s")
+
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as probe,
+        ):
+            await holder.execute(
+                select(Dataset.tile_cache_version)
+                .where(Dataset.id == locked_dataset.id)
+                .with_for_update()
+            )
+            holder_xid = await holder.scalar(text("SELECT pg_current_xact_id()::text"))
+
+            patch = asyncio.create_task(
+                client.patch(
+                    f"/datasets/{locked_dataset.id}",
+                    json=body,
+                    headers=admin_auth_header,
+                )
+            )
+            try:
+                await _await_waiter_on(probe, holder_xid)
+                assert not await _holds_record_lock(probe, locked_dataset.record_id), (
+                    "the record-only PATCH is parked on the datasets row while "
+                    "holding catalog.records, which is the inverted order"
+                )
+                await holder.execute(
+                    text(
+                        "UPDATE catalog.records SET updated_at = now() WHERE id = :rid"
+                    ),
+                    {"rid": locked_dataset.record_id},
+                )
+                await holder.commit()
+            except BaseException:
+                await holder.rollback()
+                raise
+            response = await patch
+
+        assert response.status_code == 200, response.text
+        for field, value in body.items():
+            assert response.json()[field] == value
+
+    def test_the_gate_sees_the_acquisition_on_every_path(self):
+        """The structural pin: no exemption, and the walk finds the site."""
+        key = (
+            "app.modules.catalog.datasets.domain.service_metadata.update_user_metadata"
+        )
+        assert key not in _CONDITIONAL_ACQUISITION, (
+            "update_user_metadata is exempt from the every-path rule again; a "
+            "branch around its acquisition is what #1881 removed"
+        )
+        found = [
+            (module, bindings, fn)
+            for _rel, module, bindings, fn in _walk_app_functions()
+            if f"{module}.{fn.name}" == key
+        ]
+        assert found, "the gate walk no longer sees update_user_metadata"
+        module, bindings, fn = found[0]
+        ok, why = acquisition_dominates_writes(
+            fn, bindings, module, _acquiring_functions()
+        )
+        assert ok, why
 
 
 class TestAttributeEditsTakeThePairToo:
@@ -2008,6 +2096,114 @@ class TestOnlyThisRequestsTimeoutIsAnswered:
         )
 
 
+class TestTheMarkerEndsWithItsTransaction:
+    """fix(#1890): the marker stands for a `SET LOCAL`, which ends with the
+    transaction that ran it. A conflict after that commit is not a busy
+    catalog row, and a 409 there would have the client re-apply a committed
+    update."""
+
+    async def test_commit_clears_the_marker_the_acquisition_set(self, locked_dataset):
+        import app.core.db as db_module
+
+        async with db_module.async_session() as session:
+            # Twice: the second acquisition must re-arm the marker and still
+            # register one listener.
+            for _ in range(2):
+                await catalog_locks.lock_catalog_rows(
+                    session,
+                    dataset_cls=Dataset,
+                    record_cls=Record,
+                    dataset_id=locked_dataset.id,
+                    record_id=locked_dataset.record_id,
+                )
+                assert catalog_locks.catalog_timeout_installed.get() is True
+                await session.commit()
+                assert catalog_locks.catalog_timeout_installed.get() is False, (
+                    "the transaction that installed the lock timeout has "
+                    "committed and the marker still says it is installed"
+                )
+            listeners = list(session.sync_session.dispatch.after_commit.listeners)
+            assert listeners.count(catalog_locks._forget_lock_timeout) == 1
+
+    async def test_a_conflict_after_the_commit_keeps_its_operational_answer(
+        self,
+        locked_dataset,
+        client: AsyncClient,
+        admin_auth_header,
+        test_db_session,
+        monkeypatch,
+    ):
+        """The PATCH commits, then reads to build its response."""
+        import app.modules.catalog.datasets.api.router as router_module
+
+        class _Orig:
+            sqlstate = "40P01"
+
+        async def _deadlock_victim(*_args, **_kwargs):
+            raise DBAPIError("SELECT 1", {}, _Orig())
+
+        monkeypatch.setattr(router_module, "_load_actor_identities", _deadlock_victim)
+        response = await client.patch(
+            f"/datasets/{locked_dataset.id}",
+            json={"title": "Committed before the deadlock"},
+            headers=admin_auth_header,
+        )
+        assert response.status_code == 503, (
+            "a deadlock on the response read, after the update committed, was "
+            f"answered as a retryable busy dataset: {response.status_code} "
+            f"{response.text}"
+        )
+        title = await test_db_session.scalar(
+            select(Record.title).where(Record.id == locked_dataset.record_id)
+        )
+        assert title == "Committed before the deadlock"
+
+    async def test_a_conflict_inside_the_transaction_still_answers_409(
+        self,
+        locked_dataset,
+        client: AsyncClient,
+        admin_auth_header,
+        test_db_session,
+        monkeypatch,
+    ):
+        """A wait after the acquisition, on a cascade child it does not lock.
+
+        The failed transaction is rolled back before the boundary handler
+        reads the marker, so a rollback-time reset would answer this 503.
+        """
+        monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
+        import app.core.db as db_module
+        from app.modules.catalog.maps.models import Map, MapLayer
+
+        admin_id = await get_user_id(test_db_session, "admin")
+        the_map = Map(name="marker scope map", created_by=admin_id)
+        test_db_session.add(the_map)
+        await test_db_session.flush()
+        layer = MapLayer(map_id=the_map.id, dataset_id=locked_dataset.id, sort_order=0)
+        test_db_session.add(layer)
+        await test_db_session.commit()
+
+        try:
+            async with db_module.async_session() as holder:
+                await holder.execute(
+                    select(MapLayer.id).where(MapLayer.id == layer.id).with_for_update()
+                )
+                response = await client.request(
+                    "DELETE",
+                    f"/datasets/{locked_dataset.id}",
+                    json={"confirm_title": f"Lock order {locked_dataset.table_name}"},
+                    headers=admin_auth_header,
+                )
+                await holder.rollback()
+            assert response.status_code == 409, response.text
+            assert response.json()["detail"]["code"] == "catalog_lock_conflict"
+        finally:
+            await test_db_session.execute(
+                text("DELETE FROM catalog.maps WHERE id = :m"), {"m": the_map.id}
+            )
+            await test_db_session.commit()
+
+
 class TestTheOtherSitesHoldTheOrderToo:
     """The layers DDL, the delete and the metadata PATCH, against a held row.
 
@@ -2364,11 +2560,6 @@ _ORDERS_RASTER_ITSELF = {
 # Functions whose acquisition is deliberately conditional. Every other site
 # must acquire on every path; these carry the reason the unlocked path is safe.
 _CONDITIONAL_ACQUISITION = {
-    "app.modules.catalog.datasets.domain.service_metadata.update_user_metadata": (
-        "the unlocked branch writes the records row ALONE, and a one-row write "
-        "has no order to get wrong. Gated on _DATASET_ROW_FIELDS, which is the "
-        "set of request fields that reach catalog.datasets."
-    ),
     "app.modules.catalog.features.router.patch_single_feature": (
         "both arms acquire, one through the refresh and one directly, which "
         "test_every_write_handler_acquires_on_every_path checks per arm."

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -868,12 +868,7 @@ class TestMetadataPatchTakesThePairToo:
 
 
 class TestTheMetadataPatchTakesThePairOnEveryBody:
-    """fix(#1881): the body does not decide the order.
-
-    A workflow hook runs on a `record_status` body with the dataset in its
-    context, so a PATCH that names no dataset field can still write the
-    datasets row. Every PATCH takes the pair, before its first write.
-    """
+    """fix(#1881): every PATCH takes the pair before its first write."""
 
     @pytest.mark.parametrize(
         "body",
@@ -2097,10 +2092,7 @@ class TestOnlyThisRequestsTimeoutIsAnswered:
 
 
 class TestTheMarkerEndsWithItsTransaction:
-    """fix(#1890): the marker stands for a `SET LOCAL`, which ends with the
-    transaction that ran it. A conflict after that commit is not a busy
-    catalog row, and a 409 there would have the client re-apply a committed
-    update."""
+    """fix(#1890): the marker ends with the transaction that installed it."""
 
     async def test_commit_clears_the_marker_the_acquisition_set(self, locked_dataset):
         import app.core.db as db_module
@@ -2117,6 +2109,12 @@ class TestTheMarkerEndsWithItsTransaction:
                     record_id=locked_dataset.record_id,
                 )
                 assert catalog_locks.catalog_timeout_installed.get() is True
+                async with session.begin_nested():
+                    await session.execute(text("SELECT 1"))
+                assert catalog_locks.catalog_timeout_installed.get() is True, (
+                    "a savepoint release cleared the marker while the "
+                    "SET LOCAL it stands for is still live"
+                )
                 await session.commit()
                 assert catalog_locks.catalog_timeout_installed.get() is False, (
                     "the transaction that installed the lock timeout has "
@@ -2166,11 +2164,7 @@ class TestTheMarkerEndsWithItsTransaction:
         test_db_session,
         monkeypatch,
     ):
-        """A wait after the acquisition, on a cascade child it does not lock.
-
-        The failed transaction is rolled back before the boundary handler
-        reads the marker, so a rollback-time reset would answer this 503.
-        """
+        """A wait after the acquisition, inside its transaction, is still 409."""
         monkeypatch.setattr(catalog_locks, "REQUEST_LOCK_TIMEOUT", "150ms")
         import app.core.db as db_module
         from app.modules.catalog.maps.models import Map, MapLayer

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1877,7 +1877,9 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # fix(#1847): +31. `sample_example_values` reads the data table on its
         # own and `reset_attribute` takes the sample as an argument, so the
         # reset samples before it takes the pair. Cap 488 -> 519, exact.
-        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 519,
+        # fix(#1881): -7. The PATCH takes the pair on every body, so the
+        # request-field whitelist and its branch are gone. Cap 519 -> 512, exact.
+        "backend/app/modules/catalog/datasets/domain/service_metadata.py": 512,
         # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
         # before degrading a 42P01 to an empty page. Postgres reports a missing
         # tenant data schema with the same code as a raster dataset's synthetic

--- a/backend/tests/test_workflow_extension.py
+++ b/backend/tests/test_workflow_extension.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
 
 from fastapi import HTTPException
@@ -327,9 +327,17 @@ async def test_metadata_patch_endpoint_uses_overlay_block():
     db = _FakeDB(dataset)
     ext_mod._extensions["workflow"] = BlockingWorkflow()
 
-    with patch(
-        "app.modules.catalog.datasets.domain.service_metadata.get_dataset",
-        return_value=dataset,
+    # fix(#1881): the PATCH takes the catalog pair on every body, and the
+    # fake DB has no rows to lock.
+    with (
+        patch(
+            "app.modules.catalog.datasets.domain.service_metadata.get_dataset",
+            return_value=dataset,
+        ),
+        patch(
+            "app.modules.catalog.features.service.lock_catalog_rows_for_write",
+            new=AsyncMock(return_value=None),
+        ),
     ):
         with pytest.raises(HTTPException) as exc:
             await update_dataset_metadata(


### PR DESCRIPTION
Closes #1890 and #1881. Both are follow-ups from the #1864 reviews. The lock order #1864 installed is unchanged.

## #1890: the marker ends with the transaction that installed it

`catalog_timeout_installed` (`backend/app/platform/catalog_locks.py`) stands for a `SET LOCAL lock_timeout`, which PostgreSQL drops at the end of the transaction that ran it. The marker was request-scoped, so after the metadata PATCH committed it stayed true through the response build (`refresh`, `_load_actor_identities`, the lineage read). A 40P01 on any of those was answered `catalog_lock_conflict`, a retryable 409, although the update and its audit row were already committed. A client retrying on that code re-applies the PATCH.

`_install_lock_timeout` now registers an `after_commit` listener on the session's `sync_session`, once per session (guarded through `session.info`), that resets the marker. The listener runs inside `commit()` on the request's own task, and SQLAlchemy's greenlet shares the driver task's contextvar context, so the reset lands where the set did.

SQLAlchemy dispatches `after_commit` for a savepoint release as well as for the outermost commit, and a savepoint release leaves the `SET LOCAL` live. The listener returns without clearing while `session.in_nested_transaction()` is true. Measured before settling on that predicate: `session.in_transaction()` is still true during the outer commit's dispatch (the transaction closes after it), so that predicate never clears; without a guard, a `begin_nested()` block after the acquisition clears the marker with the timeout still in force. The commit test covers both edges: the marker survives a savepoint release and goes false at the outer commit.

Rollback is deliberately not a listener site. The failed transaction is rolled back before the boundary handler reads the marker: a flush failure rolls back inside SQLAlchemy, and `get_db`'s `except` rolls back in the request stack, which FastAPI unwinds before `wrap_app_handling_exceptions` runs the `DBAPIError` handler. Measured with an `after_rollback` listener added: `test_a_conflict_inside_the_transaction_still_answers_409` (a DELETE whose record cascade waits on a held `map_layers` row) fails, the 55P03 escaping the handler as an unhandled error instead of the 409 that #1847 promised. After a rollback nothing from the timeout-bearing transaction was committed, so a 409 for a later wait in the same request keeps its "safe to retry" meaning, and the next commit clears it.

## #1881: the PATCH takes the pair on every body

`_DATASET_ROW_FIELDS` in `service_metadata.py` decided from request fields whether `update_user_metadata` took the datasets row before the records row. `_apply_record_status_change` runs on a `record_status` body, outside that set, and calls `workflow.on_transition(context)` with the dataset in the context. An overlay whose hook writes the datasets row there would reintroduce the records-first order, and the structural gate cannot see through `on_transition`.

The whitelist and its branch are gone. Every PATCH takes the pair before its first write, with the raster child ahead of it when `is_dem` is in the body. The acquisition sits after everything the handler does before it, which is the access check and `get_dataset`; the PATCH path does no network I/O before its writes. `update_user_metadata` is removed from `_CONDITIONAL_ACQUISITION`, so `test_the_acquisition_precedes_the_writes_on_every_path` now walks it with no exemption, and a new test pins that.

Cost on a metadata-only PATCH: one `SET LOCAL` and one `SELECT ... FOR UPDATE` on each of the two rows, plus the extent read the helper already does, all on rows the transaction was about to write.

Behaviour change, measured: a title, summary or record_status-only PATCH that previously succeeded beside a holder of the datasets row (200 in 0.27 s) now waits the lock timeout and answers 409 (2.17 s). That is the intended #1881 outcome: the body no longer decides the order, so every PATCH pays the same wait a tile_columns body already paid. No hot path was found that sends such a PATCH while a refresh or feature edit holds the row: the builder autosave writes maps, and CLI apply is sequential per dataset.

## Schema, API and config impact

None. No migration, no request or response schema change.

## Tests

In `tests/test_feature_lock_order_1847.py`:

- `TestTheMarkerEndsWithItsTransaction`: the marker is true after an acquisition and false after its commit, twice on one session with one listener registered; a PATCH whose post-commit response read raises a 40P01 answers 503 and the title is committed; a DELETE whose cascade waits inside the transaction still answers 409 with `catalog_lock_conflict`.
- `TestTheMetadataPatchTakesThePairOnEveryBody`: a `summary`-only body and a `record_status`-only body each park behind a held datasets row holding no records lock, then complete; and the gate finds `update_user_metadata` with the acquisition dominating every path and no exemption.
- `_RecordingSession` gained `info` and a bind-less `sync_session`, which the listener registration now touches.

`tests/test_workflow_extension.py::test_metadata_patch_endpoint_uses_overlay_block` drives the PATCH handler with a fake DB and a `record_status` body, which now reaches the acquisition; it patches `lock_catalog_rows_for_write` out, since the test is about the workflow gate.

`_MODULE_LOC_CAPS`: `service_metadata.py` 519 -> 512, exact.

## Verification

From the worktree against Postgres at localhost:5434.

```
uv run pytest tests/test_feature_lock_order_1847.py tests/test_datasets.py \
  tests/test_dataset_metadata_idor.py tests/test_dataset_tile_columns_metadata.py \
  tests/test_dataset_attribution.py tests/test_dataset_rows_db_errors.py \
  tests/test_dataset_delete_tile_cache_purge.py tests/test_dataset_history_redaction.py \
  tests/test_inherited_keywords.py tests/test_workflow_extension.py \
  tests/test_layering.py tests/test_rule1_structural.py tests/test_rule2_structural.py -q
420 passed, 1 skipped

uv run ruff check . && uv run ruff format --check .    passed
```

Counterfactuals, each with only that half reverted and every test kept:

- #1890 (listener removed): `test_commit_clears_the_marker_the_acquisition_set` fails with "the transaction that installed the lock timeout has committed and the marker still says it is installed"; `test_a_conflict_after_the_commit_keeps_its_operational_answer` fails with `409 {"title":"Catalog entry is busy",...,"code":"catalog_lock_conflict"}` where 503 was expected. 2 failed, 4 passed in the marker selection.
- #1881 (whitelist restored): both `test_a_record_only_patch_waits_for_the_datasets_row_holding_nothing` cases fail with "nothing ever queued behind transaction N; the request under test did not reach a blocking acquisition"; `test_the_gate_sees_the_acquisition_on_every_path` and `test_the_acquisition_precedes_the_writes_on_every_path` fail with "line 338 writes a catalog row with no acquisition before it on this path". 4 failed, 6 passed in that selection.

## Noticed and left alone

Option 2 in #1881 (a workflow protocol flag declaring whether `on_transition` writes the dataset row) would put a promise in the overlay that the gate still could not check. Locking unconditionally needs no promise.

The two status endpoints in `router_data.py` also call `on_transition`; they are outside this PR's scope and are not in the #1864 lock order today.
