### PR TITLE
chore(backend): trim review-history comments in sweep, backfill and artifact_cache

### DIFF
--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -51,50 +51,33 @@ from app.platform.storage.titiler_url import resolve_current_storage_key
 
 log = structlog.get_logger()
 
-# Jobs running longer than this are considered stale and auto-failed. This is
-# the worker LEASE on a RUNNING job, not the presigned-upload lifetime below:
-# the two share a number today and answer unrelated questions, so deriving one
-# from the other would only look like agreement.
+# Worker LEASE on a RUNNING job, not the presigned-upload lifetime below: the
+# two share a number today and answer unrelated questions; never derive either.
 JOB_TIMEOUT_SECONDS = 3600  # 60 minutes (accommodates remote service imports)
 
-# fix(#1709 review r7 A): grace before a childless `fanned_out` parent is
-# treated as a crashed dispatch. The flip->first-child gap is sub-second in
-# health (claim_fan_out_parent commits, then the first create_fan_out_jobs
-# commits), so one sweep cadence is generous, and a request still mid-flight
-# is never touched.
+# fix(#1709 r7): grace before a childless `fanned_out` parent counts as a crashed
+# dispatch; the flip->first-child gap is sub-second, so one cadence is generous.
 FAN_OUT_CHILDLESS_GRACE_SECONDS = 300
 
-# fix(#1709 review r8 A): the message must not advertise retry — generic
-# /jobs/{id}/retry re-queues the parent as ONE default-layer import (the
-# layer selection lived only in the fan-out request body), and retry is
-# refused outright on the marker below. Re-upload is the real path.
+# fix(#1709 r8): never advertise retry here. Generic retry re-queues the parent
+# as ONE default-layer import and is refused on the marker; re-upload is the path.
 FAN_OUT_DISPATCH_INTERRUPTED_MESSAGE = (
     "Fan-out dispatch was interrupted before any layer was queued. "
     "Re-upload the file to import its layers."
 )
 
 
