### PR TITLE
fix(scripts): judge an empty key and a tab-holding key as Compose loads them (#1909)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and releases use semantic versioning.
 
 - Tenant-ownership adoption no longer fails when a role that is a member of a gateway is dropped
   while the run is validating the cluster; the vanished member is skipped instead. (#1913)
+- `make dev` preflight now judges a `.env` line whose key is empty or holds a tab the way docker
+  compose loads it: a value compose cannot resolve is refused before the build instead of at
+  compose load, and a multiline value under such a key no longer fails the check. (#1909)
 
 ## [1.18.1] - 2026-09-05
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1808,6 +1808,44 @@ effective_env_value_into() {
 env_file_first_refused_line() {
   _efrl_file="$1"
   [ -f "$_efrl_file" ] || return 1
+
+  # fix(#1909): an empty key and a key holding a tab load under Compose but fit
+  # no record, so the file is judged from a copy naming each such key with `-`
+  # (no `${}` can reference it) and a hit on such a line is renamed from FILE.
+  _efrl_copy="${_ENV_SNAPSHOT_DIR:?}/env-file-copy.$$"
+  _efrl_renamed="$(LC_ALL=C awk -v copy="$_efrl_copy" '
+    { line = $0 }
+    match(line, /^[ \t]*(export[ \t]+)?[]A-Za-z0-9_.[\t-]*[=:]/) {
+      key = substr(line, 1, RLENGTH - 1)
+      rest = substr(line, RLENGTH)
+      sub(/^[ \t]*(export[ \t]+)?/, "", key)
+      pre = substr(line, 1, RLENGTH - 1 - length(key))
+      trail = key
+      sub(/[ \t]+$/, "", key)
+      trail = substr(trail, length(key) + 1)
+      if (key == "" || index(key, "\t") > 0) {
+        name = key
+        sub(/\t.*$/, "", name)
+        print NR, (name == "" ? "?" : name)
+        gsub(/\t/, "-", key)
+        line = pre (key == "" ? "-" : key) trail rest
+      }
+    }
+    { print line > copy }' "$_efrl_file")" || fail "env_file_first_refused_line: could not copy $_efrl_file"
+  _efrl_hit=""
+  _efrl_rc=0
+  _env_file_first_refused_line "$_efrl_copy" || _efrl_rc=$?
+  rm -f "$_efrl_copy"
+  [ "$_efrl_rc" -eq 0 ] || return "$_efrl_rc"
+  _efrl_name="$(printf '%s\n' "$_efrl_renamed" | awk -v line="${_efrl_hit%% *}" '$1 == line { print $2; exit }')"
+  [ -z "$_efrl_name" ] || _efrl_hit="${_efrl_hit%% *} $_efrl_name ${_efrl_hit##* }"
+  printf '%s' "$_efrl_hit"
+}
+
+# Sets _efrl_hit to "LINE KEY REASON" for the first line of FILE that Compose
+# refuses to load with rc 0; rc 1 when every line loads.
+_env_file_first_refused_line() {
+  _efrl_file="$1"
   _efrl_records="$(_env_tokenize "$_efrl_file")" || return 1
 
   # Compose's parse phase: a key ends at `=` or `:`, holds letters, digits,
@@ -1842,17 +1880,11 @@ env_file_first_refused_line() {
         if (substr(bad, j, 1) < "\200") { print NR, name, "unexpected-character"; exit }
       }
     }' "$_efrl_file")" || fail "env_file_first_refused_line: could not scan $_efrl_file"
-  if [ -n "$_efrl_hit" ]; then
-    printf '%s' "$_efrl_hit"
-    return 0
-  fi
+  [ -z "$_efrl_hit" ] || return 0
 
   _efrl_hit="$(printf '%s' "$_efrl_records" | awk '$1 == "U" { print $2, $4, "unterminated-quote"; exit }')" \
     || fail "env_file_first_refused_line: could not scan the records of $_efrl_file"
-  if [ -n "$_efrl_hit" ]; then
-    printf '%s' "$_efrl_hit"
-    return 0
-  fi
+  [ -z "$_efrl_hit" ] || return 0
 
   # Compose's interpolation phase. Only a value holding `$` can fail it, so
   # only those records are resolved, each bounded by its own start line.
@@ -1872,10 +1904,7 @@ env_file_first_refused_line() {
       get_env_value "$_efrl_key" "$_efrl_file" "$((_efrl_start + 1))" "$_efrl_records" >/dev/null 2>&1 \
         || { printf '%s %s unresolvable' "$_efrl_start" "$_efrl_key"; break; }
     done)"
-  if [ -n "$_efrl_hit" ]; then
-    printf '%s' "$_efrl_hit"
-    return 0
-  fi
+  [ -z "$_efrl_hit" ] || return 0
   return 1
 }
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1809,12 +1809,14 @@ env_file_first_refused_line() {
   _efrl_file="$1"
   [ -f "$_efrl_file" ] || return 1
 
-  # fix(#1909): an empty key and a key holding a tab load under Compose but fit
-  # no record, so the file is judged from a copy naming each such key with `-`
-  # (no `${}` can reference it) and a hit on such a line is renamed from FILE.
+  # fix(#1909): an empty key (`export` prefix or not) and a key holding a tab
+  # load under Compose but fit no record, so the file is judged from a copy naming
+  # each such key with `-` (no `${}` can reference it) and a hit is renamed from FILE.
   _efrl_copy="${_ENV_SNAPSHOT_DIR:?}/env-file-copy.$$"
   _efrl_renamed="$(LC_ALL=C awk -v copy="$_efrl_copy" '
-    { line = $0 }
+    BEGIN { printf "" > copy }
+    { line = $0; bom = "" }
+    NR == 1 && substr(line, 1, 3) == "\357\273\277" { bom = substr(line, 1, 3); line = substr(line, 4) }
     match(line, /^[ \t]*(export[ \t]+)?[]A-Za-z0-9_.[\t-]*[=:]/) {
       key = substr(line, 1, RLENGTH - 1)
       rest = substr(line, RLENGTH)
@@ -1831,10 +1833,10 @@ env_file_first_refused_line() {
         line = pre (key == "" ? "-" : key) trail rest
       }
     }
-    { print line > copy }' "$_efrl_file")" || fail "env_file_first_refused_line: could not copy $_efrl_file"
+    { print bom line > copy }' "$_efrl_file")" || fail "env_file_first_refused_line: could not copy $_efrl_file"
   _efrl_hit=""
   _efrl_rc=0
-  _env_file_first_refused_line "$_efrl_copy" || _efrl_rc=$?
+  _env_file_first_refused_line "$_efrl_copy" "$_efrl_file" || _efrl_rc=$?
   rm -f "$_efrl_copy"
   [ "$_efrl_rc" -eq 0 ] || return "$_efrl_rc"
   _efrl_name="$(printf '%s\n' "$_efrl_renamed" | awk -v line="${_efrl_hit%% *}" '$1 == line { print $2; exit }')"
@@ -1842,11 +1844,12 @@ env_file_first_refused_line() {
   printf '%s' "$_efrl_hit"
 }
 
-# Sets _efrl_hit to "LINE KEY REASON" for the first line of FILE that Compose
-# refuses to load with rc 0; rc 1 when every line loads.
+# Sets _efrl_hit to "LINE KEY REASON" for the first line of COPY that Compose
+# refuses to load with rc 0; rc 1 when every line loads. Messages name FILE.
 _env_file_first_refused_line() {
-  _efrl_file="$1"
-  _efrl_records="$(_env_tokenize "$_efrl_file")" || return 1
+  _efrl_read="$1"
+  _efrl_file="$2"
+  _efrl_records="$(_env_tokenize "$_efrl_read")" || return 1
 
   # Compose's parse phase: a key ends at `=` or `:`, holds letters, digits,
   # `_.-[]` or a tab, never a space; a multiline value's continuation lines
@@ -1879,7 +1882,7 @@ _env_file_first_refused_line() {
       for (j = 1; j <= length(bad); j++) {
         if (substr(bad, j, 1) < "\200") { print NR, name, "unexpected-character"; exit }
       }
-    }' "$_efrl_file")" || fail "env_file_first_refused_line: could not scan $_efrl_file"
+    }' "$_efrl_read")" || fail "env_file_first_refused_line: could not scan $_efrl_file"
   [ -z "$_efrl_hit" ] || return 0
 
   _efrl_hit="$(printf '%s' "$_efrl_records" | awk '$1 == "U" { print $2, $4, "unterminated-quote"; exit }')" \
@@ -1897,11 +1900,11 @@ _env_file_first_refused_line() {
       }
     }
     index($0, "$") > 0 { for (i = 1; i <= m; i++) if (NR >= lo[i] && NR <= hi[i]) seen[i] = 1 }
-    END { for (i = 1; i <= m; i++) if (seen[i]) print lo[i], key[i] }' "$_efrl_file")" \
+    END { for (i = 1; i <= m; i++) if (seen[i]) print lo[i], key[i] }' "$_efrl_read")" \
     || fail "env_file_first_refused_line: could not scan the values of $_efrl_file"
   _efrl_hit="$(printf '%s\n' "$_efrl_list" | while read -r _efrl_start _efrl_key; do
       [ -n "$_efrl_start" ] || continue
-      get_env_value "$_efrl_key" "$_efrl_file" "$((_efrl_start + 1))" "$_efrl_records" >/dev/null 2>&1 \
+      get_env_value "$_efrl_key" "$_efrl_read" "$((_efrl_start + 1))" "$_efrl_records" >/dev/null 2>&1 \
         || { printf '%s %s unresolvable' "$_efrl_start" "$_efrl_key"; break; }
     done)"
   [ -z "$_efrl_hit" ] || return 0

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1817,7 +1817,7 @@ env_file_first_refused_line() {
     BEGIN { printf "" > copy }
     { line = $0; bom = "" }
     NR == 1 && substr(line, 1, 3) == "\357\273\277" { bom = substr(line, 1, 3); line = substr(line, 4) }
-    match(line, /^[ \t]*(export[ \t]+)?[]A-Za-z0-9_.[\t-]*[=:]/) {
+    match(line, /^[ \t]*(export[ \t]+)?[]A-Za-z0-9_.[\t-]*[ \t]*[=:]/) {
       key = substr(line, 1, RLENGTH - 1)
       rest = substr(line, RLENGTH)
       sub(/^[ \t]*(export[ \t]+)?/, "", key)

--- a/scripts/tests/test-env-file-compose-oracle.sh
+++ b/scripts/tests/test-env-file-compose-oracle.sh
@@ -579,8 +579,8 @@ _assert_file_like_compose "$FILE_DIR/unrelated" "an unrelated line with \${MISSI
 printf 'CONTROL=${MISSING:?boom}\nCONTROL=ok\n' > "$FILE_DIR/earlier-dup"
 _assert_file_like_compose "$FILE_DIR/earlier-dup" "an earlier invalid duplicate of a key whose last definition is valid"
 
-printf '# comment\nCONTROL=ok\n\nexport EXPORTED=1\nQUOTED="with # hash" # note\nSINGLE='"'"'lit $x'"'"'\nBARE\nSPACED = value\nREF=${CONTROL}\nODD-KEY=x\n1ODD=x\nDOTTED.KEY=x\nBRACKET[0]=x\nCOLON:sep value\nTAB\t=x\nDOLLAR=$5\nJUNK="a"b\nMULTI="a\nb c\n"\n' > "$FILE_DIR/mixed-valid"
-_assert_file_like_compose "$FILE_DIR/mixed-valid" "a file of comments, export, quotes, a bare key, odd keys, a colon key, a ref, a bare \$ and a multiline value"
+printf '# comment\nCONTROL=ok\n\nexport EXPORTED=1\nQUOTED="with # hash" # note\nSINGLE='"'"'lit $x'"'"'\nBARE\nSPACED = value\nREF=${CONTROL}\nODD-KEY=x\n1ODD=x\nDOTTED.KEY=x\nBRACKET[0]=x\nCOLON:sep value\nTAB\t=x\nDOLLAR=$5\nJUNK="a"b\n=x\nA\tB="d\ne f\n"\nMULTI="a\nb c\n"\n' > "$FILE_DIR/mixed-valid"
+_assert_file_like_compose "$FILE_DIR/mixed-valid" "a file of comments, export, quotes, a bare key, odd keys, an empty key, a tab in a key, a colon key, a ref, a bare \$ and a multiline value"
 
 printf '\357\273\277# bom\nCONTROL=ok\n' > "$FILE_DIR/bom"
 _assert_file_like_compose "$FILE_DIR/bom" "a BOM before a first-line comment"
@@ -628,6 +628,13 @@ _assert_file_like_compose "$FILE_DIR/odd-colon" "a colon-terminated key whose va
 
 printf 'CONTROL=ok\n1ODD=${MISSING:?boom}\n' > "$FILE_DIR/odd-digit"
 _assert_file_like_compose "$FILE_DIR/odd-digit" "a digit-leading key whose value Compose refuses"
+
+# fix(#1909): an empty key and a key holding a tab are records too.
+printf 'CONTROL=ok\n=${MISSING:?boom}\n' > "$FILE_DIR/empty-key"
+_assert_file_like_compose "$FILE_DIR/empty-key" "an empty key whose value Compose refuses"
+
+printf 'CONTROL=ok\nA\tB=${MISSING:?boom}\n' > "$FILE_DIR/tab-key"
+_assert_file_like_compose "$FILE_DIR/tab-key" "a key holding a tab whose value Compose refuses"
 
 printf 'CONTROL=ok\nBRACKET[0]=${MISSING:?boom}\n' > "$FILE_DIR/odd-bracket"
 touch "$FILE_DIR/BRACKET0"

--- a/scripts/tests/test-env-file-compose-oracle.sh
+++ b/scripts/tests/test-env-file-compose-oracle.sh
@@ -636,6 +636,9 @@ _assert_file_like_compose "$FILE_DIR/empty-key" "an empty key whose value Compos
 printf 'CONTROL=ok\nA\tB=${MISSING:?boom}\n' > "$FILE_DIR/tab-key"
 _assert_file_like_compose "$FILE_DIR/tab-key" "a key holding a tab whose value Compose refuses"
 
+printf 'CONTROL=ok\nA\tB =${MISSING:?boom}\n' > "$FILE_DIR/tab-key-space"
+_assert_file_like_compose "$FILE_DIR/tab-key-space" "a separator space after a tab-holding key whose value Compose refuses"
+
 printf 'CONTROL=ok\nexport\t=${MISSING:?boom}\n' > "$FILE_DIR/export-empty-key"
 _assert_file_like_compose "$FILE_DIR/export-empty-key" "an export prefix before an empty key whose value Compose refuses"
 

--- a/scripts/tests/test-env-file-compose-oracle.sh
+++ b/scripts/tests/test-env-file-compose-oracle.sh
@@ -636,6 +636,18 @@ _assert_file_like_compose "$FILE_DIR/empty-key" "an empty key whose value Compos
 printf 'CONTROL=ok\nA\tB=${MISSING:?boom}\n' > "$FILE_DIR/tab-key"
 _assert_file_like_compose "$FILE_DIR/tab-key" "a key holding a tab whose value Compose refuses"
 
+printf 'CONTROL=ok\nexport\t=${MISSING:?boom}\n' > "$FILE_DIR/export-empty-key"
+_assert_file_like_compose "$FILE_DIR/export-empty-key" "an export prefix before an empty key whose value Compose refuses"
+
+printf 'export =x\nCONTROL=${export:-unset}\n' > "$FILE_DIR/export-empty-value"
+_assert_matches_compose CONTROL "$FILE_DIR/export-empty-value" "an export prefix before an empty key defines no key named export"
+
+printf '\357\273\277=${MISSING:?boom}\nCONTROL=ok\n' > "$FILE_DIR/bom-empty-key"
+_assert_file_like_compose "$FILE_DIR/bom-empty-key" "a BOM before an empty key on the first line whose value Compose refuses"
+
+: > "$FILE_DIR/empty-file"
+_assert_file_like_compose "$FILE_DIR/empty-file" "an empty file"
+
 printf 'CONTROL=ok\nBRACKET[0]=${MISSING:?boom}\n' > "$FILE_DIR/odd-bracket"
 touch "$FILE_DIR/BRACKET0"
 _afl_pwd="$PWD"

--- a/scripts/tests/test-preflight-env.sh
+++ b/scripts/tests/test-preflight-env.sh
@@ -416,6 +416,32 @@ else
     bad "a tab-holding key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
 fi
 
+run_preflight "$(printf 'export\t=${MISSING:?boom}')"
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (?)" "$WORK/out.txt"; then
+    ok "an export prefix before an empty key still leaves the key empty, as Compose reads it"
+else
+    bad "an export-prefixed empty key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+printf '\357\273\277=${MISSING:?boom}\n' > "$FAKE/.env"
+printf '%s\n' "$REQUIRED_LINES" >> "$FAKE/.env"
+bash "$FAKE/scripts/preflight-env.sh" > "$WORK/out.txt" 2>&1
+STATUS=$?
+if [ "$STATUS" -ne 0 ] && grep -q "line 1 (?)" "$WORK/out.txt"; then
+    ok "a BOM before an empty key on the first line does not hide it"
+else
+    bad "a BOM-prefixed empty key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+: > "$FAKE/.env"
+bash "$FAKE/scripts/preflight-env.sh" > "$WORK/out.txt" 2>&1
+STATUS=$?
+if [ "$STATUS" -ne 0 ] && grep -q "JWT_SECRET_KEY" "$WORK/out.txt" && ! grep -q "cannot be loaded" "$WORK/out.txt" && ! grep -q "No such file" "$WORK/out.txt"; then
+    ok "an empty .env loads and fails only on the required vars, with no stray error"
+else
+    bad "an empty .env was misjudged (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
 printf '%s\n' "$REQUIRED_LINES" > "$FAKE/.env"
 printf 'BRACKET[0]=${MISSING:?boom}\n' >> "$FAKE/.env"
 touch "$WORK/BRACKET0"

--- a/scripts/tests/test-preflight-env.sh
+++ b/scripts/tests/test-preflight-env.sh
@@ -320,10 +320,10 @@ else
     bad "an earlier invalid duplicate was masked by the last definition (exit $STATUS): $(cat "$WORK/out.txt")"
 fi
 
-MIXED_VALID="$(printf '# comment\n\nexport EXPORTED=1\nQUOTED="with # hash" # note\nSINGLE='"'"'lit $x'"'"'\nBARE\nSPACED = value\nREF=${JWT_SECRET_KEY}\nODD-KEY=x\n1ODD=x\nDOTTED.KEY=x\nCOLON:sep value\nTAB\t=x\nDOLLAR=$5\nJUNK="a"b\nMULTI="a\nb c\n"')"
+MIXED_VALID="$(printf '# comment\n\nexport EXPORTED=1\nQUOTED="with # hash" # note\nSINGLE='"'"'lit $x'"'"'\nBARE\nSPACED = value\nREF=${JWT_SECRET_KEY}\nODD-KEY=x\n1ODD=x\nDOTTED.KEY=x\nCOLON:sep value\nTAB\t=x\nDOLLAR=$5\nJUNK="a"b\n=x\nA\tB="d\ne f\n"\nMULTI="a\nb c\n"')"
 run_preflight "$MIXED_VALID"
 if [ "$STATUS" -eq 0 ]; then
-    ok "a file of lines Compose loads still passes (comments, export, quotes, bare, odd keys, refs, multiline)"
+    ok "a file of lines Compose loads still passes (comments, export, quotes, bare, odd keys, an empty key, a tab in a key, refs, multiline)"
 else
     bad "a valid file was refused by the whole-file check: $(cat "$WORK/out.txt")"
 fi
@@ -399,6 +399,21 @@ if [ "$STATUS" -ne 0 ] && grep -q "line 4 (1ODD)" "$WORK/out.txt"; then
     ok "a digit-leading key with a value Compose refuses is refused"
 else
     bad "a digit-leading key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+# fix(#1909): an empty key and a key holding a tab are records too.
+run_preflight '=${MISSING:?boom}'
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (?)" "$WORK/out.txt"; then
+    ok "an empty key with a value Compose refuses is refused"
+else
+    bad "an empty key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
+run_preflight "$(printf 'A\tB=${MISSING:?boom}')"
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (A)" "$WORK/out.txt"; then
+    ok "a key holding a tab with a value Compose refuses is refused, named up to the tab"
+else
+    bad "a tab-holding key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
 fi
 
 printf '%s\n' "$REQUIRED_LINES" > "$FAKE/.env"

--- a/scripts/tests/test-preflight-env.sh
+++ b/scripts/tests/test-preflight-env.sh
@@ -416,6 +416,13 @@ else
     bad "a tab-holding key's value was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
 fi
 
+run_preflight "$(printf 'A\tB =${MISSING:?boom}')"
+if [ "$STATUS" -ne 0 ] && grep -q "line 4 (A)" "$WORK/out.txt"; then
+    ok "a separator space after a tab-holding key does not hide its value"
+else
+    bad "a tab-holding key with a separator space was never interpolated (exit $STATUS): $(cat "$WORK/out.txt")"
+fi
+
 run_preflight "$(printf 'export\t=${MISSING:?boom}')"
 if [ "$STATUS" -ne 0 ] && grep -q "line 4 (?)" "$WORK/out.txt"; then
     ok "an export prefix before an empty key still leaves the key empty, as Compose reads it"


### PR DESCRIPTION
Follow-up to #1907 (whole-file preflight for `.env`, #1899).

## Defect

Two assignment shapes Compose accepts sit outside `_env_tokenize`'s record format, so `env_file_first_refused_line` never validated their values:

- an empty key (`=${MISSING:?boom}`) produces no record;
- a key holding a tab (`A<TAB>B=${MISSING:?boom}`) stops the scan at the tab and becomes a bare `A` record.

Preflight passed such a file and `docker compose` refused it at load. The same gap ran the other way: a multiline value under either key had no span, so its continuation lines were judged as keys and a `b c` line was refused as whitespace-in-key although Compose loads the file.

Measured against Compose v5.1.2 before writing the fix: `=x`, `<TAB>=x`, `A<TAB><TAB>B<TAB>=x`, `=`, ` = x # c`, `="a\nb c\n"` and `A<TAB>B="a\nb c\n"` all load; `=${MISSING:?boom}`, `A<TAB>B=${MISSING:?boom}`, `A<TAB>B="unterminated` and `=${X` are refused, the first two without a line number and the third with one.

## Fix

`scripts/lib/common.sh`: `env_file_first_refused_line` writes a copy of the file in which every empty or tab-holding key (leading whitespace, `export` and trailing whitespace excluded) is rewritten to `-`, with each tab in the key becoming `-`. A name holding `-` cannot be referenced by any `${...}`, in Compose's grammar or in ours, so no other line's interpolation changes. The unchanged three-phase check (now `_env_file_first_refused_line`, which sets `_efrl_hit` instead of printing so a `fail` inside it still exits the caller) judges the copy. A hit on a rewritten line is reported under the name the parse phase already uses for such keys: `?` for an empty key, the text before the first tab otherwise. Everything else reports byte-for-byte as before. The copy lives in the snapshot directory the file already creates, so the EXIT trap removes it when the check fails closed. The copy pass adds no measurable time on an `.env.example`-sized file (4.1 s before and after, whole-file check alone, bash).

## Tests

`scripts/tests/test-preflight-env.sh`: an empty key and a tab-holding key with a value Compose refuses are refused naming line 4 and `?` / `A`; the mixed valid file gains `=x` and a multiline value under `A<TAB>B` and still passes.

`scripts/tests/test-env-file-compose-oracle.sh`: the same two refusals against real Compose, and the mixed valid file gains the same two lines.

## Verification

At 2c4aed906:

| command | sh (macOS) | dash |
|---|---|---|
| `sh scripts/tests/test-preflight-env.sh` | 43 passed, 0 failed | 43 passed, 0 failed |
| `sh scripts/tests/test-env-file-compose-oracle.sh` | 130 passed, 0 failed | 130 passed, 0 failed |
| `sh scripts/tests/test-restore-env-sourcing-safety.sh` | 54 passed | 54 passed |
| `sh scripts/tests/test-upgrade-order.sh` | 102 passed | 102 passed |
| `sh scripts/tests/test-restore-trap-safety.sh` | 10 passed | 10 passed |
| `sh scripts/tests/test-runbook-env-value-guarded.sh`, `test-no-gnu-only-flags.sh` | pass | pass |
| `python3 scripts/tests/test-changelog-gate.py` / `test-changelog-links.py` | 25 / 35 passed | |

The preflight suite also passes with gawk 5.4.1 as `awk` on the host and under dash with mawk 1.3.4 in an `ubuntu:24.04` container, so the `match()` group regex is portable across the three awks.

`shellcheck -s sh` on the three shell files: four new SC2016 infos on the single-quoted `${...}` test literals, the same class the files already carry; nothing else changed.

Counterfactual, with `scripts/lib/common.sh` reset to `origin/main` and the tests kept:

```
$ sh scripts/tests/test-preflight-env.sh
not ok 29 - a valid file was refused by the whole-file check: ... line 21 (e) cannot be loaded by docker compose: its key contains a space.
not ok 40 - an empty key's value was never interpolated (exit 0): ...
not ok 41 - a tab-holding key's value was never interpolated (exit 0): ...
# 40 passed, 3 failed

$ sh scripts/tests/test-env-file-compose-oracle.sh
not ok 30 - a file of comments, ... (Compose loads the file, ours refuses it: [20 e whitespace-in-key])
not ok 46 - an empty key whose value Compose refuses (Compose refuses the file ...; ours loads it)
not ok 47 - a key holding a tab whose value Compose refuses (Compose refuses the file ...; ours loads it)
# 127 passed, 3 failed
```

## Impact

Scripts only. No schema, API or config change.

Closes #1909

## Round 1 (codex P2 plus three edges)

Codex flagged a BOM-prefixed first line: the copy's key anchor ran before the BOM was stripped, so a BOM before an empty or tab-holding key on line 1 was never rewritten. Fixed in 234e8e9e6 together with three edges from the pre-trigger audit of the same commit: the inner check now takes the copy to read and the operator's file to name, so a fail-closed message never prints a temp path; `export<TAB>=x` was probed against Compose (`export` is a prefix and the key is empty, so a later `${export:-unset}` resolves to `unset`), which the rewrite already produced, and the oracle pins that reading; and the copy is opened in a BEGIN block, because awk otherwise never created it for a zero-line file and the check then read a missing path, printing a `cat` error on an empty `.env`.

Tests: preflight gains four cases (export-prefixed empty key, BOM before an empty key on line 1, an empty `.env` failing only on the required vars with no stray error, and the BOM case named line 1); the oracle gains four (the export shape both ways, the BOM shape, and an empty file). At 234e8e9e6: preflight 46 passed, oracle 134 passed, the other five scripts suites green, in sh and dash, plus gawk 5.4.1 and dash with mawk 1.3.4 in `ubuntu:24.04`. Counterfactual against 2c4aed906's `common.sh` with the new tests: the BOM and empty-file cases fail in each suite, nothing else.
