### PR TITLE
fix(ingest): bump tile_cache_version atomically once the worker swaps hold the row (#1911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and releases use semantic versioning.
 - `make dev` preflight now judges a `.env` line whose key is empty or holds a tab the way docker
   compose loads it: a value compose cannot resolve is refused before the build instead of at
   compose load, and a multiline value under such a key no longer fails the check. (#1909)
+- A raster replace or a dataset reupload that waited behind a feature edit, column change or
+  tile-columns edit wrote back the tile cache version it had read before waiting, so the edit
+  committed during the wait was served under a stale tile URL. Both worker swaps now roll the
+  version atomically once they hold the catalog row, as the request side has since #1910. (#1911)
 
 ## [1.18.1] - 2026-09-05
 

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2386,7 +2386,7 @@ async def _apply_reupload_swap(
     # fix(#1847): the catalog writes start here, and this function dirties both
     # rows. `lock_timeout=None` so SET LOCAL does not clamp an ingest swap to a
     # request's budget.
-    from app.platform.catalog_locks import lock_catalog_rows
+    from app.platform.catalog_locks import bump_tile_cache_version_on, lock_catalog_rows
     from app.platform.extensions import get_processing_port
 
     _port = get_processing_port()
@@ -2472,10 +2472,9 @@ async def _apply_reupload_swap(
     dataset.source_filename = source_filename
     dataset.original_srid = original_srid
     dataset.current_version = new_version
-    # fix(#525 B-038): tile_version now reads tile_cache_version (not
-    # current_version), so reupload must roll it too or the _v= tile-URL
-    # cache-buster stops changing on the largest content mutation of all.
-    dataset.bump_tile_cache_version()
+    # fix(#1911): evaluated at write time, under the lock, so the counter read
+    # into `dataset` before the wait is never written back over a peer's commit.
+    await bump_tile_cache_version_on(session, dataset)
     dataset.record.updated_by = actor_id
     if source_url is not None:
         dataset.source_url = source_url

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -689,7 +689,10 @@ async def reupload_raster(
             # fix(#1847): below `archive_lossy_original`, which PUTs the whole
             # original raster; holding the pair across that upload is the #1848
             # class. Still ahead of the first write, the autoflush below.
-            from app.platform.catalog_locks import lock_catalog_rows
+            from app.platform.catalog_locks import (
+                bump_tile_cache_version_on,
+                lock_catalog_rows,
+            )
 
             await lock_catalog_rows(
                 session,
@@ -699,6 +702,10 @@ async def reupload_raster(
                 record_id=dataset.record_id,
                 lock_timeout=None,
             )
+            # fix(#1911): evaluated at write time, under the lock, so the counter
+            # read into `dataset` before the wait is never written back over a
+            # peer's commit.
+            await bump_tile_cache_version_on(session, dataset)
 
             await reserve_replacement_bytes(
                 session,

--- a/backend/app/processing/ingest/tasks_raster_swap.py
+++ b/backend/app/processing/ingest/tasks_raster_swap.py
@@ -45,10 +45,10 @@ def _write_swapped_fields(
 ) -> int:
     """Move every catalog field the swap owns, and return the new version.
 
-    Extracted from ``reupload_raster`` when the round-3 archive step pushed
-    that function back over the McCabe gate. Pure field assignment on two
-    attached ORM instances — the caller's transaction is what makes it atomic
-    with the storage puts and the job's terminal write.
+    Pure field assignment on two attached ORM instances; the caller's
+    transaction is what makes it atomic with the storage puts and the job's
+    terminal write. ``tile_cache_version`` is not among the fields: the caller
+    rolls it through ``bump_tile_cache_version_on`` once it holds the row.
     """
     nodata_val = cog_meta.get("nodata")
     raster_asset.asset_uri = cog_key
@@ -101,10 +101,6 @@ def _write_swapped_fields(
     dataset.original_srid = source_meta.get("epsg")
     dataset.source_filename = source_filename
     dataset.source_format = "geotiff"
-    # fix(#525 B-038): the Valkey purge cannot reach CDN or browser
-    # caches keyed on the tile URL, so the `_v=` buster has to roll in
-    # the same transaction as the pointer it invalidates.
-    dataset.bump_tile_cache_version()
     # feat(#1218) ADR-002 Decision 7: the dataset IS the COG and the
     # upload is a transient input, so the origin restamps to the new
     # file with no remote URI to point at.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3606,7 +3606,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 2601, exact.
     # fix(#1847): the cache-bump docstring states its contract. Cap 2601 -> 2596.
     # fix(#1902): the atomic bump moved to platform/catalog_locks. Cap 2596 -> 2559.
-    "backend/app/processing/ingest/tasks_common.py": 2559,
+    # fix(#1911): the reupload swap bumps atomically under the lock. Cap 2559 -> 2558.
+    "backend/app/processing/ingest/tasks_common.py": 2558,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_reupload_swap_lock_retry.py
+++ b/backend/tests/test_reupload_swap_lock_retry.py
@@ -89,12 +89,17 @@ def _make_dataset_stub(table_name: str):
         source_url=None,
         quality_detail=None,
     )
-    # fix(#525 B-038): _apply_reupload_swap now rolls the `_v=` tile
-    # cache-buster alongside current_version.
-    dataset.bump_tile_cache_version = lambda: setattr(
-        dataset, "tile_cache_version", dataset.tile_cache_version + 1
-    )
     return dataset
+
+
+def _stub_atomic_bump(monkeypatch) -> None:
+    """Roll the stub's counter in place of ``bump_tile_cache_version_on``."""
+
+    async def _bump(session, dataset):
+        dataset.tile_cache_version = dataset.tile_cache_version + 1
+        return dataset.tile_cache_version
+
+    monkeypatch.setattr("app.platform.catalog_locks.bump_tile_cache_version_on", _bump)
 
 
 def _make_port():
@@ -221,11 +226,7 @@ class TestSwapLocksBeforeItWrites:
             source_url=None,
             quality_detail=None,
         )
-        object.__setattr__(
-            dataset,
-            "bump_tile_cache_version",
-            lambda: setattr(dataset, "tile_cache_version", 2),
-        )
+        _stub_atomic_bump(monkeypatch)
 
         async def _noop(*args, **kwargs):
             return None
@@ -379,6 +380,7 @@ class TestApplyReuploadSwapRetry:
             "app.platform.extensions.get_processing_port",
             _make_port,
         )
+        _stub_atomic_bump(monkeypatch)
         # ``session.add`` rejects unknown types; swap to a recording shim.
         monkeypatch.setattr(self.session, "add", lambda *a, **kw: None)
 
@@ -438,6 +440,8 @@ class TestApplyReuploadSwapRetry:
         # last_refreshed_at but leaves last_checked_at cleared.
         assert dataset.last_refreshed_at is not None
         assert dataset.last_checked_at is None
+        # The swap rolled the `_v=` cache-buster, through the atomic spelling.
+        assert dataset.tile_cache_version == 2
 
     async def test_service_swap_stamps_last_checked_at(self, monkeypatch) -> None:
         """fix(#1271 review): a service reupload fetched its bytes from the
@@ -472,6 +476,7 @@ class TestApplyReuploadSwapRetry:
             "app.platform.extensions.get_processing_port",
             _make_port,
         )
+        _stub_atomic_bump(monkeypatch)
         monkeypatch.setattr(self.session, "add", lambda *a, **kw: None)
 
         await _apply_reupload_swap(
@@ -527,6 +532,7 @@ class TestApplyReuploadSwapRetry:
             "app.platform.extensions.get_processing_port",
             _make_port,
         )
+        _stub_atomic_bump(monkeypatch)
         monkeypatch.setattr(self.session, "add", lambda *a, **kw: None)
 
         # Record asyncio.sleep durations so we can assert the 200ms gap.

--- a/backend/tests/test_worker_swap_bump_after_lock_1911.py
+++ b/backend/tests/test_worker_swap_bump_after_lock_1911.py
@@ -1,0 +1,260 @@
+"""The two worker swaps publish N+2 behind an edit that published N+1 (#1911).
+
+The holder stands in for a request-side edit: it holds the datasets row, rolls
+the counter and commits while the swap is parked behind it. Each swap loaded
+its instance before it waited, so an absolute write from that instance would
+publish N+1 a second time and serve the swapped content under the edit's URL.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.orm import joinedload
+
+import app.core.db as db_module
+from app.modules.catalog.datasets.domain.models import Dataset
+from app.processing.ingest.tasks_common import _apply_reupload_swap
+from app.processing.ingest.tasks_raster_replace import reupload_raster
+from app.processing.raster.models import RasterAsset
+from tests import test_feature_lock_order_1847 as lock_order
+from tests.factories import get_user_id
+from tests.test_feature_lock_order_1847 import (
+    _await_waiter_on,
+    _published_version,
+    _seed_dataset,
+)
+from tests.test_raster_replace_1221 import (
+    _geotiff_bytes,
+    _make_live_raster,
+    _purge,
+    _queue_replace_job,
+)
+from tests.test_raster_replace_1221 import raster_storage as raster_storage
+
+_SWAP_METADATA = {
+    "srid": 4326,
+    "geometry_type": "Point",
+    "feature_count": 1,
+    "extent_wkt": None,
+    "column_info": [{"name": "name", "type": "character varying"}],
+}
+
+# Complete, because the row outlives the swap on the shared per-worker
+# database and a partial detail fails response validation elsewhere.
+_QUALITY = {
+    "overall": 90.0,
+    "metadata_completeness": 90.0,
+    "geometry_validity": 100.0,
+    "attribute_completeness": 90.0,
+    "crs_defined": 100.0,
+}
+
+
+async def _parked_statement(probe, holder_xid: str) -> str:
+    """The statement of whichever backend is queued behind *holder_xid*."""
+    query = await probe.scalar(
+        text(
+            "SELECT string_agg(query, ' | ') FROM pg_stat_activity WHERE pid IN ("
+            "SELECT pid FROM pg_locks WHERE NOT granted "
+            "AND locktype = 'transactionid' AND transactionid::text = :xid)"
+        ),
+        {"xid": holder_xid},
+    )
+    await probe.rollback()
+    return query or ""
+
+
+async def _overlap(holder, probe, dataset_id, swap_coro):
+    """Hold the row, park the swap on its acquisition, bump, commit, finish.
+
+    FOR NO KEY UPDATE: the raster task's job-row writes take KEY SHARE on this
+    row before the swap's FOR UPDATE, and they must pass through the holder.
+    """
+    before = await holder.scalar(
+        select(Dataset.tile_cache_version)
+        .where(Dataset.id == dataset_id)
+        .with_for_update(key_share=True)
+    )
+    holder_xid = await holder.scalar(text("SELECT pg_current_xact_id()::text"))
+    task = asyncio.create_task(swap_coro)
+    try:
+        await _await_waiter_on(probe, holder_xid)
+        parked = await _parked_statement(probe, holder_xid)
+        assert "FOR UPDATE" in parked and "catalog.datasets" in parked, (
+            f"the barrier released on {parked!r}, not on the swap's catalog acquisition"
+        )
+        first = await holder.scalar(
+            text(
+                "UPDATE catalog.datasets SET tile_cache_version = "
+                "tile_cache_version + 1 WHERE id = :d RETURNING tile_cache_version"
+            ),
+            {"d": dataset_id},
+        )
+        await holder.commit()
+    except BaseException:
+        await holder.rollback()
+        task.cancel()
+        raise
+    result = await task
+    assert first == before + 1
+    return before, result
+
+
+def _message(before: int, published: int) -> str:
+    return (
+        f"the swap published {published}. The edit committed {before + 1} while "
+        f"the swap was parked, so the swap must publish {before + 2}: an "
+        "absolute write from the instance loaded before the wait re-publishes "
+        "the edit's version."
+    )
+
+
+@pytest.fixture
+async def vector_dataset(test_db_session):
+    admin_id = await get_user_id(test_db_session, "admin")
+    seeded = await _seed_dataset(test_db_session, created_by=admin_id)
+    yield seeded, admin_id
+    for suffix in ("", "_staging", "_old"):
+        await test_db_session.execute(
+            text(f"DROP TABLE IF EXISTS data.{seeded.table_name}{suffix}")
+        )
+    await test_db_session.commit()
+    await _purge(test_db_session, dataset_id=seeded.id, record_id=seeded.record_id)
+
+
+class TestTheReuploadSwapPublishesTheNextVersion:
+    async def test_behind_a_committed_edit(self, vector_dataset, test_db_session):
+        seeded, admin_id = vector_dataset
+        dataset = (
+            await test_db_session.execute(
+                select(Dataset)
+                .options(joinedload(Dataset.record))
+                .where(Dataset.id == seeded.id)
+            )
+        ).scalar_one()
+        staging = f"{dataset.table_name}_staging"
+        await test_db_session.execute(
+            text(
+                f"CREATE TABLE data.{staging} ("
+                "gid SERIAL PRIMARY KEY, "
+                "geom geometry(Point, 4326), "
+                "geom_4326 geometry(Geometry, 4326), "
+                "name TEXT)"
+            )
+        )
+        await test_db_session.commit()
+
+        with (
+            patch(
+                "app.processing.ingest.metadata.refresh_attribute_metadata",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "app.processing.ingest.metadata.compute_quality_score",
+                new_callable=AsyncMock,
+            ) as mock_quality,
+        ):
+            mock_quality.return_value = _QUALITY
+            async with (
+                db_module.async_session() as holder,
+                db_module.async_session() as probe,
+            ):
+                before, _version = await _overlap(
+                    holder,
+                    probe,
+                    dataset.id,
+                    _apply_reupload_swap(
+                        test_db_session,
+                        dataset=dataset,
+                        staging_table=staging,
+                        metadata=_SWAP_METADATA,
+                        sample_values={"name": ["A"]},
+                        user_id=str(admin_id),
+                        source_filename="again.geojson",
+                        source_format="geojson",
+                        original_srid=4326,
+                    ),
+                )
+            await test_db_session.commit()
+
+        published = await _published_version(dataset.id)
+        assert published == before + 2, _message(before, published)
+        assert dataset.tile_cache_version == published
+
+
+class TestTheRasterReplacePublishesTheNextVersion:
+    async def test_behind_a_committed_edit(
+        self, test_db_session, raster_storage, tmp_path, monkeypatch
+    ):
+        # The conversion runs before the swap reaches its lock wait.
+        monkeypatch.setattr(lock_order, "_BARRIER_POLLS", 3000)
+        admin_id = await get_user_id(test_db_session, "admin")
+        live = await _make_live_raster(
+            test_db_session, raster_storage, created_by=admin_id
+        )
+        dataset_id = live.dataset.id
+        record_id = live.dataset.record_id
+        old_cog_key = live.cog_key
+        source = tmp_path / "replacement.tif"
+        source.write_bytes(_geotiff_bytes(seed=1911))
+        job = await _queue_replace_job(
+            test_db_session,
+            dataset_id=dataset_id,
+            user_id=admin_id,
+            file_path=str(source),
+        )
+        try:
+            async with (
+                db_module.async_session() as holder,
+                db_module.async_session() as probe,
+            ):
+                before, _ = await _overlap(
+                    holder,
+                    probe,
+                    dataset_id,
+                    reupload_raster.func(
+                        job_id=str(job.id),
+                        dataset_id=str(dataset_id),
+                        file_path=str(source),
+                        user_id=str(admin_id),
+                        attempt_id=str(job.attempt_id),
+                    ),
+                )
+
+            published = await _published_version(dataset_id)
+            assert published == before + 2, _message(before, published)
+            test_db_session.expire_all()
+            asset = (
+                await test_db_session.execute(
+                    select(RasterAsset).where(RasterAsset.dataset_id == dataset_id)
+                )
+            ).scalar_one()
+            assert asset.asset_uri != old_cog_key, "the replace did not swap"
+        finally:
+            await _purge(test_db_session, dataset_id=dataset_id, record_id=record_id)
+
+
+class TestNoWorkerSwapWritesAnAbsoluteTileVersion:
+    """The two swap doors call the atomic spelling, not the instance method."""
+
+    def test_the_swap_modules_call_the_atomic_bump(self):
+        import ast
+        import inspect
+
+        from app.processing.ingest import (
+            tasks_common,
+            tasks_raster_replace,
+            tasks_raster_swap,
+        )
+
+        scan = lock_order.TestNoCatalogModuleWritesAnAbsoluteTileVersion
+        for module in (tasks_common, tasks_raster_replace, tasks_raster_swap):
+            tree = ast.parse(inspect.getsource(module))
+            assert not scan._calls_named(tree, scan.ABSOLUTE), (
+                f"{module.__name__} writes an absolute tile_cache_version"
+            )
+        for module in (tasks_common, tasks_raster_replace):
+            tree = ast.parse(inspect.getsource(module))
+            assert len(scan._calls_named(tree, scan.ATOMIC)) == 1, module.__name__

--- a/backend/tests/test_worker_swap_bump_after_lock_1911.py
+++ b/backend/tests/test_worker_swap_bump_after_lock_1911.py
@@ -1,10 +1,4 @@
-"""The two worker swaps publish N+2 behind an edit that published N+1 (#1911).
-
-The holder stands in for a request-side edit: it holds the datasets row, rolls
-the counter and commits while the swap is parked behind it. Each swap loaded
-its instance before it waited, so an absolute write from that instance would
-publish N+1 a second time and serve the swapped content under the edit's URL.
-"""
+"""Each worker swap publishes N+2 behind an edit that published N+1 (#1911)."""
 
 import asyncio
 from unittest.mock import AsyncMock, patch
@@ -69,8 +63,7 @@ async def _parked_statement(probe, holder_xid: str) -> str:
 async def _overlap(holder, probe, dataset_id, swap_coro):
     """Hold the row, park the swap on its acquisition, bump, commit, finish.
 
-    FOR NO KEY UPDATE: the raster task's job-row writes take KEY SHARE on this
-    row before the swap's FOR UPDATE, and they must pass through the holder.
+    FOR NO KEY UPDATE, so the job-row KEY SHARE does not release the barrier.
     """
     before = await holder.scalar(
         select(Dataset.tile_cache_version)


### PR DESCRIPTION
## What changed

Follow-up to #1910. The two worker swap doors assigned an absolute `Dataset.bump_tile_cache_version()` on an instance loaded before their lock wait, so a request-side edit that committed while the swap waited was overwritten by the swap's N+1 and its tiles stayed served under the earlier URL. Both doors now roll the counter through `bump_tile_cache_version_on` after the catalog rows are locked, the same spelling #1910 gave every request-side writer.

- `tasks_raster_swap._write_swapped_fields` no longer bumps. Its caller in `tasks_raster_replace.reupload_raster` bumps atomically right after `lock_catalog_rows`, which is also after the last I/O the door does before the lock (`archive_lossy_original`).
- `tasks_common._apply_reupload_swap` bumps atomically at the site of the old absolute write, which was already below its `lock_catalog_rows`.
- No new 409 or retry mapping. Both doors are workers: `lock_catalog_rows(lock_timeout=None)` and `CatalogLockConflict` propagates and fails the job, as #1910 left it.
- `tasks_common.py` cap in `tests/test_layering.py` lowered 2559 -> 2558, exact.

## Remaining absolute `bump_tile_cache_version()` callers in `backend/app/`

Grepped `bump_tile_cache_version(` and `tile_cache_version`. Every remaining absolute caller loads its instance under a `FOR UPDATE` on the datasets row that it already holds, so the value it writes back is the row's current value:

| Site | Why it is outside this class |
|---|---|
| `tasks_postgis_refresh.py` phase 3 (`_apply_measurement` tail) | Takes `select(Dataset.tile_cache_version).with_for_update()` for its superseded guard, then loads the instance. |
| `tasks_stac_refresh.py` moved-asset refresh | Takes `select(Dataset.origin_uri, ...).with_for_update()` for its binding guard, then loads the instance. |
| `tasks_vrt.py` regenerate swap | `select(RasterAsset).join(Dataset).with_for_update()` locks the joined datasets row, then loads `vrt_dataset`. |
| `Dataset.bump_tile_cache_version` (models.py) | The method itself; its docstring already names the atomic spelling for a caller that loaded before waiting. |

`modules/catalog/` has no absolute callers; `test_feature_lock_order_1847.py::TestNoCatalogModuleWritesAnAbsoluteTileVersion` gates that, and the new structural test extends the scan to the three worker modules touched here.

Adjacent, not in scope: both doors also write `dataset.current_version = new_version` from the same pre-wait read. That is a different counter, only these two doors write it, and #1911 scopes to `tile_cache_version`.

## Tests

`tests/test_worker_swap_bump_after_lock_1911.py`, one concurrency test per door, shaped like #1910's: a holder takes the datasets row, the swap parks behind it, the holder publishes N+1 and commits, the swap must publish N+2.

- The holder takes `FOR NO KEY UPDATE`, not `FOR UPDATE`. The raster task's phase-1 job-row writes re-run their foreign-key check against the datasets row (the job row was already updated in that transaction), and that `KEY SHARE` queued behind a `FOR UPDATE` holder and released the barrier before the swap reached its own acquisition. The barrier now also asserts that the parked statement is the swap's `catalog.datasets ... FOR UPDATE`.
- Counterfactual: with the three `backend/app` files restored to `origin/main`, both concurrency tests fail with "the swap published 2 ... must publish 3". With the fix, they pass.

`tests/test_reupload_swap_lock_retry.py` is a mock mirror of the swap (SimpleNamespace dataset, real session) and was updated deliberately: the stub can no longer carry a `bump_tile_cache_version` method, because the door now issues `UPDATE catalog.datasets` against `type(dataset)`, which a SimpleNamespace cannot satisfy. A `_stub_atomic_bump(monkeypatch)` helper stands in for `bump_tile_cache_version_on` and rolls the stub's counter in place; the happy-path test asserts the counter rolled, and the write-ordering test still sees that write after the acquisition.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
# All checks passed! / 1181 files already formatted

uv run pytest tests/test_worker_swap_bump_after_lock_1911.py tests/test_reupload_swap_lock_retry.py tests/test_layering.py -q
# 62 passed

uv run pytest tests/test_feature_lock_order_1847.py tests/test_raster_replace_1221.py tests/test_dataset_source_state.py tests/test_provenance_attribution.py tests/test_job_cancel_no_swap.py -q -n 4
# 353 passed, 1 skipped
```

Closes #1911