-# fix(#1235 review r4): the margin between the last moment a client may still
-# legitimately PUT and the moment its completion request has finished freezing,
-# verifying and committing. Added on top of the upload lifetime wherever a
-# timer has to sit strictly BEYOND it.
+# fix(#1235 r4): margin between the last legitimate PUT and a finished completion
+# commit, added on top of the upload lifetime wherever a timer must sit beyond it.
 _COMMIT_HEADROOM_SECONDS = 3600
 
 
 def stale_pending_cutoff_seconds(*, completion_bound: bool) -> int:
     """Age at which each half of the pending sweep may fail a job.
 
-    fix(#1235 review r4): both halves read the one setting, at CALL time.
-    #1234 made the pending lifetime configurable but left the consumers holding
-    the numbers that used to be its fixed value. The 24h backstop was one of
-    them: configure the timeout past a day and a legitimate completion at hour
-    25 committed the frozen path into a row that was instantly eligible for its
-    own backstop. Deriving it keeps the backstop strictly beyond the upload
-    lifetime by construction, rather than by the accident that 86400 > 3600.
-
-    Module-level constants would reproduce the same class one indirection down:
-    a copy taken at import can disagree with the value the presign handlers
-    read per request.
+    fix(#1235 r4): read from the setting at CALL time, and the bound half stays
+    strictly beyond the upload lifetime by construction; a module-level copy
+    could disagree with what the presign handlers read per request.
     """
     if completion_bound:
         return max(
@@ -104,9 +87,7 @@ def stale_pending_cutoff_seconds(*, completion_bound: bool) -> int:
     return settings.pending_job_timeout_seconds
 
 
-# fix(#1235 review r4): the message no longer names an hour. The timeout is
-# configurable, so a hard-coded "over 1 hour" is a claim the code stopped
-# guaranteeing in #1234; "never queued" is the part that is always true.
+# fix(#1235 r4): no hour in the message; the timeout is configurable.
 STALE_PENDING_UNBOUND_MESSAGE = "Stale: pending too long (never queued)"
 STALE_PENDING_BOUND_MESSAGE = "Stale: upload completed but never committed"
 
@@ -114,62 +95,26 @@ STALE_PENDING_BOUND_MESSAGE = "Stale: upload completed but never committed"
 def stale_pending_clauses(now: datetime, *, completion_bound: bool) -> tuple:
     """Every predicate required to fail a timed-out pending job.
 
-    fix(#1235 review r2): ONE boundary, because there are four sites that flip
-    pending -> failed on a timeout and #1234 only guarded two of them. The
-    background sweep was fixed; `get_job_status` — which the comment above it
-    correctly calls "the path that actually fires", since the frontend polls
-    every 2s — kept the old predicates, so a poll that blocked on a completing
-    job's row lock resumed after the commit and failed the row it had just
-    waited for. The worker's startup recovery had neither this guard nor the
-    live-queue predicate.
+    fix(#1235 r2): ONE boundary for the four sites that flip pending -> failed
+    on a timeout, so a new site cannot take the age check without the
+    bound/unbound split and the live-queue check.
 
-    Returning the whole clause set rather than just the guard is the point: a
-    caller cannot express "fail stale pending jobs" here without also getting
-    the bound/unbound split and the live-queue check, so the next site added
-    cannot forget them by being written carefully — only by not using this.
-
-    `completion_bound` selects which half, and the class is defined by the
-    `staging/` PREFIX rather than by file_path being merely truthy. That
-    distinction is the point: the race being fixed involves exactly the rows a
-    presigned completion has bound, and both doors bind
-    `staging/{job}/frozen/...` — nothing else writes a staging-prefixed
-    file_path on a pending row. Same discriminator #1213 established for the
-    reapers, same reason.
-
-    Defining the class as "truthy" instead swept in rows with nothing to do
-    with the race: a direct upload whose dispatch failed binds an ABSOLUTE
-    local path, and giving it the 24h backstop leaves it `pending` for a day —
-    during which /jobs/{id}/retry is unavailable, because retry requires
-    status `failed`. That turns a 1h-to-recoverable state into a
-    24h-to-recoverable one on a real path.
-
-    So False is the 1h abandonment policy and now covers everything that is
-    not a completion — falsy file_path AND non-staging absolute paths (direct
-    uploads, manifest operator keys), all keeping their original message.
-    True is the 24h backstop for completions that bound but never committed:
-    exempt from the 1h clause, and the retention purge only considers terminal
-    rows, so without it they never die.
+    ``completion_bound`` selects the half. The class is the ``staging/`` PREFIX
+    of ``file_path``, not truthiness: only a presigned completion binds a
+    staging-prefixed path on a pending row, and a truthy test swept in direct
+    uploads (absolute local path) and left them ``pending`` for a day with
+    retry unavailable. False is the 1h abandonment policy for everything that
+    is not a completion; True is the 24h backstop for completions that bound
+    but never committed, which the retention purge would otherwise never reach.
     """
-    # coalesce, not a bare LIKE: `NOT (NULL LIKE ...)` is NULL, not TRUE, so a
-    # bare negation silently drops every row whose file_path is NULL — the
-    # "never bound anything" case that most needs the 1h policy. Three-valued
-    # logic turns the guard into a filter that excludes what it should catch.
+    # coalesce, not a bare LIKE: `NOT (NULL LIKE ...)` is NULL, so a bare negation
+    # drops every row whose file_path is NULL, the case that most needs the 1h
+    # policy.
     completion_key = func.coalesce(IngestJob.file_path, "").like("staging/%")
     cutoff_seconds = stale_pending_cutoff_seconds(completion_bound=completion_bound)
-    # fix(#1708 codex r6): pending age is measured from the last moment the
-    # flow declared the artifact STAGED, falling back to creation. A URL
-    # import spends up to FETCH_MAX_SECONDS downloading before its
-    # running->pending CAS, with created_at unchanged — measured from
-    # created_at, a local-mode staged import (absolute file_path, so the
-    # unbound half) arrived pre-aged: at the 61s floor of
-    # pending_job_timeout_seconds the very next sweep or get_job_status poll
-    # failed it while the user was mid-preview. `staged_at` is stamped by
-    # upload_from_url's completion CAS (always an isoformat timestamptz, the
-    # only writer); every other flow lacks the key and keeps aging from
-    # created_at exactly as before, so a genuinely abandoned pre-fetch row
-    # is not softened. The window RESTARTS at staging, it does not become an
-    # exemption — a staged row whose staged_at itself ages past the cutoff
-    # is reaped like any other.
+    # fix(#1708 r6): age from `staged_at` (stamped only by upload_from_url's
+    # completion CAS) falling back to created_at. The window RESTARTS at staging;
+    # a staged row whose staged_at ages past the cutoff is reaped like any other.
     age_basis = func.coalesce(
         IngestJob.user_metadata.op("->>")("staged_at").cast(DateTime(timezone=True)),
         IngestJob.created_at,
@@ -182,14 +127,8 @@ def stale_pending_clauses(now: datetime, *, completion_bound: bool) -> tuple:
     )
 
 
-# fix(#1556): the terminal state for an upload nobody ever committed. `failed`
-# claims an ingest was attempted and broke; for a visitor who staged an upload
-# and walked away, nothing was ever attempted, and on the public demo those
-# rows are indistinguishable from real ingest failures in the admin jobs list
-# and the failed-jobs badge that counts it. `cancelled` is already in the
-# `ingest_jobs` status CHECK constraint, in the admin `JobStatus` literal and
-# in openapi.json, so this needs no migration and changes no published
-# contract.
+# fix(#1556): an upload nobody ever committed settles `cancelled`, not `failed`.
+# `cancelled` is already in the status CHECK, the admin literal and openapi.json.
 ABANDONED_UPLOAD_MESSAGE = "Abandoned: upload was never completed"
 
 
@@ -207,55 +146,15 @@ def is_abandoned_upload(user_metadata: dict | None) -> bool:
 def abandoned_upload():
     """Predicate: nothing was ever dispatched for this row.
 
-    fix(#1744): asks the row whether a dispatch was attempted, instead of
-    guessing from its shape. ``defer_with_orphan_guard`` stamps
-    ``commit_attempted_at`` immediately before every ``defer_async`` in the
-    codebase and commits it, so an unbound pending row that carries no stamp
-    was never handed to the queue at all.
+    fix(#1744): ``defer_with_orphan_guard`` stamps ``commit_attempted_at`` before
+    every ``defer_async`` and commits it, so an unbound pending row with no
+    stamp was never handed to the queue. Replaces the #1556 presigned-only
+    carve-out, which left direct uploads reporting ``failed``.
 
-    This replaces the ``file_path`` empty AND ``presigned`` carve-out #1556
-    installed, and folds that class in rather than sitting beside it. The
-    carve-out was keyed to the presign doors because those were the only ones
-    that stamped anything, which left the door the demo actually uses
-    unprotected: a direct upload binds an ABSOLUTE staging path and stamps no
-    `presigned` marker, so four abandoned direct uploads over two weeks each
-    reported `failed` with "never queued" while the queue was working
-    correctly. The absolute-path carve-out the old docstring defended no
-    longer needs a branch of its own, because the shape of ``file_path`` was
-    never what the two classes differed by; a broken commit and an abandoned
-    upload can both carry the same absolute path, and only the stamp
-    distinguishes them.
-
-    Everything the old predicate deliberately excluded stays excluded, and now
-    for a reason that holds at every door rather than at two of them. A
-    service/URL import, an analysis run and an admin embedding backfill all
-    reach the queue through the same guard, so a dispatch that never landed
-    for one of them carries the stamp and keeps reporting `failed`.
-    ``/jobs/{id}/retry`` requires status `failed` and ``_retry_capability``
-    offers exactly those rows, so this is what keeps a recoverable job's only
-    recovery path open (the 1h-to-recoverable-becomes-unrecoverable trap
-    #1235 avoided), and #1550's audit trail still settles the backfill
-    `never_started` in the same transaction as the row.
-
-    Rows created before the stamp existed carry no stamp, so a pending unbound
-    row that predates the deploy reclassifies as `cancelled`. That is the
-    right answer for the abandoned uploads it will mostly be (the demo audit
-    found four of those and zero broken commits) and the wrong one for a
-    genuinely broken commit; accepted rather than migrated, because a
-    migration would have to guess the same thing from the same missing fact.
-
-    Two residual gaps, recorded rather than papered over. A door commits its
-    row and then dispatches, so a process death in the gap between those two
-    leaves the row unstamped and it settles `cancelled` instead of `failed`.
-    That window is one statement wide, and it was unbounded before this change
-    for the same class. ``create_fan_out_jobs`` is the one door that closes it
-    outright, by putting the stamp in the metadata it commits: it runs inside
-    a worker task, and its child cannot be recreated by repeating a user
-    action, because the layer selection lived in the fan-out request body and
-    nowhere else. The second gap is storage-mode-shaped: in S3 mode a direct
-    upload binds ``staging/{job}/{name}``, which is the BOUND half's business,
-    so an abandoned S3 upload still settles `failed` after the 24h backstop
-    with the bound message. #1744's evidence and scope are the unbound half.
+    Known gaps: a process death between a door's commit and its dispatch
+    settles ``cancelled`` (one statement wide); pre-stamp rows reclassify as
+    ``cancelled``; an abandoned S3-mode direct upload is the BOUND half's and
+    still settles ``failed`` after the 24h backstop.
     """
     return (
         func.coalesce(IngestJob.user_metadata[COMMIT_ATTEMPTED_METADATA_KEY].astext, "")
@@ -266,19 +165,10 @@ def abandoned_upload():
 def stale_pending_unbound_values(now: datetime, *, message: str) -> dict:
     """Every column the unbound half of the pending sweep writes.
 
-    The companion to ``stale_pending_clauses``, for the same reason it exists:
-    three sites flip an unbound pending row terminal — the background sweep,
-    `get_job_status` (the one that actually fires, polled every 2s) and the
-    worker's startup recovery — and a split expressed in the ACTION at one of
-    them, with the other two still writing `failed`, would make the same
-    abandoned upload report two different terminal states depending on which
-    actor reached it first. Returning the whole mapping rather than just the
-    status means a caller cannot take the split without also taking the
-    message.
-
-    ``message`` is the caller's own unbound wording (the poll path interpolates
-    the elapsed seconds); it survives untouched for every row that is not an
-    abandoned upload, so nothing about the existing failure reporting moves.
+    Companion to ``stale_pending_clauses``: three sites flip an unbound pending
+    row terminal, and a caller cannot take the cancelled/failed split without
+    also taking the matching message. ``message`` is the caller's own unbound
+    wording and survives for every row that is not an abandoned upload.
     """
     abandoned = abandoned_upload()
     return {
@@ -291,25 +181,11 @@ def stale_pending_unbound_values(now: datetime, *, message: str) -> dict:
 def no_live_procrastinate_job():
     """Predicate: this ``ingest_jobs`` row has no queued or running task.
 
-    fix(#724): age alone conflated two states. A job Procrastinate still holds
-    as 'todo' was queued correctly and is simply waiting — and since fix(#695)
-    deferred analysis to priority -10, waiting behind a steady upload stream is
-    by design, with no upper bound. Failing those at the one-hour mark is both
-    a lie and a loss: the analysis dies while its task sits in the queue, and
-    the worker later picks the task up against a row already marked failed.
-
-    A genuine orphan — committed, then the process died before defer landed a
-    row, the gap defer_with_orphan_guard structurally cannot cover — has no row
-    at all, so it is still reaped and the message is true by construction.
-
-    Correlated on args->>'job_id', which every task in this codebase passes.
-    Schema hard-coded to 'catalog', matching observability/metrics/jobs.py.
-
-    fix(#724 review): BOTH pending auto-fail paths must use this. The periodic
-    sweeper is the lesser one — get_job_status() runs the same age check on
-    every poll, and the frontend polls it every 2s via useJobStatus /
-    AnalysisJobWatcher, so the polling path is what actually kills a starved
-    job the moment it crosses an hour.
+    fix(#724): age alone conflated a starved-but-queued job (analysis waits at
+    priority -10 with no upper bound) with a true orphan. Correlated on
+    args->>'job_id', which every task passes; schema hard-coded to 'catalog'.
+    BOTH pending auto-fail paths must use this; the 2s ``get_job_status`` poll
+    is the one that actually fires.
     """
     return text(
         "NOT EXISTS (SELECT 1 FROM catalog.procrastinate_jobs pj"
@@ -332,15 +208,9 @@ class StaleCleanupOutcome:
     storage_objects_reaped: int
     staged_paths_skipped: int
     staged_cleanup_failures: int
-    # fix(#1556 review, codex P2): pending rows the sweep settled `cancelled`
-    # rather than `failed` — abandoned presigned uploads. Counted apart from
-    # `pending_failed` because that number is read as a failure count by the
-    # admin cleanup response, its audit event and the sweeper's log line, and
-    # folding abandonments back into it would undo the split at exactly the
-    # surfaces the split exists for.
-    #
-    # Last, with a default, only because a dataclass cannot put a defaulted
-    # field before undefaulted ones; it belongs beside `pending_failed`.
+    # fix(#1556): abandoned uploads settled `cancelled`, counted apart from
+    # `pending_failed` because that number is read as a failure count. Last, with
+    # a default, only because dataclasses forbid a defaulted field before others.
     pending_cancelled: int = 0
     _staged_paths: tuple[str, ...] = field(default=(), repr=False, compare=False)
     # fix(#1202 review r5): presigned staging keys of the purged rows. Kept
@@ -349,24 +219,16 @@ class StaleCleanupOutcome:
     _staged_presigned_keys: tuple[str, ...] = field(
         default=(), repr=False, compare=False
     )
-    # fix(#1277 review): refresh runs the sweep finalized, carried out to
-    # whoever commits so the metric is published only once that commit lands.
-    # Private and absent from as_dict() like the two fields above, so the
-    # published API and audit shape is unchanged.
+    # fix(#1277): refresh runs the sweep finalized, published only after the
+    # commit lands. Private and absent from as_dict(), like the fields above.
     _refresh_runs_reconciled: int = field(default=0, repr=False, compare=False)
-    # fix(#1322 review): a dead VRT regeneration attempt's own generation-
-    # scoped storage keys (source.vrt + 2 quicklooks), already resolved by
-    # sweep_stale_vrt_assets but deliberately NOT yet deleted — carried out to
-    # whoever commits, same rule as _staged_paths below, because deleting
-    # before that commit is durable can destroy a generation a rolled-back
-    # reconciliation still owns.
+    # fix(#1322): a dead VRT attempt's generation-scoped keys, resolved by
+    # sweep_stale_vrt_assets but deleted only after the commit, like _staged_paths.
     _stale_generation_storage_keys: tuple[str, ...] = field(
         default=(), repr=False, compare=False
     )
-    # fix(#1778): logical object keys a raster ingest or replace named on its
-    # job row before writing them, carried out to whoever commits under the
-    # same rule as the two fields above. Logical, not tenant-resolved: the reap
-    # resolves them in its own tenant context, like _staged_presigned_keys.
+    # fix(#1778): logical (not tenant-resolved) object keys a raster ingest named
+    # on its job row before writing them; reaped after the commit, same rule.
     _unpublished_storage_keys: tuple[str, ...] = field(
         default=(), repr=False, compare=False
     )
@@ -380,9 +242,8 @@ class StaleCleanupOutcome:
     def total_cleaned(self) -> int:
         """Legacy count: ingest jobs transitioned from active to failed.
 
-        fix(#1556 review): still literally that, which is why cancellations
-        are absent. Its published identity is `pending_failed + running_failed`
-        and a caller reading "cleaned" as "failed" is reading it correctly.
+        fix(#1556): cancellations are absent; the published identity stays
+        `pending_failed + running_failed`.
         """
         return self.pending_failed + self.running_failed
 
@@ -390,10 +251,7 @@ class StaleCleanupOutcome:
     def total_affected(self) -> int:
         """Rows and staged objects mutated by the cleanup pass.
 
-        fix(#1556 review): cancellations DO belong here. This one counts work
-        done, not failures, so leaving them out would under-report the rows the
-        pass actually mutated — a number that hides work is worse than one that
-        does not break down.
+        fix(#1556): cancellations DO belong here; this counts work done.
         """
         return (
             self.total_cleaned
@@ -408,15 +266,9 @@ class StaleCleanupOutcome:
     def as_dict(self) -> dict[str, int]:
         """Return the stable API and audit detail shape.
 
-        fix(#1556 review): `pending_cancelled` reaches the audit event (a JSONB
-        `details` blob with no schema) and the multi-tenant fleet totals, which
-        is where an operator reconstructs what a pass did. It deliberately does
-        NOT reach the HTTP response: `StaleCleanupResponse` is a published
-        model, generated into both SDKs and `api.generated.ts`, and pydantic's
-        default `extra="ignore"` drops the key on the way out. Surfacing it
-        there is a contract change with a regen attached, and it is not needed
-        to fix the misreport — `pending_failed` no longer counts abandonments
-        on any of the three surfaces.
+        fix(#1556): `pending_cancelled` reaches the audit event and fleet totals
+        but NOT the HTTP response: `StaleCleanupResponse` is a published model
+        and pydantic drops the extra key on the way out.
         """
         return {
             "pending_failed": self.pending_failed,
@@ -441,75 +293,26 @@ _POST_EXPIRY_SWEEP_MARGIN_SECONDS = 900
 def post_expiry_sweep_after_seconds() -> int:
     """Job age past which no PUT URL for it can recreate the staging object.
 
-    fix(#1202 review r8): the sweep below has to wait out the window in which a
-    presigned PUT URL can still recreate the staging object after the
-    event-triggered sweeps have already run.
-
-    fix(#1235 review r3): that window used to be grounded on "the provider
-    default is 3600 and no call site passes one". The ground is now firmer:
-    every signing site passes an expiration computed as the job's REMAINING
-    lifetime (`remaining_job_lifetime_seconds`), so a URL expires at
-    `created_at + pending_job_timeout_seconds` rather than that long after
-    whenever it happened to be signed. The window is therefore EXACT rather
-    than conservative, and URL life only ever shortens. The provider-side
-    min() clamps stay as the backstop for any future site that forgets.
-
-    fix(#1235 review r4): and it is computed from the setting rather than from
-    a fixed 3600, which the r3 comment already claimed while the constant it
-    described still did not. Configure the timeout longer and the sweep ran
-    while the URL was still live; a re-PUT after it then survived forever,
-    because the reaped marker takes the row out of every later pass.
-
-    Part URLs default to 7200 but cannot recreate an OBJECT either way: they
-    need a live upload id, and CompleteMultipartUpload consumes it (an abort
-    kills it). Only the single-part object-key URL is a recreation vector.
-
-    `created_at` is the anchor on both sides — the row is inserted before any
-    URL for it is minted, and the URLs are signed against that same value.
+    fix(#1202 r8, #1235 r3/r4): computed from the setting, not a fixed 3600.
+    Every signing site passes the job's REMAINING lifetime, so a URL expires at
+    `created_at + pending_job_timeout_seconds` exactly. Part URLs cannot
+    recreate an object (CompleteMultipartUpload consumes the upload id); only
+    the single-part object-key URL is a recreation vector.
     """
     return settings.pending_job_timeout_seconds + _POST_EXPIRY_SWEEP_MARGIN_SECONDS
 
 
-# Set on the post-expiry sweep's first pass over a job. Not permanent on its
-# own — see _STAGING_REAPED_FINAL_MARKER below (fix #1236).
+# Set on the post-expiry sweep's first pass; not permanent on its own (#1236).
 _STAGING_REAPED_MARKER = "s3_key_reaped"
 
-# fix(#1236): set once the sweep's RE-CHECK pass has run AND cleared the
-# transfer margin below, which only happens after
-# MAX_PRESIGNED_URL_LIFETIME_SECONDS have elapsed since `created_at` — the
-# latest moment any URL for the job, signed under any setting the deployment
-# ever ran, can still be live. Only rows carrying this marker are excluded
-# from every future pass; _STAGING_REAPED_MARKER alone no longer is.
+# fix(#1236): set once the RE-CHECK pass has run past
+# MAX_PRESIGNED_URL_LIFETIME_SECONDS + the transfer margin. Only rows carrying
+# this marker are excluded from every future pass.
 _STAGING_REAPED_FINAL_MARKER = STAGING_REAPED_FINAL_MARKER
 
-# fix(#1236 review, codex P1): SigV4 bounds when a URL may be SIGNED for, not
-# when an already-accepted PUT finishes transferring bytes — S3 validates the
-# signature at request start, not completion. A slow single-part upload begun
-# just under the ceiling can still be writing after it, so the re-check's
-# first delete attempt must not retire the row on the spot: only once an
-# additional margin has ALSO elapsed is a live transfer no longer credible.
-#
-# fix(#1236 review r2, codex P1): that margin used to reuse
-# `_COMMIT_HEADROOM_SECONDS` — APPLICATION commit-round-trip headroom.
-# Presigned PUTs bypass the app entirely, so it never actually bounded
-# anything about them.
-#
-# fix(#1236 review r3/second-opinion/r4, codex P1 x3): rounds r2-r3 then
-# scaled the margin from `presigned_multipart_threshold_mb` and, after that
-# proved config-fragile, from a job's own declared `expected_size` instead.
-# Round 4 found the actual root cause under BOTH attempts:
-# `generate_presigned_put_url` signs only `ContentType`, never a
-# content-length constraint, so nothing ever enforced `expected_size` —
-# a client can declare one byte and stream anything up to S3's real limit
-# regardless. A margin derived from an unenforced declaration was tighter
-# than the fixed ceiling, but never actually SAFE, which is worse than
-# simply being wide: fixed and correct beats tight and wrong. The margin is
-# now S3's own single-PUT ceiling, unconditionally, for every job — the one
-# bound nothing but S3 itself enforces, so no per-job data or setting can
-# ever undermine it. (Signing `Content-Length` into the URL so a mismatched
-# PUT gets rejected by S3, making a declared-size margin trustworthy, was
-# the other option; not worth the API-surface change for a low-frequency
-# finalization check.)
+# fix(#1236 r4): SigV4 bounds when a URL may be SIGNED, not when an accepted PUT
+# finishes transferring, so the re-check waits out S3's single-PUT ceiling at a
+# slow rate. `expected_size` is never enforced, so nothing per-job may replace it.
 _MIN_ASSUMED_UPLOAD_KBPS = 32  # ~256kbit/s: slow, but a still-progressing PUT
 _S3_SINGLE_PUT_MAX_BYTES = 5 * 1024 * 1024 * 1024  # AWS hard limit, 5GiB
 _RECHECK_TRANSFER_MARGIN_SECONDS = max(
@@ -522,56 +325,17 @@ async def _sweep_expired_presigned_staging(
 ) -> StaleCleanupOutcome:
     """Sweep staging objects a now-dead PUT URL may have recreated.
 
-    The other two sweeps are EVENT-triggered — one at completion, one at job
-    end — and a fast ingest fires both while the client's URL is still valid.
-    A re-PUT after them recreates an object nothing later reaps, because a
-    successful job is the per-dataset latest-complete that the retention purge
-    exempts forever. Those sweeps close the URL's past; this closes its future.
+    The two event-triggered sweeps close a URL's past; this closes its future.
+    Runs at most twice per job: an ordinary pass reaps and sets
+    ``_STAGING_REAPED_MARKER``; the re-check pass runs once the row is older
+    than ``MAX_PRESIGNED_URL_LIFETIME_SECONDS`` (the bound every URL obeys
+    whatever setting minted it, fix(#1236)) and sets the FINAL marker only
+    after ``_RECHECK_TRANSFER_MARGIN_SECONDS`` has also elapsed, because SigV4
+    expiry stops new requests, not an accepted transfer.
 
-    Runs up to twice per job, ever: an ordinary pass reaps once and sets
-    ``_STAGING_REAPED_MARKER``, which excludes the row from the ordinary
-    window from then on but not from the re-check window below. Only
-    ``_STAGING_REAPED_FINAL_MARKER`` — set once the re-check has actually run
-    — takes a row out of the query for good, so the steady-state cost stays
-    one excluded row per pass rather than one delete forever.
-
-    Delete first, mark second — the opposite of ``_reap_committed_staged_paths``
-    and for a different reason. That one must not destroy an artifact a
-    rolled-back row DELETE might still need. Here the row survives either way,
-    so the only asymmetric outcome is marking a FAILED delete as done, which
-    leaks the object permanently. A crash between the two costs one redundant
-    delete on the next pass instead, which is a no-op.
-
-    fix(#1236): closes the #1235 review r5 known gap. The ordinary window is
-    computed from the CURRENT `pending_job_timeout_seconds`, but a live URL was
-    signed against whatever value was in force when it was issued. Lower the
-    setting and restart while presigned uploads are in flight, and the
-    ordinary pass ran early against those older, longer-lived URLs — it reaped
-    the object and set the first marker while a PUT could still recreate it,
-    and that marker used to exempt the row forever.
-
-    The fix does not need to know which deadline a given URL actually carries
-    — persisting that per job was rejected in #1235 for exactly that reason,
-    plus a JSONB-to-timestamptz cast in the candidate WHERE that could throw
-    and fail the whole bulk pass. Instead it uses the one bound every URL
-    obeys regardless of history: SigV4 rejects any `X-Amz-Expires` beyond
-    `MAX_PRESIGNED_URL_LIFETIME_SECONDS`, and `pending_job_timeout_seconds` has
-    always been capped at that same ceiling, so no URL for a job can still be
-    live past `created_at + MAX_PRESIGNED_URL_LIFETIME_SECONDS` no matter which
-    setting minted it. A row already carrying the first marker gets a delete
-    attempt every pass once it crosses that age, which either recovers an
-    object a stale marker was hiding or costs one no-op DeleteObject against a
-    key that was never recreated — but does not finalize it until
-    `_RECHECK_TRANSFER_MARGIN_SECONDS` past that same age has ALSO elapsed
-    (codex P1 on this PR): SigV4 expiry stops new requests, not one already
-    accepted, so a slow PUT begun just under the ceiling can still be writing
-    after it. Only once no such transfer is credible does the final marker
-    retire the row for good.
-
-    fix(#1236 review r4, codex P1): that margin is FIXED at S3's own
-    single-PUT ceiling for every job, not derived from anything a client
-    declared or an operator configured — see `_RECHECK_TRANSFER_MARGIN_SECONDS`
-    above for why rounds r2/r3 both proved unsafe.
+    Delete first, mark second: the row survives either way, so the only
+    asymmetric outcome is marking a FAILED delete as done, which leaks the
+    object permanently.
     """
     now = now or datetime.now(timezone.utc)
     first_pass_cutoff = now - timedelta(seconds=post_expiry_sweep_after_seconds())
@@ -695,13 +459,9 @@ async def _reap_committed_staged_paths(
                 file_path=file_path,
             )
 
-    # fix(#1202 review r5): the presigned staging keys. A completed presigned
-    # job points `file_path` at its frozen copy, so the loop above never
-    # reaches the key the client still holds a PUT URL for — and a
-    # post-completion re-PUT recreates an object that escapes size and quota
-    # accounting. These are always provider keys (never local paths) and are
-    # namespaced by the job that presigned them, which is what makes deleting
-    # them safe without a survivor query.
+    # fix(#1202 r5): a completed presigned job's `file_path` is its frozen copy,
+    # so the loop above never reaches the key a PUT URL can still recreate. Keys
+    # are namespaced by the job that presigned them, so no survivor query.
     for staging_key in outcome._staged_presigned_keys:
         try:
             from app.platform.storage import get_storage
@@ -715,13 +475,8 @@ async def _reap_committed_staged_paths(
                 storage_key=staging_key,
             )
 
-    # fix(#1322 review): a dead VRT regeneration attempt's own generation-
-    # scoped objects, resolved by sweep_stale_vrt_assets but withheld from
-    # deletion until now — this function IS "after the commit landed" for
-    # every caller (fail_stale_jobs's own commit=True branch calls it
-    # immediately after `await db.commit()`; the admin commit=False branch
-    # calls it immediately after its own commit). Already tenant-resolved at
-    # capture time, unlike the two loops above, so no resolve_current_storage_key.
+    # fix(#1322): a dead VRT attempt's generation-scoped objects, withheld until
+    # the caller's commit landed. Already tenant-resolved at capture time.
     for stale_key in outcome._stale_generation_storage_keys:
         try:
             from app.platform.storage import get_storage
@@ -763,18 +518,10 @@ def unpublished_storage_keys_from_metadata(
 ) -> tuple[str, ...]:
     """Read the object keys a killed raster tail named on its own job row.
 
-    fix(#1778). ``written_storage_keys`` is a local list, so a SIGKILL or an
-    OOM between the puts and the terminal ``finally`` reclaimed nothing: the
-    key embeds a dataset id the rolled-back transaction took with it, and no
-    row, no ``delete_dataset`` prefix reap and no staging reconciler
-    (``STAGING_PREFIX`` is ``staging/`` only) could name the objects again. The
-    tails now write the keys to ``user_metadata`` before the puts, and the two
-    stale-job passes are the remaining owners.
-
-    Defensive about the shape because ``user_metadata`` is a schemaless JSONB
-    blob: a non-list, or a list carrying anything but the two managed prefixes,
-    yields nothing. That prefix check is the only thing standing between a
-    hand-edited job row and an arbitrary delete, so it is not optional.
+    fix(#1778): the tails write their keys to ``user_metadata`` before the
+    puts, so a SIGKILL between the puts and the terminal ``finally`` still
+    leaves an owner. The prefix check is the only thing standing between a
+    hand-edited job row and an arbitrary delete; any other shape yields nothing.
     """
     from app.processing.ingest.tasks_raster_common import (
         UNPUBLISHED_STORAGE_KEYS_FIELD,
@@ -797,16 +544,9 @@ def unpublished_storage_keys_from_metadata(
 def unadopted_analysis_tables_from_metadata(user_metadata: object) -> tuple[str, ...]:
     """Read EVERY output table an analysis job named on its own job row.
 
-    fix(#1778). The name is generated inside the worker and every DROP of it
-    lives in a handler a SIGKILL never runs, so the table used to survive with
-    no catalog row and nothing able to name it. ``drop_unadopted_analysis_output``
-    re-validates the identifier before it reaches DDL; this only reads it.
-
-    fix(#1778 codex r10): all of them, not one. The record accumulates across
-    attempts now, because a retry keeps the row and its old name would
-    otherwise be overwritten. Delegated to the writer's own normaliser so the
-    two cannot disagree about the shape, including about the string an existing
-    row still holds.
+    fix(#1778 r10): all of them, because the record accumulates across attempts.
+    Delegated to the writer's own normaliser so the two cannot disagree;
+    ``drop_unadopted_analysis_output`` re-validates the identifier before DDL.
     """
     from app.processing.analysis.tasks import recorded_analysis_output_tables
 
@@ -816,14 +556,9 @@ def unadopted_analysis_tables_from_metadata(user_metadata: object) -> tuple[str,
 async def _live_referenced_storage_keys(keys: tuple[str, ...]) -> set[str]:
     """Which of ``keys`` a live catalog row still points at.
 
-    fix(#1778 codex r1). Catalog rows hold LOGICAL keys, which is the form the
-    job row records and the form this sweep carries, so the comparison is a
-    plain match with no tenant resolution on either side.
-
-    Three columns on ``raster_assets`` (the published COG or VRT and its two
-    quicklooks) plus ``dataset_assets.href`` (the kept pre-conversion original,
-    and every other counted asset). Together those are every column in the
-    schema that names an object under `rasters/` or `originals/`.
+    Catalog rows hold LOGICAL keys, the form the job row records, so this is a
+    plain match. The four columns are every column in the schema that names an
+    object under `rasters/` or `originals/`.
     """
     from sqlalchemy import Text, any_, bindparam, union_all
     from sqlalchemy.dialects.postgresql import ARRAY
@@ -833,15 +568,9 @@ async def _live_referenced_storage_keys(keys: tuple[str, ...]) -> set[str]:
     from app.processing.raster.models import RasterAsset
 
     DatasetAsset = get_catalog_port().dataset_asset_orm_class()
-    # fix(#1778 codex r5): ONE array parameter, shared by all four arms, rather
-    # than four IN clauses that expand to one bind per key each. At four times
-    # the key count this query crossed asyncpg's 32767-argument ceiling from
-    # about 8192 keys, and the caller's "a survivor query that fails deletes
-    # nothing" rule then skipped every delete. Correct in isolation, and by
-    # then the retention purge had committed the deletion of the rows that were
-    # those keys' last durable owners, so the objects leaked for good. The
-    # argument count is one now, whatever the key count, and reusing the same
-    # BindParameter object in all four arms is what keeps it at one.
+    # fix(#1778 r5): ONE array parameter shared by all four arms. Four IN clauses
+    # crossed asyncpg's 32767-argument ceiling from ~8192 keys, and a failed
+    # survivor query skips every delete, so the objects leaked for good.
     keys_param = bindparam("reap_keys", value=list(keys), type_=ARRAY(Text))
     async with async_session() as session:
         stmt = union_all(
@@ -861,43 +590,18 @@ async def _live_referenced_storage_keys(keys: tuple[str, ...]) -> set[str]:
         return {row[0] for row in (await session.execute(stmt)).all() if row[0]}
 
 
-# fix(#1778 codex r6): the outcomes that license forgetting a storage key,
-# the peer of `ANALYSIS_OUTPUT_FINAL_OUTCOMES`. "refused" is final because a
-# key a live row names is answered, not pending: re-refusing it every sweep
-# forever would pin the job row for the life of the dataset. "failed" is the
-# only outcome that keeps the record, and it is the whole point of the split.
+# fix(#1778 r6): outcomes that license forgetting a storage key. "refused" is
+# final (a key a live row names is answered); only "failed" keeps the record.
 STORAGE_KEY_FINAL_OUTCOMES = frozenset({"deleted", "refused"})
 
 
-# fix(#1778 codex r9): the settled keys come off the recorded list one by one,
-# and the field is dropped only when the list empties. Expressed as SQL rather
-# than read-modify-write in Python because two rows can name overlapping keys
-# and the sweep must not race itself.
-#
-# `jsonb_exists_any` rather than the `?|` operator it implements: `?` is not a
-# bind marker for SQLAlchemy, but keeping it out of the string leaves nothing
-# for a driver or a future dialect to misread. Every bind is cast explicitly,
-# because `jsonb - $1` is ambiguous between the text, integer and text[] forms
-# until the parameter has a type.
-# fix(#1778 codex r10): how many artifact-owing rows one pass collects. The set
-# shrinks only as reaps succeed, so a backlog can outlive several passes, and a
-# pass that took all of one would hold its reaping session open across every
-# delete in it. What this leaves behind, the next pass picks up.
+# fix(#1778 r10): rows one pass collects; what it leaves, the next pass takes.
 _ARTIFACT_REAP_BATCH = 500
 
 
-# fix(#1778 codex r10): `analysis_out_table` has a real pre-PR production
-# shape this SQL has to keep clearing — a plain JSONB string, from a row an
-# earlier build wrote before the field became a list. `unpublished_storage_keys`
-# never had that shape (it was born a list in r9), so the STRING arm below is
-# dead code for that field and exercised only by the analysis one. Read it as
-# a one-element list would: a string that IS the settled value clears the
-# field outright, the same as an array that empties out. Without this arm the
-# WHERE clause's `jsonb_typeof(...) = 'array'` guard silently excluded every
-# legacy row from ever matching, so a reap that dropped the table correctly
-# left the pointer on the row forever and the retention purge could never
-# take it — the exact "row the retention purge refuses to delete" state this
-# whole mechanism exists to make temporary, turned permanent.
+# fix(#1778 r9/r10): settled keys come off the list one by one, in SQL so two
+# rows cannot race; the STRING arm clears a legacy pre-list value. `?` is not a
+# bind marker (hence jsonb_exists_any) and `jsonb - $1` is ambiguous untyped.
 _CLEAR_SETTLED_LIST_SQL = """
 UPDATE catalog.ingest_jobs SET user_metadata =
   CASE
@@ -938,26 +642,10 @@ async def _clear_settled_artifact_records(
 ) -> None:
     """Drop the job-row record of artifacts that are now accounted for.
 
-    fix(#1778 codex r5). The job row is the durable pending-reap record: the
-    retention purge refuses to delete a row that still names an unreaped
-    artifact, so a reap that fails as a whole is retried by the next sweep
-    instead of losing its last owner. That only terminates if success clears
-    the record, which is what this does.
-
-    "Accounted for" is deliberately wider than "deleted": a key a live row
-    still names was REFUSED, and refusing it again every sweep forever would
-    pin the job row for the life of the dataset. Both outcomes are final
-    answers about the object; only an error is not.
-
-    Storage keys clear as a set, not per key. A row names all three of its
-    objects at once, and clearing the field while one of them is still
-    unresolved would drop the other two from the record with it -- hence the
-    containment test, which fires only when every key the row names is in the
-    accounted set.
-
-    Best effort by the same rule as its callers: this buys the NEXT purge a
-    row it may delete, and failing to do it costs one more sweep, not
-    correctness.
+    fix(#1778 r5): the row is the durable pending-reap record (the retention
+    purge refuses a row that still names an unreaped artifact), so this is what
+    lets a purge terminate. "Accounted for" is deleted OR refused; only an
+    error keeps the record. Best effort: failing costs one more sweep.
     """
     from sqlalchemy import Text, bindparam
     from sqlalchemy.dialects.postgresql import ARRAY
@@ -973,13 +661,8 @@ async def _clear_settled_artifact_records(
     try:
         async with async_session() as session:
             if storage_keys:
-                # fix(#1778 codex r9): remove the settled KEYS, not the whole
-                # field. The record accumulates across attempts now, so a
-                # retried job's row names the previous attempt's objects as
-                # well as this one's, and dropping the field wholesale would
-                # forget keys this pass never reached an answer about. The
-                # field itself goes only once nothing is left owed on it,
-                # which is what lets the retention purge finally take the row.
+                # fix(#1778 r9): remove the settled KEYS, not the whole field;
+                # the record accumulates across attempts.
                 await session.execute(
                     text(_CLEAR_SETTLED_LIST_SQL).bindparams(
                         bindparam("field", value=UNPUBLISHED_STORAGE_KEYS_FIELD),
@@ -989,12 +672,8 @@ async def _clear_settled_artifact_records(
                     )
                 )
             if analysis_tables:
-                # fix(#1778 codex r10): by VALUE, through the same statement the
-                # storage keys use. r7 keyed this on the row id, which was safe
-                # only while a row named one table; the record accumulates
-                # across attempts now, so clearing "the field for this job"
-                # would forget a name this pass never answered for. A name is a
-                # safe key again because it carries the attempt that made it.
+                # fix(#1778 r10): by VALUE, through the same statement; a name
+                # carries the attempt that made it, so it is a safe key.
                 await session.execute(
                     text(_CLEAR_SETTLED_LIST_SQL).bindparams(
                         bindparam("field", value=ANALYSIS_OUTPUT_TABLE_FIELD),
@@ -1019,25 +698,12 @@ async def reap_unpublished_storage_keys(
 
     Returns ``(reaped, skipped, failures)``.
 
-    fix(#1778 codex r1): the survivor check lives HERE, in the only function
-    that deletes these keys, rather than only at the two sites that record
-    them. A raster replace whose conversion reproduces the published COG byte
-    for byte derives the same content hash, so the keys it intends to write are
-    the keys the dataset is serving. The recording sites now subtract what the
-    live asset names, but that is a promise each writer has to keep; this is
-    the one that holds whatever the job row says, including for a job row
-    written by a version of this code that did not know to subtract.
-
-    A survivor query that fails deletes NOTHING. The asymmetry is the one every
-    reaper in this module makes: leaving objects behind is recoverable by the
-    next pass or an operator, and deleting the raster a dataset is serving is
-    not.
+    fix(#1778 r1): the survivor check lives HERE, in the only function that
+    deletes these keys, so it holds whatever the job row says. A survivor
+    query that fails deletes NOTHING: leaving objects behind is recoverable,
+    deleting the raster a dataset serves is not.
     """
-    # fix(#1778 codex r5): deduplicated once, here, so the survivor query and
-    # the delete loop each see a key exactly once and the counts below mean
-    # "distinct objects" rather than "list entries". Two purged rows can name
-    # one prefix, and a sweep that reaps a whole retention window can hand this
-    # tens of thousands of keys.
+    # fix(#1778 r5): deduplicated once so the counts mean distinct objects.
     keys = tuple(dict.fromkeys(keys))
     if not keys:
         return (0, 0, 0)
@@ -1054,16 +720,9 @@ async def reap_unpublished_storage_keys(
     reaped = 0
     skipped = 0
     failures = 0
-    # fix(#1778 codex r5): keys this pass reached a final answer about, which
-    # is what licenses clearing them off the job row. A delete that raised is
-    # absent from it on purpose, so its row keeps the record and the next
-    # sweep retries.
-    #
-    # fix(#1778 codex r6): the outcome is named, and the settle keys off the
-    # NAME rather than off where a statement sits in a try block. This arm was
-    # already correct, and correct by an ordering an edit could undo without
-    # looking wrong -- which is precisely how the analysis arm came to settle
-    # tables whose DROP had failed. Both arms now read the same way.
+    # fix(#1778 r5/r6): keys this pass reached a FINAL answer about, keyed off
+    # the named outcome rather than statement position. A delete that raised
+    # stays on the row so the next sweep retries.
     settled: set[str] = set()
     for key in keys:
         if key in live:
@@ -1099,15 +758,9 @@ async def _reap_unadopted_analysis_outputs(
 ) -> None:
     """Drop the analysis outputs of jobs this pass just settled.
 
-    fix(#1778). Its own session, opened after the settling commit, for the two
-    reasons the storage reaps give: a DROP inside the sweep transaction would
-    block the whole pass on a lock the dead worker might still hold, and
-    deleting before the settle is durable can destroy an output a rolled-back
-    reconciliation still owns. Empty is the common case and opens nothing.
-
-    The tenant context is the caller's: both callers run inside
-    ``tenant_job_context`` per tenant in multi-tenant mode, the same context
-    the analysis worker resolved its schema under.
+    fix(#1778): its own session, opened after the settling commit, so a DROP
+    cannot block the pass on a dead worker's lock or destroy an output a
+    rolled-back reconciliation still owns. Tenant context is the caller's.
     """
     if not out_tables:
         return
@@ -1121,25 +774,9 @@ async def _reap_unadopted_analysis_outputs(
     )
 
     schema = tenant_data_schema(current_tenant_var.get() if is_multi_tenant() else None)
-    # fix(#1778 codex r5): the peer of the storage reaper's `settled` set. A
-    # table this pass reached a final answer about (dropped, or left alone
-    # because a dataset row adopted it) comes off the job row; one whose drop
-    # did not resolve stays on it, so the row survives the retention purge and
-    # the next sweep tries again.
-    #
-    # fix(#1778 codex r6): keyed on what the call REPORTS, not on whether it
-    # returned. `drop_unadopted_analysis_output` catches its own probe and DROP
-    # failures, so "it did not raise" was true of a failed cleanup too, and
-    # settling on that stripped the table's last durable name and orphaned it
-    # permanently. Only a final outcome settles; "failed" is retryable and
-    # keeps the record. The try/except stays for a failure the callee does not
-    # catch at all, and it deliberately does not settle either.
-    # fix(#1778 codex r10): names, and settled by name. r7 carried (job, table)
-    # pairs so the drop could check ownership against the job, and r10 moved
-    # that proof into the name itself: it carries the job AND the attempt that
-    # made it, so no two attempts of one job can name one table and the name is
-    # a safe key for the clear again. The drop still re-derives the check from
-    # the scope, which is what refuses a name from a foreign row.
+    # fix(#1778 r5/r6/r10): settle by what the call REPORTS, never by "it did
+    # not raise" (the callee catches its own DROP failures). Names carry the
+    # attempt, so a name is the safe key; the drop re-derives ownership.
     settled: set[str] = set()
     async with async_session() as session:
         for job_uuid, out_table in set(out_tables):
@@ -1169,25 +806,11 @@ def _stale_generation_storage_keys(
 ) -> tuple[str, ...]:
     """Resolve (never delete) a dead attempt's immutable object keys.
 
-    feat(#1267): ``regenerate_vrt`` writes its rebuilt VRT + quicklooks to an
-    immutable ``rasters/{vrt_dataset_id}/generations/{generation_id}/...`` key
-    (the full generation UUID, unset by attempt-fencing convention A3 —
-    mirroring ``attempt_scoped_staging_table``'s full-hex rule for staging
-    tables) BEFORE the phase-2 transaction that would otherwise clean them up
-    via ``_cleanup_orphaned_storage_keys``. A worker killed between that write
-    and the commit leaves the objects with no reference anywhere — this sweep
-    is the only remaining owner of the key, so its caller reaps them the same
-    way, but only once the reconciliation itself is durable (see
-    ``_reap_stale_generation_storage`` for why deletion is a separate,
-    later step).
-
-    ``current_tenant_var`` carries the right tenant because every caller of
-    ``sweep_stale_vrt_assets`` (the startup recovery pass and the periodic
-    sweep, both directly and via ``fail_stale_jobs``) runs inside
-    ``tenant_job_context`` per tenant in multi-tenant mode — the same context
-    ``regenerate_vrt`` itself reads to resolve these same keys. A missing
-    tenant context in multi-tenant mode resolves no keys rather than raising:
-    the asset/generation reconciliation is not gated on this best-effort pass.
+    feat(#1267): ``regenerate_vrt`` writes to an immutable per-generation key
+    BEFORE its phase-2 transaction, so a worker killed in between leaves
+    objects only this sweep can name. The caller reaps them after its commit
+    (see ``_reap_stale_generation_storage``). A missing tenant context in
+    multi-tenant mode resolves no keys rather than raising.
     """
     from app.core.db.tenant_session import current_tenant_var
     from app.core.tenancy import is_multi_tenant
@@ -1210,74 +833,24 @@ def _stale_generation_storage_keys(
 async def _reap_stale_generation_storage(keys: tuple[str, ...]) -> None:
     """Best-effort delete of already-resolved, already-committed keys.
 
-    fix(#1322 review): deleting these objects had lived inside
-    ``sweep_stale_vrt_assets`` itself, before its caller's commit. A worker
-    is declared dead by a timed-out heartbeat, not by proof it can never run
-    another statement — if the reconciling transaction then failed to commit
-    (or a later statement in the same pass raised), the generation/asset
-    UPDATEs rolled back while these objects were already gone. A resumed
-    "dead" worker could pass the (rolled-back-to) ownership checks and
-    publish a generation whose own source.vrt and quicklooks no longer
-    exist, leaving a `'ready'` asset backed by deleted data. Every caller now
-    resolves the keys during the sweep (``_stale_generation_storage_keys``,
-    read-only) but defers this call until strictly after its own commit
-    succeeds — mirroring ``_reap_committed_staged_paths``, which reaps
-    ``StaleCleanupOutcome._staged_paths`` under the identical rule.
-
-    A dead attempt may have written none, some, or all three objects before
-    the worker died; deleting a key that was never written is a documented
-    no-op on every StorageProvider.
+    fix(#1322): must run strictly after the caller's commit. A "dead" worker
+    is declared by heartbeat, not proof, and a rolled-back reconciliation can
+    let it publish a generation whose objects this had already deleted.
+    Deleting a never-written key is a documented no-op on every provider.
     """
     if not keys:
         return
 
-    # Function-local: mirrors the deferred processing-import convention
-    # already used for RasterAsset/VrtGeneration below (D-17,
-    # test_platform_processing_imports_stay_deferred) — the exact same helper
-    # regenerate_vrt itself uses to reap its own orphaned writes.
+    # Function-local: platform may not import processing eagerly
+    # (test_platform_processing_imports_stay_deferred).
     from app.processing.ingest.tasks_raster import _cleanup_orphaned_storage_keys
 
     await _cleanup_orphaned_storage_keys(list(keys), job_id="vrt-stale-sweep")
 
 
-# fix(#1322 review round 3): does the PUBLISHED VRT's member set (built_from's
-# keys — feat(#1290 review): "what the published VRT was assembled FROM")
-# still equal the CATALOG's current member set (vrt_source_links)? A bare
-# fragment, not a full statement, so it can be embedded as-is in one UPDATE's
-# WHERE and wrapped in NOT(...) for its mirror — see sweep_stale_vrt_assets.
-#
-# fix(#1327): this check is now near-unreachable in the FALSE direction, and
-# that is the point. add_vrt_source/remove_vrt_source no longer mutate
-# vrt_source_links at request time — they stage the intended member set on the
-# VrtGeneration row, and regenerate_vrt applies it in the same transaction that
-# publishes the artifact and writes built_from. A composition-changing attempt
-# that dies before that swap now leaves the links exactly as built_from
-# describes them, so it takes the honest restore branch like any other dead
-# attempt. The check stays because it is the guard, not the mechanism: rows
-# written before #1327, a generation staged by future code that forgets to
-# apply it, or any path that mutates the link table outside a publish
-# transaction all still produce real drift, and the sweep must keep refusing to
-# call that 'ready'. A check whose FALSE branch has become rare is the outcome
-# of fixing the cause; deleting it would only make the next cause invisible.
-#
-# Count-match + one-directional subset (every built_from key has a live
-# link) proves full set equality: a JSONB object cannot repeat a key, and
-# uq_vsl_vrt_source forbids vrt_source_links from repeating a
-# (vrt_dataset_id, source_dataset_id) pair, so neither side can inflate its
-# own count to fake a subset match.
-#
-# jsonb_typeof(...) = 'object', not built_from IS NOT NULL — a real-DB test
-# caught the difference: SQLAlchemy's plain JSONB type (no none_as_null=True)
-# serializes a Python None to the JSON scalar `null`, not SQL NULL, so
-# "IS NOT NULL" alone is TRUE for a column holding JSON null and
-# jsonb_object_keys() raises "cannot call jsonb_object_keys on a scalar" —
-# turning the conservative branch into a 500 instead of a safe fallback.
-# jsonb_typeof() returns SQL NULL for a genuinely NULL column and 'null' (a
-# string, not a match) for a JSON-null scalar, so both forms — and any other
-# non-object value — fail the `= 'object'` test the same safe way. A legacy
-# VRT predating the built_from column cannot answer the question at all,
-# and the unanswerable case must fall to the SAME conservative branch as a
-# proven mismatch.
+# fix(#1322 r3, #1327): is the PUBLISHED member set (built_from keys) still the
+# CATALOG's (vrt_source_links)? Count-match + one-way subset proves equality.
+# `jsonb_typeof = 'object'`, not IS NOT NULL: a JSON `null` scalar raises.
 _COMPOSITION_PRESERVED_SQL = """
     jsonb_typeof(built_from) = 'object'
     AND (SELECT COUNT(*) FROM jsonb_object_keys(built_from)) = (
@@ -1294,68 +867,9 @@ _COMPOSITION_PRESERVED_SQL = """
     )
 """
 
-# fix(#1322 review round 4): composition-preserving is necessary but not
-# sufficient. regenerate_vrt_endpoint's guard only rejects 'regenerating' —
-# a caller may retry an asset that is already 'failed'. If THAT retry is
-# also abandoned and its membership still matches built_from, the check
-# above alone would call it composition-preserving and restore 'ready',
-# erasing a real failure signal a worker crash had nothing to do with:
-# no successful artifact was ever produced by the retry, and whatever made
-# the FIRST attempt fail is still unaddressed.
-#
-# There is no column recording "the asset's status the instant this
-# generation started" — router.py's own `previous_status` is a local
-# variable, never persisted. The nearest STORED fact is the outcome of the
-# attempt immediately before this one: at most one generation is ever
-# in-flight per dataset (the 409 + advisory lock in regenerate_vrt_endpoint
-# / add_vrt_source / remove_vrt_source forbid a second), so
-# `vrt_generations` rows for one dataset form a strict, gap-free timeline,
-# and the row immediately preceding the one being reconciled records
-# exactly what happened right before THIS attempt was allowed to start.
-# 'completed' (or no such row — the dataset's first-ever attempt, whose
-# prior state is 'ready' by construction, per create_vrt_dataset) means the
-# asset was 'ready' when this attempt began; 'failed' means it was not.
-#
-# Accepted conservative cost, stated plainly: a generation this sweep
-# itself restores to 'ready' still leaves its OWN vrt_generations row
-# 'failed' below (only the asset recovers, not the attempt's record) — so
-# a LATER dead attempt on the same dataset, whose immediately-prior row IS
-# that earlier swept-and-recovered one, reads 'failed' here and is kept
-# 'failed' even though the asset was legitimately 'ready' when it started.
-# The alternative (a further stored marker distinguishing "recovered by
-# the sweep" from "never recovered") is a bigger schema surface than this
-# fix's blast radius, and the safety direction is right for a reconciler:
-# never claims 'ready' the moment there is any doubt, at the cost of
-# occasionally staying 'failed' one cycle longer than strictly necessary,
-# which self-corrects the moment an operator retries and it succeeds.
-#
-# fix(#1322 review round 5): raw `status` alone over-counts what "failed"
-# means. regenerate_vrt_endpoint's own orphan guard (_rollback,
-# lines ~507-520) marks the just-created VrtGeneration 'failed' when
-# Procrastinate's ENQUEUE itself throws — a dispatch failure the task never
-# reached — and in the SAME rollback reverts the asset to whatever it was
-# (commonly 'ready'). That generation row genuinely never ran: nothing
-# about its outcome describes the asset's state, only that it could not be
-# queued. Reading its 'failed' status here as "the asset was not ready"
-# would be wrong in exactly the direction this predicate exists to avoid —
-# not a false 'ready', but a false 'failed' for an asset that never had a
-# real attempt run against it.
-#
-# `heartbeat_at IS NOT NULL` is the fact that separates them: it is set in
-# exactly one place in this codebase, `tasks_vrt.regenerate_vrt`'s Phase-1
-# claim (either the CAS `UPDATE ... status='pending' -> 'running'`, or the
-# equivalent field on a freshly-created legacy-pointer generation) — the
-# first thing the TASK does once a worker actually picks it up, never
-# anything the ENDPOINT touches at creation. A synchronous enqueue failure
-# never reaches that line, so its generation keeps heartbeat_at NULL
-# forever; the same is true of a generation stuck 'pending' because no
-# worker ever claimed it before this sweep's own cutoff — which is the
-# same "never actually ran" fact, so excluding it here is consistent with,
-# not a special case against, its own eventual sweep as a dead attempt.
-# Filtering to `heartbeat_at IS NOT NULL` therefore finds the most recent
-# OTHER generation that a worker actually claimed and ran, skipping past
-# any number of enqueue-failures or claim-starved rows in between — those
-# never touched the asset's state, so they carry no information about it.
+# fix(#1322 r4/r5): a retry of an already-'failed' asset that also dies must
+# stay 'failed', read off the prior claimed generation's outcome;
+# `heartbeat_at IS NOT NULL` skips enqueue-rollback rows no worker ever ran.
 _PRIOR_ATTEMPT_WAS_READY_SQL = """
     (
         SELECT g.status FROM catalog.vrt_generations g
@@ -1371,34 +885,9 @@ _READY_WORTHY_SQL = (
     f"({_COMPOSITION_PRESERVED_SQL}) AND ({_PRIOR_ATTEMPT_WAS_READY_SQL})"
 )
 
-# fix(#1322 review round 6, completed): the proven-dead proof for a
-# 'pending' VrtGeneration — mirrors _ABANDONED_RUN_SQL's
-# `catalog.procrastinate_jobs` correlation in platform/refresh/service.py,
-# keyed on `generation_id` instead of `ingest_job_id` because that is the
-# kwarg every regenerate_vrt dispatch site (regenerate_vrt_endpoint,
-# add_vrt_source, remove_vrt_source) actually passes — there is no
-# ingest_job_id column on VrtGeneration to correlate through. `'todo'`/
-# `'doing'` is Procrastinate's own live-job vocabulary, same two statuses
-# stale_pending_clauses excludes for IngestJob.
-#
-# Two correlation forms, because `tasks_vrt.regenerate_vrt` accepts two
-# delivery shapes and this predicate has to cover both to be complete:
-#   1. Modern: `generation_id` is present in `args` — exact 1:1 match.
-#   2. Legacy: a delivery queued by pre-upgrade code carries no
-#      `generation_id` at all (the task parameter is optional precisely to
-#      keep such deliveries alive across a rolling deploy). On execution it
-#      adopts `RasterAsset.current_generation_id` instead (see the
-#      "Legacy queued deliveries" comment at tasks_vrt.py's claim site). A
-#      live legacy row is therefore correlated by dataset (`vrt_dataset_id`
-#      is a required, non-optional task argument, so every delivery of
-#      either shape always carries it) PLUS current ownership: it counts as
-#      live for THIS generation only if this generation IS, right now, that
-#      dataset's `RasterAsset.current_generation_id` — the exact row the
-#      legacy task will claim once it runs.
-# Deliberately conservative in the direction the finding asked for: an
-# ambiguous or legacy-shaped live row blocks the sweep rather than being
-# read as absence of one — a delayed sweep of a truly-dead attempt costs a
-# retry window; sweeping a live one loses real work.
+# fix(#1322 r6): proven-dead proof for a 'pending' VrtGeneration, keyed on
+# `generation_id`; the legacy arm correlates a pre-upgrade delivery (no
+# generation_id) by dataset PLUS current ownership. Ambiguity blocks the sweep.
 _NO_LIVE_GENERATION_JOB_SQL = """
     NOT EXISTS (
         SELECT 1 FROM catalog.procrastinate_jobs pj
@@ -1425,92 +914,27 @@ async def sweep_stale_vrt_assets(
 ) -> tuple[int, int, tuple[str, ...]]:
     """Reconcile RasterAsset rows stuck in status='regenerating' past ``stale_cutoff``.
 
-    GAP-002 / feat(#1267): a worker crash mid-regeneration leaves the VRT
-    asset permanently stuck in ``status='regenerating'``, causing all future
-    link/regenerate calls to 409. This helper mirrors the IngestJob
-    stale-recovery pattern and uses the same
-    ``stale_cutoff = now - JOB_TIMEOUT_SECONDS`` threshold.
+    GAP-002 / feat(#1267): a worker crash mid-regeneration otherwise leaves the
+    asset 'regenerating' forever and every link/regenerate call 409s. Staleness
+    is ``VrtGeneration.heartbeat_at`` (falling back to ``started_at``), which
+    a live worker renews every 30s.
 
-    Staleness is measured via ``VrtGeneration.heartbeat_at`` (falling back to
-    ``started_at`` for a generation whose worker died before its first
-    renewal) — the same self-reported liveness signal ``maintain_vrt_
-    generation_heartbeat`` renews every 30s while the worker is alive, so a
-    live job's row never crosses the cutoff and this sweep never touches it.
+    Recovery is ``'ready'`` only when ``_READY_WORTHY_SQL`` holds (the
+    published member set still matches the catalog AND the asset was provably
+    ready when the attempt started, fix(#1322 r3/r4)); ``'failed'`` otherwise,
+    with ``current_generation_id`` cleared either way so a retry stays
+    possible. The dead attempt's own generation row is marked ``'failed'``.
 
-    Recovery status: ``'ready'`` only when BOTH hold (fix(#1322 review
-    rounds 3-4) — see ``_READY_WORTHY_SQL``, ``_COMPOSITION_PRESERVED_SQL``,
-    ``_PRIOR_ATTEMPT_WAS_READY_SQL``); ``'failed'`` otherwise. ``regenerate_
-    vrt`` only overwrites the asset's published pointer (``asset_uri``,
-    ``sha256``, ...) in the SAME transaction that clears
-    ``current_generation_id`` on success — a dead attempt never reaches
-    that transaction, so those fields still describe the last-good VRT the
-    asset was serving before this attempt started. That is necessary to
-    restore ``'ready'`` but not sufficient on its own, for two independent
-    reasons:
-
-    1. Nothing about the dataset's declared MEMBERSHIP may have changed
-       underneath the attempt. Restoring ``'ready'`` over such a change
-       would erase the only visible signal of it — the status endpoint
-       reads the link set, not the served VRT, and would report a reduced
-       (or expanded) source list as fully healthy while stale composition
-       keeps being served. fix(#1327) removed the path that used to
-       produce this state routinely: ``add_vrt_source``/``remove_vrt_
-       source`` stage their intended member set on the ``VrtGeneration``
-       row and ``regenerate_vrt`` applies it in the same transaction as
-       the artifact swap, so a dead composition-changing attempt now
-       leaves the links untouched and takes the restore branch. The check
-       remains as the guard for what it cannot see: rows written before
-       #1327, and any future path that mutates the link table outside a
-       publish transaction.
-    2. The asset must have actually BEEN ``'ready'`` — not ``'failed'`` —
-       the instant this attempt was allowed to start. ``regenerate_vrt_
-       endpoint``'s guard rejects only ``'regenerating'``, so a caller may
-       retry an asset that is already ``'failed'``. If that retry then dies
-       too and its membership still matches, condition 1 alone would call
-       it composition-preserving and restore ``'ready'`` — erasing a real
-       failure a worker crash had nothing to do with, since no successful
-       artifact was ever produced by the retry and whatever caused the
-       FIRST failure is still unaddressed.
-
-    The degraded branch keeps ``current_generation_id`` cleared (a retry
-    can still be triggered) but leaves ``status='failed'``, matching the
-    ordinary explicit-failure path.
-
-    Either branch marks the dead attempt's own ``VrtGeneration`` row
-    ``'failed'`` below; an operator or retry call can re-trigger
-    regeneration regardless of which branch fired.
-
-    There is no "first-ever generation, no built_from to compare" gap.
-    ``status='regenerating'`` is reachable from exactly three call sites
-    (``regenerate_vrt_endpoint``, ``add_vrt_source``, ``remove_vrt_source``),
-    and all three 404 unless a VRT dataset already exists — which means its
-    ``RasterAsset`` row was already created, and the only constructor of that
-    row (``create_vrt_dataset``, run inside ``ingest_vrt``) sets
-    ``status='ready'`` with a real ``asset_uri`` AND a real ``built_from`` in
-    the same flush the row first becomes queryable. No code path ever
-    inserts a ``RasterAsset`` row pre-set to ``'regenerating'``, and no VRT
-    created after ``built_from`` shipped (#1290) ever has a NULL value for
-    it — only a legacy pre-#1290 row can, and that case is exactly the
-    "cannot answer, so don't guess ready" branch above.
-
-    Also resolves the dead attempt's own generation-scoped storage keys for
-    the caller to reap, but does NOT delete anything itself — the caller must
-    not do so either until its own commit lands (fix(#1322 review); see
-    ``_reap_stale_generation_storage``). Deleting before that commit is
-    durable can destroy a generation a rolled-back reconciliation just
-    restored ownership of, orphaning a `'ready'` asset against missing bytes.
+    Resolves the dead attempt's generation-scoped storage keys but deletes
+    nothing; the caller must not either until its own commit lands.
 
     Args:
-        db: The active async session (must NOT be committed before returning
-            — the caller is responsible for the final ``await db.commit()``).
-        stale_cutoff: Any regenerating asset whose generation started before
-            this timestamp is considered stale.
+        db: The active async session; must NOT be committed before returning.
+        stale_cutoff: Generations started before this are stale.
 
     Returns:
-        ``(assets_recovered, gens_failed, storage_keys)`` — ``assets_
-        recovered`` counts BOTH branches (restored to ready and kept
-        failed; both are a resolved outcome for a dead attempt).
-        ``storage_keys`` are resolved, not yet deleted.
+        ``(assets_recovered, gens_failed, storage_keys)``; ``assets_recovered``
+        counts BOTH branches, and ``storage_keys`` are resolved, not deleted.
     """
     from app.processing.raster.models import RasterAsset, VrtGeneration
 
@@ -1528,43 +952,9 @@ async def sweep_stale_vrt_assets(
         generation_scope.append(VrtGeneration.vrt_dataset_id.in_(select(Dataset.id)))
         asset_scope.append(RasterAsset.dataset_id.in_(select(Dataset.id)))
 
-    # --- 1. Find stale regenerating RasterAssets ---
-    # A VRT asset is stale when:
-    #   - status = 'regenerating'
-    #   - its latest VrtGeneration (matched by vrt_dataset_id) has
-    #     started_at older than stale_cutoff.
-    # We query via VrtGeneration so the staleness signal is the
-    # regeneration start time, not the asset's last_regenerated_at
-    # (which is only written on successful completion).
-    # Fail generation leases atomically. The status + liveness predicates are
-    # re-evaluated by PostgreSQL at UPDATE time, so a heartbeat racing the
-    # sweep wins and the generation remains live.
-    #
-    # fix(#1322 review round 6): 'running' and 'pending' need DIFFERENT
-    # proof, mirroring the split this file already applies to IngestJob
-    # (the running-job sweep just above trusts a stale heartbeat outright;
-    # stale_pending_clauses additionally requires no_live_procrastinate_job
-    # because queue waits are unbounded). A 'running' generation's
-    # heartbeat_at is the worker's own, actively-renewed liveness signal —
-    # stale on it is proof enough, independent of what Procrastinate's OWN
-    # bookkeeping currently shows (a crashed worker can leave its
-    # procrastinate_jobs row reading 'doing' until the separate stalled-
-    # queue sweep prunes it, so requiring "no live row" here would make a
-    # genuinely-dead running generation UNSWEEPABLE until that other sweep
-    # runs). A 'pending' generation has no such signal — nothing has
-    # claimed it yet, so its `started_at` age alone cannot distinguish
-    # "orphaned" from "sitting in a sustained worker backlog, still queued
-    # and will run" — so it additionally requires proof no live
-    # Procrastinate row still references it, correlated via `generation_id`
-    # in `args` (the same kwarg all three dispatch call sites pass), the
-    # exact fact stale_pending_clauses checks for IngestJob and for the
-    # identical reason.
-    #
-    # RETURNING carries vrt_dataset_id alongside id (feat(#1267)): the
-    # generation-scoped storage key each dead attempt wrote to is keyed on
-    # BOTH, and the asset UPDATE below cannot supply that pairing back — its
-    # own current_generation_id is nulled in the same statement, so RETURNING
-    # it would report the value AFTER the SET, not the attempt being reaped.
+    # fix(#1322 r6): 'running' trusts its own stale heartbeat (procrastinate may
+    # still read 'doing'); 'pending' also needs proof of no live queue row.
+    # RETURNING vrt_dataset_id: the asset UPDATE below nulls current_generation_id.
     stale_gen_result = await db.execute(
         update(VrtGeneration)
         .where(
@@ -1600,47 +990,9 @@ async def sweep_stale_vrt_assets(
     ]
     stale_generation_ids = [generation_id for generation_id, _ in stale_generations]
 
-    # Restore the asset only if it still points at the generation just
-    # failed. A newer regeneration has a different current_generation_id and
-    # is fenced — same CAS discipline as the failure-handler path in
-    # tasks_vrt.regenerate_vrt.
-    #
-    # fix(#1322 review round 3): 'ready' is only honest for a COMPOSITION-
-    # PRESERVING attempt. If the catalog's link set reflects a NEW composition
-    # while the published asset_uri (untouched by the dead attempt) still
-    # serves the OLD one, restoring 'ready' would erase the only visible signal
-    # of that drift: the status endpoint reads the link set, not the served
-    # bytes, and would report the new (reduced) source list as fully healthy
-    # while stale data keeps being served.
-    #
-    # fix(#1327): the routine producer of that drift is gone — add_vrt_source /
-    # remove_vrt_source stage their member set on the generation and
-    # regenerate_vrt applies it in the publish transaction, so a dead
-    # composition-changing attempt leaves the links matching built_from and
-    # lands in the restore branch below. What remains for this check is what it
-    # was always the guard against rather than the mechanism for: pre-#1327
-    # rows and any unforeseen writer of the link table.
-    #
-    # There is no stored "attempt type" to key off — VrtGeneration.
-    # triggered_by holds a user id on every call site, not a kind, and
-    # source_count is populated post-mutation on both. So this asks the
-    # question the drift itself is about, from state rather than provenance:
-    # does the PUBLISHED composition (built_from's key set — what the served
-    # VRT was actually assembled from, feat(#1290 review)) still equal the
-    # CATALOG's current composition (vrt_source_links)? Count-match plus a
-    # one-directional subset check proves set equality here because neither
-    # side can hold a duplicate id (a JSONB object key is unique by
-    # construction; vrt_source_links carries uq_vsl_vrt_source).
-    #
-    # NULL built_from (a pre-#1290 VRT with no recorded build set) cannot
-    # answer the question at all, and falls to the same conservative branch
-    # as a genuine mismatch — matching the "unknown answers unknown, not
-    # fresh" posture in source_freshness.py, not the other one.
-    #
-    # fix(#1322 review round 4): composition-preserving is necessary but not
-    # sufficient — see _PRIOR_ATTEMPT_WAS_READY_SQL above for the second,
-    # independently-required fact (was the asset actually 'ready', not
-    # 'failed', the instant this attempt was allowed to start).
+    # Restore only if the asset still points at the generation just failed; a
+    # newer regeneration is fenced. fix(#1322 r3/r4): 'ready' only when
+    # _READY_WORTHY_SQL holds; NULL built_from falls to the conservative branch.
     _asset_composition = (
         *asset_scope,
         RasterAsset.status == "regenerating",
@@ -1688,16 +1040,8 @@ async def sweep_stale_vrt_assets(
 def publish_refresh_reconciliation(outcome: StaleCleanupOutcome) -> None:
     """Publish the sweep's reconciliation counter, AFTER its commit landed.
 
-    fix(#1277 review): this used to increment where the sweep runs, inside the
-    transaction. A later failure in the same pass rolls the cancellations back
-    but not the counter, and a counter only goes up — so the overcount is
-    permanent and every rate() over that window stays wrong. Publishing waits
-    for durability rather than intent.
-
-    Both commit sites call it: ``fail_stale_jobs`` when it owns the commit,
-    and the admin cleanup endpoint when it passes ``commit=False``. A
-    rolled-back pass reaches neither. Every increment is a run that reached a
-    terminal status with no worker reporting one.
+    fix(#1277): a counter incremented inside the transaction survives a
+    rollback, and the overcount is permanent. Both commit sites call this.
     """
     if outcome._refresh_runs_reconciled:
         refresh_sweep_reconciled_total.inc(outcome._refresh_runs_reconciled)
@@ -1706,27 +1050,11 @@ def publish_refresh_reconciliation(outcome: StaleCleanupOutcome) -> None:
 async def purge_terminal_job_tokens(db: AsyncSession) -> None:
     """Backstop the token purge the service tasks run on their own failure.
 
-    ``purge_token_on_failure`` (processing/ingest/tasks_common.py) drops the
-    raw service token from a dying attempt's own queue row. A row that never
-    reached that handler still holds it — a worker killed mid-attempt, a job
-    cancelled before it was ever claimed, a row deferred before #1746 — and
-    the worker's ``delete_jobs="successful"`` only ever removes the rows that
-    succeeded. Terminal statuses only: `todo` is still waiting to be worked
-    with those args, and `doing` is being worked right now (`aborting` is
-    legacy in procrastinate 3.x and never written).
-
-    fix(#1746 codex r1): NOT part of ``fail_stale_jobs``. That runs once per
-    TENANT in hosted mode, and ``catalog.procrastinate_jobs`` is shared queue
-    infrastructure with no tenant column — so living there repeated one
-    unscoped UPDATE tenants-many times per pass, per API process, every
-    cadence. It belongs to the pass, not to a tenant, so
-    ``sweep_stale_jobs_once`` calls it exactly once. Keeping it out of
-    ``fail_stale_jobs`` also keeps the dry-run cleanup endpoint
-    (``commit=False, detailed=True``) from writing.
-
-    Deliberately unindexed: the retention purge already bounds how many
-    terminal rows survive, and one sequential scan per pass is cheaper than a
-    write-amplifying index on a hot queue table.
+    Drops the raw service token from terminal queue rows that never reached
+    ``purge_token_on_failure``. fix(#1746 r1): NOT part of ``fail_stale_jobs``,
+    which runs once per TENANT; the queue table is shared, so
+    ``sweep_stale_jobs_once`` calls this exactly once per pass. Deliberately
+    unindexed: one sequential scan beats a write-amplifying index on a hot table.
     """
     await db.execute(
         text(
@@ -1782,28 +1110,16 @@ async def fail_stale_jobs(
     """
     now = datetime.now(timezone.utc)
 
-    # fix(#1234): the 1h abandonment policy applies only to jobs that never
-    # got as far as binding bytes. A presigned completion sets `file_path` and
-    # then commits; between those two the row is still `pending` with a
-    # `file_path`, and this sweep used to fail it out from under the request —
-    # a race whose loser is a completion that actually succeeded.
-    #
-    # The guard is a FALSY check, not IS NULL. The column is nullable, but no
-    # creator ever writes NULL: `create_ingest_job` is called with "" by both
-    # presign endpoints, and analysis jobs carry "" too (see
-    # `_retry_capability`). An IS NULL guard would match nothing and leave the
-    # race exactly as it was, while looking fixed.
+    # fix(#1234): the 1h policy applies only to rows that never bound bytes. The
+    # guard is FALSY, not IS NULL: every creator writes "" for file_path, so an
+    # IS NULL guard would match nothing while looking fixed.
     unbound_result = await db.execute(
         update(IngestJob)
         .where(*stale_pending_clauses(now, completion_bound=False))
         .values(
             **stale_pending_unbound_values(now, message=STALE_PENDING_UNBOUND_MESSAGE)
         )
-        # fix(#1556 review, codex P2): RETURNING carries the status the CASE
-        # actually chose. Postgres returns the NEW row, so this is what the
-        # database wrote — the alternative, re-deriving the predicate in
-        # Python to classify the rows, is a second copy of the rule that can
-        # disagree with the one that ran.
+        # fix(#1556): RETURNING carries the status the CASE actually chose.
         .returning(
             IngestJob.id,
             IngestJob.user_metadata,
@@ -1816,20 +1132,14 @@ async def fail_stale_jobs(
     # hands back plain tuples, and attribute access would work against the
     # database while raising in the unit suites that drive this with doubles.
     pending_cancelled = sum(1 for row in unbound_rows if row[3] == "cancelled")
-    # Back to the three columns every consumer below expects; the audit loop
-    # still visits cancelled rows, and closing the trail is the right write for
-    # either terminal state. fix(#1744): a backfill reaches the queue through
-    # the same guard that stamps `commit_attempted_at`, so it is in the
-    # cancelled class only when the process died between its own commit and
-    # the dispatch, which is exactly the `never_started` the loop records.
+    # fix(#1744): cancelled rows still get their audit trail closed; a backfill
+    # in the cancelled class is exactly the `never_started` the loop records.
     pending_rows = [(row[0], row[1], row[2]) for row in unbound_rows]
     pending_job_ids = [row[0] for row in unbound_rows]
 
-    # fix(#1234): the other half. A row that DID bind bytes but never committed
-    # its status is now exempt from the 1h clause, and the retention purge only
-    # considers terminal rows — so without this it is immortal. A day is far
-    # past any legitimate completion, and the message says which failure this
-    # is so an operator is not told the upload "never queued".
+    # fix(#1234): the bound half. A row that bound bytes but never committed is
+    # exempt from the 1h clause and the purge only takes terminal rows, so it
+    # needs this backstop or it is immortal.
     bound_pending_result = await db.execute(
         update(IngestJob)
         .where(*stale_pending_clauses(now, completion_bound=True))
@@ -1844,15 +1154,9 @@ async def fail_stale_jobs(
     pending_rows += bound_pending_rows
     pending_job_ids += [row[0] for row in bound_pending_rows]
 
-    # fix(#1778 codex r4/r10): "this row still names an artifact nothing has
-    # reaped". The retention purge refuses to delete such a row, so the record
-    # survives for a later pass to retry, and the artifact collection below
-    # starts from the same predicate so the two can never disagree about which
-    # rows still owe something.
-    #
-    # A string test on the JSONB blob, never a cast: the same rule the `s3_key`
-    # clause states, because a malformed value must not be able to throw and
-    # fail the whole bulk pass.
+    # fix(#1778 r4/r10): "this row still names an unreaped artifact". The purge
+    # refuses such rows and the collection below starts from the same predicate.
+    # A string test on the JSONB blob, never a cast that can throw.
     from app.processing.analysis.tasks import ANALYSIS_OUTPUT_TABLE_FIELD
     from app.processing.ingest.tasks_raster_common import (
         UNPUBLISHED_STORAGE_KEYS_FIELD,
@@ -1864,19 +1168,9 @@ async def fail_stale_jobs(
     )
 
     running_cutoff = now - timedelta(seconds=JOB_TIMEOUT_SECONDS)
-    # fix(#1778 audit r12): the candidate set is read through its own `FOR
-    # UPDATE SKIP LOCKED` subquery rather than matched directly in the
-    # UPDATE's WHERE clause. A phase-2 write now holds `FOR NO KEY UPDATE` on
-    # its job row for as long as its own session stays open (see
-    # `_job_phase_session`'s `require_status` docstring) -- a bare `UPDATE
-    # ... WHERE status = 'running'` sharing this statement would have to WAIT
-    # for that lock on every row it scans, and a `lock_timeout` on a
-    # set-based UPDATE like this one does not skip the one busy row, it
-    # cancels the WHOLE statement, failing every OTHER genuinely stale job in
-    # the same pass along with it. `SKIP LOCKED` excludes exactly the rows a
-    # live phase-2 transaction currently owns and touches nothing else, so a
-    # row a worker is actively finishing is simply left for the next pass
-    # rather than costing this one its entire batch.
+    # fix(#1778 audit r12): candidates come through their own `FOR UPDATE SKIP
+    # LOCKED` subquery. A phase-2 write holds `FOR NO KEY UPDATE` on its row,
+    # and a `lock_timeout` on a set-based UPDATE cancels the WHOLE statement.
     running_candidates = (
         select(IngestJob.id)
         .where(
@@ -1901,10 +1195,8 @@ async def fail_stale_jobs(
     running_rows = list(running_result.all())
     running_job_ids = [row[0] for row in running_rows]
 
-    # fix(#1550 review): the row and its audit trail are settled by the same
-    # actor, in the same transaction. After a hard kill this sweep is the only
-    # actor left, so an embedding backfill it fails here would otherwise stay
-    # `requested` in the audit log forever while its job row is terminal.
+    # fix(#1550): the row and its audit trail are settled by the same actor in
+    # the same transaction; after a hard kill this sweep is the only actor left.
     for job_id_, user_metadata_, created_by_ in running_rows:
         await audit_settled_embedding_backfill(
             db,
@@ -1922,44 +1214,9 @@ async def fail_stale_jobs(
             error_code="never_started",
         )
 
-    # fix(#1709 review r7 A): reconcile fan-out parents stranded by a crash
-    # between the pre-dispatch flip and the first child commit. Since the r5
-    # fix, `fanned_out` COMMITS before any child exists (the mutex that
-    # closed the fast-child cancel window) — which regressed the
-    # recoverability the old late transition got for free: the old crash
-    # left a `pending` parent this sweep's one-hour clause self-healed,
-    # while the new one left a terminal parent that retry (failed-only) and
-    # cancel (terminal -> 409) both refuse. Permanently stuck, zero
-    # children, staged file idle.
-    #
-    # A childless `fanned_out` parent is the crash signature and nothing
-    # else's: a layer's `queued` result requires its child row to have
-    # committed first (a failed defer still leaves the row, flipped `failed`
-    # by the orphan guard; a failure before the insert commits leaves no row
-    # AND no queued result), and an ALL-failed dispatch restores the parent
-    # to `pending` rather than leaving it `fanned_out`
-    # (restore_fan_out_parent_pending). Two bounds keep the signature exact:
-    #
-    # - the grace above: never touch a dispatch still in flight.
-    # - the retention horizon: a LEGIT old fan-out's children can be deleted
-    #   by the retention purge, after which "never existed" and "purged at
-    #   age" are indistinguishable — but the purge cutoff is
-    #   coalesce(completed_at, created_at) and every child postdates its
-    #   parent's flip, so a parent still INSIDE the horizon cannot have lost
-    #   children to it. Parents past the horizon are the purge's to delete,
-    #   not this clause's to relabel (the freak alignment — children crossing
-    #   the horizon seconds before an old-ordering parent — costs a `failed`
-    #   label the same purge erases seconds later). retention_days=0 keeps
-    #   every row forever, so no bound is needed.
-    #
-    # `failed`, not `cancelled`: nothing was asked to stop — a dispatch was
-    # interrupted — and `failed` is what makes /jobs/{id}/retry offer the
-    # parent again (retry flips it to `pending`; the fan-out is then
-    # committable again), which is the recoverability being restored.
-    #
-    # Not folded into StaleCleanupOutcome, same reasoning as the refresh-run
-    # sweep below: the dataclass is a published shape several callers
-    # reconstruct field by field, and the log line carries the ids.
+    # fix(#1709 r7): a childless `fanned_out` parent past the grace and inside
+    # the retention horizon is the crash signature of a dispatch interrupted
+    # before its first child commit. `failed`, so /jobs/{id}/retry offers it.
     childless_fanout_clauses = [
         IngestJob.status == "fanned_out",
         IngestJob.completed_at.is_not(None),
@@ -1982,13 +1239,8 @@ async def fail_stale_jobs(
             status="failed",
             error_message=FAN_OUT_DISPATCH_INTERRUPTED_MESSAGE,
             completed_at=now,
-            # fix(#1709 review r8 A): the marker _retry_capability refuses on.
-            # Generic retry of this parent would silently import ONE default
-            # layer of a multi-layer file; restore-to-pending is no better —
-            # the pending sweep's unbound clause keys on created_at, so any
-            # parent older than that cutoff would be re-reaped into the
-            # GENERIC failed message on the next pass, and the generic row
-            # retries into exactly that wrong import.
+            # fix(#1709 r8): the marker _retry_capability refuses on; a generic
+            # retry would import ONE default layer of a multi-layer file.
             user_metadata=func.coalesce(
                 IngestJob.user_metadata, text("'{}'::jsonb")
             ).op("||")(
@@ -2004,24 +1256,16 @@ async def fail_stale_jobs(
             job_ids=[str(job_id_) for job_id_ in childless_fanout_ids],
         )
 
-    # GAP-002: sweep stale VRT regenerating assets using the same cutoff.
-    # fix(#1322 review): stale_generation_storage_keys are resolved, not yet
-    # deleted — carried into StaleCleanupOutcome and reaped only after this
-    # function's own commit (or its commit=False caller's) lands, exactly
-    # like _staged_paths below.
+    # GAP-002: stale VRT assets, same cutoff. fix(#1322): the generation keys
+    # are resolved here and reaped only after the commit, like _staged_paths.
     (
         vrt_assets_recovered,
         vrt_generations_failed,
         stale_generation_storage_keys,
     ) = await sweep_stale_vrt_assets(db, running_cutoff)
 
-    # feat(#1219): cancel refresh runs whose task is proven gone. Ordered
-    # AFTER the two job sweeps above on purpose — those flip an orphaned job
-    # to `failed`, which is one of the two facts the run sweep requires before
-    # it may write a terminal status. Deliberately not folded into
-    # StaleCleanupOutcome: the run rows are themselves the record, and the
-    # dataclass is a published shape several callers reconstruct field by
-    # field.
+    # feat(#1219): AFTER the two job sweeps, which supply one of the facts the
+    # run sweep requires. Not folded into StaleCleanupOutcome (published shape).
     cancelled_runs = await sweep_abandoned_refresh_runs(db, now)
     if cancelled_runs:
         log.info("abandoned_refresh_runs_cancelled", count=cancelled_runs)
@@ -2035,16 +1279,9 @@ async def fail_stale_jobs(
     deleted_paths: set[str] = set()
     deleted_presigned_keys: set[str] = set()
 
-    # fix(#434): purge terminal jobs past retention so the admin Jobs page
-    # doesn't accumulate history forever. Cutoff is on finished-at
-    # (coalesce(completed_at, created_at)) rather than created_at — the stale
-    # sweep above fails ancient pending/running rows with completed_at=now, and
-    # a created_at cutoff would delete that fresh failure evidence in the same
-    # transaction (codex P2 r8). 0 = keep forever. Each dataset's most recent
-    # complete job is exempt regardless of age: /jobs/by-dataset/{id} serves the
-    # dataset page's persistent ingest warnings and the reupload source_layer
-    # hint from it (codex P2 on #434). Jobs whose dataset was deleted have
-    # dataset_id nulled (FK ondelete=SET NULL) and stay purgeable.
+    # fix(#434): purge terminal jobs past retention, cut off on finished-at so
+    # the sweep's fresh completed_at=now survives. 0 = keep forever. Each
+    # dataset's latest complete job is exempt (/jobs/by-dataset/{id} reads it).
     if settings.ingest_jobs_retention_days > 0:
         retention_cutoff = now - timedelta(days=settings.ingest_jobs_retention_days)
         latest_complete_ids = (
@@ -2056,22 +1293,16 @@ async def fail_stale_jobs(
             .distinct(IngestJob.dataset_id)
             .order_by(IngestJob.dataset_id, IngestJob.created_at.desc())
         )
-        # codex P2 (r7) on #434: manifest apply classifies skip/update-vs-create
-        # via _latest_completed_manifest_job (manifest_service.py), which looks
-        # up the newest complete job per user_metadata->>'manifest_key'. A
-        # manual reupload makes the manual job the per-dataset exemption, so
-        # without this second exemption the manifest-keyed row would age out
-        # and the next apply would duplicate the dataset. Mirrors the lookup's
-        # ordering (completed_at desc, created_at desc).
+        # #434 r7: manifest apply looks up the newest complete job per
+        # manifest_key, so that row is exempt too or the next apply duplicates.
         manifest_key = IngestJob.user_metadata["manifest_key"].astext
         latest_manifest_ids = (
             select(IngestJob.id)
             .where(
                 IngestJob.status == "complete",
                 manifest_key.is_not(None),
-                # codex P2 (r9): the mirrored lookup joins Dataset, so a job
-                # whose dataset was deleted (dataset_id nulled by the FK) can't
-                # influence reapply — exempting it would only defeat cleanup.
+                # #434 r9: the mirrored lookup joins Dataset, so a job whose
+                # dataset was deleted cannot influence reapply.
                 IngestJob.dataset_id.is_not(None),
             )
             .distinct(manifest_key)
@@ -2081,43 +1312,9 @@ async def fail_stale_jobs(
                 IngestJob.created_at.desc(),
             )
         )
-        # fix(#1236 review, codex P1): a presigned job's ROW is the only place
-        # _sweep_expired_presigned_staging's markers live. Purging it before
-        # any URL issued for it can possibly still be live removes that
-        # tracking outright — worse than the marker gap this PR closes,
-        # because a re-PUT afterward recreates an object no row anywhere
-        # references, and retention (unlike the sweep's own cutoff) is
-        # commonly configured well under a week (1 day is an exercised
-        # value).
-        #
-        # fix(#1236 review r2, codex P1): deferred exactly as long as the
-        # sweep's own FINALIZATION window, not just its ceiling — an accepted
-        # PUT can still be transferring past MAX_PRESIGNED_URL_LIFETIME_SECONDS,
-        # which is why the sweep itself withholds its final marker for
-        # _RECHECK_TRANSFER_MARGIN_SECONDS longer. Purging on the bare
-        # ceiling reopened the exact race this row exists to close, just
-        # moved to the retention purge instead of the sweep. Past the
-        # combined window purging is safe and `deleted_presigned_keys` below
-        # still reaps the object at that same moment — the row just doesn't
-        # need to survive to see it happen.
-        #
-        # fix(#1236 review r4, codex P1): that margin is now the SAME fixed
-        # constant the sweep uses (see its definition for why r3's per-job
-        # `expected_size` scaling proved unsafe) — no per-row data needed, so
-        # this bulk DELETE never has to branch per row on JSONB.
-        #
-        # fix(#1236 review r5, codex P2): a non-null `s3_key` alone is not
-        # OWNERSHIP. `create_fan_out_jobs` clones the parent's `user_metadata`
-        # wholesale (processing/ingest/service.py), so every fan-out child
-        # carries the PARENT's `s3_key` too — the exact case
-        # `owned_presigned_staging_key` exists to reject, by requiring the
-        # key's prefix match the ROW'S OWN id. Without that same check here,
-        # every terminal fan-out child was exempted from retention for
-        # ~8.9 days regardless of how short `ingest_jobs_retention_days` was
-        # configured, since it can never be the row that legitimately reaps
-        # or finalizes that key. A `LIKE` prefix match is a safe string
-        # comparison — unlike a JSONB-to-numeric/timestamptz cast, it cannot
-        # throw and fail the whole bulk pass on a malformed value.
+        # fix(#1236 r1-r5): a presigned job's ROW carries the post-expiry
+        # sweep's markers, so it outlives the whole finalization window. Owned
+        # = key prefix matches the ROW'S OWN id (fan-out children clone s3_key).
         presigned_url_may_still_be_live = and_(
             IngestJob.user_metadata["s3_key"].astext.is_not(None),
             IngestJob.user_metadata["s3_key"].astext.like(
@@ -2138,30 +1335,9 @@ async def fail_stale_jobs(
             IngestJob.id.not_in(latest_manifest_ids),
             not_(presigned_url_may_still_be_live),
         ]
-        # fix(#1778 codex r4) made the purge feed the two artifact reaps, on
-        # the reasoning that the row it is about to delete is the last thing
-        # that can name them: the stale passes only read rows they move OFF
-        # `running`, so a job that reached `failed` or `cancelled` on its own
-        # and whose in-process cleanup then failed once keeps its objects with
-        # the record still pointing at them and nothing looks again.
-        #
-        # fix(#1778 codex r5): feeding the reap is not enough, because the reap
-        # runs AFTER this function's commit and can fail as a whole. When it
-        # does, the pointer is already gone and the objects leak for good.
-        #
-        # So a row that still names an unreaped artifact is not purged at all.
-        # The row IS the durable pending-reap record the retry needs: it costs
-        # no new table, it is what the reapers already read, and it survives
-        # exactly until the artifacts it names are accounted for, at which
-        # point the reaper clears the two fields and the next pass purges the
-        # row normally. A reap that fails leaves the fields in place and the
-        # next sweep tries again.
-        #
-        # Single DELETE .. RETURNING re-applies every predicate atomically at
-        # delete time — a SELECT-then-DELETE-by-id pair let /jobs/{id}/retry
-        # flip a candidate back to pending between the two statements and
-        # still lose the row (codex P2 r10 on #434). The exemption above is a
-        # predicate here rather than an id list for the same reason.
+        # fix(#1778 r4/r5): a row still naming an unreaped artifact is not
+        # purged; it IS the pending-reap record and the reap can fail. One
+        # DELETE .. RETURNING so retry cannot flip a candidate mid-way (#434).
         deleted = await db.execute(
             delete(IngestJob)
             .where(*purge_clauses, not_(carries_unreaped_artifacts))
@@ -2184,18 +1360,9 @@ async def fail_stale_jobs(
                 retention_days=settings.ingest_jobs_retention_days,
             )
 
-        # codex P2 (r3) on #434: failed local uploads keep their staged file
-        # for retry (_should_unlink_staging), and fan-out children's shared S3
-        # original is explicitly deferred to "a retention policy" (#430 BA-09)
-        # — this purge is that policy. Reap staged objects whose last pointer
-        # was just deleted, but (codex P2 r4) only when no surviving row that
-        # still NEEDS the file references the same path: pending/running read
-        # it now; failed keeps it for /jobs/{id}/retry (a failed-only
-        # endpoint). Surviving complete rows (e.g. the exemptions above) keep
-        # their metadata row but not the staged file — otherwise a successful
-        # fan-out's shared original, referenced forever by children that are
-        # each a dataset's latest complete job, would never be reaped
-        # (codex P2 r5). Running after the DELETE, any remaining row counts.
+        # #434 r3-r5: this purge is the retention policy for staged files. Reap
+        # only paths no surviving row still NEEDS (pending/running read it,
+        # failed keeps it for retry); complete rows keep the row, not the file.
         if deleted_paths:
             survivors = await db.execute(
                 select(IngestJob.file_path).where(
@@ -2206,27 +1373,9 @@ async def fail_stale_jobs(
             deleted_paths -= set(survivors.scalars())
         staged_paths_considered = len(deleted_paths)
 
-    # fix(#1778 codex r10): ONE collection, and it answers only "does this row
-    # still owe a reap". It replaces the two that came before it, and both of
-    # them could miss rows that owed one.
-    #
-    # The running-row collection saw only rows THIS pass moved off `running`,
-    # so a job that failed on an earlier pass, or that later SUCCEEDED with a
-    # dead attempt's keys carried over on its row, was never looked at again.
-    # The retention collection sat inside the purge block behind the purge's
-    # own clauses, so it skipped anything the retention cutoff had not reached
-    # and anything the latest-complete exemption held back -- and a job can be
-    # its dataset's latest complete job and still owe a reap for the attempt
-    # that failed before it.
-    #
-    # So: terminal status, still carrying a record, whatever its age and
-    # whatever else exempts it from deletion. It runs outside the retention
-    # block because a deployment with retention disabled still owes these
-    # reaps. It sits after every status write above so a row this pass just
-    # settled is already terminal to it. Bounded, because the set is only as
-    # small as the reaps that have succeeded, and a pass that tried to take all
-    # of a large backlog would hold its session open across every delete; what
-    # it does not reach, the next pass does.
+    # fix(#1778 r10): ONE collection: terminal, still carrying a record,
+    # whatever its age or exemption. Outside the retention block, after every
+    # status write above, and bounded so a pass cannot hold its session open.
     artifact_rows = await db.execute(
         select(IngestJob.id, IngestJob.user_metadata)
         .where(
@@ -2276,13 +1425,9 @@ async def fail_stale_jobs(
         publish_refresh_reconciliation(outcome)
         outcome = await _reap_committed_staged_paths(outcome)
         outcome = await _sweep_expired_presigned_staging(db, outcome, now=now)
-        # fix(#1249): the row-driven reapers above can only clean up objects
-        # some surviving row still names. This one starts from the objects and
-        # asks whether any row still owns them, which is the only direction
-        # that finds one nothing references. Deliberately not folded into
-        # StaleCleanupOutcome — that dataclass is a published API and audit
-        # shape several callers reconstruct field by field, and this pass
-        # answers a different question with its own log line and counter.
+        # fix(#1249): starts from the OBJECTS and asks whether any row owns them,
+        # the only direction that finds one nothing references. Not folded into
+        # StaleCleanupOutcome (published shape).
         await reconcile_orphaned_staging_objects(db, now=now)
     if detailed:
         return outcome
@@ -2300,47 +1445,18 @@ async def audit_settled_embedding_backfill(
 ) -> None:
     """Close an embedding backfill's audit trail when a sweeper settles its row.
 
-    fix(#1550 review): every other way a backfill can end is closed inside the
-    worker — the dispatch failure, a lost fence, cancellation, a failing
-    terminal write, a lost commit acknowledgement. A hard kill has no
-    in-process path to close, because after SIGKILL there is no process. The
-    row is then settled by whoever notices it is stale, and that actor is the
-    only one left that can record the outcome. Without this the trail stays at
-    `requested` forever while the job is terminal, and on the force path that
-    can be a catalog whose vectors were deleted.
-
-    The rule the module now follows: **the job row and the audit trail are
-    written together by whichever actor settles the job.** After a hard kill,
-    that actor is the sweeper.
-
-    Emitted on the caller's session, deliberately, so the audit row and the
-    status change commit or roll back as one. `audit_emit_durable` would use
-    its own session and could record an outcome for a row whose update was
-    later rolled back — the same divergence in the other direction.
-
-    Correlated by `operation_id`, read back off the job row's own metadata, so
-    it pairs with the `requested` entry the route committed alongside the job.
-    A no-op for every other kind of job.
+    fix(#1550): the job row and the audit trail are written together by
+    whichever actor settles the job; after a hard kill that is the sweeper.
+    Emitted on the caller's session so the audit row and the status change
+    commit or roll back as one. Correlated by `operation_id` from the job row's
+    own metadata. A no-op for every other kind of job.
     """
     marker = (user_metadata or {}).get(EMBEDDING_BACKFILL_METADATA_KEY)
     if not marker:
         return
-    # One operation gets one terminal entry, and the DATABASE decides which —
-    # `uq_audit_logs_terminal_embedding_backfill` (migration 0051). Three
-    # actors can close the same run, so an existence check here would be a
-    # check-then-insert: both read "nothing yet", both insert, and the trail
-    # carries two conflicting outcomes.
-    #
-    # Wrapped in a SAVEPOINT so losing that race rolls back only this insert.
-    # The audit is emitted on the caller's session precisely so it commits with
-    # the status change; an unguarded IntegrityError would take the status
-    # change down with it.
-    # fix(#1709 review r10): the terminal event is attributed to the actor
-    # who SETTLED the run when one exists. The sweeps have no acting user —
-    # a lease expiry is nobody's click, so the requester (created_by) stays
-    # the honest attribution there — but the cancel endpoint acts on behalf
-    # of a specific person, and in the arm-3/cross-user case that person is
-    # not the requester. Same rule refresh.cancelled follows since r8.
+    # The DATABASE decides which actor's terminal entry wins
+    # (`uq_audit_logs_terminal_embedding_backfill`, migration 0051); SAVEPOINT so
+    # losing the race rolls back only this insert. fix(#1709 r10): actor = settler.
     actor = settled_by if settled_by is not None else created_by
     try:
         async with session.begin_nested():
@@ -2362,9 +1478,7 @@ async def _emit_terminal_backfill_event(
     actor: uuid.UUID | None,
     error_code: str,
 ) -> None:
-    """Write the one terminal entry. ``actor`` is whoever SETTLED the run —
-    the canceller when a person cancelled it, else the requester (fix(#1709
-    review r10); a sweep has no acting user to name)."""
+    """Write the one terminal entry; ``actor`` is whoever settled the run."""
     # Deferred by design to preserve the platform -> modules layer boundary,
     # matching `cleanup_stale_jobs` above.
     from app.modules.audit.service import AuditEvent, audit_emit

--- a/backend/app/processing/embeddings/backfill.py
+++ b/backend/app/processing/embeddings/backfill.py
@@ -1,13 +1,8 @@
-"""Backfill embeddings for records that don't have them yet.
+"""Backfill embeddings for records that lack one under the ACTIVE model.
 
-Processes every record with no RecordEmbedding row under the ACTIVE embedding
-model (fix #1506) — a vector left behind by a superseded model is unusable to
-semantic search, so the record counts as missing until it has a current one.
-fix(#448): texts are embedded in batches of _BATCH_SIZE per provider call
-(the embeddings endpoint accepts input lists) instead of one call per
-record — a 50-200x reduction in API round trips on bulk backfills.
-A failed batch is retried per record so a single rejected input doesn't
-sink its batchmates; only the individually-failing records count as errors.
+Texts are embedded in batches of _BATCH_SIZE per provider call; a failed batch
+is retried per record so one rejected input does not sink its batchmates, and
+only the individually failing records count as errors (#448, #449, #1506).
 
 Can be run as a module: python -m app.embeddings.backfill
 """
@@ -33,57 +28,29 @@ from app.processing.embeddings.service import (
 
 logger = structlog.stdlib.get_logger(__name__)
 
-# fix(#448): texts per provider call. OpenAI accepts up to 2048 inputs per
-# request; 128 keeps request bodies modest for compatible providers (Ollama,
-# Groq, Together) while still collapsing a 10K-record backfill to ~80 calls.
+# fix(#448): 128 keeps request bodies modest for compatible providers while
+# collapsing a 10K-record backfill to ~80 calls.
 _BATCH_SIZE = 128
 
 # Text for the force-path pre-flight embedding. Short, so the call is cheap,
 # and constant, so a provider's cache can serve it.
 _PREFLIGHT_TEXT = "geolens embedding preflight"
 
-# fix(#1544): how much of a caught exception's message survives into a log line.
-# Everything an operator acts on is at the front ("expected 1536 dimensions, not
-# 768"); the tail is the statement and its bound parameters, one of which is the
-# vector.
+# fix(#1544): the actionable part of an error is at the front; the tail is the
+# statement and its bound parameters, one of which is the vector.
 _MAX_ERROR_CHARS = 200
 
 
 def _compact_error(exc: BaseException) -> str:
     """Describe an exception in one short line, without its bound parameters.
 
-    Prefers the driver's own message (`DBAPIError.orig`), which names the actual
-    failure and carries neither the statement nor the parameters. For anything
-    else — a provider error, say — cut at the marker SQLAlchemy puts before the
-    statement, collapse to one line, truncate.
+    Prefers the driver's own message (`DBAPIError.orig`); otherwise cuts at
+    SQLAlchemy's `[SQL:` marker, collapses whitespace and truncates.
 
-    Redacted because this message now reaches the log on its own rather than
-    buried in one traceback among thousands: a provider error names its
-    endpoint, and an endpoint can carry a key in its query string.
-
-    fix(#1577 reviews r1 and r2, codex P1 twice): THE REDACTOR RUNS FIRST, ON
-    THE RAW STRING. Nothing may be inserted above it. Both rounds found the same
-    bug at a different transformation, because every one of them can break the
-    pattern the redactor matches on:
-
-    - Truncating first (r1) cuts the `@` that terminates userinfo, leaving
-      `https://alice:hunter2`, which reads as a host and a port and passes
-      through untouched.
-    - Collapsing whitespace first (r2) turns a tab, CR or LF inside a URL into a
-      space, and `URL_LIKE_RE` stops at whitespace. `https://alice:hun\\nter2@…`
-      becomes `https://alice:hun ter2@…` and the match dies before the `@`. A
-      split in the HOST is worse still: the match ends there and a query-string
-      key further along is never even reached.
-
-    The `[SQL:` cut moved below for the same reason — it is a cut, and the rule
-    cannot have exceptions and still be a rule. Cost of redacting the untrimmed
-    string instead: measured below.
-
-    What is left above the redactor is choosing `orig` over `exc` and calling
-    `str()`. Neither can split a match: `orig` is a different, shorter string
-    rather than a mangled one, so it can only omit a credential the SQL tail
-    would have carried, never expose a split one. A driver that itself hands us
-    a message already cut mid-URL is out of reach of any ordering here.
+    fix(#1577 r1/r2): THE REDACTOR RUNS FIRST, ON THE RAW STRING. Truncating
+    first can cut the `@` that terminates userinfo; collapsing whitespace first
+    can split a URL so the match dies before the `@`. Nothing may be inserted
+    above it.
     """
     origin = getattr(exc, "orig", None)
     message = redact_url_credentials(str(origin if origin is not None else exc))
@@ -99,29 +66,9 @@ def _compact_error(exc: BaseException) -> str:
 def _error_fields(exc: BaseException, traced: set[str]) -> dict[str, Any]:
     """Log fields for a caught exception; MUTATES `traced` to spend the traceback.
 
-    fix(#1544): a failing backfill used to cost more than a succeeding one, and
-    all of it was inside the log formatter. Measured end to end on the #1533
-    failure shape — a run where every insert fails the column's typmod, so the
-    batch falls into this retry and every record raises a `DataError` out of the
-    ORM flush. `exc_info=True` per record cost 964 ms and 60.6 KiB of output per
-    record under the dev console renderer, and 3.1 ms and 12.7 KiB under the JSON
-    renderer production uses. A 200-record run took 194 s before and 1.5 s after;
-    a 1,000-record one wrote 12.4 MB of log output before and 0.35 MB after.
-
-    The vector is in that rendering, but it is not the expensive part: SQLAlchemy
-    already truncates a long bound parameter to about 150 characters a side, so
-    the ~6 KB vector reaches the log as ~440 characters. The traceback is what
-    costs — 33 frames over a three-exception chain, 12 KB of text before any
-    renderer decorates it — which is why this drops the traceback rather than
-    only the parameters.
-
-    One traceback per distinct exception type per run, not per run: the same type
-    raised repeatedly on this path has the same stack, while a second type is a
-    second failure mode and its stack is new information. Types are tracked by
-    qualified name so two `DataError`s from different libraries stay distinct.
-    The set is owned by `backfill_embeddings`, so the budget spans the whole run
-    rather than resetting at each batch boundary, and one type first seen at the
-    batch level does not then spend a second traceback on the retry path.
+    fix(#1544): one traceback per distinct exception type per run, tracked by
+    qualified name. The traceback, not the vector, is the expensive part of a
+    failing backfill (a 200-record run took 194 s before and 1.5 s after).
     """
     error_type = f"{type(exc).__module__}.{type(exc).__qualname__}"
     first_of_type = error_type not in traced
@@ -136,13 +83,9 @@ def _error_fields(exc: BaseException, traced: set[str]) -> dict[str, Any]:
 async def _live_column_dims(session: AsyncSession) -> int | None:
     """Read the declared width of the embedding column, straight from storage.
 
-    pgvector puts the declared dimension straight in `atttypmod` (no -4 offset),
-    and -1 means an unconstrained `vector`, which accepts any width.
-
-    Storage rather than `EMBEDDING_DIMS`, because the two are written by
-    different code at different times and the whole point of asking is that they
-    can disagree. Measured on the scratch catalog: 0.32 ms median, against 2.7 ms
-    for the config reads it runs beside.
+    pgvector stores the dimension in `atttypmod` with no offset; -1 means an
+    unconstrained `vector`. Storage rather than `EMBEDDING_DIMS`, because the
+    two can disagree and that is the point of asking.
     """
     return (
         await session.execute(
@@ -158,26 +101,16 @@ async def _live_column_dims(session: AsyncSession) -> int | None:
 class _AnomalousVectorWidth(RuntimeError):
     """ONE record's vector does not fit a column that has not moved.
 
-    fix(#1579 review, codex P2): a bad record, not a broken run. Deliberately
-    NOT a `_PinDrift`, so the per-record handler counts it and carries on, which
-    is the #449 isolation this module has defended since. It is named rather
-    than a bare `RuntimeError` only so the compact per-record log line says what
-    happened (#1544 puts the qualified type in `error_type`).
+    fix(#1579): deliberately NOT a `_PinDrift`, so the per-record handler
+    counts it and carries on (#449 isolation).
     """
 
 
 def _column_rejects_width(generated: int, pinned_column_dims: int | None) -> str | None:
     """Describe a generated width the column will not take, or None if it will.
 
-    The fit test on its own, with no opinion about what the mismatch MEANS. Its
-    two callers supply that: agreement across a batch on one path, a storage
-    read on the other. Splitting it out is what stops the two rules from having
-    to share one predicate, which is how a change meant for the batch path
-    silently disarmed the retry path once already.
-
-    `isinstance` rather than `is not None`, because `scalar_one_or_none` answers
-    `int | None` and -1 means an unconstrained `vector`, which accepts any width
-    and so can never mismatch.
+    The fit test only; callers decide what a mismatch means. `isinstance`
+    rather than `is not None`, because -1 means unconstrained and never mismatches.
     """
     if not isinstance(pinned_column_dims, int) or pinned_column_dims <= 0:
         return None
@@ -194,56 +127,15 @@ def _structural_width_mismatch(
 ) -> str | None:
     """Describe vectors that UNIFORMLY do not fit the column, or None otherwise.
 
-    fix(#1533): the sibling class to drift, and the one the non-force path is
-    otherwise blind to. Drift is a width that MOVES; this is a width that was
-    already wrong when the run started, which every comparison guard is
-    correctly silent about because nothing changed. The force path catches it in
-    `_preflight_embedding`, before it has spent a single provider call on the
-    catalog. The non-force path has no
-    pre-flight, so the first batch insert failed the typmod, the batch was
-    retried per record, and each retry spent a provider call before dying on the
-    same error.
-
-    Deliberately NOT a pre-flight on the non-force path, which is the obvious
-    symmetry and is wrong twice over. It costs a provider call per run, on a
-    path that destroys nothing and therefore has nothing to promise. Worse, it
-    aborts a run that a single transient provider failure would otherwise
-    survive: `test_batch_errors_do_not_stop_backfill` and
-    `test_failed_batch_retries_per_record` pin the #449 contract that a failed
-    batch is retried per record and only the bad records count, and a pre-flight
-    consuming the first provider call turns a partial success into no run at
-    all. Measured on the tree: adding one there fails 5 of the 7 tests in
-    `test_embedding_backfill.py`, two of them for that reason rather than for
-    test-double churn.
-
-    Asking the vectors the provider ACTUALLY returned costs nothing extra, and
-    it answers the same question the pre-flight asks: will storage take this.
-
-    fix(#1579 review, codex P2): UNIFORMLY is the whole distinction, and an
-    earlier revision missed it — any single wrong-width vector stopped the run,
-    which broke the same #449 isolation the paragraph above defends. What makes
-    a mismatch structural is AGREEMENT ACROSS INPUTS: a provider does not answer
-    one anomalous width for all 128 texts by accident, whereas a column that was
-    already wrong, or that has just been rebuilt, produces exactly that. Mixed
-    widths mean one bad input among good ones, so this returns None and lets the
-    batch fail into the per-record retry, where each vector is judged alone.
+    fix(#1533): a width that was already wrong when the run started, which no
+    comparison guard can see. Not a pre-flight on the non-force path: that
+    would cost a provider call and abort a run one transient failure would
+    otherwise survive (#449). fix(#1579): UNIFORMLY is the distinction; mixed
+    widths are one bad input and fall to the per-record retry.
     """
-    # fix(#1579 review r2, codex P2): TWO vectors minimum. Agreement is the
-    # evidence, and one input agrees with itself vacuously — the same reason
-    # `_raise_on_retry_vector_width` asks storage instead of counting widths.
-    # A final batch of one, which is any catalog sized 1 mod _BATCH_SIZE, was
-    # otherwise read as structural and stopped the whole run over a single bad
-    # record: the isolation bug the previous round fixed on the retry path,
-    # surviving at the one batch size where the batch path cannot tell the two
-    # apart either.
-    #
-    # It falls through instead of growing a branch here. The insert fails, the
-    # record is retried, and the retry rule decides it from storage, which is
-    # the evidence that does work for one input. The cost is one extra provider
-    # call for that one record, which is what a mixed-width batch already pays.
-    #
-    # An empty response lands here too, and for the same reason rather than by
-    # accident: no vectors, no agreement, nothing structural to claim.
+    # fix(#1579 r2): TWO vectors minimum. One input agrees with itself
+    # vacuously, and a final batch of one (any catalog sized 1 mod _BATCH_SIZE)
+    # was read as structural; it falls through to the retry rule instead.
     if len(vectors) < 2:
         return None
     widths = {len(vector) for vector in vectors}
@@ -276,38 +168,11 @@ async def _raise_on_retry_vector_width(
 ) -> None:
     """The retry's post-call bracket, plus a judgement on the vector it returned.
 
-    Two questions, in this order, because the second only makes sense once the
-    first is answered:
-
-    1. Is the pinned configuration still the active one? This is the post-call
-       bracket #1525 review r6 installed on this path, restored here. It went
-       missing when the r3 review moved the batch's post-call check below the
-       flush so it could hold the relation lock: the check is still there, but
-       it now sits after an insert that raises on its own when the column has
-       moved to a different fixed width, so it never runs.
-    2. Does THIS vector fit that column? A mismatch against a column that has
-       not moved is one bad record, raised as `_AnomalousVectorWidth` so the
-       caller counts it and carries on (#449).
-
-    fix(#1579 review r4, codex P2): the earlier revision asked (2) first and
-    returned early when the vector matched, so (1) went unasked whenever the
-    provider answered at the pinned width. A column that moved to a DIFFERENT
-    fixed width during the provider call then reached the flush, which raised
-    the typmod error, which the broad handler counted as a bad record. Every
-    record but the last was covered anyway, by the next one's pre-call check —
-    but on the last there is no next one, and the run reported "complete with
-    one error" for a configuration change. A misreport rather than a bad row,
-    and narrow, but the rule is easier to hold when it has no exceptions.
-
-    Asking `_raise_on_pin_drift` rather than reading the width here and
-    phrasing the abort locally. The cheaper read (0.32 ms against ~3 ms) would
-    put a second author of "the column moved" in the module, and two places
-    that decide the same thing drift apart. One rule, one message.
-
-    Cost is one more full drift check per retried record: about 9 ms against the
-    ~0.22 s that record's provider call costs, so roughly 4% of a legitimate
-    per-record retry, and nothing at all on the storm this PR exists to stop,
-    which now ends on its first record.
+    Drift first, then fit (fix(#1579 r4)): asking fit first returned early on a
+    matching vector and left the LAST record's drift unobserved. A mismatch
+    against a column that has not moved raises `_AnomalousVectorWidth` so the
+    caller counts it and carries on (#449). Delegates the drift wording to
+    `_raise_on_pin_drift` so the module has one author of "the column moved".
     """
     await _raise_on_pin_drift(
         session,
@@ -325,27 +190,13 @@ async def _raise_on_retry_vector_width(
 def _upsert_embeddings(rows: list[dict[str, Any]]):  # type: ignore[no-untyped-def]
     """INSERT the batch, replacing any row this record already has for the model.
 
-    fix(#1546): a plain INSERT stopped being safe once rows carry a
-    configuration stamp. `uq_record_embedding_model` is `(record_id,
-    model_name)`, and the non-force run now offers a record whose only row for
-    the ACTIVE model was written under a different configuration — that row is
-    invisible to search, so the record genuinely is uncovered — which a plain
-    INSERT would answer with a unique violation instead of a vector.
-
-    Replacing in place rather than widening the constraint: one row per
-    (record, model) keeps the table's size independent of how many
-    configurations an instance has been through, and leaves the key that #1549
-    needs for a per-batch delete-and-replace intact.
-
-    `updated_at` is set explicitly because `onupdate=` is an ORM-level default
-    and this is a Core statement.
+    fix(#1546): `uq_record_embedding_model` is `(record_id, model_name)` and a
+    non-force run may offer a record whose only row was written under another
+    configuration, which a plain INSERT answers with a unique violation.
+    `updated_at` is set explicitly because `onupdate=` is ORM-level only.
     """
-    # fix(#1583 review): stamp the INSERT branch too. `set_` below only governs
-    # the ON CONFLICT path; a row that does not collide takes the column's
-    # `server_default`, which is `now()` — so half the writes kept the
-    # transaction-start stamp and the fix would have covered replacements but
-    # not first-time inserts. The server_default stays as it is for writers
-    # that have no opinion; this states one.
+    # fix(#1583): stamp the INSERT branch too; `set_` only governs ON CONFLICT
+    # and the server_default is transaction-start `now()`.
     stmt = pg_insert(RecordEmbedding).values(
         [row | {"updated_at": func.clock_timestamp()} for row in rows]
     )
@@ -355,15 +206,9 @@ def _upsert_embeddings(rows: list[dict[str, Any]]):  # type: ignore[no-untyped-d
             "embedding": stmt.excluded.embedding,
             "content_hash": stmt.excluded.content_hash,
             "config_fingerprint": stmt.excluded.config_fingerprint,
-            # fix(#1583 review): `clock_timestamp()`, not `now()`. `now()` is
-            # TRANSACTION-START time, and a backfill transaction opens, spends
-            # the length of a provider call in it, and only then writes — so a
-            # row written at the end of that gets a stamp EARLIER than a job
-            # which started and committed while the provider was still
-            # thinking. #1583 orders the related-items anchor by `updated_at
-            # DESC`, which makes that inversion visible as the wrong anchor.
-            # The column's server_default stays as it is; this is about the
-            # value a write of ours records.
+            # fix(#1583): `clock_timestamp()`, not `now()`. `now()` is
+            # transaction-start time, and a batch spends a provider call in its
+            # transaction, which inverts the related-items `updated_at` order.
             "updated_at": func.clock_timestamp(),
         },
     )
@@ -372,11 +217,9 @@ def _upsert_embeddings(rows: list[dict[str, Any]]):  # type: ignore[no-untyped-d
 def _content_fields(record) -> dict[str, Any]:  # type: ignore[no-untyped-def]
     """The fields ``build_content_text`` reads, pulled off a record eagerly.
 
-    Eager, because a rollback expires every ORM instance in the session and a
-    later attribute access would lazy-load and raise ``MissingGreenlet``. One
-    function for both readers — the run's fetch and the reclamation's re-check
-    (fix(#1584 review r4)) — so "is this record empty" is asked the same way at
-    both ends of the run.
+    Eager, because a rollback expires every ORM instance and a later attribute
+    access raises ``MissingGreenlet``. One function for both readers so "is
+    this record empty" is asked the same way at both ends of the run.
     """
     return {
         "title": record.title,
@@ -398,25 +241,13 @@ def _content_fields(record) -> dict[str, Any]:  # type: ignore[no-untyped-def]
 
 
 async def _records_still_empty(session, port, record_orm, record_ids) -> set[Any]:  # type: ignore[no-untyped-def]
-    """Which of these records have no embeddable content RIGHT NOW — and hold them.
+    """Which of these records have no embeddable content RIGHT NOW, and hold them.
 
-    fix(#1584 review r4): the reclamation asks this immediately before it
-    deletes, one read per record, through the same loader and the same field
-    extraction the run used at its start. ``expire_all`` first, deliberately:
-    this session does not expire on commit, so its identity map still holds the
-    instances the run loaded at the start, and a re-select would hand back their
-    pre-edit attributes rather than the row's. A record that no longer exists
-    counts as empty; its rows are orphans either way.
-
-    fix(#1584 review r5): the records are locked ``FOR UPDATE`` first, and the
-    caller keeps this transaction open through its DELETE. Without the lock the
-    re-read and the delete were two statements with a gap, and an editor who
-    restored the content in that gap had the ingest writer skip on an unchanged
-    hash while the row still existed — then the delete took it, and nothing
-    would ever regenerate it. Held, the editor's write lands on one side or the
-    other: before the read, and the record is spared; after the delete, and
-    the writer finds no row and regenerates. The lock is on the records the
-    caller is about to reclaim, one chunk at a time, released by its commit.
+    fix(#1584 r4/r5): ``expire_all`` first, because this session's identity
+    map still holds the instances the run loaded at its start. Records are
+    locked ``FOR UPDATE`` and the caller keeps the transaction open through
+    its DELETE, so an editor's restore lands on one side or the other. A
+    record that no longer exists counts as empty.
     """
     session.expire_all()
     await session.execute(
@@ -462,28 +293,10 @@ async def _reclaim_observed_rows(session, port, record_orm, reclaimable) -> int:
 def _delete_embeddings_for(record_orm, record_ids: list[Any], *, observed=None):  # type: ignore[no-untyped-def]
     """Remove EVERY embedding these records hold, under any model.
 
-    The `Record` subquery is the tenant boundary: `RecordEmbedding` carries no
-    RLS policy of its own, so scoping through the records table is what keeps a
-    force run inside the calling tenant (#1511). The ids already come from a
-    tenant-scoped select, so this is the second half of a belt-and-braces pair
-    rather than the only one, and it is bounded to the batch rather than the
-    whole table.
-
-    fix(#1584 review r3): ``observed`` narrows the delete to the exact row
-    VERSIONS the run saw, as `(record_id, updated_at)` pairs. Only the
-    end-of-run reclamation passes it, and it needs it, because that pass acts on
-    an observation made much earlier and must not delete anything written since.
-
-    This replaced a `updated_at < cutoff` comparison, which was the same idea
-    expressed as a clock and got the answer wrong in both directions. It spared
-    rows it should have reclaimed whenever a stored stamp was AHEAD of the
-    cutoff — rows written before this release by an application clock running
-    ahead of PostgreSQL, or by an older worker mid-rolling-deploy — and moving
-    the writers to `clock_timestamp()` does nothing for stamps already on disk.
-    Matching versions asks a question no clock can answer wrongly: has this row
-    changed since I looked at it? Any write by any writer on any clock moves
-    `updated_at`, so a fresh vector survives and a stale one is reclaimed,
-    whatever wrote either of them and whatever clock it read.
+    The `Record` subquery is the tenant boundary: `RecordEmbedding` has no RLS
+    policy of its own (#1511). fix(#1584 r3): ``observed`` narrows the delete
+    to the exact `(record_id, updated_at)` row versions the run saw, which no
+    clock comparison can get wrong; only the end-of-run reclamation passes it.
     """
     predicate = RecordEmbedding.record_id.in_(
         select(record_orm.id).where(record_orm.id.in_(record_ids))
@@ -504,32 +317,13 @@ async def _replace_embeddings(
 ) -> None:
     """Remove what `rows` replace, then write them. Does NOT commit.
 
-    fix(#1549): this ordering IS the fix, which is why both write sites go
-    through one function rather than repeating it. A force run used to commit
-    `DELETE FROM catalog.record_embeddings` before it had generated anything,
-    so every abort after that point left the catalog with no vectors at all.
-    Deleting inside the transaction that writes the replacements closes the
-    window: either both land or neither does, and a run that dies between
-    batches has replaced some records and left the rest untouched.
-
-    The DELETE must precede the INSERT and must be in the same transaction.
-    Reversed, it would remove the rows just written, since it clears every row
-    the record holds under any model. That breadth is deliberate and is what
-    the bulk delete used to provide: force means "replace what is there",
-    including vectors left behind by a superseded model, which the upsert alone
-    cannot reach because it is keyed on (record_id, model_name).
-
-    The COMMIT belongs to the caller, deliberately, and it is the reason this
-    function does not own one. fix(#1579 review r3): both callers run a drift
-    check between writing and committing, and that check is only sound while it
-    holds the RowExclusiveLock these statements take. Committing here would
-    release the lock before the check ran and reopen the window that reorder
-    closed, so the two fixes have to share one transaction rather than each
-    owning theirs.
-
-    ``record_orm`` is the `Record` class on a force run and None otherwise. A
-    non-force run has nothing to replace: it only fills gaps, so it must not
-    delete, and passing None is what says so.
+    fix(#1549): the DELETE precedes the INSERT in the same transaction, so an
+    aborted run has replaced some records and left the rest untouched. The
+    delete clears every row the record holds under any model, which the
+    upsert alone cannot reach. The COMMIT belongs to the caller (fix(#1579
+    r3)): its drift check is only sound while it holds the RowExclusiveLock
+    these statements take. ``record_orm`` is `Record` on a force run and None
+    otherwise, which means "delete nothing".
     """
     if record_orm is not None:
         await session.execute(
@@ -543,70 +337,21 @@ async def _snapshot_embedding_config(
 ) -> tuple[str, int | None, str | None]:
     """Capture (model, dimensions, endpoint) as one consistent set, or refuse.
 
-    The values come from separate `PersistentConfig` reads — there is no
-    combined read, and building one would bypass the per-key validation and
-    cache machinery in `PersistentConfig.get`. So capture them, then read them
-    again and compare. Any single admin change lands inside one of the windows
-    and shows up as a difference; only a change-and-revert inside the same few
-    milliseconds slips through, which is not a case worth more code.
+    The values come from separate `PersistentConfig` reads, so they are
+    captured, read again and compared (fix(#1511 r2)); a change inside the
+    window shows up as a difference. fix(#1525): the endpoint is captured in
+    the same window and resolved through the provider, whose fallback chain
+    and credential binding it owns.
 
-    fix(#1525): the endpoint is captured and compared inside that same single
-    window, for the reason below. It is resolved through the provider rather
-    than read here, because the fallback chain and the credential binding
-    belong to whichever provider extension is registered (see
-    `resolve_embedding_base_url`).
-
-    KNOWN RESIDUE (#1525 review r2): the model and dimensions are read
-    uncached, so they are always the committed state. The endpoint is not, and
-    cannot be from here — it is resolved BY THE PROVIDER, which reads its own
-    keys through the same per-key cache. Making that read uncached needs either
-    a copy of the provider's fallback chain and credential binding in this
-    caller, which would be wrong for any extension resolving its endpoint from
-    somewhere else, or an uncached mode on the extension interface itself.
-
-    What that leaves open: a settings update that is committed but whose
-    endpoint key is not yet evicted, so the provider answers from a stale entry
-    beside an uncached model. For the SHIPPED provider it is unreachable, on
-    both branches of `ai_credentials.bind_openai_credential_base_url`:
-
-    - With an API key configured, the candidate value is used only to compare
-      against the operator-approved environment URL. Equal returns that same
-      approved string; unequal raises `OpenAICredentialDestinationError`. A
-      stale cached endpoint therefore either resolves to the identical string
-      or fails loudly, and can never silently pin a different destination.
-    - With no API key, `DefaultOpenAIEmbeddingProvider.embed` raises
-      `EmbeddingUnavailableError` before producing a vector, and on the force
-      path `_preflight_embedding` runs before the batch loop, so the run aborts
-      having written nothing and, since fix(#1549), having removed nothing
-      either.
-
-    So the residue is confined to an extension provider that resolves its
-    endpoint from the database and applies no such binding. Closing it needs an
-    uncached mode on the extension interface, which does not belong in a fix
-    PR; the underlying per-key eviction window is #1543.
-
-    A partial guard was tried here and removed: comparing the cached model and
-    dimensions against the uncached ones detects the eviction window, but only
-    the half where the model key has not been evicted yet, and it aborts
-    whenever a caller mocks one read and not the other. A guard that fires on
-    incomplete test doubles more often than on the hazard does not survive.
-
-    fix(#1511 review r2, codex P1): without the comparison a run could pin
-    model A with model B's dimensions, a pairing that never existed in config.
-    A provider that rejects it fails every insert; one that accepts it writes
-    vectors under a configuration nobody chose.
-
-    The re-read observes a concurrent change because `PersistentConfig.set`
-    commits and then deletes the cache entry (`apply_side_effects`,
-    persistent_config.py), so the second `get` misses the cache and hits the
-    DB. If a stale entry did survive, both reads would return the same stale
-    pair and the provider is handed that same pair explicitly, so the run stays
-    internally consistent and simply reflects the older config.
+    Known residue (#1525 r2, tracked as #1543): the endpoint is read through
+    the provider's per-key cache and cannot be read uncached from here. For
+    the shipped provider a stale entry either resolves to the identical
+    approved URL or fails loudly, so only an extension provider that resolves
+    its endpoint from the database is exposed.
 
     Raises:
-        RuntimeError: If the model cannot be resolved, or if either value
-            changed while it was being captured. Callers must invoke this
-            BEFORE anything destructive, which is what makes aborting safe.
+        RuntimeError: If the model cannot be resolved, or if any value changed
+            while it was being captured. Call BEFORE anything destructive.
     """
     # Imported in-function, as the port does, so patching the module attribute
     # reaches this call site.
@@ -615,20 +360,9 @@ async def _snapshot_embedding_config(
         resolve_embedding_model_name,
     )
 
-    # fix(#1525 review r2, codex P1): read the pinned values straight from the
-    # DB. `PersistentConfig.get` answers from a PER-KEY cache, and
-    # `update_settings` commits the whole batch of setting writes before any
-    # cache entry is evicted (`apply_side_effects_batch`, after the commit in
-    # `update_settings`). A cached read can therefore land on the far side of a
-    # committed update, and comparing two of them cannot see it: two reads
-    # through the same stale entry agree with each other perfectly.
-    # `get_uncached` neither reads nor writes the cache, so these observe the
-    # committed state instead.
-    #
-    # The eviction was a per-key loop when this was written, which made the
-    # window wider still: two keys could be read on opposite sides of one
-    # update. #1543 made it a single batched step, which narrows the window
-    # without closing it, and does not change what these reads have to do.
+    # fix(#1525 r2): read uncached. `PersistentConfig.get` answers from a
+    # per-key cache that `update_settings` evicts only after its commit, so two
+    # cached reads can agree with each other on the far side of an update.
     model_name = await resolve_embedding_model_name(session, uncached=True)
     if model_name == UNKNOWN_EMBEDDING_MODEL:
         # Loud, not silent: the admin route maps this to a 502 and a "failed"
@@ -643,14 +377,8 @@ async def _snapshot_embedding_config(
     dimensions = await EMBEDDING_DIMS.get_uncached(session)
     base_url = await resolve_embedding_base_url(session)
 
-    # fix(#1525 review, codex P1): ONE window over all three, not a window per
-    # value. An earlier revision gave the endpoint its own capture-and-compare
-    # after the pair had already been compared, which left a gap between the
-    # two: an admin updating model and endpoint together in that gap produced
-    # old model + new endpoint, a configuration that never existed, and neither
-    # comparison could see it. Splitting a race guard by value does not close
-    # the race, it relocates it. If values are pinned as a unit they have to be
-    # verified as a unit.
+    # fix(#1525): ONE window over all three. A per-value capture-and-compare
+    # leaves a gap in which "old model + new endpoint" is invisible to both.
     if (
         await resolve_embedding_model_name(session, uncached=True) != model_name
         or await EMBEDDING_DIMS.get_uncached(session) != dimensions
@@ -667,20 +395,11 @@ async def _snapshot_embedding_config(
 
 
 class _PinDrift(RuntimeError):
-    """Drift detected with a batch already generated but not yet committed.
+    """A run-stopping condition found with a batch generated but not committed.
 
-    A distinct type only so the two broad handlers below can re-raise it: the
-    per-batch one instead of retrying the batch record by record, and the
-    per-record one instead of counting it as a bad input. It is a
-    `RuntimeError`, so every caller that already treats this module's aborts as
-    one — the admin route included — is unaffected.
-
-    fix(#1533): also carries a STRUCTURAL generated-width mismatch, which is not
-    drift. The name is narrower than the job: what the two handlers need is "a
-    run-stopping condition discovered with a batch already generated", and both
-    conditions want exactly the same treatment from them. An ISOLATED width
-    mismatch is `_AnomalousVectorWidth` instead, precisely so it does NOT get
-    this treatment.
+    A distinct type so the two broad handlers re-raise it instead of retrying
+    per record or counting it as a bad input. fix(#1533): also carries a
+    STRUCTURAL width mismatch; an ISOLATED one is `_AnomalousVectorWidth`.
     """
 
 
@@ -720,47 +439,20 @@ async def _retry_batch_per_record(
 ) -> tuple[int, int]:
     """Re-embed a failed batch one record at a time; return (created, errors).
 
-    fix(#449, codex P2): one rejected input (e.g. a record over the model's
-    token limit) must not sink the other 127, so only the bad ones count as
-    errors. That behaviour is unchanged; what is new is the drift bracketing.
-    It lives in its own function because adding that pushed
-    `backfill_embeddings` past the McCabe gate, and the per-file burn-down list
-    in pyproject.toml may shrink but never grow.
-
-    `created` is the run's running total, passed in only so an abort message
-    can say how many records the run had written before it stopped.
-
-    `pinned_column_dims` is the storage width the run pinned, carried in so the
-    bracketing below covers it too. fix(#1533): a width that moves is what puts
-    this loop in its worst state, because the batch insert that failed and sent
-    the run here fails again for every record, one provider call at a time.
-
-    `traced_errors` is the run's traceback budget, shared with the batch handler
-    that calls this. See `_error_fields`.
-
-    fix(#1549): `record_orm` carries the force flag here, as `Record` or None,
-    because the retry replaces per record for the same reason the batch path
-    replaces per batch. It matters more on this path than on that one: the
-    batch failed, which is exactly when a record can fail again, and a record
-    that fails again must keep the vector it already had rather than lose it to
-    a delete that was committed on the promise of a replacement never written.
+    fix(#449): only the bad records count as errors. Split out because the
+    drift bracketing pushed `backfill_embeddings` past the McCabe gate.
+    `created` is the run's total so an abort message can report it;
+    `pinned_column_dims` is the pinned storage width (fix(#1533));
+    `traced_errors` is the run's traceback budget; `record_orm` carries the
+    force flag (fix(#1549)) so a record that fails again keeps its old vector.
     """
     made = 0
     failed = 0
     for record_id, content in batch:
         try:
-            # fix(#1525 review r6, codex P2): the drift checks bracket the
-            # retry's own provider call too. This path had none, so the window
-            # the batch path closed survived one path over, and it is the
-            # LIKELIER one: a provider outage is exactly when an operator goes
-            # and edits the endpoint. The batch call raised, so the batch's
-            # post-call check never ran, and every vector generated here would
-            # otherwise be committed under a pin that had already stopped being
-            # active.
-            #
-            # The check before the call is not redundant with the one after the
-            # previous record's: that record may have FAILED, in which case its
-            # post-call check never ran either.
+            # fix(#1525 r6): the drift checks bracket the retry's provider call
+            # too. The pre-call check is not redundant with the previous
+            # record's post-call one, which never ran if that record failed.
             await _raise_on_pin_drift(
                 session,
                 pinned,
@@ -775,16 +467,9 @@ async def _retry_batch_per_record(
                 dimensions=embedding_dims,
                 base_url=base_url,
             )
-            # fix(#1533): per vector on this path, not per batch. This loop is
-            # where a mismatch costs a provider call per record, so it is the
-            # one that has to stop on the first — but only when the column has
-            # moved. One record's vector against a column that has not moved is
-            # a bad record, and the handler below counts it (#1579 review).
-            #
-            # Ahead of the write, deliberately: it decides NOT to write, so it
-            # needs no lock, and putting it after the write would let the write
-            # raise the typmod error first and turn a named abort into a counted
-            # one. It carries the post-call drift bracket for the same reason.
+            # fix(#1533): per vector on this path, ahead of the write so a
+            # typmod error cannot turn a named abort into a counted one. A
+            # mismatch against an unmoved column is one bad record (#1579).
             await _raise_on_retry_vector_width(
                 session, pinned, vector, pinned_column_dims, created + made
             )
@@ -795,34 +480,17 @@ async def _retry_batch_per_record(
                         "record_id": record_id,
                         "embedding": vector,
                         "model_name": model_name,
-                        # fix(#1546): from `pinned`, which IS the
-                        # configuration this call was made under — the
-                        # retry passes the same three values to the
-                        # provider. Re-resolving here would stamp what the
-                        # config says now rather than what produced the
-                        # vector, which is the fabrication the whole column
-                        # exists to avoid.
+                        # fix(#1546): from `pinned`, the configuration this
+                        # call was made under, never a fresh read.
                         "config_fingerprint": embedding_config_fingerprint(*pinned),
                         "content_hash": compute_content_hash(content),
                     }
                 ],
                 record_orm=record_orm,
             )
-            # fix(#1579 review r3, codex P2): the row is SENT before the
-            # post-call check, so the check runs holding the lock its answer
-            # depends on. See the same ordering on the batch path.
-            #
-            # fix(#1546): what sends it is a Core INSERT ... ON CONFLICT rather
-            # than an ORM add followed by `session.flush()`. The ordering is
-            # unchanged and so is the reason for it: the INSERT takes the same
-            # RowExclusiveLock the flush did, so an ALTER TABLE still either
-            # lands before the check and is seen, or waits for our commit.
-            #
-            # fix(#1549): and the delete that clears what this row replaces is
-            # inside `_replace_embeddings`, in this same transaction, ahead of
-            # the write. So the abort below rolls back the delete along with the
-            # row, and a record whose replacement never commits keeps the vector
-            # it already had.
+            # fix(#1579 r3): the row is SENT before the post-call check so the
+            # check holds the RowExclusiveLock; fix(#1549): the delete inside
+            # `_replace_embeddings` rolls back with it on abort.
             await _raise_on_pin_drift(
                 session,
                 pinned,
@@ -833,11 +501,7 @@ async def _retry_batch_per_record(
             await session.commit()
             made += 1
         except _PinDrift:
-            # fix(#1525 review r6, codex P2): drift is not a bad record.
-            # Counting it would leave the run reporting partial success with
-            # the rest of the catalog written into a vector space the active
-            # search cannot match — the silent outcome these checks exist to
-            # prevent. It stops the run, as on the batch path.
+            # fix(#1525 r6): drift is not a bad record; it stops the run.
             await session.rollback()
             raise
         except Exception as exc:  # broad: same isolation, per record
@@ -858,38 +522,16 @@ async def _pinned_config_drift(
 ) -> str | None:
     """Describe how the live config has left the pinned one, or None if it has not.
 
-    fix(#1525 review r4, codex P2): every guard on this path so far protects a
-    run from config moving DURING a read. This one notices that the run itself
-    has outlived the configuration it pinned, which no amount of care inside a
-    single batch can see.
+    fix(#1525 r4): notices that the run has outlived its pinned configuration,
+    read uncached for the reason `_snapshot_embedding_config` gives.
+    fix(#1533): the storage width is checked too, because the column moves
+    without a settings write (ENV_ONLY_CONFIG, a hand `ALTER TABLE`, a
+    restored dump, a failed rebuild).
 
-    Read the same way `_snapshot_embedding_config` reads, for the same reason:
-    a cached read can agree with a stale entry and report no drift.
-
-    fix(#1533): the storage width is checked alongside the settings, because the
-    settings are only ONE of the routes it moves by. `update_settings` publishes
-    `embedding_dims` and then rebuilds the column, so the dimensions comparison
-    above catches that route within a batch. It catches nothing else, and the
-    column moves without a settings write in an ENV_ONLY_CONFIG deployment
-    (there is no settings row and no rebuild ever fires), after a hand
-    `ALTER TABLE`, after a restored dump, and after a rebuild that failed
-    partway. Measured on 1,000 records with the width moved by hand and the
-    settings row untouched: 1,009 provider calls and 1,000 errors reported as if
-    the provider were broken, against 2 calls and a named cause with this check.
-
-    Two states are deliberately NOT treated as drift, because neither is
-    evidence that the pinned configuration stopped being the right one:
-
-    - An unresolvable model. `resolve_embedding_model_name` answers with its
-      sentinel when persistent-config resolution fails for any reason, so
-      treating it as a change would abort a long run on a transient DB blip.
-    - A provider resolve that RAISES. For the shipped provider that is what an
-      endpoint edit diverging from the operator-approved environment URL looks
-      like (`ai_credentials.bind_openai_credential_base_url`), and it says
-      nothing about where vectors are going: `embed` re-binds to that same
-      approved URL, so the pin is still accurate. Aborting there would undo the
-      abandon-the-catalog fix earlier in this PR. Only a resolve that SUCCEEDS
-      and answers differently means the endpoint actually moved.
+    NOT drift: an unresolvable model (a transient DB blip must not abort a
+    long run) and a provider resolve that RAISES (for the shipped provider
+    that is an endpoint edit diverging from the approved URL, and `embed`
+    re-binds to the approved one, so the pin is still accurate).
     """
     from app.processing.embeddings.helpers import (
         UNKNOWN_EMBEDDING_MODEL,
@@ -908,18 +550,9 @@ async def _pinned_config_drift(
             f"the embedding dimensions changed from {dimensions!r} to {active_dims!r}"
         )
 
-    # fix(#1533): BEFORE the endpoint block, not after it, and not because of
-    # message quality. That block returns None from its `except`, so a
-    # deployment where the endpoint cannot be resolved would never reach a check
-    # placed below it — and an endpoint that will not resolve is exactly the
-    # kind of half-configured install where a column gets altered by hand. The
-    # settings comparisons stay ahead of this one so that when both have moved,
-    # the message names the admin action rather than its consequence.
-    #
-    # Any change counts, including one that widens the column or drops the
-    # constraint. A run that carried on would leave the table holding two vector
-    # widths under one model label, and the inserts that make that happen are
-    # the ones that SUCCEED, so nothing else would report it.
+    # fix(#1533): BEFORE the endpoint block, whose `except` returns None and
+    # would hide this on a half-configured install. Any change counts,
+    # including a widening: those inserts SUCCEED, so nothing else reports it.
     active_column_dims = await _live_column_dims(session)
     if active_column_dims != pinned_column_dims:
         return (
@@ -947,28 +580,14 @@ async def _preflight_embedding(
 ) -> None:
     """Generate one throwaway embedding to prove regeneration can work.
 
-    fix(#1511 review r3, codex P1): three rounds of this review each guarded a
-    different way for a force run to destroy vectors it then could not rebuild
-    — unresolvable model, model and dimensions disagreeing across reads, model
-    and dimensions disagreeing in a committed and stable state. Guarding modes
-    one at a time keeps finding another mode. This proves the capability
-    instead: if the provider returns a vector for the pinned pair right now,
-    regeneration works with the configuration as it actually stands, whatever
-    the mode would have been.
-
-    It subsumes the stable-mismatch case that no amount of re-reading can
-    catch, and also provider outages, revoked keys, exhausted quota and
-    dimensions the model rejects. The cost is one provider call per force run,
-    against regenerating the entire catalog.
-
-    The earlier guards are kept rather than replaced. They are cheaper, they
-    fail before any provider round trip, and they name the problem better than
-    a provider rejection would.
+    fix(#1511 r3): proves the capability instead of guarding failure modes one
+    at a time; subsumes provider outages, revoked keys, exhausted quota and
+    rejected dimensions for one provider call per force run. The cheaper
+    guards stay because they fail earlier and name the problem better.
 
     Raises:
-        RuntimeError: If the embedding cannot be generated, or cannot be stored
-            in the column as it currently stands. The caller must run this
-            BEFORE deleting anything.
+        RuntimeError: If the embedding cannot be generated or cannot be stored
+            in the column as it stands. Run this BEFORE deleting anything.
     """
     model_name, dimensions, base_url = pinned
     try:
@@ -993,37 +612,9 @@ async def _preflight_embedding(
             "embedding configuration or provider and re-run."
         ) from exc
 
-    # fix(#1511 review r4, codex P1): generating a vector is only half the
-    # promise — it also has to fit the column. The width a model produces and
-    # the width the column declares are written by different code at different
-    # times, so they can disagree, and when they do the provider answers
-    # happily at the new width, this pre-flight passes, the DELETE commits and
-    # every insert dies on the typmod.
-    #
-    # The case that found it was a settings write that persisted a newly
-    # detected width without rebuilding the column, so switching model without
-    # naming dimensions left storage at the old width. #1529 closed that route:
-    # an auto-detected width now joins `validated_settings` and goes down the
-    # same rebuild branch as one an admin typed, so the column follows every
-    # width the settings API publishes.
-    #
-    # This check is deliberately NOT written against that route, which is why
-    # closing it did not retire the check. It asks storage what it will accept,
-    # so it holds for any cause. Still live after #1529: a rebuild that failed
-    # partway, a restored dump, a column altered by hand, and ENV_ONLY_CONFIG
-    # deployments, where the model comes from the environment, no settings
-    # write happens, and therefore no rebuild is ever triggered.
-    #
-    # The width comes off the live column rather than EMBEDDING_DIMS (the
-    # setting is what disagreed with storage in the first place), and it is the
-    # caller's read rather than one of this function's own.
-    #
-    # fix(#1533): one read, deliberately. The caller pins that same value and
-    # stops the run if the column stops matching it, so what this proves is not
-    # "the width fitted a moment ago" but "the width fits, and the run will not
-    # outlive it". Reading storage twice would put a window between the two: a
-    # rebuild landing inside it passes this check against the old width and gets
-    # pinned at the new one, so nothing afterwards has anything to notice.
+    # fix(#1511 r4, #1533): the vector must also FIT the column, asked of
+    # storage so it holds for any cause (failed rebuild, restored dump, hand
+    # ALTER, ENV_ONLY_CONFIG), and read once by the caller so the run pins it.
     column_dims = pinned_column_dims
 
     generated = len(vectors[0])
@@ -1054,19 +645,12 @@ async def backfill_embeddings(
     Args:
         session: Database session.
         force: If True, regenerate every record and replace whatever vectors it
-               already holds. Useful when the model, dimensions or endpoint
-               change. fix(#1549): "replace" is per batch, inside the
-               transaction that writes the batch's new rows, so an aborted run
-               leaves the records it reached rewritten and the rest exactly as
-               they were. It no longer empties the table up front.
+               already holds, per batch inside the transaction that writes the
+               batch (fix(#1549)); the table is never emptied up front.
         should_continue: Optional zero-argument async callable polled once per
-               batch, BEFORE that batch's provider call; a False answer stops
-               the run at the boundary (fix(#1709 review r6)). The queued-run
-               caller passes a fenced job-row read so a user cancel whose
-               best-effort queue abort was lost stops the run within one batch
-               of provider spend instead of the whole remaining catalog. Kept
-               opaque here on purpose: this module knows records and vectors,
-               not jobs.
+               batch BEFORE its provider call; False stops the run at the
+               boundary (fix(#1709 r6)). Opaque here: this module knows
+               records and vectors, not jobs.
 
     Returns:
         Dict with counts: processed, created, skipped, errors.
@@ -1080,42 +664,27 @@ async def backfill_embeddings(
     port = get_processing_port()
 
     pinned: tuple[str, int | None, str | None] | None = None
-    # fix(#1533): the storage width the run commits to, pinned beside the config
-    # rather than inside it. It is not configuration — it is read off
-    # `pg_attribute` rather than `PersistentConfig`, and the two disagree often
-    # enough that this whole check exists.
+    # fix(#1533): the storage width the run commits to, read off `pg_attribute`
+    # rather than `PersistentConfig`, because the two can disagree.
     pinned_column_dims: int | None = None
-    # fix(#1549): non-None only on a force run, where it is both the tenant
-    # boundary for the per-batch delete and the flag that says a batch replaces
-    # rather than fills a gap. A non-force run must delete nothing, so it stays
-    # None all the way down to `_replace_embeddings`.
+    # fix(#1549): non-None only on a force run; it is both the tenant boundary
+    # for the per-batch delete and the flag that a batch replaces.
     record_orm = None
 
     if force:
         Record = port.get_record_orm_class()
         record_orm = Record
 
-        # fix(#1511 review r5, codex P2): every guard below exists to protect
-        # rows from the DELETE. That DELETE is bounded by the record foreign
-        # key, so a tenant with no visible records has nothing it could remove
-        # and nothing to regenerate. Demanding a working provider just to
-        # discover that turned a harmless no-op into a 502 on a fresh install.
-        # Returning here matches what the old code produced by the longer route
-        # (an empty select, then the `total == 0` return below) minus the
-        # pointless provider call, delete and commit.
+        # fix(#1511 r5): a tenant with no visible records has nothing the
+        # DELETE could remove, so demanding a working provider first turned a
+        # no-op into a 502 on a fresh install.
         if (await session.execute(select(Record.id).limit(1))).first() is None:
             logger.info("Backfill: no visible records, nothing to regenerate")
             return {"processed": 0, "created": 0, "skipped": 0, "errors": 0}
 
-        # fix(#1511): everything that could stop this run from regenerating has
-        # to happen BEFORE the delete below commits. Every row this run writes
-        # back is stamped with the active model and `model_name` is NOT NULL,
-        # so a force run started while the config is unusable clears the whole
-        # table and then cannot insert a single replacement — a Regenerate All
-        # clicked during a config blip converts full coverage into zero.
-        #
-        # The AI gate further down runs after the delete, which on this path
-        # would mean deleting everything and then declining to regenerate it.
+        # fix(#1511): everything that could stop this run must fail BEFORE the
+        # first per-batch delete; `model_name` is NOT NULL, so a run started
+        # under an unusable config could otherwise write nothing back.
         if not await AI_ENABLED.get(session):
             logger.error("backfill_force_aborted_ai_disabled")
             raise RuntimeError(
@@ -1123,103 +692,22 @@ async def backfill_embeddings(
                 "Existing vectors were left untouched; enable AI and re-run."
             )
 
-        # Fail-closed on an unresolvable model, as documented in
-        # DefaultProcessingPort.get_records_without_embeddings (#1506), which
-        # could not cover this branch: force asks that query for every record
-        # rather than for the ones a configuration cannot use, so it never
-        # consults the model at all.
+        # Fail-closed on an unresolvable model (#1506): force never consults the
+        # model through get_records_without_embeddings.
         pinned = await _snapshot_embedding_config(session)
         pinned_column_dims = await _live_column_dims(session)
 
-        # fix(#1511 review r3, codex P1): the checks above test proxies for
-        # "regeneration will work". This one tests the property itself, because
-        # the proxies keep running out. A comparison-based guard can only catch
-        # a value that MOVES. It is blind to a pair that is wrong, committed and
-        # stable, because re-reading such a pair agrees with itself and learns
-        # nothing. What made that concrete was a settings write publishing a new
-        # model before its dimensions were known (that publish is the subject of
-        # #1529), but the blindness belongs to comparing, not to that one writer.
-        #
-        # One real embedding proves the live config can produce a vector, and
-        # covers the modes nobody has enumerated yet: provider down, revoked
-        # key, exhausted quota, dimensions the model rejects.
+        # fix(#1511 r3): a comparison guard is blind to a pair that is wrong,
+        # committed and stable; one real embedding tests the property itself.
         await _preflight_embedding(session, pinned, pinned_column_dims)
 
-        # fix(#1549): there is no bulk DELETE here any more. It used to commit
-        # before the run knew it could finish, so any failure after it — a
-        # provider outage, drift detected mid-run, a worker restart — ended the
-        # run with the old vectors gone and few or none written. Every guard
-        # above sits correctly before that commit for the conditions it can see
-        # at the start; none of them can see a change that lands after it.
-        #
-        # The delete now happens per batch, inside the transaction that writes
-        # that batch's replacement rows (`_replace_embeddings`), so there is no
-        # window in which the old rows are gone and the new ones are not
-        # written. What an aborted run leaves is a MIX: replaced records hold
-        # rows from this run's pinned configuration, untouched records hold
-        # exactly what they held before it started.
-        #
-        # #1546 is what makes that mix readable rather than ambiguous for every
-        # row it stamped: a row from a superseded configuration is invisible to
-        # search instead of being silently compared across vector spaces. The
-        # residue is the one #1546 documents — a row written before that column
-        # existed carries no stamp and is still matched on model name alone, so
-        # after an endpoint change it may be compared cross-space. That is not
-        # something this change introduces. It is true of an unstamped catalog
-        # from the moment the endpoint moves, whether or not anyone runs a
-        # regenerate, and an aborted run now leaves those records no worse than
-        # it found them rather than leaving them with nothing.
-        #
-        # The HNSW index lives in Alembic migration 0012 (and is recreated by
-        # service.rebuild_embedding_column on dimension change); a per-batch
-        # delete does not need it dropped either. RecordEmbedding is not
-        # RLS-scoped itself, so the Record subquery inside `_replace_embeddings`
-        # remains the required tenant boundary in hosted mode.
+        # fix(#1549): no bulk DELETE here any more. Deletion is per batch, inside
+        # the transaction that writes the replacements (`_replace_embeddings`),
+        # so an aborted run leaves a MIX that #1546's stamp keeps readable.
 
-    # Find the records still needing a vector, eager-loading keywords.
-    # fix(#1506): pass `force` through instead of hardcoding False. force=True
-    # asks for "every record" directly, which is what this branch has always
-    # meant, and the port's non-force branch would answer a different question:
-    # it selects only records with no vector the live configuration can use, so
-    # routing a regenerate through it would skip precisely the records that are
-    # already covered and that force exists to rewrite.
-    #
-    # fix(#1549): this used to be able to lean on "the delete above already
-    # emptied the table, so both flags select the same rows". It cannot any
-    # more — nothing has been deleted at this point — which makes the explicit
-    # force=True the only thing separating the two questions.
-    # fix(#1549 review): the end-of-run reclamation acts on an observation made
-    # here, at the start, and must not delete anything written since. What it
-    # needs is not a clock but the IDENTITY of the rows it saw: `(record_id,
-    # updated_at)` pairs, which any write by any writer changes.
-    #
-    # fix(#1584 review r1, codex P2): taken BEFORE the fetch below, not after.
-    # The emptiness this protects against is decided BY that fetch — it is the
-    # read that sees a record's title and summary — and materialising every
-    # record takes as long as it takes. A snapshot taken afterwards leaves that
-    # whole interval unguarded: a record read as empty, then edited and
-    # re-embedded before the snapshot was taken, would be captured in its NEW
-    # version and reclaimed. The snapshot has to precede the observation it
-    # protects, not follow it.
-    #
-    # fix(#1584 review r3, codex P2): versions rather than a timestamp cutoff.
-    # See `_delete_embeddings_for` for why a clock got this wrong in both
-    # directions. Force-only: a non-force run reclaims nothing, so it does not
-    # pay for this read.
-    #
-    # Narrowed to records with no TITLE, which is a superset of what the
-    # reclamation can ever touch and is what keeps this from being a copy of the
-    # whole table in worker memory. `build_content_text` returns "" only when
-    # the title, summary, keywords, lineage and translations are ALL empty, so a
-    # record carrying a title is never skipped and its rows are never
-    # reclaimable. Titleless records are a rounding error on a real catalog,
-    # where the unnarrowed form would be one (uuid, timestamp) pair per
-    # embedding row. The one thing the narrowing gives up: a record whose title
-    # is cleared between this snapshot and the fetch is skipped but was not
-    # snapshotted, so its rows wait for the next force run, which sees it
-    # titleless. The ingest writer already leaves such rows in place (it skips
-    # empty content rather than deleting), so this defers a reclamation rather
-    # than inventing a stale row.
+    # fix(#1506): `force` passes through; the port's non-force branch answers a
+    # different question. fix(#1584 r1/r3): the reclamation snapshot, taken
+    # BEFORE the fetch that decides emptiness, as row versions, titleless only.
     observed_rows: list[tuple[Any, Any]] = []
     if record_orm is not None:
         observed_rows = [
@@ -1252,43 +740,21 @@ async def backfill_embeddings(
         logger.info("Backfill: no records without embeddings found")
         return {"processed": 0, "created": 0, "skipped": 0, "errors": 0}
 
-    # Gate once for the whole run (the per-record path checked this per call).
-    # fix(#1511): force already gated above, before the pre-flight spends a
-    # provider call. Re-reading here could only turn a run that has already
-    # proved it can embed into one that skips everything, so force does not ask
-    # twice. fix(#1549): the original reason was blunter — the gate sat ahead of
-    # a delete, and a second read could have left the catalog emptied and then
-    # skipped. That delete is gone; the gate stays because paying for a
-    # pre-flight and then declining to use it is still the wrong shape.
+    # Gate once for the whole run. fix(#1511): force gated above, before the
+    # pre-flight spent a provider call, and does not ask twice.
     if not force and not await AI_ENABLED.get(session):
         logger.info("Backfill: AI disabled, skipping", total_records=total)
         return {"processed": 0, "created": 0, "skipped": total, "errors": 0}
 
-    # fix(#1511): on the force path reuse the snapshot the guard above already
-    # validated. A second read here would reopen the window that guard closes —
-    # resolution can fail between the two calls, and by then the delete has
-    # committed. The non-force path has nothing to destroy, so it snapshots
-    # here, where the original read lived.
-    # fix(#1511 review, codex P1): all three parts are pinned into every provider
-    # call below. generate_embeddings_batch would otherwise re-read the config
-    # per call, so an admin swapping models mid-run gets model B's vectors
-    # stored under model A's label — search on the active model then skips rows
-    # it believes it wrote. fix(#1525): the endpoint is the third part. The rows
-    # name a model, and a model served by two endpoints is two vector spaces
-    # under one label; on the shipped provider the same edit instead makes every
-    # remaining batch raise, which abandons the rest of the catalog.
-    # fix(#1533): the storage width is pinned in the same two places and for the
-    # same reason. On the force path it is the value the pre-flight was measured
-    # against, so it is read up there rather than re-read here.
+    # fix(#1511, #1525, #1533): force reuses the validated snapshot; all three
+    # parts plus the storage width are pinned into every provider call so a
+    # mid-run config change cannot store model B's vectors under A's label.
     if pinned is None:
         pinned = await _snapshot_embedding_config(session)
         pinned_column_dims = await _live_column_dims(session)
     model_name, embedding_dims, base_url = pinned
-    # fix(#1546): every row this run writes is stamped with THIS, the identity
-    # of the configuration the run pinned. Not a fresh read at write time: the
-    # endpoint half in particular has to be the one the provider call was made
-    # against, and `base_url` above is exactly the value passed to
-    # `generate_embeddings_batch` below.
+    # fix(#1546): every row is stamped with the PINNED configuration, never a
+    # fresh read at write time.
     config_fingerprint = embedding_config_fingerprint(*pinned)
 
     # Build embeddable (record_id, content_text) pairs; empty content skips.
@@ -1316,17 +782,9 @@ async def backfill_embeddings(
     traced_errors: set[str] = set()
 
     for start in range(0, len(items), _BATCH_SIZE):
-        # fix(#1709 review r6): the cooperative stop for a run whose job was
-        # settled underneath it — a user cancel above all. Procrastinate's
-        # abort for an async task IS asyncio cancellation and needs no polling
-        # once the request reaches the worker; this check covers the request
-        # that never landed (the cancel endpoint's queue abort is best-effort
-        # by design — the DB CAS is the correctness mechanism). One indexed
-        # read per batch bounds the post-cancel overlap to a single batch of
-        # provider spend, instead of the whole remaining catalog running
-        # concurrently with a successor run admitted by the freed
-        # one-active-backfill slot. Before _raise_on_pin_drift so a stopped
-        # run does not pay even the config read.
+        # fix(#1709 r6): cooperative stop for a run whose job was settled under
+        # it; the cancel endpoint's queue abort is best-effort and the DB CAS
+        # is the mechanism. Before the drift check so a stopped run pays nothing.
         if should_continue is not None and not await should_continue():
             logger.warning(
                 "backfill_stopped_job_no_longer_running",
@@ -1336,31 +794,9 @@ async def backfill_embeddings(
             )
             break
 
-        # fix(#1525 review r4, codex P2): the pin protects each batch from the
-        # config moving underneath it, but nothing was noticing that it HAD
-        # moved. A run pinned to endpoint A that keeps going after the active
-        # endpoint becomes B writes A-space vectors for the rest of the
-        # catalog, and `RecordEmbedding` recorded only `model_name`, so semantic
-        # search later built its query vector from the live endpoint and
-        # filtered stored rows by model alone — B-space queries against A-space
-        # documents under one label, and the backfill reported success.
-        #
-        # fix(#1546): those rows are now stamped with the pin, so search skips
-        # them rather than matching them. This check stays: invisible is better
-        # than wrong, but not writing a whole catalog nobody can use is better
-        # than either, and stopping is also what tells the operator to re-run
-        # under the new configuration.
-        #
-        # Outside the try below, deliberately: this must stop the run, not be
-        # counted as a batch error and retried per record. The sibling check
-        # after the provider call cannot have that placement, so it raises
-        # `_PinDrift` and the batch handler re-raises it to the same effect.
-        #
-        # Kept alongside that one rather than replaced by it: a post-call check
-        # alone is sufficient for correctness, but drift that lands BETWEEN
-        # batches would then only surface after the next batch had already been
-        # generated and paid for. One config read per batch is the cheaper half
-        # of that trade.
+        # fix(#1525 r4): stop when the pin is no longer active; a catalog
+        # written into a stale vector space reports success and matches nothing.
+        # Outside the try: this must stop the run, not count as a batch error.
         await _raise_on_pin_drift(
             session, pinned, created, pinned_column_dims=pinned_column_dims
         )
@@ -1374,92 +810,28 @@ async def backfill_embeddings(
                 dimensions=embedding_dims,
                 base_url=base_url,
             )
-            # fix(#1533): the whole batch, not the first vector. Agreement
-            # across inputs is what makes a width mismatch structural rather
-            # than one bad record, so a batch of mixed widths deliberately does
-            # NOT stop here: it fails its insert, drops into the retry loop, and
-            # every vector is judged on its own down there (#1579 review).
-            #
-            # Ahead of the inserts because it decides not to write at all, so
-            # unlike the drift check below it needs no lock to be sound.
+            # fix(#1533): the whole batch, so mixed widths fall to the
+            # per-record retry (#1579). Ahead of the inserts, so no lock needed.
             _raise_on_structural_width(vectors, pinned_column_dims, created)
-            # fix(#1549): the batch's own old rows are removed HERE, in the
-            # transaction that writes their replacements, rather than by a bulk
-            # DELETE committed before the run generated anything.
+            # fix(#1549): the batch's own old rows go in this same transaction.
             rows = [
                 {
                     "record_id": record_id,
                     "embedding": vector,
                     "model_name": model_name,
-                    # fix(#1546): stamped from the PIN. `pinned` is the triple
-                    # that was handed to the provider call above, so the stamp
-                    # names the configuration that actually produced this vector
-                    # rather than whatever the live configuration happens to be
-                    # by the time the row is written.
+                    # fix(#1546): stamped from the PIN that produced the vector.
                     "config_fingerprint": config_fingerprint,
                     "content_hash": compute_content_hash(content),
                 }
-                # fix(#1581 review): `strict=True`, because `zip` silently
-                # truncating is only the visible half of the problem. A provider
-                # that skips a MIDDLE input answers `[v1, v3]` for
-                # `[t1, t2, t3]` — the shipped `embed()` returns
-                # `[item.embedding for item in response.data]` with no index
-                # sort and no count check — and a truncating zip then pairs the
-                # second record with the THIRD vector, writing a permanently
-                # wrong vector under a valid-looking content hash and stamp. No
-                # guard downstream can see that: the row is well formed, in the
-                # right space, and simply not this record's.
-                #
-                # Raising instead sends the whole batch to the per-record retry,
-                # where `[vector] = await generate_embeddings_batch(...)` is
-                # alignment-safe by construction: a single-element unpack cannot
-                # pair a text with another text's vector. Paying k provider
-                # calls for that is the right trade in a failure mode where the
-                # provider has already broken its contract.
+                # fix(#1581): `strict=True`. A provider that skips a MIDDLE
+                # input pairs a record with another text's vector under a
+                # valid-looking hash; raising sends the batch to the retry.
                 for (record_id, content), vector in zip(batch, vectors, strict=True)
             ]
             await _replace_embeddings(session, rows, record_orm=record_orm)
-            # fix(#1579 review r3, codex P2): WRITE, then check, then commit.
-            # The check reads `pg_attribute`, which locks nothing, so checking
-            # before the rows were sent left a window in which an `ALTER TABLE`
-            # could take ACCESS EXCLUSIVE, commit, and be missed entirely. When
-            # that ALTER widened the column to an unconstrained `vector` the
-            # old-width inserts then SUCCEEDED, and the run reported success
-            # over a column that had moved under it — the one outcome
-            # `_pinned_config_drift` says a widening change must not produce.
-            #
-            # The write takes RowExclusiveLock on the relation, which ACCESS
-            # EXCLUSIVE conflicts with. So an ALTER that landed first is seen by
-            # the check (and these rows roll back with the abort), and one that
-            # arrives after waits for our commit. Check-then-act is only sound
-            # while the thing checked cannot move, and this is what stops it
-            # moving.
-            #
-            # fix(#1546): the write is a Core INSERT ... ON CONFLICT rather than
-            # an ORM add plus `session.flush()`. It takes the same lock at the
-            # same point, so everything above still holds; what changed is only
-            # that the statement is emitted by `session.execute` directly.
-            #
-            # fix(#1549): the delete that clears what these rows replace is
-            # inside `_replace_embeddings`, in this same transaction and ahead
-            # of the write, so it takes the lock at the same moment and the
-            # abort below rolls back both halves together. A batch whose
-            # replacements never commit leaves its records holding the vectors
-            # they already had.
-            #
-            # A write that RAISES because the column moved to a different fixed
-            # width is not lost: the batch handler retries per record, and the
-            # retry's pre-call check reads the new width and stops the run.
-            #
-            # fix(#1525 review r5, codex P2): and the drift check runs again
-            # before ACCEPTING the batch, not only before requesting it. The
-            # check above has no successor for the LAST batch, so an edit
-            # landing during that final provider call was never observed: the
-            # vectors were written and the run reported success while the active
-            # endpoint had moved. Checking here means the batch in flight is
-            # discarded rather than committed, so the run stops without adding a
-            # row nothing will match. `_PinDrift` is re-raised past the batch
-            # handler below.
+            # fix(#1579 r3): WRITE, then check, then commit: the write's
+            # RowExclusiveLock makes an ALTER either visible or waiting.
+            # fix(#1525 r5): the last batch has no successor check; drop it here.
             await _raise_on_pin_drift(
                 session,
                 pinned,
@@ -1468,28 +840,17 @@ async def backfill_embeddings(
                 error=_PinDrift,
             )
             await session.commit()
-            # fix(#1581): count what was WRITTEN, not what was asked for. With
-            # the strict zip above these are the same number on the success
-            # path, which is the point: a batch either wrote a row for every
-            # text or raised and wrote none. `created += len(batch)` was wrong
-            # because it stayed true after a truncating zip had dropped the
-            # tail, and #1550's "errors and nothing created" guard cannot fire
-            # on a run claiming it created everything.
+            # fix(#1581): count what was WRITTEN; with the strict zip this equals
+            # the batch size on success.
             created += len(rows)
         except _PinDrift:
-            # fix(#1525 review r5, codex P2): not a batch failure. Retrying it
-            # per record would generate the same vectors against the same stale
-            # pin and commit them one at a time, which is the outcome the check
-            # exists to prevent.
+            # fix(#1525 r5): drift is not a batch failure; retrying per record
+            # would commit the same stale vectors one at a time.
             await session.rollback()
             raise
         except Exception as exc:  # broad: per-batch backfill is isolated; embedding API/DB errors are counted not raised
             await session.rollback()
-            # fix(#1544): the same treatment `_retry_batch_per_record` gives a
-            # record, sharing its budget. One batch failure is 1/128th the volume
-            # of the retry storm it opens, but a batch that fails usually fails
-            # every one of its records too, so the two paths raise the same type
-            # and the run should pay for that stack once between them, not twice.
+            # fix(#1544): shares the traceback budget with the per-record retry.
             logger.warning(
                 "Backfill: batch failed, retrying records individually",
                 batch_start=start,
@@ -1519,44 +880,17 @@ async def backfill_embeddings(
             errors=errors,
         )
 
-    # fix(#1549): a record whose metadata no longer builds any embeddable text
-    # has a stale vector and no replacement to pair a delete with. The bulk
-    # DELETE used to reclaim those; per-batch replacement cannot, because these
-    # records never reach a batch. Cleaning them up LAST rather than first is
-    # what keeps the rest of this function's promise: an aborted run has not
-    # touched them, and a completed one honours what force means. Nothing is
-    # lost by the delay — regenerating them is impossible either way, so a
-    # re-run would not bring these rows back at any point in the run.
-    #
-    # fix(#1549 review): but "last" is what makes the observation stale. The
-    # emptiness was decided when the run read its records, and by the time this
-    # pass runs an editor may have given one of them a title, in which case the
-    # ingest path has already written it a fresh, correctly stamped vector. The
-    # bulk delete could not hit that case because it ran before any such write.
-    # `observed_rows` bounds this to the exact row versions the run saw before
-    # it looked at the catalog, so a vector written DURING the run — by any
-    # writer, on any clock — no longer matches and survives.
+    # fix(#1549): records with no embeddable text have a stale vector and no
+    # replacement to pair a delete with, so they are reclaimed LAST, bounded to
+    # the row versions the run observed at its start (#1549 review).
     if record_orm is not None and skipped_ids:
         # NOT `skipped`: that name holds the run's skipped COUNT and is
         # reported back to the caller.
         skipped_set = set(skipped_ids)
         reclaimable = [pair for pair in observed_rows if pair[0] in skipped_set]
-        # fix(#1584 review r4, codex P2): an unchanged ROW is not proof of an
-        # unchanged RECORD. The ingest writer skips its write when the content
-        # hash is unchanged, so an editor who restores exactly the content a
-        # row was computed from leaves the row, and its `updated_at`, untouched:
-        # the pair still matches and the row would be reclaimed although it is
-        # valid again. So every record whose rows are about to go is re-read
-        # first, and only those still empty NOW are reclaimed. One read per
-        # titleless record that holds vectors, which is the bound the snapshot
-        # already has.
-        #
-        # fix(#1584 review r5): re-read and delete under one row lock, one
-        # chunk per transaction. `_records_still_empty` locks the chunk's
-        # records FOR UPDATE; the delete follows in the same transaction; the
-        # commit releases them. Chunked for the same reason the run is: asyncpg
-        # caps a statement at 32767 bind parameters, and each pair spends two
-        # of them — and a chunk is also how long any one editor can be held.
+        # fix(#1584 r4/r5): an unchanged ROW is not an unchanged RECORD (the
+        # ingest writer skips on an unchanged hash), so each record is re-read
+        # and deleted under one FOR UPDATE lock, one chunk per transaction.
         removed = await _reclaim_observed_rows(session, port, record_orm, reclaimable)
         logger.info(
             "Backfill: dropped vectors for records with no embeddable content",

--- a/backend/app/processing/export/artifact_cache.py
+++ b/backend/app/processing/export/artifact_cache.py
@@ -1,84 +1,29 @@
 """A stable stored artifact behind ``GET /datasets/{id}/export`` (fix(#1532)).
 
-The route used to run a fresh conversion on every request, including every range
-request. It advertises ``Accept-Ranges: bytes``, so one ``/vsicurl/`` open cost
-roughly ten conversions — and, whenever the data moved under them, ten different
-artifacts served under one URL, with two probes reporting different total sizes.
-
-This module is the other half of the fix: the conversion output is stored once
-and every subsequent range is a slice of that one object.
+The conversion output is stored once and every subsequent range request is a
+slice of that one object, so ``Accept-Ranges: bytes`` cannot splice two
+conversions.
 
 Everything is in the key
 ------------------------
 An artifact is named ``{built_at}-{size}-{digest}-{nonce}.bin`` and there is
-nothing else — no pointer, no index, no metadata object. Lookup lists the
-selection's prefix and takes the newest key still inside the freshness window;
-publishing is one ``put``; the sweep deletes any key past the horizon. Nothing is
-ever rewritten, so there is no flip to race and no read-decide-delete to lose.
-(Freshness and reclamation also read the object's own modified time, for
-reasons ``lookup`` and ``sweep`` give; the key remains the portable floor.)
-
-fix(#1532 review r3) arrived at that by removing the last piece of mutable state.
-A ``current.json`` pointer per selection was the previous design, and it failed
-in three ways across two review rounds: r2 found a sweep deleting a pointer
-another worker had just published, r2's own fix could only narrow that window
-rather than close it (``StorageProvider`` has no compare-and-delete), and leaving
-pointers undeleted turned them into an amplification — anonymous callers can
-export a public dataset with arbitrary ``bbox``/``where``, so every distinct
-selection left one small object forever and the sweep's listing grew with them.
-Removing the pointer answers all three at once, and the properties the earlier
-rounds fought for now hold by construction:
-
-- **Two concurrent builders need no lock.** Both publish, under different keys
-  because the timestamp differs; readers take the newer. Neither can delete the
-  other's object, because publishing deletes nothing.
-- **A reader mid-stream keeps its object** until the horizon, which is chosen to
-  be well past any download.
-- **A sweep cannot race a publish.** An aged key can never become fresh and a
-  fresh key can never look aged, so no judgement depends on a read that another
-  worker can invalidate.
-- **Total objects are bounded by build rate times horizon**, not by the number of
-  distinct selections ever requested.
-
-The size in the name is what makes this safe on a provider whose ``put`` writes
-in place. ``LocalStorageProvider.put`` streams straight to the destination, so a
-process killed mid-copy leaves a truncated file at the final key, and a
-"newest wins" reader would serve it. Lookup compares the stored object's real
-size against the size the key claims and skips a mismatch — the pointer only ever
-avoided naming such a file, where this detects it. The check is free: the
-response needs the length anyway.
+nothing else: no pointer, no index, no metadata object. Lookup lists the
+selection's prefix and takes the newest key inside the freshness window;
+publishing is one ``put``; the sweep deletes any key past the horizon. Nothing
+is rewritten, so two builders need no lock, a reader mid-stream keeps its
+object until the horizon, a sweep cannot race a publish, and total objects are
+bounded by build rate times horizon. The size in the name detects a file
+truncated by a provider whose ``put`` writes in place.
 
 Why freshness rests on a TTL
 ----------------------------
-#1532 is explicit that the tempting fix is the dangerous one. Anything that lets
-one request's range be answered from bytes another request built is only correct
-if the cache is invalidated on *every* path that can change the exported bytes,
-and this repository has the cautionary example already: ``bump_tile_cache_version``
-is called from fourteen places and was designed for tile cache-busting, where a
-missed call costs a stale tile. Keying export freshness on a hand-audited list
-like that would make a missed call cost a *wrong download that looks right*,
-which is strictly worse than the bug, because today's failure is loud (a spliced
-GeoJSON dies with ``ERROR 4: Failed to read GeoJSON data``).
-
-So correctness rests on ``_ttl_seconds()``, a property nobody can forget to
-maintain. The counter still earns its keep — it is folded into ``selection_key``,
-where a bump moves the request to a different key and invalidates instantly — but
-as a key input it can only ever invalidate MORE often than the TTL already
-forces. A missed bump costs bounded staleness, not a wrong answer: an artifact
-answers for one TTL after publication, its key is stamped with the moment the
-conversion took its snapshot of the data, and publication is placed no later
-than ``_MAX_PUBLISH_SECONDS`` after that stamp (fix(#1532 review r25)) — so a
-request served from the cache sees data at most TTL plus that ceiling old, and
-a conversion plus upload that outlives the ceiling produces an artifact no
-request will use. That inversion is the whole design: the audited list is an
-optimization by construction rather than by promise.
-
-A data-derived version (``count(*)`` plus ``max(xmin)`` over the selection) was
-the other candidate and is rejected on cost, not on correctness: it is complete
-for INSERT/UPDATE/DELETE, but ``max(xmin)`` has no index, so every range request
-on the cache-HIT path would pay a sequential scan — 509 ms on the 5M-row table
-#905 measured. Ten of those to save ten conversions is the wrong trade against a
-prefix listing.
+Keying freshness on ``bump_tile_cache_version`` (fourteen call sites, designed
+for tile cache-busting) would make a missed call cost a wrong download that
+looks right. So correctness rests on ``_ttl_seconds()``; the counter is folded
+into ``selection_key`` where a bump can only invalidate MORE often. A request
+served from the cache sees data at most TTL plus ``_MAX_PUBLISH_SECONDS`` old.
+A data-derived version (``max(xmin)``) was rejected on cost: no index, so every
+cache hit would pay a sequential scan.
 """
 
 import hashlib
@@ -99,26 +44,13 @@ logger = structlog.stdlib.get_logger(__name__)
 # and no other subsystem's objects can be reached by it.
 _ROOT = "export-cache"
 
-# How long a stored artifact may answer for. Deliberately short: this is the
-# whole correctness guarantee (see the module docstring), so it is the bound on
-# how stale a download can be, not a performance knob. Long enough to cover a
-# /vsicurl/ open, which is seconds.
+# How long a stored artifact may answer for. This is the correctness bound on
+# how stale a download can be, not a performance knob.
 _DEFAULT_TTL_SECONDS = 60
 
-# Reclaim anything older than this. Well past the TTL, because expiry and
-# reclamation answer different questions: expiry asks whether an artifact may
-# answer a NEW request, reclamation asks whether a request that started before
-# expiry could still be streaming from it.
-#
-# fix(#1532 review r4): the SAME horizon the temp-export sweeper uses, and
-# reused rather than restated so the two cannot drift. `staging.py` already
-# worked this out for the identical hazard: at one hour, "an in-flight export
-# survives a restart" becomes "any export whose generation plus client download
-# time exceeds an hour is deleted out from under it on the very next cycle" —
-# guaranteed, not an unlucky coincidence. A full cached export still streaming
-# after an hour would have had its object removed by the next build's sweep,
-# and on Azure `downloader.chunks()` fetches later chunks as it goes, so an
-# already-started 200 dies truncated rather than failing to start.
+# Reclaim anything older than this. fix(#1532 r4): the SAME horizon the
+# temp-export sweeper uses, so the two cannot drift; a cached export still
+# streaming after an hour is otherwise removed under its reader.
 _SWEEP_AGE_SECONDS = EXPORTS_PERIODIC_SWEEP_AGE_SECONDS
 
 # How often one process will bother sweeping. The sweep is cheap next to the
@@ -126,40 +58,18 @@ _SWEEP_AGE_SECONDS = EXPORTS_PERIODIC_SWEEP_AGE_SECONDS
 # objects it reclaims have been unusable for an hour.
 _SWEEP_INTERVAL_SECONDS = 900
 
-# fix(#1532 review, internal): how far into the future a key's timestamp may sit
-# before this refuses to serve it. Small, because it exists to tolerate ordinary
-# NTP jitter between workers rather than to accommodate a broken clock: a
-# genuinely future-stamped artifact stays fresh for the TTL PLUS the skew and
-# unreclaimable for the horizon plus the skew, and it outranks every honest
-# sibling because the newest wins.
+# fix(#1532): how far into the future a key's stamp may sit before this refuses
+# to serve it. Small: it tolerates NTP jitter, not a broken clock.
 _CLOCK_SLACK_SECONDS = 5
 
-# fix(#1532 review r23, then r25): the longest a conversion and its upload can
-# take and still have a client waiting for the response they precede.
-# `frontend/nginx.conf` closes the request at `proxy_read_timeout 600s`, and
-# both run before the first response byte, so a publication that outlives this
-# has already lost its request. It is the ceiling on how far past its key stamp
-# — the conversion's snapshot time — an artifact's publication may be placed
-# (see `_published_at`), which bounds a store clock running ahead AND how old
-# the data behind a served artifact can be. Not a settings field: it restates
-# an edge fact, and raising it widens the staleness bound.
+# fix(#1532 r23/r25): the longest a conversion plus upload can take with a
+# client still waiting (nginx `proxy_read_timeout 600s`). It bounds how far past
+# its key stamp an artifact's publication may be placed (`_published_at`).
 _MAX_PUBLISH_SECONDS = 600
 
-# fix(#1532 review, internal): the ceiling on what this cache may hold.
-#
-# On the local backend `_ROOT` sits inside `settings.upload_staging_dir` — the
-# same volume `export_dataset` writes its conversions to and every ingest stages
-# uploads on. Before this cache those export bytes were transient; retaining a
-# copy of every distinct selection for a horizon turns a few large exports into a
-# volume that has no room for the next conversion. Filters are caller-controlled,
-# so "a few large distinct selections" needs no adversary — five bbox tiles of a
-# multi-gigabyte dataset will do it.
-#
-# 8 GiB: enough for the case the cache exists for (one client range-reading one
-# export, plus its neighbours) and small enough to leave an ordinary staging
-# volume room to work. An absolute number rather than a fraction of the volume,
-# because the provider protocol reports no capacity and a fraction of an
-# unknowable whole is not a bound.
+# fix(#1532): the ceiling on what this cache may hold. On the local backend
+# `_ROOT` shares the staging volume with every conversion and ingest, and
+# filters are caller-controlled. Absolute: the provider reports no capacity.
 _BUDGET_BYTES = 8 * 1024 * 1024 * 1024
 
 _last_sweep_at = 0.0
@@ -168,10 +78,8 @@ _last_sweep_at = 0.0
 def _ttl_seconds() -> int:
     """The artifact freshness window.
 
-    A module constant rather than a settings field. It is the correctness bound
-    on how stale a download can be, and an operator who raises it is widening
-    that window rather than tuning a cache — a change that wants its own
-    decision, not a knob shipped by default. Tests substitute this function.
+    A constant rather than a settings field: raising it widens the correctness
+    bound, which wants its own decision. Tests substitute this function.
     """
     return _DEFAULT_TTL_SECONDS
 
@@ -193,52 +101,23 @@ class ExportArtifact:
     built_at: float
     filename: str
     media_type: str
-    # fix(#1532 review, internal): more than one DISTINCT set of bytes was fresh
-    # under this selection when the lookup ran, so a client reading in slices
-    # can be handed a different one between two requests and splice them.
-    #
-    # Nothing prevents two artifacts inside one TTL: every client that arrives
-    # during a slow build misses and builds its own, and the herd repeats at each
-    # window boundary. The bytes differ whenever the format is GPKG — the default,
-    # whenever a write landed without moving `tile_cache_version`. So "a
-    # forgotten bump costs one TTL of staleness" was really "a forgotten bump
-    # plus overlapping builders costs a silent splice".
-    #
-    # fix(#1532 review r12): GeoPackage used to be the other source of distinct
-    # bytes, because ogr2ogr stamped `gpkg_contents.last_change` per conversion —
-    # which made the DEFAULT format permanently contested under steady traffic
-    # and meant it never served a range at all. `normalize_gpkg_timestamps` fixed
-    # the input rather than this rule: unchanged data now hashes the same twice,
-    # so only a genuine change contests a selection, which is the case that
-    # SHOULD refuse ranges.
-    #
-    # The caller answers ranges with the complete representation while this is
-    # set. HEAD and the ETag are unaffected: each artifact is still internally
-    # consistent, and a whole-object read of either is a correct answer.
+    # fix(#1532 r12): more than one DISTINCT set of bytes was fresh under this
+    # selection at lookup, so a slicing client could splice them. The caller
+    # answers ranges whole while this is set; HEAD and the ETag are unaffected.
     contested: bool = False
 
     @property
     def etag(self) -> str:
         """A strong entity-tag: the artifact's own SHA-256.
 
-        Strong by construction rather than by assertion — the object is NAMED by
-        this digest, so two responses carrying one tag are slices of literally
-        the same stored bytes. That is what starlette's ``FileResponse`` ETag
-        could not promise here: it derives from a temp file's mtime, and #1532
-        observed two different tags for two conversions of one unchanged
-        dataset.
+        Strong by construction: the object is NAMED by this digest, which
+        starlette's mtime-derived ``FileResponse`` ETag could not promise.
         """
         return strong_etag(self.digest)
 
 
 def strong_etag(digest: str) -> str:
-    """The quoted strong entity-tag for a set of export bytes.
-
-    fix(#1532 review r18): one place, because two responses now name bytes by
-    digest — the stored artifact through ``ExportArtifact.etag``, and the
-    conversion served directly when publication does not happen. A validator
-    formatted twice is one that can drift.
-    """
+    """The quoted strong entity-tag for a set of export bytes (fix(#1532 r18))."""
     return f'"{digest}"'
 
 
@@ -266,47 +145,16 @@ def selection_key(
 ) -> str:
     """Identity of the bytes a request is asking for, as a storage path segment.
 
-    ``table_name`` because a replace swaps the physical table the export reads.
-    ``dataset_title`` because it becomes the output FILENAME, and ogr2ogr names a
-    GPKG layer after the file it is writing — a retitle therefore changes the
-    bytes, not merely the Content-Disposition.
-
-    ``tile_cache_version`` is how invalidation-on-mutation happens, and putting it
-    HERE rather than in the freshness check is the whole reason this is safe.
-    The counter is bumped by fourteen call sites (feature edits, column DDL,
-    reupload, the PostGIS and STAC refreshes, the raster swap) and was designed
-    for tile cache-busting, where a missed bump costs a stale tile. Reading it as
-    the authority on freshness would make a missed bump cost a wrong download
-    that looks right — the trap #1532 spends three paragraphs warning about.
-
-    As a key INPUT it cannot do that. A bump can only ever move the request to a
-    different key, so it can only make the cache invalidate MORE often than the
-    TTL already forces. A writer that forgets costs bounded staleness (the
-    module docstring states the bound); a
-    writer that remembers costs nothing and invalidates instantly. The
-    hand-maintained list is an optimization by construction rather than by
-    promise, which is the property the issue asks for and the one an audit cannot
-    supply.
-
-    It also needs no cross-layer call. ``processing/`` may not import
-    ``modules/catalog/``, so a hook next to each ``bump_tile_cache_version()``
-    would have meant a new ``ProcessingPort`` method and an
-    EXTENSION_API_VERSION bump to deliver an optimization; the counter is already
-    on the dataset row this route has in hand.
-
-    ``None`` and the empty string are kept distinct by the JSON encoding, for the
-    reason ``embedding_config_fingerprint`` gives in #1546: a delimiter join
-    collapses them, and ``where=""`` is not ``where`` absent.
+    ``table_name`` because a replace swaps the physical table; ``dataset_title``
+    because it becomes the GPKG layer name. ``tile_cache_version`` sits HERE
+    rather than in the freshness check: as a key input a bump can only
+    invalidate MORE often than the TTL, so a missed bump costs bounded
+    staleness rather than a wrong download. ``None`` and ``""`` stay distinct
+    through the JSON encoding (#1546).
     """
-    # Two path segments, deliberately (fix(#1532) follow-up, #1585): the URL's
-    # identity first, then the version's. `format`, `target_crs`, `bbox` and
-    # `where` are what a client can see in the URL it is reading; `table_name`,
-    # `dataset_title` and `tile_cache_version` are the server-side facts that
-    # move the bytes under that same URL. Every artifact of one URL, at every
-    # version, therefore lives under one prefix, and
-    # `url_answered_other_bytes_recently` can ask "has this URL answered with
-    # different bytes inside the last TTL" with one listing. `lookup`, `store` and the sweep are
-    # indifferent to the shape: they take the whole thing as an opaque prefix.
+    # Two segments (#1585): the URL's identity, then the version's. Every
+    # artifact of one URL at every version shares a prefix, so
+    # `url_answered_other_bytes_recently` needs one listing.
     url_payload = json.dumps(
         [str(dataset_id), str(format_key), target_crs, bbox, where],
         separators=(",", ":"),
@@ -330,39 +178,13 @@ async def url_answered_other_bytes_recently(
 ) -> bool:
     """Has this URL answered with DIFFERENT bytes inside the last TTL?
 
-    fix(#1532) follow-up (#1585): the bound on bare ranges. A client that read
-    a block of an earlier representation of this URL and comes back for the
-    next one — to a hit on the new artifact, to a fresh build of it, or
-    re-reading the header — makes that request within the change's first TTL,
-    and for that TTL the route answers it whole. Answering requires a fresh
-    artifact, and a fresh artifact is one published within the TTL, so "the
-    URL answered other bytes within the last TTL" is exactly "an artifact with
-    another digest was published under this URL within the last TWO TTLs" (a
-    TTL of serving, then a TTL of grace for the client that took the last
-    answer) — at any version,
-    which is why every version of a URL shares a prefix (``selection_key``).
-    A→B→A within retention is caught by the same test: while B is still being
-    answered, B artifacts keep being published, and the moment they stop the
-    clock starts. Same bytes cannot splice and do not count. After the TTL a
-    client holding a handle across a longer gap without ``If-Range`` is the
-    residual every range-serving origin has.
-
-    Bounded: the URL's own versions, not the dataset's selections, and called
-    only for a request that could receive a 206 (a bare, satisfiable Range).
-    Fails CLOSED on a listing error: an unknown history reads as a recent
-    change, and the client gets the whole file, which is safe.
-
-    The parent revision of #1582 wrote a single-segment layout that lives
-    outside every URL prefix. Nothing can be served from it after this
-    revision (``lookup`` never lists it), no release wrote it, and retention
-    ages it out; the exposure is a client spanning both the upgrade and a data
-    change, and it is stated rather than paid for on every range.
+    #1585: the bound on bare ranges. A client that read a block of an earlier
+    representation and comes back within the change's first TTL is answered
+    whole. Bounded to the URL's own versions, called only for a request that
+    could receive a 206, and fails CLOSED on a listing error.
     """
-    # fix(#1532) follow-up (#1585 review r5): TWO TTLs, not one. An artifact
-    # answers for a TTL after publication, so its last possible answer is a
-    # TTL after that, and the client that took it needs a TTL of its own to
-    # come back. Publication one TTL old means "could have been served a
-    # moment ago"; two TTLs old means "nobody has held it for less than a TTL".
+    # #1585 r5: TWO TTLs. An artifact answers for a TTL after publication, and
+    # the client that took its last answer needs a TTL of its own to come back.
     cutoff = time.time() - 2 * _ttl_seconds()
     try:
         async for page in get_storage().iter_object_pages(
@@ -386,24 +208,13 @@ def _selection_prefix(dataset_id: uuid.UUID, selection: str) -> str:
 def _artifact_key(
     dataset_id: uuid.UUID, selection: str, digest: str, size: int, built_at: float
 ) -> str:
-    """``{built_at}-{size}-{digest}-{nonce}.bin`` — an artifact's whole metadata.
+    """``{built_at}-{size}-{digest}-{nonce}.bin``, an artifact's whole metadata.
 
-    Each part earns its place. ``built_at`` makes every freshness and
-    reclamation decision a pure function of the name, so no judgement depends on
-    a read another worker can invalidate. ``size`` detects a truncated object on
-    a provider that writes in place. ``digest`` is the strong ETag.
-
-    ``nonce`` makes the key WRITER-OWNED, which the first three do not
-    (fix(#1532 review, internal)). ``built_at`` is whole seconds, so two builders
-    of a deterministic format finishing in the same second computed the same key
-    — and then a failed write on one of them called `_discard` on a key the
-    OTHER had just published successfully, deleting a live object out from under
-    readers who were already past their response headers. A writer can only ever
-    clean up its own attempts now.
-
-    Two builders with identical bytes therefore leave two objects carrying one
-    ETag, which is harmless: they are byte-identical by construction, the newer
-    answers, and the horizon reclaims the other.
+    ``built_at`` makes freshness and reclamation pure functions of the name,
+    ``size`` detects a truncated object, ``digest`` is the strong ETag, and
+    ``nonce`` makes the key WRITER-OWNED (fix(#1532)): two builders finishing
+    in the same second otherwise shared a key and one's `_discard` deleted the
+    other's live object. Two identical objects under one ETag are harmless.
     """
     nonce = uuid.uuid4().hex[:12]
     return (
@@ -434,14 +245,9 @@ def parse_artifact_key(key: str) -> tuple[float, int, str] | None:
 def parse_tmp_key(key: str) -> float | None:
     """The build time of a ``.tmp`` scratch file, or None if it is not one.
 
-    fix(#1532 review, internal): ``LocalStorageProvider.put`` writes to
-    ``<key>.<hex>.tmp`` and renames, so a SIGKILL, an OOM or a power loss leaves
-    that scratch file behind. ``parse_artifact_key`` answers None for it, every
-    caller reads None as "leave it alone", and it leaked onto the shared staging
-    volume permanently.
-
-    Aged from the ``<stamp>`` of the artifact key it was going to become: a write
-    that started more than a horizon ago and never renamed is not going to.
+    fix(#1532): ``LocalStorageProvider.put`` writes ``<key>.<hex>.tmp`` and
+    renames, so a SIGKILL leaves the scratch file; aged from the stamp of the
+    key it was going to become.
     """
     name = key.rsplit("/", 1)[-1]
     if not name.endswith(".tmp") or ".bin." not in name:
@@ -459,53 +265,18 @@ async def lookup(
 ) -> ExportArtifact | None:
     """The newest usable artifact for this selection, or None.
 
-    "Usable" means inside the TTL and intact. Both are decided from the key plus
-    one ``size()``, so a request that goes on to transfer bytes has already
-    learned its Content-Length.
-
-    The size check is not belt-and-braces. ``LocalStorageProvider.put`` streams
-    to the destination, so a process killed mid-copy leaves a truncated file at
-    the final key, and taking the newest key without verifying it would serve
-    that truncation to every reader until the horizon. Comparing against the size
-    the key claims turns it into a miss and a rebuild.
-
-    fix(#1532 review, internal): the returned artifact says whether the fresh
-    set was CONTESTED — more than one distinct digest inside the window. See
-    ``ExportArtifact.contested``; the caller turns it into "answer ranges with
-    the whole thing".
-
-    A future-stamped key is unusable. A worker whose clock runs ahead writes one
-    that stays fresh for the TTL plus the skew and unreclaimable for the horizon
-    plus the skew, and it outranks every honest sibling because the newest wins.
-    Ignoring it costs a rebuild; trusting it costs correctness for as long as the
-    skew lasts.
-
-    Every failure here is a miss. This is a cache in front of a conversion that
-    still works, so a storage hiccup should cost a rebuild, not the download.
+    "Usable" means published inside the TTL, not future-stamped, and intact:
+    the size in the key is compared with one ``size()`` call, which the
+    response needs anyway, so a file truncated by an in-place ``put`` is a
+    miss rather than a served truncation. ``contested`` reports more than one
+    distinct digest among the siblings. Every failure here is a miss.
     """
     now = time.time()
     cutoff = now - _ttl_seconds()
     horizon = now + _CLOCK_SLACK_SECONDS
-    # fix(#1532 review r9): freshness is measured from the object's own modified
-    # time, which every backend reports as COMPLETION time — S3 and Azure use
-    # the put's completion, and locally it is the temp file's last write, since
-    # the atomic rename preserves it. The key's stamp is taken BEFORE the
-    # upload, so a multi-gigabyte push to an object store spent the whole TTL
-    # getting there and the artifact was expired the moment it existed: the next
-    # probe missed and reconverted, defeating the cache for exactly the exports
-    # big enough to need ranges.
-    #
-    # The key keeps its stamp, and reclamation keeps using it — that decision is
-    # about whether anything could still be reading, it must be portable, and it
-    # must not depend on a value a backend could revise.
-    #
-    # The honest bound: an artifact can be up to TTL plus its own upload
-    # duration old, the upload duration capped at `_MAX_PUBLISH_SECONDS` (r23:
-    # `_published_at` bounds the store's clock by the key, both ways). That is
-    # inherent rather than a compromise — bytes cannot answer before they
-    # exist, and a client pulling a ten-gigabyte export is spending that long
-    # anyway — and `tile_cache_version` in the selection key still invalidates
-    # a known mutation instantly.
+    # fix(#1532 r9/r23): freshness is measured from the object's modified time
+    # (COMPLETION of the put, bounded by the key through `_published_at`), so a
+    # slow upload cannot expire an artifact before it exists.
     try:
         storage = get_storage()
         modified: dict[str, float] = {}
@@ -530,37 +301,20 @@ async def lookup(
         oldest_by_digest[digest] = min(
             oldest_by_digest.get(digest, _publication), _publication
         )
-        # fix(#1532 review r8): `contested` counts EVERY sibling under this
-        # selection, not just the fresh ones. Computed over the fresh set it
-        # missed the staggered case entirely: two builders a second apart are
-        # both inside the window at first, so ranges are correctly refused —
-        # and then the older one crosses the TTL, the fresh set holds one
-        # digest, `contested` flips false, and a bare-Range client that started
-        # on the older artifact resumes into a 206 of the newer. The silent
-        # splice, arriving late.
-        #
-        # Old siblings are exactly the ones a client can still be reading: they
-        # live until the horizon by design, so a reader that resolved one keeps
-        # streaming it. Freshness answers "may this serve a NEW request"; this
-        # question is "could anyone be part-way through a different one".
+        # fix(#1532 r8): `contested` counts EVERY sibling, not just the fresh
+        # ones; old siblings live until the horizon and a client may still be
+        # reading one.
         siblings.add(digest)
         if built_at > horizon:
-            # A key stamped in the future, from a worker whose clock runs ahead.
-            # fix(#1532 review r9) moved FRESHNESS onto the object's modified
-            # time, which comes from the backend rather than that worker and so
-            # is no longer fooled — but the ordering below still sorts on the
-            # key's stamp, so a future one would outrank every honest sibling
-            # for as long as the skew lasts. Skipping it costs a rebuild.
+            # A future-stamped key from a worker whose clock runs ahead would
+            # outrank every honest sibling in the sort below.
             continue
         published_at = _published_at(modified.get(key, built_at), built_at)
         if cutoff <= published_at:
             candidates.append((built_at, size, digest, key))
 
-    # The cost, stated: a selection that ever had two distinct artifacts serves
-    # no ranges until the sweep clears the older, which is up to a horizon. Only
-    # bare-Range clients pay it — anything sending If-Range is already safe
-    # through the strong ETag — and the pre-publish re-check keeps a second
-    # artifact rare in the first place.
+    # A selection that ever had two distinct artifacts serves no ranges until
+    # the sweep clears the older; anything sending If-Range is already safe.
     contested = len(siblings) > 1
 
     for built_at, size, digest, key in sorted(candidates, reverse=True):
@@ -587,51 +341,14 @@ async def lookup(
 def _published_at(modified: float, built_at: float) -> float:
     """When this artifact became readable, bounded by the key that names it.
 
-    ``modified`` is the object's ``last_modified`` and comes from the STORE's
-    clock; ``built_at`` is the key stamp, from the writer's. Freshness compares
-    the result against this worker's cutoff, so a skew between the clocks moves
-    the window, and this is what bounds it (fix(#1532 review r22, then r23)):
-
-    - A store clock BEHIND the writer by more than the TTL made every artifact
-      expired the moment it appeared, and every probe reconverted and uploaded
-      it — the cache silently dead. Publication cannot precede the stamp the
-      writer minted before uploading, so ``built_at`` is the FLOOR. Worst case
-      is the pre-r9 rule, which is a cache that works.
-    - A store clock AHEAD reports a publication later than it was. The CEILING
-      is ``built_at`` plus the longest a build and its upload can take with a
-      client still waiting: ``_MAX_PUBLISH_SECONDS``. Past that, a modified
-      time carries no information about THIS artifact — the request that
-      produced it has already been closed at the edge — so it is not trusted.
-      (``built_at`` is the conversion's snapshot time since r25, so this also
-      bounds how old the DATA behind a served artifact can be.)
-
-    A pure function of the object, deliberately (r23). An earlier revision
-    distrusted a modified time beyond ``now`` plus the jitter allowance and
-    fell back to the stamp, which was right at first and wrong later: as
-    ``now`` moved, the same immutable object crossed from expired back to fresh
-    the moment its future mtime came within reach — stale bytes served well
-    past the TTL, on a schedule set by the skew. Nothing here reads ``now``, so
-    an artifact's verdict can only ever go fresh → expired.
-
-    Symmetric, since fix(#1532 review r28): the STAMP is clamped to the store's
-    modified time plus the same allowance before the floor and ceiling apply. A
-    stamp more than the allowance after the store saw the bytes is a writer
-    clock running ahead — a build cannot start after its own upload finished by
-    more than one request budget — and left unclamped it pinned the object:
-    ``lookup`` refused the future key, but the sweep floored publication at
-    that future stamp and could not reclaim it until then plus the horizon,
-    while its size counted against the budget and its digest kept the
-    selection contested for as long as it lived. So neither clock may place
-    publication more than ``_MAX_PUBLISH_SECONDS`` from the other, in either
-    direction, and every input remains immutable per object.
-
-    Honest bound, restated: the data behind a served artifact is at most TTL
-    plus ``min(build + upload, _MAX_PUBLISH_SECONDS)`` old under honest clocks;
-    a store clock ahead, or a writer clock ahead, can add at most the unused
-    part of that allowance. A store behind the fleet by more than the allowance
-    plus the TTL makes every artifact expired at publication — a cache that
-    does not serve rather than one that serves stale — and that store is
-    within a few minutes of refusing the fleet's requests altogether.
+    ``modified`` comes from the STORE's clock, ``built_at`` from the writer's.
+    fix(#1532 r22/r23/r28): ``built_at`` is the floor (a store behind the
+    writer otherwise made every artifact expired at birth), ``built_at`` plus
+    ``_MAX_PUBLISH_SECONDS`` is the ceiling (a store ahead reports a
+    publication later than it was), and the stamp is first clamped to the
+    modified time plus the same allowance (a writer ahead otherwise pinned an
+    unreclaimable object). A pure function of the object: nothing reads
+    ``now``, so a verdict can only ever go fresh to expired.
     """
     stamp = min(built_at, modified + _MAX_PUBLISH_SECONDS)
     return min(max(modified, stamp), stamp + _MAX_PUBLISH_SECONDS)
@@ -650,92 +367,35 @@ async def store(
 ) -> ExportArtifact | None:
     """Publish a freshly converted file. One ``put``, nothing rewritten.
 
-    ``snapshot_at`` is when the conversion read the data, and it becomes the
-    key's stamp (fix(#1532 review r25)). The stamp used to be minted just before
-    the upload, so a mutation that missed ``tile_cache_version`` and landed
-    during a long conversion produced an artifact that was stale at birth and
-    then aged from a point AFTER the staleness began. Stamping the snapshot
-    makes ``built_at`` mean what its name says, and the publish ceiling in
-    ``_published_at`` then bounds build plus upload rather than upload alone.
-    None means now, for callers that convert and store in one breath.
-
-    ``digest`` and ``size`` may be supplied by a caller that has already run
-    ``digest_and_size`` — the route does, so the validator it evaluates
-    preconditions against exists whether or not this publishes (fix(#1532
-    review r18)). Left out, they are computed here.
-
-    Publishing is a single write to a key nothing else can be using, so two
-    builders racing the same selection simply both succeed and readers take the
-    newer. There is no pointer to flip, so there is no window in which a
-    half-published state exists.
+    ``snapshot_at`` is when the conversion read the data and becomes the key's
+    stamp (fix(#1532 r25)); None means now. ``digest`` and ``size`` may be
+    supplied by a caller that already ran ``digest_and_size`` (r18).
 
     Returns the published artifact; or, when publication does not happen, the
-    INCUMBENT artifact under this selection if there is one (fix(#1532 review
-    r29) — the caller must serve that, not its own bytes, so a client's later
-    bare Range resolves the same representation); or None when there is nothing
-    to serve but the caller's own file. The caller has the converted file in
-    hand and can serve it directly, so a cache that cannot store must not be
-    able to fail a download.
-
-    Only ``Exception`` is caught, deliberately. A ``CancelledError`` is a
-    ``BaseException`` and must keep propagating so the caller's cleanup runs —
-    the same distinction fix(#1550) turned on. The caller owns the conversion
-    directory until a response takes it, and swallowing a cancel here would leave
-    it stranded.
+    INCUMBENT under this selection (r29: the caller must serve that, not its
+    own bytes, so a later bare Range resolves the same representation); or
+    None. Only ``Exception`` is caught: a ``CancelledError`` must propagate so
+    the caller's cleanup runs.
     """
     global _last_sweep_at
     try:
         if digest is None or size is None:
             digest, size = await digest_and_size(file_path)
-        # fix(#1532 review, internal): do not publish if a fresh artifact has
-        # appeared while this request was converting. Every client arriving
-        # during a slow build misses and builds its own, so the overlap is the
-        # normal case rather than a rare one, and each extra publication is
-        # another set of bytes a range-reading client can be flipped onto.
-        #
-        # fix(#1532 review r29, P1): and hand that INCUMBENT back, so the caller
-        # serves it rather than its own conversion. Returning None here had the
-        # caller stream its own bytes whole — which, when the two builders had
-        # taken different snapshots (a mutation that missed `tile_cache_version`
-        # landing between them), put a client on bytes no later request would
-        # resolve: an interrupted download resumed with a bare Range against the
-        # sole, uncontested incumbent and was handed a 206 of the OTHER
-        # conversion at its offsets. Serving the incumbent keeps every response
-        # under this selection on the artifact the next Range will find. The
-        # losing conversion is discarded; it published nothing and adds nothing.
+        # fix(#1532 r29): a fresh artifact that appeared while this request was
+        # converting wins, and the caller serves THAT, so every response under
+        # this selection is on the artifact the next Range will find.
         incumbent = await lookup(
             dataset_id, selection, filename=filename, media_type=media_type
         )
         if incumbent is not None:
             return incumbent
-        # And do not publish past the byte budget. The local root IS the shared
-        # staging volume that `export_dataset` and every ingest writes to, and
-        # before this cache those export bytes were transient; retaining them for
-        # a horizon means a handful of large distinct selections can block every
-        # conversion and upload on the instance. r4's reclaim-and-retry only
-        # frees AGED artifacts, so a volume filled with FRESH ones has nothing to
-        # give back — the budget is what keeps that from happening at all.
-        #
-        # fix(#1532 review r4): reclaim BEFORE writing, not after. This is the
-        # only production call to the sweep, so a `put` that raises on a full
-        # store used to exit before it — and with nothing else sweeping
-        # `export-cache/`, the aged artifacts that filled the volume could never
-        # be reclaimed by a later request. Caching stayed dead, and on the local
-        # backend the shared staging volume stayed too full to generate larger
-        # exports at all, until an operator deleted files by hand.
-        #
-        # fix(#1532 review r6): and reclaim before the BUDGET CHECK, not after.
-        # The check was an early return sitting above the sweep, so once claimed
-        # sizes reached the ceiling every later publication left before the only
-        # thing that reclaims could run — and once those artifacts passed the
-        # horizon, nothing was ever going to. The exact deadlock r4 fixed for
-        # ENOSPC, re-created by a new early exit above the same sweep.
+        # fix(#1532 r4/r6): reclaim BEFORE the budget check and BEFORE writing.
+        # This is the only production call to the sweep, so an early exit above
+        # it deadlocked a full store for good.
         await _sweep_occasionally()
         if not await _fits_in_budget(size):
-            # The cadence guard means the sweep above may not have run at all,
-            # so a budget that looks exhausted has not necessarily been tested
-            # against the horizon yet. Force one pass and ask again — the same
-            # shape `_put_with_reclaim` uses, and for the same reason.
+            # The cadence guard may have skipped the sweep; force one and ask
+            # again, the shape `_put_with_reclaim` uses.
             await sweep()
             _last_sweep_at = time.time()
             if not await _fits_in_budget(size):
@@ -753,13 +413,8 @@ async def store(
             file_path,
             built_at=time.time() if snapshot_at is None else snapshot_at,
         )
-        # fix(#1532 review r7): PUBLICATION IS FINAL. A post-write re-check that
-        # dropped this artifact when the total had moved lived here for one
-        # round, and it could delete a key another request had already resolved
-        # through `lookup` — that response has declared a Content-Length and is
-        # about to open its stream, so the delete truncates it. Trading an
-        # overshoot for a truncated download is the wrong direction, and the
-        # overshoot is bounded anyway. See `_fits_in_budget` for the contract.
+        # fix(#1532 r7): PUBLICATION IS FINAL. A post-write re-check could delete
+        # a key another request had already resolved and truncate its stream.
         return ExportArtifact(
             key=key,
             digest=digest,
@@ -769,19 +424,15 @@ async def store(
             media_type=media_type,
         )
     except Exception:  # broad: caching is best-effort; the conversion succeeded
-        # And let the NEXT attempt sweep whatever the interval says. A store
-        # that failed is the one signal available that the horizon may need
-        # applying sooner than the fifteen-minute cadence, so recovery from a
-        # full store takes one request rather than up to a quarter of an hour.
+        # A failed store is the one signal the horizon may need applying sooner
+        # than the cadence, so the next attempt sweeps.
         _last_sweep_at = 0.0
         logger.warning(
             "export_artifact_store_failed",
             dataset_id=str(dataset_id),
             exc_info=True,
         )
-        # r29: same reasoning as the budget exit. `lookup` never raises — a
-        # store that cannot even list answers None, and the caller falls back to
-        # its own bytes, which no incumbent can then contradict.
+        # r29: same reasoning as the budget exit; `lookup` never raises.
         return await lookup(
             dataset_id, selection, filename=filename, media_type=media_type
         )
@@ -798,30 +449,11 @@ async def _put_with_reclaim(
 ) -> tuple[float, str]:
     """Write the artifact, reclaiming and retrying once if the store is full.
 
-    fix(#1532 review r4): sweeping before the write is not enough on its own,
-    because ``_sweep_occasionally`` is interval-guarded — a store that fills
-    between two cadence ticks would fail without one having been attempted, and
-    with nothing else sweeping ``export-cache/`` the volume stays full. So a
-    failed write forces an unconditional sweep and tries once more, which makes a
-    full store heal inside the request that hit it rather than fifteen minutes
-    later.
-
-    Once, not in a loop. If reclaiming everything past the horizon does not make
-    room, the store is full of something this cache does not own and retrying is
-    just a slower way to fail.
-
-    fix(#1532 review r5): every key this function attempts is deleted if its
-    write fails, and that is the difference between a failure and a leak. A
-    partial carries a FRESH timestamp, so the forced sweep cannot reclaim it — it
-    is young by every rule this module has — and the retry would then fail for
-    the same reason the first attempt did, on a volume the first attempt made
-    worse. Two attempts, two partials, and the space held for the whole horizon.
-
-    ``LocalStorageProvider.put`` is atomic now, so on the shipped backends a
-    failed write leaves nothing to delete and these calls are belt-and-braces.
-    They are here because this module cannot see which provider it has, and
-    because a cleanup that only runs on the backends known today is one a new
-    backend silently opts out of.
+    fix(#1532 r4): ``_sweep_occasionally`` is interval-guarded, so a failed
+    write forces an unconditional sweep and one retry. Once, not a loop: if
+    the horizon frees nothing the store is full of something this cache does
+    not own. fix(#1532 r5): every attempted key is deleted on failure, because
+    a fresh-stamped partial cannot be reclaimed by any rule here.
     """
     global _last_sweep_at
     attempted: list[str] = []
@@ -835,17 +467,9 @@ async def _put_with_reclaim(
             await get_storage().put(key, handle)
         return built_at, key
 
-    # fix(#1532 review, internal): BaseException on the outside, Exception on
-    # the inside. A CancelledError — a client disconnect, a worker shutdown — is
-    # not an Exception, so the first write's failure arm did not see it: it
-    # skipped the retry (correctly, a cancelled request wants no retry) AND the
-    # discard (not correctly, the attempt it made may have landed). The local
-    # provider is atomic now so its final key is safe either way, but a
-    # non-atomic backend keeps the partial, and even locally the scratch file's
-    # removal depends on `put` seeing the cancel itself rather than on anything
-    # here.
-    #
-    # So: clean up on ANY exit, retry only on the ones a retry can help.
+    # fix(#1532): BaseException outside, Exception inside. A CancelledError is
+    # not an Exception, so the discard must run on ANY exit while the retry
+    # runs only on the ones a retry can help.
     try:
         try:
             return await _write()
@@ -879,55 +503,19 @@ async def _discard(keys: list[str]) -> None:
 async def _fits_in_budget(size: int) -> bool:
     """Would publishing ``size`` more bytes keep the cache under its budget?
 
-    Free to compute: every artifact's size is in its own key, so the current
-    total is a listing and some string parsing rather than a stat per object.
-
-    A SOFT ceiling, and the contract is worth stating exactly (fix(#1532 review
-    r6, then r7)).
-
-    ``StorageProvider`` offers no way to claim space, so two publishers can
-    measure the same total, both pass, and both write. The excess is therefore
-    bounded by the number of concurrent publishers times one artifact each, and
-    it lasts at most one reclamation horizon. It is not eliminated, and this is
-    the only check: a post-write re-check that dropped the writer's own artifact
-    was tried and withdrawn, because once ``put`` returns, ``lookup`` can hand
-    that key to another request — which has declared a Content-Length and is
-    about to open its stream, so deleting it truncates a download. An overshoot
-    that expires is a better failure than a truncated file.
-
-    Making it hard would need publication to become visible only after a check,
-    which needs a rename primitive: S3 and Azure have no such thing short of a
-    server-side copy, which for a multi-gigabyte export is not a cheap
-    afterthought. A lock is the other answer and does not belong in this fix.
-
-    Failing OPEN on an unreadable listing. The budget bounds a resource this
-    cache borrows; a cache that refused to work whenever it could not measure
-    itself would trade a bounded disk cost for an unbounded conversion one.
-
+    A SOFT ceiling (fix(#1532 r6/r7)): ``StorageProvider`` cannot claim space,
+    so concurrent publishers can each overshoot by one artifact for at most
+    one horizon. This is the only check; a post-write re-check was withdrawn
+    because it could truncate a download already resolved through ``lookup``.
+    Fails OPEN on an unreadable listing.
     """
-    # fix(#1532 review r16): the ceiling on ONE artifact, checked before the
-    # listing and outside the fail-open below.
-    #
-    # The running check lives inside the page loop, and a provider yields NO
-    # page for an empty prefix — so on a cold cache the loop body never ran and
-    # this returned True for an artifact of any size. The first export after a
-    # deploy is exactly when the prefix is empty, and a single one larger than
-    # the whole budget could publish, doubling the biggest conversion on the
-    # shared staging volume rather than bounding it.
-    #
-    # It sits above the `try` as well, because whether one artifact exceeds the
-    # entire budget is knowable without measuring anything. Failing open on an
-    # unreadable listing is right for the running total, which is a comparison
-    # against other objects; it is not right here.
+    # fix(#1532 r16): the ceiling on ONE artifact, above the listing and outside
+    # the fail-open: a provider yields NO page for an empty prefix, so a cold
+    # cache let an artifact of any size through.
     if size > _BUDGET_BYTES:
         return False
-    # fix(#1532 review r11): paged, and stopped as soon as the answer is known.
-    # This materialised the whole `export-cache/` listing on every publication,
-    # and the prefix is caller-controlled — anonymous callers vary bbox and
-    # where — so the inventory grew with the number of distinct selections in
-    # the window and every publication paid for all of them. Accumulating page
-    # by page and returning at the first overrun bounds the work by the BUDGET
-    # rather than by the object count: at most one page beyond whatever fits.
+    # fix(#1532 r11): paged, and stopped at the first overrun, so the work is
+    # bounded by the budget rather than by a caller-controlled object count.
     total = 0
     try:
         async for page in get_storage().iter_object_pages(f"{_ROOT}/"):
@@ -945,16 +533,9 @@ async def _fits_in_budget(size: int) -> bool:
 async def digest_and_size(file_path: str) -> tuple[str, int]:
     """SHA-256 and byte length of a converted export, read in bounded chunks.
 
-    Public because the route calls it BEFORE ``store`` (fix(#1532 review r18)):
-    the digest is the response's validator, and a client's ``If-Match`` or
-    ``If-None-Match`` has to be answered from what was built even when
-    publication does not happen — a full store, a lost race, an outage. Passed
-    back into ``store`` so the file is hashed once.
-
-    Chunked because an export can be gigabytes and this runs on the API worker.
-    Off the event loop for the same reason the shapefile zip is (#435): hashing
-    a multi-GB file is CPU-bound, and doing it inline stalls every other request
-    and the job heartbeats for the duration.
+    Public because the route calls it BEFORE ``store`` (fix(#1532 r18)): the
+    digest is the validator whether or not publication happens. Off the event
+    loop because hashing a multi-GB file inline stalls every other request.
     """
     from app.core.async_io import run_in_thread_draining
 
@@ -973,14 +554,8 @@ async def digest_and_size(file_path: str) -> tuple[str, int]:
 async def _sweep_occasionally() -> None:
     """Run the sweep at most once every ``_SWEEP_INTERVAL_SECONDS`` per process.
 
-    Riding a build rather than a startup hook, deliberately. The worker's
-    existing ``sweep_orphaned_exports`` runs before ``init_storage``, so a
-    storage-backed sweep cannot join it without reordering boot; and a process
-    that has just converted a dataset is one that demonstrably has a working
-    object store. The cost is a paged listing next to an ogr2ogr run.
-
-    Failures are swallowed for the same reason everything else here is: this is
-    housekeeping attached to a request that has already succeeded.
+    Rides a build rather than a startup hook: the worker's export sweep runs
+    before ``init_storage``. Failures are swallowed; this is housekeeping.
     """
     global _last_sweep_at
     now = time.time()
@@ -996,30 +571,11 @@ async def _sweep_occasionally() -> None:
 async def sweep(*, age_threshold_seconds: int = _SWEEP_AGE_SECONDS) -> int:
     """Reclaim what nothing can still be reading. Returns how many keys went.
 
-    One rule, and it is chosen so a concurrent publish cannot satisfy it rather
-    than so the window is merely small: an object goes when the timestamp IN ITS
-    OWN NAME is past the horizon. A publish mints its key from ``time.time()``,
-    so an aged key can never become fresh and a fresh one can never look aged.
-    Nothing else is consulted, so there is no read that another worker can make
-    stale before the delete runs.
-
-    That is the third shape this sweep has had, and the earlier two are why the
-    rule is phrased that way. It deleted by PREFIX first, so a selection whose
-    pointer looked old took a neighbouring worker's just-uploaded artifact with
-    it (review r2). It then read each pointer to decide, which merely narrowed
-    the same window (review r2 again). Both are gone with the pointer itself
-    (review r3).
-
-    Ages come from the key's stamp as the portable floor, raised to the object's
-    ``last_modified`` where the provider reports one (review r10 — the stamp is
-    taken before the upload, and a slow push must not make a live artifact look
-    aged). ``iter_object_pages`` supplies both, one page at a time — the whole
-    cache is not materialized in memory to be swept (review r3).
-
-    Well past the TTL because expiry and reclamation are different questions.
-    Expiry asks whether an artifact may answer a NEW request; reclamation asks
-    whether a request that started before expiry could still be streaming from
-    it.
+    An object goes when its publication, floored at the timestamp IN ITS OWN
+    NAME and raised to ``last_modified`` (r10), is past the horizon. An aged
+    key can never become fresh, so no judgement depends on a read another
+    worker can invalidate; earlier shapes deleted by prefix or read a pointer
+    (r2/r3). Paged, so the cache is never materialized in memory.
     """
     cutoff = time.time() - age_threshold_seconds
     removed = 0
@@ -1032,29 +588,9 @@ async def sweep(*, age_threshold_seconds: int = _SWEEP_AGE_SECONDS) -> int:
                 built_at = parsed[0] if parsed is not None else parse_tmp_key(obj.key)
                 if built_at is None:
                     continue
-                # fix(#1532 review r10): age from the LATER of the two clocks.
-                # The key's stamp is taken before the upload, so once freshness
-                # moved onto `last_modified` the two diverged by however long the
-                # push took — an S3 or Azure upload that consumed most of the
-                # horizon could be reclaimed shortly after becoming visible,
-                # while a client was streaming it, and one that exceeded the
-                # horizon was eligible the moment it appeared.
-                #
-                # The key stamp stays as the portable floor (a backend that
-                # reports no useful modified time still gets an answer) and
-                # `last_modified` raises it to publication. Both are already in
-                # hand here, and neither moves for a writer-owned key that
-                # nothing copies.
-                #
-                # fix(#1532 review r24): through the SAME bound freshness uses.
-                # An unbounded `max` let a store clock running ahead push the
-                # age origin into the future, and an object then lived a full
-                # horizon past a time that had not happened yet — the inventory
-                # pinned at its ceiling and every later export forced onto the
-                # uncached path. `_published_at` caps publication at the stamp
-                # plus the publish ceiling, so the worst an ahead store can do
-                # to reclamation is what it can do to freshness: at most that
-                # allowance, once, per object.
+                # fix(#1532 r10/r24): age from the LATER of the two clocks,
+                # through the SAME bound freshness uses, so a store clock ahead
+                # cannot push the age origin into the future.
                 published_at = _published_at(obj.last_modified.timestamp(), built_at)
                 if published_at >= cutoff:
                     continue
@@ -1068,19 +604,9 @@ async def sweep(*, age_threshold_seconds: int = _SWEEP_AGE_SECONDS) -> int:
     except Exception:  # broad: a sweep that cannot list is a no-op, not an error
         logger.warning("export_cache_sweep_list_failed", exc_info=True)
 
-    # fix(#1532 review r7): prune this prefix's empty directories HERE rather
-    # than inside `StorageProvider.delete`. A filesystem keeps a directory after
-    # its last file goes, an object store has none to keep, and the export cache
-    # creates one per caller-controlled selection — so they accumulate and every
-    # listing scandirs all of them. Doing it in the generic delete made an
-    # unrelated writer's `mkdir` race this `rmdir`; doing it here confines the
-    # pruning to the prefix this module owns, at the moment it knows a selection
-    # is finished.
-    #
-    # Duck-typed rather than isinstance-checked: a provider with no directories
-    # simply does not offer this, which is the honest way to ask. `storage` is
-    # None if `get_storage()` itself raised above, and then there is nothing to
-    # prune either.
+    # fix(#1532 r7): prune empty directories HERE, not in the generic delete,
+    # where an unrelated writer's `mkdir` raced the `rmdir`. Duck-typed: an
+    # object store has no directories. `storage` is None if get_storage() raised.
     prune = getattr(storage, "prune_empty_dirs", None)
     if prune is not None:
         try:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3998,7 +3998,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # instead, aborting the entire batch on one busy row. Most of the growth
     # is the comment stating why a set-based UPDATE cannot use `lock_timeout`
     # the way a single-row write does. Cap 2374 -> 2392, exact.
-    "backend/app/platform/jobs/sweep.py": 2392,
+    # chore(#1873): review-history comments trimmed. Cap 2392 -> 1506, exact.
+    "backend/app/platform/jobs/sweep.py": 1506,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and
@@ -4345,7 +4346,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # remaining catalog racing a successor run. Kept opaque here (the queued
     # caller passes a fenced job-row read) because this module knows records
     # and vectors, not jobs. Cap 1555 -> 1588, exact.
-    "backend/app/processing/embeddings/backfill.py": 1588,
+    # chore(#1873): review-history comments trimmed. Cap 1588 -> 922, exact.
+    "backend/app/processing/embeddings/backfill.py": 922,
     # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
     # the inclusion rule's own comment predicted for this file ("watched by
     # nothing until they cross 1000. The threshold catches them then"). The
@@ -5962,7 +5964,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # ranges are whole, which is what lets a fresh build honour the leading
     # Range of a cold GDAL open without reopening the splice, on the hit path
     # too. Cap 1020 -> 1090, exact.
-    "backend/app/processing/export/artifact_cache.py": 1090,
+    # chore(#1873): review-history comments trimmed. Cap 1090 -> 616, exact.
+    "backend/app/processing/export/artifact_cache.py": 616,
     # fix(#1548 review P2): crossed the inclusion threshold. The growth is
     # assert_domain_lock_is_enforceable — the write-side precondition that
     # refuses a domain lock this deployment could never enforce, because


### PR DESCRIPTION
Refs #1873

First slice of the measured cleanup: the three modules with the highest prose share. Comments and docstrings only. No code line changed, not even a reformat: a tokenizer check that drops comments and replaces every docstring with a placeholder reports the token stream identical before and after for each file.

Rules applied, per the amended convention in AGENTS.md: a comment that references a finding keeps its anchor and the invariant, three lines at most; review history and rejected alternatives move to this PR body (below, grouped by file and anchor) so nothing is lost; every trap comment that names a concrete failure stays (the `NULL LIKE` three-valued-logic trap, JSONB mutation tracking, the `?` bind marker, the JSON `null` scalar, the `# type: ignore` markers, the test-double positional-row notes); docstrings now state the contract (inputs, outputs, errors, the one trap a caller must know). Comments that restated the next line were deleted. No comment block was added. Structural tests that read these files (`test_analysis_output_reap_1778`, `test_raster_object_ownership_1778`, `test_tasks_common_phase_brackets`, `test_analysis_provenance`, `test_export_artifact_cache_1532`) pin AST shapes and code needles, not comment text, and were run.

`_MODULE_LOC_CAPS` in `tests/test_layering.py` is lowered to each file's new exact size (`test_module_loc_caps_have_no_headroom` requires exact).

## Before and after

Counted with a tokenizer: "prose" is comment plus docstring lines, "blocks" is runs of eight or more consecutive comment lines. Target was halving the block count per file.

| file | lines before | lines after | prose before | prose after | blocks >= 8 before | blocks >= 8 after |
| --- | --- | --- | --- | --- | --- | --- |
| `platform/jobs/sweep.py` | 2392 | 1506 | 1296 | 410 | 24 | 0 |
| `processing/embeddings/backfill.py` | 1588 | 922 | 962 | 296 | 23 | 0 |
| `processing/export/artifact_cache.py` | 1090 | 616 | 716 | 242 | 13 | 0 |

No comment block over three lines remains in any of the three files.

## Verification

```
cd backend && uv run ruff check . && uv run ruff format --check .
# All checks passed! / 1180 files already formatted

# code-token equivalence, per file (scratch script; comments dropped, docstrings placeholdered)
# OK: code tokens identical  x3

cd backend && set -a && source ../.env.test && set +a && uv run pytest -q \
  tests/test_layering.py tests/test_codeql_qtable_suppressions.py \
  tests/test_rule2_structural.py tests/test_rule1_structural.py \
  <the 30 test files that import or path-reference the three modules>
# 937 passed, 1 failed (test_module_loc_caps_have_no_headroom: caps were rounded up; made exact)
# then: tests/test_layering.py -> 50 passed
# then after the final tightening pass: test_layering, codeql, rule1, rule2, analysis_output_reap_1778,
#   export_artifact_cache_1532, embedding_backfill, tasks_common_phase_brackets, raster_object_ownership_1778 -> all passed
```

## History moved out of the source

### `backend/app/platform/jobs/sweep.py`

**`JOB_TIMEOUT_SECONDS` / `_COMMIT_HEADROOM_SECONDS` (#1235 r4).** The 24h backstop used to be a fixed 86400 that happened to exceed a fixed 3600 upload lifetime. #1234 made the pending lifetime configurable and left the consumers holding the old numbers: configure the timeout past a day and a legitimate completion at hour 25 committed the frozen path into a row that was instantly eligible for its own backstop. `stale_pending_cutoff_seconds` derives the bound from the setting at call time. Module-level constants were rejected because a copy taken at import can disagree with the value the presign handlers read per request. The `STALE_PENDING_UNBOUND_MESSAGE` stopped naming an hour for the same reason.

**`stale_pending_clauses` (#1235 r2, #1234, #1213).** Four sites flip pending to failed on a timeout and #1234 guarded two. `get_job_status` (polled every 2s by the frontend, so the path that actually fires) kept the old predicates, so a poll that blocked on a completing job's row lock resumed after the commit and failed the row it had just waited for; the worker's startup recovery had neither the guard nor the live-queue predicate. Returning the whole clause set is deliberate: a caller cannot express "fail stale pending jobs" without the bound/unbound split and the live-queue check. The `staging/` prefix discriminator is the one #1213 established for the reapers. Defining the class as "truthy file_path" swept in a direct upload whose dispatch failed (it binds an absolute local path), gave it the 24h backstop, and left it `pending` for a day during which `/jobs/{id}/retry` was unavailable because retry requires `failed`: a 1h-to-recoverable state turned into a 24h one on a real path.

**`staged_at` age basis (#1708 r6).** A URL import spends up to FETCH_MAX_SECONDS downloading before its running-to-pending CAS with `created_at` unchanged. Measured from `created_at`, a local-mode staged import (absolute path, so the unbound half) arrived pre-aged: at the 61s floor of `pending_job_timeout_seconds` the very next sweep or poll failed it while the user was mid-preview. Every flow that lacks the key keeps aging from `created_at`, so a genuinely abandoned pre-fetch row is not softened.

**`ABANDONED_UPLOAD_MESSAGE` / `abandoned_upload` (#1556, #1744, #1550).** `failed` claims an ingest was attempted and broke; for a visitor who staged an upload and walked away nothing was attempted, and on the public demo those rows were indistinguishable from real failures in the admin jobs list and the failed-jobs badge. The #1556 carve-out was keyed to the presign doors because those were the only ones that stamped anything, which left the door the demo actually uses unprotected: four abandoned direct uploads over two weeks each reported `failed` with "never queued" while the queue was working. The `commit_attempted_at` stamp replaced the file_path-shape test because the shape was never what the two classes differed by; a broken commit and an abandoned upload can carry the same absolute path. Everything the old predicate excluded stays excluded: a service/URL import, an analysis run and an admin backfill all reach the queue through the same guard, so a dispatch that never landed for one of them carries the stamp and keeps reporting `failed`, which keeps `/jobs/{id}/retry` (failed-only) open and lets #1550's audit trail settle `never_started` in the same transaction. Pre-stamp rows reclassify as `cancelled`: the right answer for the abandoned uploads they will mostly be (the demo audit found four of those and zero broken commits), accepted rather than migrated because a migration would guess from the same missing fact. `create_fan_out_jobs` closes the commit-then-dispatch gap outright by putting the stamp in the metadata it commits, because its child cannot be recreated by repeating a user action.

**`StaleCleanupOutcome.pending_cancelled` and `as_dict` (#1556 codex P2).** Counted apart from `pending_failed` because that number is read as a failure count by the admin cleanup response, its audit event and the sweeper's log line. `pending_cancelled` reaches the audit event (schemaless JSONB details) and the fleet totals but not the HTTP response: `StaleCleanupResponse` is generated into both SDKs and `api.generated.ts`, pydantic's `extra="ignore"` drops the key, and surfacing it would be a contract change with a regen attached that the misreport fix did not need.

**`no_live_procrastinate_job` (#724, #695).** Since #695 deferred analysis to priority -10, waiting behind a steady upload stream is by design with no upper bound; failing those at the hour mark killed the analysis while its task sat in the queue and the worker later picked the task up against a row already marked failed. A genuine orphan (committed, then the process died before defer landed a row, the gap `defer_with_orphan_guard` structurally cannot cover) has no row at all and is still reaped.

**`post_expiry_sweep_after_seconds` (#1202 r8, #1235 r3/r4).** The window was first grounded on "the provider default is 3600 and no call site passes one". r3 made every signing site pass the job's remaining lifetime, so the window became exact rather than conservative and URL life only ever shortens; the provider-side `min()` clamps stay as the backstop for a future site that forgets. r4 found the r3 comment already claimed the value came from the setting while the constant it described still did not: configure the timeout longer and the sweep ran while the URL was still live, and a re-PUT after it survived forever because the reaped marker took the row out of every later pass.

**`_STAGING_REAPED_FINAL_MARKER` / `_RECHECK_TRANSFER_MARGIN_SECONDS` (#1236, four codex P1 rounds).** #1236 closed the #1235 r5 known gap: the ordinary window is computed from the current setting but a live URL was signed against whatever value was in force when issued, so lowering the setting and restarting mid-upload reaped the object and set the first marker while a PUT could still recreate it, and that marker exempted the row forever. Persisting each URL's deadline per job was rejected in #1235 (a JSONB-to-timestamptz cast in the candidate WHERE could throw and fail the whole bulk pass); instead the re-check uses the one bound every URL obeys, `MAX_PRESIGNED_URL_LIFETIME_SECONDS`. Codex P1 r1: SigV4 bounds when a URL may be signed for, not when an accepted PUT finishes transferring, so the first re-check delete must not retire the row. r2: the margin reused `_COMMIT_HEADROOM_SECONDS`, which is application commit headroom and never bounded anything about presigned PUTs that bypass the app. r3 and a second opinion scaled the margin from `presigned_multipart_threshold_mb`, then from the job's declared `expected_size`. r4 found the root cause under both: `generate_presigned_put_url` signs only `ContentType`, never a content-length constraint, so nothing enforces `expected_size` and a client can declare one byte and stream anything up to S3's limit; a margin derived from an unenforced declaration was tighter than the fixed ceiling but never safe. The margin is now S3's single-PUT ceiling at 32 KB/s, unconditionally. Signing `Content-Length` into the URL was the other option and was not worth the API-surface change for a low-frequency finalization check.

**`_sweep_expired_presigned_staging` delete-first ordering.** The opposite of `_reap_committed_staged_paths`, for a different reason: that one must not destroy an artifact a rolled-back row DELETE might still need; here the row survives either way, so the only asymmetric outcome is marking a failed delete as done. A crash between the two costs one redundant no-op delete on the next pass.

**`_reap_committed_staged_paths` presigned keys (#1202 r5).** A completed presigned job points `file_path` at its frozen copy, so the local-path loop never reaches the key the client still holds a PUT URL for, and a post-completion re-PUT recreated an object that escaped size and quota accounting.

**`_reap_stale_generation_storage` / `_stale_generation_storage_keys` (#1322 review, #1267, A3).** Deleting the generation objects had lived inside `sweep_stale_vrt_assets` before its caller's commit. A worker is declared dead by a timed-out heartbeat, not by proof it can never run another statement; if the reconciling transaction then failed to commit, the generation/asset UPDATEs rolled back while the objects were already gone, and a resumed worker could pass the rolled-back-to ownership checks and publish a generation whose `source.vrt` and quicklooks no longer existed, leaving a `ready` asset backed by deleted data. The key uses the full generation UUID by attempt-fencing convention A3, mirroring `attempt_scoped_staging_table`. The function-local import mirrors the deferred processing-import convention (D-17, `test_platform_processing_imports_stay_deferred`).

**`unpublished_storage_keys_from_metadata`, `_live_referenced_storage_keys`, `STORAGE_KEY_FINAL_OUTCOMES`, `_CLEAR_SETTLED_LIST_SQL`, `_clear_settled_artifact_records`, `reap_unpublished_storage_keys`, `_reap_unadopted_analysis_outputs` (#1778 codex r1, r4, r5, r6, r9, r10).** r1: `written_storage_keys` was a local list, so a SIGKILL between the puts and the terminal `finally` reclaimed nothing; the key embeds a dataset id the rolled-back transaction took with it, and no row, `delete_dataset` prefix reap or staging reconciler (`STAGING_PREFIX` is `staging/` only) could name the objects again. The survivor check lives in the one function that deletes these keys because a raster replace whose conversion reproduces the published COG byte for byte derives the same content hash, so the keys it intends to write are the keys the dataset is serving; the recording sites subtract what the live asset names, but that is a promise each writer has to keep, and a job row written by an older version did not know to subtract. r4 made the purge feed the reaps (the stale passes only read rows they move off `running`, so a job that reached `failed` on its own with a failed in-process cleanup kept its objects with nothing looking again). r5: feeding the reap was not enough because the reap runs after the commit and can fail as a whole, leaking the objects for good; so a row that still names an unreaped artifact is not purged and is itself the durable pending-reap record. Also r5: four `IN` clauses expanding to one bind per key crossed asyncpg's 32767-argument ceiling from about 8192 keys, the "survivor query that fails deletes nothing" rule then skipped every delete, and by then the retention purge had committed the deletion of the rows that were those keys' last owners. Dedup happens once so the counts mean distinct objects. r6: settle keyed off a named outcome, not statement position in a try block; the storage arm was correct by an ordering an edit could undo, which is precisely how the analysis arm came to settle tables whose DROP had failed (`drop_unadopted_analysis_output` catches its own probe and DROP failures, so "it did not raise" was true of a failed cleanup). "refused" is final because a key a live row names is answered, and re-refusing it every sweep would pin the job row for the life of the dataset. r9: the record accumulates across attempts, so clearing the whole field would forget keys this pass never reached an answer about; expressed as SQL because two rows can name overlapping keys. r10: `analysis_out_table` has a real pre-PR production shape (a plain JSONB string from a row an earlier build wrote), and the `jsonb_typeof = 'array'` guard silently excluded every legacy row so a correct drop left the pointer on the row forever and the retention purge could never take it. r10 also replaced r7's (job, table) keying with names that carry the attempt, and replaced two collections (running rows this pass moved, and rows inside the purge block behind its clauses) with one predicate, because a job can be its dataset's latest complete job and still owe a reap for the attempt that failed before it. `_ARTIFACT_REAP_BATCH` bounds the pass because the set only shrinks as reaps succeed.

**`_COMPOSITION_PRESERVED_SQL` (#1322 r3, #1327, #1290).** Nothing stored records the attempt type (`triggered_by` holds a user id, `source_count` is populated post-mutation), so the check asks the question from state: does the published composition (`built_from`, "what the published VRT was assembled from", #1290 review) still equal the catalog's (`vrt_source_links`)? Count-match plus a one-directional subset proves set equality because a JSONB object cannot repeat a key and `uq_vsl_vrt_source` forbids duplicate pairs. `jsonb_typeof(...) = 'object'` rather than `IS NOT NULL`: a real-DB test caught that SQLAlchemy's plain JSONB (no `none_as_null`) serializes Python None as the JSON scalar `null`, `IS NOT NULL` is true for it, and `jsonb_object_keys()` raises "cannot call jsonb_object_keys on a scalar", turning the conservative branch into a 500. A legacy VRT predating `built_from` falls to the same conservative branch as a proven mismatch, matching the "unknown answers unknown, not fresh" posture in `source_freshness.py`. #1327 moved the link mutation into the publish transaction, so the FALSE direction is now near-unreachable; the check stays as the guard for pre-#1327 rows and any future writer of the link table.

**`_PRIOR_ATTEMPT_WAS_READY_SQL` (#1322 r4, r5).** `regenerate_vrt_endpoint`'s guard rejects only `regenerating`, so a caller may retry an already-`failed` asset; if that retry also dies with matching membership, the composition check alone would restore `ready` and erase a real failure signal. No column records the asset's status at attempt start (`router.py`'s `previous_status` is a local variable), so the nearest stored fact is the outcome of the immediately preceding generation, which is well defined because at most one generation is in flight per dataset. Accepted conservative cost: a generation this sweep restores still leaves its own row `failed`, so a later dead attempt on the same dataset reads that and stays `failed` one cycle longer than necessary; a further stored marker was a bigger schema surface than the fix's blast radius. r5: `regenerate_vrt_endpoint`'s orphan guard marks the just-created generation `failed` when Procrastinate's enqueue itself throws and reverts the asset in the same rollback, so that row never ran and says nothing about the asset; `heartbeat_at` is set in exactly one place, `tasks_vrt.regenerate_vrt`'s phase-1 claim, so filtering on it finds the most recent generation a worker actually ran.

**`_NO_LIVE_GENERATION_JOB_SQL` (#1322 r6).** Mirrors `_ABANDONED_RUN_SQL`'s `procrastinate_jobs` correlation in `platform/refresh/service.py`, keyed on `generation_id` because `VrtGeneration` has no `ingest_job_id` column. Two correlation forms because `tasks_vrt.regenerate_vrt` accepts two delivery shapes: modern deliveries carry `generation_id`; a legacy delivery queued by pre-upgrade code carries none (the parameter is optional to keep such deliveries alive across a rolling deploy) and adopts `RasterAsset.current_generation_id` on execution, so it is correlated by `vrt_dataset_id` (required on both shapes) plus current ownership. A delayed sweep of a dead attempt costs a retry window; sweeping a live one loses real work.

**`sweep_stale_vrt_assets` (GAP-002, #1267, #1322 r3/r4/r6, #1327, #1290).** `regenerate_vrt` only overwrites the published pointer (`asset_uri`, `sha256`) in the same transaction that clears `current_generation_id`, so a dead attempt leaves those fields describing the last-good VRT; that is necessary but not sufficient to restore `ready`, for the two reasons the SQL fragments encode. `running` and `pending` need different proof: a running generation's heartbeat is the worker's own actively renewed signal, and requiring "no live queue row" as well would make a genuinely dead running generation unsweepable until the separate stalled-queue sweep pruned its `doing` row; a pending generation has no such signal because nothing has claimed it. There is no "first-ever generation, no built_from" gap: `regenerating` is reachable from three call sites that all 404 unless the VRT dataset exists, and the only constructor of the `RasterAsset` row (`create_vrt_dataset`, inside `ingest_vrt`) sets `ready` with a real `built_from` in the same flush; only a pre-#1290 row can hold NULL, and that is the conservative branch. RETURNING carries `vrt_dataset_id` because the asset UPDATE's own `current_generation_id` is nulled in the same statement, so RETURNING it would report the value after the SET. Rows are tuple-unpacked so a test double can stand in with plain tuples.

**`publish_refresh_reconciliation` (#1277 review).** The counter used to increment inside the transaction; a later failure in the pass rolled the cancellations back but not the counter, and a counter only goes up, so every `rate()` over that window stayed wrong.

**`purge_terminal_job_tokens` (#1746 codex r1).** `fail_stale_jobs` runs once per tenant in hosted mode and `catalog.procrastinate_jobs` has no tenant column, so living there repeated one unscoped UPDATE tenants-many times per pass per API process. Keeping it out also keeps the dry-run cleanup endpoint (`commit=False, detailed=True`) from writing. `aborting` is legacy in procrastinate 3.x and never written.

**`fail_stale_jobs` pending halves (#1234).** A presigned completion sets `file_path` and then commits; between those the row is still `pending` with a `file_path`, and the sweep used to fail it out from under the request. The guard is falsy rather than `IS NULL` because `create_ingest_job` is called with `""` by both presign endpoints and analysis jobs carry `""` too (see `_retry_capability`); an `IS NULL` guard would match nothing while looking fixed. The bound half needs its own backstop because the retention purge only considers terminal rows.

**RETURNING the CASE-chosen status (#1556 codex P2).** Postgres returns the new row, so this is what the database wrote; re-deriving the predicate in Python would be a second copy of the rule that can disagree with the one that ran. Rows are read positionally because the unit suites drive this with doubles that hand back plain tuples.

**`FOR UPDATE SKIP LOCKED` candidate subquery (#1778 audit r12).** A phase-2 write holds `FOR NO KEY UPDATE` on its job row for as long as its session stays open (see `_job_phase_session`'s `require_status` docstring). A bare `UPDATE ... WHERE status = 'running'` would wait on every such row, and a `lock_timeout` on a set-based UPDATE does not skip the busy row, it cancels the whole statement and fails every other stale job in the pass. The worker's startup recovery carries the identical fix; `test_tasks_common_phase_brackets` pins both.

**Childless `fanned_out` parents (#1709 r7, r8).** Since the r5 fix, `fanned_out` commits before any child exists (the mutex that closed the fast-child cancel window), which regressed the recoverability the old late transition got for free: the old crash left a `pending` parent the one-hour clause self-healed, the new one left a terminal parent that retry (failed-only) and cancel (terminal gives 409) both refuse. A childless `fanned_out` parent is the crash signature and nothing else's: a layer's `queued` result requires its child row to have committed, and an all-failed dispatch restores the parent to `pending` (`restore_fan_out_parent_pending`). The retention horizon bound exists because a legitimate old fan-out's children can be purged, after which "never existed" and "purged" are indistinguishable; the purge cutoff is `coalesce(completed_at, created_at)` and every child postdates its parent's flip, so a parent inside the horizon cannot have lost children to it. `retention_days=0` keeps every row, so no bound is needed then. r8: generic retry re-queues the parent as one default-layer import because the layer selection lived only in the fan-out request body; restore-to-pending was no better because the unbound clause keys on `created_at`, so an old parent would be re-reaped into the generic message and then retried into exactly the wrong import.

**Refresh-run sweep placement (#1219).** Ordered after the two job sweeps because those flip an orphaned job to `failed`, one of the two facts the run sweep requires before it may write a terminal status. Not folded into `StaleCleanupOutcome` because the run rows are themselves the record and the dataclass is a published shape several callers reconstruct field by field (the same reasoning as the fan-out reconciliation and the #1249 object-driven pass).

**Retention purge (#434 codex P2 r3, r4, r5, r7, r8, r9, r10).** r8: cutoff on finished-at because the stale sweep fails ancient rows with `completed_at=now` and a `created_at` cutoff would delete that fresh failure evidence in the same transaction. Per-dataset latest-complete exemption: `/jobs/by-dataset/{id}` serves the dataset page's persistent ingest warnings and the reupload `source_layer` hint from it. r7: manifest apply classifies skip/update-vs-create via `_latest_completed_manifest_job`, which looks up the newest complete job per `manifest_key`; a manual reupload makes the manual job the per-dataset exemption, so without a second exemption the manifest-keyed row would age out and the next apply would duplicate the dataset. r9: the mirrored lookup joins Dataset, so a job whose dataset was deleted cannot influence reapply and exempting it would only defeat cleanup. r10: a SELECT-then-DELETE-by-id pair let `/jobs/{id}/retry` flip a candidate back to pending between the two statements and still lose the row. r3: failed local uploads keep their staged file for retry (`_should_unlink_staging`) and fan-out children's shared S3 original was deferred to "a retention policy" (#430 BA-09); this purge is that policy. r4: only when no surviving row that still needs the file references the path. r5: surviving complete rows keep their metadata row but not the staged file, otherwise a successful fan-out's shared original, referenced forever by children that are each a dataset's latest complete job, would never be reaped.

**Presigned-row retention exemption (#1236 codex P1 r1, r2, r4; P2 r5).** Purging a presigned job's row before any URL for it could still be live removed the sweep's marker tracking outright, and retention is commonly configured well under a week (1 day is an exercised value). r2: deferred for the sweep's whole finalization window rather than its ceiling alone, because an accepted PUT can still be transferring past it; purging on the bare ceiling reopened the race at the purge instead of the sweep. r4: the margin is the same fixed constant the sweep uses, so the bulk DELETE never branches per row on JSONB. r5: a non-null `s3_key` alone is not ownership, because `create_fan_out_jobs` clones the parent's `user_metadata` wholesale, so every fan-out child carried the parent's `s3_key` and was exempted from retention for about 8.9 days regardless of the configured retention; the `LIKE` prefix match is the same check `owned_presigned_staging_key` makes and cannot throw on a malformed value.

**`audit_settled_embedding_backfill` (#1550 review, #1709 r10, migration 0051).** Every other way a backfill can end is closed inside the worker; a hard kill has no in-process path, so the trail stayed at `requested` forever while the job was terminal, and on the force path that can be a catalog whose vectors were deleted. `audit_emit_durable` would use its own session and could record an outcome for a row whose update was later rolled back. Three actors can close the same run, so an existence check would be a check-then-insert that carries two conflicting outcomes; the unique constraint decides and a SAVEPOINT keeps a lost race from taking the status change down. r10: the cancel endpoint acts on behalf of a specific person who in the arm-3/cross-user case is not the requester, the same rule `refresh.cancelled` follows since r8. The action is a literal because `test_audit_action_registry` checks emit sites statically; `ip_address=None` because inventing a request behind a sweep would be a fiction in a record whose purpose is attribution.

### `backend/app/processing/embeddings/backfill.py`

**Module and `_BATCH_SIZE` (#448, #449, #1506).** One call per record was replaced by batches of 128 (OpenAI accepts 2048; 128 keeps bodies modest for Ollama, Groq and Together), a 50-200x reduction in round trips. #1506: a vector left behind by a superseded model is unusable to semantic search, so the record counts as missing until it has a current one.

**`_compact_error` (#1577 codex P1 r1 and r2).** Both rounds found the same bug at a different transformation: truncating first cut the `@` that terminates userinfo, leaving `https://alice:hunter2`, which reads as host and port and passes through; collapsing whitespace first turned a tab, CR or LF inside a URL into a space, and `URL_LIKE_RE` stops at whitespace, so the match died before the `@`, and a split in the host meant a query-string key further along was never reached. The `[SQL:` cut moved below the redactor for the same reason. Choosing `orig` over `exc` cannot split a match: it is a different, shorter string, so it can only omit a credential the SQL tail would have carried.

**`_error_fields` (#1544, measured on the #1533 failure shape).** `exc_info=True` per record cost 964 ms and 60.6 KiB per record under the dev console renderer, 3.1 ms and 12.7 KiB under the JSON renderer production uses; a 200-record run took 194 s before and 1.5 s after, a 1,000-record one wrote 12.4 MB of log before and 0.35 MB after. SQLAlchemy already truncates a long bound parameter to about 150 characters a side, so the vector reaches the log as about 440 characters; the traceback (33 frames over a three-exception chain, 12 KB before any renderer) is what costs. The budget is owned by `backfill_embeddings` so it spans the run and a type first seen at the batch level does not spend a second traceback on the retry path.

**`_live_column_dims`.** Measured on the scratch catalog: 0.32 ms median against 2.7 ms for the config reads it runs beside.

**`_structural_width_mismatch` (#1533, #1579 codex P2 r1 and r2).** A pre-flight on the non-force path was rejected twice over: it costs a provider call on a path that destroys nothing, and it aborts a run a single transient failure would otherwise survive; adding one fails 5 of the 7 tests in `test_embedding_backfill.py`, two of them for that reason. r1: any single wrong-width vector stopped the run, breaking the #449 isolation. r2: a final batch of one (any catalog sized 1 mod 128) was read as structural, because one input agrees with itself vacuously; it falls through to the retry rule, which asks storage, at the cost of one extra provider call for that record.

**`_raise_on_retry_vector_width` (#1525 r6, #1579 codex P2 r4).** The post-call bracket went missing when r3 moved the batch's post-call check below the flush so it could hold the relation lock: the check sits after an insert that raises on its own when the column has moved, so it never runs on that path. r4: asking fit first returned early whenever the provider answered at the pinned width, so a column that moved during the provider call reached the flush, raised the typmod error, and was counted as one bad record; every record but the last was covered by the next one's pre-call check. Cost is about 9 ms per retried record against the ~0.22 s provider call, and nothing on the storm the PR exists to stop.

**`_upsert_embeddings` (#1546, #1549, #1583 review).** Replacing in place rather than widening the constraint keeps the table's size independent of how many configurations an instance has been through and leaves the key #1549 needs intact. #1583: `now()` is transaction-start time and a backfill transaction spends a provider call before writing, so a row written at the end got a stamp earlier than a job that started and committed while the provider was thinking; #1583 orders the related-items anchor by `updated_at DESC`, which made the inversion visible. The INSERT branch had to be stamped too, because `set_` only governs ON CONFLICT and half the writes would have kept the server default.

**`_records_still_empty` / `_reclaim_observed_rows` / `_delete_embeddings_for` (#1511, #1584 r3, r4, r5).** The `updated_at < cutoff` comparison got the answer wrong in both directions: it spared rows whose stored stamp was ahead of the cutoff (an application clock ahead of PostgreSQL, or an older worker mid-rolling-deploy), and moving writers to `clock_timestamp()` does nothing for stamps already on disk. r4: the ingest writer skips its write on an unchanged content hash, so an editor who restores exactly the content a row was computed from leaves the row and its `updated_at` untouched; the pair still matched and a valid row would have been reclaimed. r5: without the `FOR UPDATE` lock the re-read and the delete were two statements with a gap in which an editor's restore had the ingest writer skip while the row still existed, then the delete took it and nothing would regenerate it. Chunked because asyncpg caps a statement at 32767 bind parameters and each pair spends two, and a chunk is also how long any one editor can be held.

**`_replace_embeddings` (#1549, #1579 r3).** A force run used to commit `DELETE FROM catalog.record_embeddings` before it had generated anything, so every abort after that left the catalog with no vectors. Committing inside the helper would release the RowExclusiveLock before the drift check ran.

**`_snapshot_embedding_config` (#1511 codex P1 r2, #1525, #1525 r2, #1543).** Without the comparison a run could pin model A with model B's dimensions, a pairing that never existed in config. The re-read observes a concurrent change because `PersistentConfig.set` commits and then deletes the cache entry (`apply_side_effects`), so the second `get` misses the cache. #1525 r2 known residue: the endpoint is resolved by the provider through its own per-key cache; making that read uncached needs either a copy of the provider's fallback chain and credential binding in this caller (wrong for any extension resolving elsewhere) or an uncached mode on the extension interface. For the shipped provider it is unreachable on both branches of `bind_openai_credential_base_url`: with an API key the candidate is only compared against the operator-approved environment URL (equal returns the approved string, unequal raises `OpenAICredentialDestinationError`); with no key `embed` raises `EmbeddingUnavailableError` before producing a vector and the force path aborts having written and removed nothing. A partial guard comparing cached against uncached reads was tried and removed: it detects only the half of the eviction window where the model key has not been evicted yet, and it aborts whenever a caller mocks one read and not the other. The per-key eviction window itself is #1543; it made the eviction a single batched step, which narrows the window without closing it. The one-window rule: an earlier revision gave the endpoint its own capture-and-compare after the pair had been compared, and an admin updating model and endpoint together in the gap produced old model plus new endpoint.

**`_PinDrift` and `_retry_batch_per_record` (#449, #1525 r6, #1533, #1546, #1549).** The retry loop exists because adding the drift bracketing pushed `backfill_embeddings` past the McCabe gate, and the per-file burn-down list in `pyproject.toml` may shrink but never grow. r6: this path had no drift checks, and it is the likelier one, because a provider outage is exactly when an operator edits the endpoint; the batch call raised, so the batch's post-call check never ran. The pre-call check is not redundant with the previous record's post-call check because that record may have failed. `record_orm` matters more here than on the batch path: a record that fails again must keep the vector it already had rather than lose it to a delete committed on the promise of a replacement never written.

**`_pinned_config_drift` (#1525 codex P2 r4, #1533).** Measured on 1,000 records with the width moved by hand and the settings row untouched: 1,009 provider calls and 1,000 errors reported as if the provider were broken, against 2 calls and a named cause with the storage-width check. The width check sits before the endpoint block because that block returns None from its `except`, and an endpoint that will not resolve is exactly the half-configured install where a column gets altered by hand; the settings comparisons stay ahead so that when both have moved the message names the admin action. Any change counts, including a widening or a dropped constraint: a run that carried on would leave two widths under one model label, and the inserts that make that happen succeed, so nothing else would report it. The endpoint message is unquoted because it can name an internal host and reaches an audit log.

**`_preflight_embedding` (#1511 codex P1 r3 and r4, #1529).** Three rounds each guarded a different way for a force run to destroy vectors it could not rebuild; guarding modes one at a time kept finding another mode, so this proves the capability. r4: the case that found the width half was a settings write that persisted a newly detected width without rebuilding the column; #1529 closed that route (an auto-detected width joins `validated_settings` and goes down the rebuild branch), but the check is deliberately not written against that route, which is why closing it did not retire the check.

**`backfill_embeddings` (#1511 r5, #1511, #1506, #1549, #1546, #1584 r1, #1709 r6, #1525 r4/r5, #1533, #1581, #1544).** r5: demanding a working provider on a tenant with no visible records turned a harmless no-op into a 502 on a fresh install. #1511: a Regenerate All clicked during a config blip converted full coverage into zero, because `model_name` is NOT NULL and the old bulk delete had already committed. #1549: what an aborted run leaves is a mix; #1546's stamp makes that readable, and the residue (a row written before the stamp column existed is still matched on model name alone) is true of an unstamped catalog from the moment the endpoint moves, whether or not anyone runs a regenerate. The HNSW index lives in Alembic migration 0012 and is recreated by `service.rebuild_embedding_column`, so a per-batch delete does not need it dropped. #1584 r1: a snapshot taken after the fetch left the whole materialisation interval unguarded. The titleless narrowing: `build_content_text` returns "" only when title, summary, keywords, lineage and translations are all empty, so a record carrying a title is never reclaimable; a record whose title is cleared between the snapshot and the fetch waits for the next force run. #1709 r6: Procrastinate's abort for an async task is asyncio cancellation and needs no polling once the request reaches the worker; the check covers the request that never landed, and one indexed read per batch bounds the post-cancel overlap to a single batch of provider spend instead of the whole catalog running concurrently with a successor admitted by the freed one-active-backfill slot. #1525 r4: `RecordEmbedding` recorded only `model_name`, so semantic search built its query vector from the live endpoint and filtered rows by model alone, B-space queries against A-space documents, and the backfill reported success. The pre-call check is kept alongside the post-call one because drift landing between batches would otherwise surface only after the next batch had been paid for. #1581: the shipped `embed()` returns `[item.embedding for item in response.data]` with no index sort and no count check, so a provider that skips a middle input answers `[v1, v3]` for `[t1, t2, t3]` and a truncating zip pairs the second record with the third vector under a valid-looking hash and stamp; the single-element unpack in the retry is alignment-safe by construction. `created += len(batch)` stayed true after a truncating zip and #1550's "errors and nothing created" guard cannot fire on a run claiming it created everything. #1579 r3: when an ALTER widened the column to an unconstrained `vector`, the old-width inserts succeeded and the run reported success over a column that had moved under it.

### `backend/app/processing/export/artifact_cache.py`

**Module docstring (#1532, review r3, r25, #905).** One `/vsicurl/` open cost roughly ten conversions and, whenever the data moved under them, ten different artifacts served under one URL with two probes reporting different total sizes. A `current.json` pointer per selection was the previous design and failed three ways across two rounds: r2 found a sweep deleting a pointer another worker had just published, r2's own fix could only narrow that window (`StorageProvider` has no compare-and-delete), and leaving pointers undeleted turned them into an amplification because anonymous callers can export a public dataset with arbitrary `bbox`/`where`. Today's failure mode is loud (a spliced GeoJSON dies with `ERROR 4: Failed to read GeoJSON data`), which is why a hand-audited invalidation list would have been strictly worse. The `max(xmin)` version was rejected because it costs 509 ms on the 5M-row table #905 measured, per range request on the hit path.

**`_SWEEP_AGE_SECONDS` (r4).** `staging.py` already worked out the identical hazard: at one hour, "an in-flight export survives a restart" becomes "any export whose generation plus client download time exceeds an hour is deleted out from under it on the next cycle", and on Azure `downloader.chunks()` fetches later chunks as it goes, so an already-started 200 dies truncated.

**`_CLOCK_SLACK_SECONDS`, `_MAX_PUBLISH_SECONDS` (internal review, r23, r25).** A future-stamped artifact stays fresh for the TTL plus the skew and unreclaimable for the horizon plus the skew, and outranks every honest sibling. The publish ceiling is not a settings field because it restates an edge fact (`frontend/nginx.conf` `proxy_read_timeout 600s`) and raising it widens the staleness bound.

**`_BUDGET_BYTES` (internal review).** Five bbox tiles of a multi-gigabyte dataset fill the shared staging volume with no adversary; 8 GiB is enough for one client range-reading one export plus its neighbours. An absolute number because the provider protocol reports no capacity and a fraction of an unknowable whole is not a bound.

**`ExportArtifact.contested` (internal review, r12).** Every client arriving during a slow build misses and builds its own, so "a forgotten bump costs one TTL of staleness" was really "a forgotten bump plus overlapping builders costs a silent splice". r12: ogr2ogr stamped `gpkg_contents.last_change` per conversion, which made the default format permanently contested under steady traffic and meant it never served a range; `normalize_gpkg_timestamps` fixed the input rather than this rule.

**`strong_etag` (r18).** Two responses name bytes by digest (the stored artifact and the conversion served directly when publication does not happen); a validator formatted twice can drift.

**`selection_key` (#1585, #1546).** A hook next to each `bump_tile_cache_version()` would have needed a new `ProcessingPort` method and an EXTENSION_API_VERSION bump to deliver an optimization, because `processing/` may not import `modules/catalog/`; the counter is already on the dataset row. The two-segment layout puts URL-visible inputs (`format`, `target_crs`, `bbox`, `where`) first and server-side facts that move the bytes under that URL second, so every version of one URL shares a prefix; `lookup`, `store` and the sweep take the whole thing as an opaque prefix.

**`url_answered_other_bytes_recently` (#1585, r5).** "The URL answered other bytes within the last TTL" is exactly "an artifact with another digest was published under this URL within the last two TTLs": a TTL of serving, then a TTL of grace for the client that took the last answer. A to B to A within retention is caught because while B is still answered, B artifacts keep being published. The parent revision of #1582 wrote a single-segment layout outside every URL prefix; nothing is served from it, no release wrote it, retention ages it out, and the exposure (a client spanning both the upgrade and a data change) is stated rather than paid for on every range.

**`_artifact_key` nonce (internal review).** `built_at` is whole seconds, so two builders of a deterministic format finishing in the same second computed the same key, and a failed write on one called `_discard` on a key the other had just published, deleting a live object out from under readers already past their response headers.

**`parse_tmp_key` (internal review).** `parse_artifact_key` answered None for the `.tmp` scratch file and every caller reads None as "leave it alone", so it leaked onto the shared staging volume permanently.

**`lookup` (r8, r9, r23).** r9: every backend reports modified time as completion time (S3 and Azure use the put's completion; locally it is the temp file's last write, preserved by the atomic rename), while the key stamp is taken before the upload, so a multi-gigabyte push spent the whole TTL getting there and was expired the moment it existed, defeating the cache for exactly the exports big enough to need ranges. r8: `contested` computed over the fresh set missed the staggered case: two builders a second apart were both inside the window, then the older crossed the TTL, `contested` flipped false, and a bare-Range client that started on the older artifact resumed into a 206 of the newer. The cost: a selection that ever had two distinct artifacts serves no ranges until the sweep clears the older; the pre-publish re-check keeps a second artifact rare.

**`_published_at` (r22, r23, r28).** A store clock behind the writer by more than the TTL made every artifact expired on arrival and every probe reconverted (the cache silently dead); a store clock ahead reports a publication later than it was. An earlier revision distrusted a modified time beyond `now` plus jitter and fell back to the stamp, which was wrong later: as `now` moved, the same immutable object crossed from expired back to fresh the moment its future mtime came within reach. r28: a stamp more than the allowance after the store saw the bytes is a writer clock ahead; left unclamped it pinned the object, because `lookup` refused the future key but the sweep floored publication at that stamp and could not reclaim it, while its size counted against the budget and its digest kept the selection contested. Honest bound: data behind a served artifact is at most TTL plus `min(build + upload, _MAX_PUBLISH_SECONDS)` old under honest clocks; a store behind the fleet by more than the allowance plus the TTL makes every artifact expired at publication, a cache that does not serve rather than one that serves stale.

**`store` (internal review, r4, r6, r7, r18, r25, r29 P1, #1550).** r25: the stamp used to be minted just before the upload, so a mutation that missed `tile_cache_version` during a long conversion produced an artifact stale at birth that then aged from a point after the staleness began. r29 P1: returning None on a lost race had the caller stream its own bytes whole, and when the two builders had taken different snapshots, an interrupted download resumed with a bare Range against the sole incumbent and was handed a 206 of the other conversion at its offsets. r4: `put` raising on a full store used to exit before the only production sweep, so aged artifacts could never be reclaimed and on the local backend the volume stayed too full to generate larger exports until an operator deleted files by hand. r6: the budget check was an early return above the sweep, re-creating the same deadlock for a full budget. r7: a post-write re-check that dropped the artifact when the total had moved could delete a key another request had resolved through `lookup` and truncate its stream. The `CancelledError` distinction is the one #1550 turned on: the caller owns the conversion directory until a response takes it. `_last_sweep_at = 0.0` on failure so recovery from a full store takes one request rather than up to fifteen minutes.

**`_put_with_reclaim` (r4, r5, internal review).** r5: a partial carries a fresh timestamp, so the forced sweep could not reclaim it and the retry failed on a volume the first attempt made worse (two attempts, two partials, the space held for the whole horizon). `LocalStorageProvider.put` is atomic now, so on shipped backends the discards are belt-and-braces; they stay because the module cannot see which provider it has. The `BaseException` outer handler: a `CancelledError` skipped the retry (correctly) and the discard (not correctly); locally the scratch file's removal depends on `put` seeing the cancel itself.

**`_fits_in_budget` (r6, r7, r11, r16).** Making the ceiling hard would need publication to become visible only after a check, which needs a rename primitive S3 and Azure lack short of a server-side copy. r16: the running check lived inside the page loop and a provider yields no page for an empty prefix, so on a cold cache (the first export after a deploy) an artifact larger than the whole budget could publish. r11: the whole `export-cache/` listing was materialised on every publication and the prefix is caller-controlled, so every publication paid for all distinct selections in the window.

**`digest_and_size` (r18, #435).** Off the event loop for the same reason the shapefile zip is: hashing a multi-GB file inline stalls every other request and the job heartbeats.

**`sweep` (r2, r3, r7, r10, r24).** The rule is phrased around the key's own timestamp because the first shape deleted by prefix (taking a neighbouring worker's just-uploaded artifact with it) and the second read each pointer to decide (which merely narrowed the window). r10: once freshness moved onto `last_modified`, an S3 or Azure upload that consumed most of the horizon could be reclaimed shortly after becoming visible while a client was streaming it. r24: an unbounded `max` let a store clock ahead push the age origin into the future, and an object then lived a full horizon past a time that had not happened yet, the inventory pinned at its ceiling and every later export forced onto the uncached path. r7: pruning in the generic `StorageProvider.delete` made an unrelated writer's `mkdir` race the `rmdir`.
