### PR TITLE
fix(tenancy): judge gateway members by oid so a dropped role cannot fail adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- Tenant-ownership adoption no longer fails when a role that is a member of a gateway is dropped
+  while the run is validating the cluster; the vanished member is skipped instead. (#1913)
+
 ## [1.18.1] - 2026-09-05
 
 Security release. Upgrade is a plain image pull; there are no migrations.

--- a/backend/app/core/db/tenant_adoption_sql.py
+++ b/backend/app/core/db/tenant_adoption_sql.py
@@ -352,6 +352,8 @@ BEGIN
                       '{CONTROL}';
         END IF;
 
+        -- fix(#1913): members are judged by oid, never by name; a role dropped
+        -- since the scan is then no hazard instead of an undefined-object error.
         IF direct_membership_unsafe
            OR membership_row.granted_name = '{PROVISIONER}'
            OR NOT membership_row.rolcanlogin
@@ -371,7 +373,7 @@ BEGIN
                    OR powerful_role.rolbypassrls
                )
                  AND pg_catalog.pg_has_role(
-                     membership_row.member_name, powerful_role.oid, 'MEMBER'
+                     membership_row.member_oid, powerful_role.oid, 'MEMBER'
                  )
            )
            OR (
@@ -383,7 +385,7 @@ BEGIN
                        '{CONTROL}', '{WRITER}', '{SANDBOX}'
                    )
                      AND pg_catalog.pg_has_role(
-                         membership_row.member_name,
+                         membership_row.member_oid,
                          application_gateway.oid,
                          'MEMBER'
                      )
@@ -396,7 +398,7 @@ BEGIN
                    FROM pg_catalog.pg_roles AS tile_gateway
                    WHERE tile_gateway.rolname = '{TILE}'
                      AND pg_catalog.pg_has_role(
-                         membership_row.member_name, tile_gateway.oid, 'MEMBER'
+                         membership_row.member_oid, tile_gateway.oid, 'MEMBER'
                      )
                )
            ) THEN

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2820,7 +2820,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # three type surfaces; schema-less default privileges counted in the
     # fast-path guard and refused cluster-wide for the provisioner (the
     # per-tenant pass never runs with zero tenants).
-    "backend/app/core/db/tenant_adoption_sql.py": 2102,
+    # fix(#1913): +2 — the anchor on the member-judgement clause, which now
+    # resolves a gateway member by oid so a role dropped since the scan is
+    # skipped rather than raised.
+    "backend/app/core/db/tenant_adoption_sql.py": 2104,
     # fix(#998): the tool the DDL above serves — the catalog reads that decide
     # whether anything is left to do, the steps that close the gap, and the
     # operator CLI. Already decomposed three ways (report types and the success

--- a/backend/tests/test_tenant_ownership_adoption.py
+++ b/backend/tests/test_tenant_ownership_adoption.py
@@ -1442,6 +1442,38 @@ class TestReportedStateMatchesWhatApplyEnforces:
         finally:
             await engine.dispose()
 
+    async def test_a_member_dropped_after_the_scan_does_not_fail_validation(self):
+        """fix(#1913): a gateway member the scan enumerated and a peer dropped
+        before it is judged is no hazard; validation completes.
+        """
+        vanishing = f"w1913_member_{uuid.uuid4().hex[:12]}"
+        engine = _make_engine()
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    sa.text(
+                        f"CREATE ROLE {vanishing} LOGIN NOSUPERUSER NOCREATEDB "
+                        "NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS"
+                    )
+                )
+                await conn.execute(
+                    sa.text(f"GRANT {TILE} TO {vanishing} WITH INHERIT FALSE, SET TRUE")
+                )
+            try:
+                async with engine.connect() as scan:
+                    await scan.execution_options(isolation_level="REPEATABLE READ")
+                    async with scan.begin():
+                        # Pins the scan's snapshot ahead of the drop.
+                        await scan.execute(sa.text("SELECT 1"))
+                        async with engine.begin() as other:
+                            await other.execute(sa.text(f"DROP ROLE {vanishing}"))
+                        await scan.execute(sa.text(CLUSTER_ROLE_VALIDATE_SQL))
+            finally:
+                async with engine.begin() as conn:
+                    await conn.execute(sa.text(f"DROP ROLE IF EXISTS {vanishing}"))
+        finally:
+            await engine.dispose()
+
     async def test_healthy_cluster_topology_reports_no_error(self):
         engine = _make_engine()
         try:


### PR DESCRIPTION
## What changed

`CLUSTER_ROLE_VALIDATE_SQL` (`backend/app/core/db/tenant_adoption_sql.py`) enumerates every direct member of the reserved gateway roles and then calls `pg_has_role` on each one **by name** at three sites. Roles are cluster objects, so a member that another session drops between the scan and that call raises `UndefinedObjectError: role "..." does not exist` and aborts the whole adoption run. The three calls now pass the member's **oid**, which the scan already holds; the oid form returns false for a role that no longer exists, so the vanished member is skipped and validation completes.

Under xdist this is the tile-cache suite creating and dropping a `geolens_tile_gateway` member on another worker while the adoption suite runs on this one (#1913). Outside tests it is an operator's concurrent `DROP ROLE`, which adoption has no business failing on. Adoption keys on gateway membership, not on a naming convention, so renaming the tile-cache test's throwaway role would not have removed the exposure; the test role is left as it is.

## Files

- `backend/app/core/db/tenant_adoption_sql.py`: three `pg_has_role(member_name, ...)` -> `pg_has_role(member_oid, ...)`, plus the two-line fix anchor.
- `backend/tests/test_tenant_ownership_adoption.py`: `test_a_member_dropped_after_the_scan_does_not_fail_validation` creates a gateway member, pins a repeatable-read snapshot that still holds the membership row, drops the role from a second connection, then runs the validation block. Before the fix this reproduces the exact CI error deterministically (verified); after it passes.
- `backend/tests/test_layering.py`: `_MODULE_LOC_CAPS` for `tenant_adoption_sql.py` 2102 -> 2104 for the anchor.
- `CHANGELOG.md`: Unreleased / Fixed entry.

## Verification

```
uv run pytest tests/test_tenant_ownership_adoption.py tests/test_tile_cache.py tests/test_layering.py -q
154 passed in 69.67s

uv run ruff check . && uv run ruff format --check .
All checks passed! / 1180 files already formatted
```

Positive control: the new test run against the unfixed module fails with `asyncpg.exceptions.UndefinedObjectError: role "w1913_member_..." does not exist`, the same class and message shape as the CI failure in #1913.

Closes #1913
