### PR TITLE
fix(ingest): keep the swap DDL lock_timeout inside its savepoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and releases use semantic versioning.
   tile-columns edit wrote back the tile cache version it had read before waiting, so the edit
   committed during the wait was served under a stale tile URL. Both worker swaps now roll the
   version atomically once they hold the catalog row, as the request side has since #1910. (#1911)
+- A reupload could fail with a catalog-lock conflict instead of waiting when another operation
+  briefly held the dataset's catalog row. The lock budget the table swap sets for its own DDL no
+  longer carries over to the wait that follows it. (#1917)
 
 ## [1.18.1] - 2026-09-05
 

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2208,7 +2208,7 @@ async def _retire_geometry_attribute_row(
 
 
 # The AccessExclusiveLock budget the reupload swap DDL spends: first attempt,
-# the single retry, and the pause between them (ING-06 / P2-08).
+# the single retry, and the pause between them (#1917).
 _SWAP_FIRST_TIMEOUT = "5s"
 _SWAP_RETRY_TIMEOUT = "15s"
 _SWAP_RETRY_SLEEP_MS = 200

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2207,6 +2207,13 @@ async def _retire_geometry_attribute_row(
     )
 
 
+# The AccessExclusiveLock budget the reupload swap DDL spends: first attempt,
+# the single retry, and the pause between them (ING-06 / P2-08).
+_SWAP_FIRST_TIMEOUT = "5s"
+_SWAP_RETRY_TIMEOUT = "15s"
+_SWAP_RETRY_SLEEP_MS = 200
+
+
 async def _apply_reupload_swap(
     session,
     *,
@@ -2284,6 +2291,9 @@ async def _apply_reupload_swap(
 
         All three references (live, staging, _old) use the SAME _tenant_schema
         so the RENAME operations are intra-schema (T-1209-07).
+
+        The ``SET LOCAL`` outlives a released savepoint, so the caller restores
+        the previous value once the swap is done.
         """
         await session.execute(text(f"SET LOCAL lock_timeout = '{timeout_str}'"))
         if live_exists:
@@ -2309,13 +2319,16 @@ async def _apply_reupload_swap(
         # give the new live table's PK its final name.
         await rename_pkey_to_match_table(session, table_name)
 
-    _FIRST_TIMEOUT = "5s"
-    _RETRY_TIMEOUT = "15s"
-    _RETRY_SLEEP_MS = 200
+    # fix(#1917): a `SET LOCAL` survives RELEASE SAVEPOINT, so the DDL budget
+    # below outlives its savepoint and would clamp every later wait in this
+    # transaction. Capture what is in effect; it is put back after the swap.
+    pre_swap_lock_timeout = await session.scalar(
+        text("SELECT current_setting('lock_timeout')")
+    )
 
     try:
         async with session.begin_nested():
-            await _swap_with_timeout(_FIRST_TIMEOUT)
+            await _swap_with_timeout(_SWAP_FIRST_TIMEOUT)
     except Exception as first_exc:  # broad: catch any swap failure to inspect for lock-timeout before re-raising
         if not _is_lock_timeout_error(first_exc):
             raise
@@ -2327,18 +2340,18 @@ async def _apply_reupload_swap(
             attempt=1,
             first_timeout_seconds=5,
             retry_timeout_seconds=15,
-            sleep_ms=_RETRY_SLEEP_MS,
+            sleep_ms=_SWAP_RETRY_SLEEP_MS,
             hint=(
                 "AccessExclusiveLock contention on first swap attempt — "
                 "likely autovacuum collision; retrying once with longer "
                 "timeout. Correlate with pg_stat_activity / pg_stat_user_tables."
             ),
         )
-        await asyncio.sleep(_RETRY_SLEEP_MS / 1000.0)
+        await asyncio.sleep(_SWAP_RETRY_SLEEP_MS / 1000.0)
 
         # Retry inside its own SAVEPOINT so a second failure surfaces cleanly.
         async with session.begin_nested():
-            await _swap_with_timeout(_RETRY_TIMEOUT)
+            await _swap_with_timeout(_SWAP_RETRY_TIMEOUT)
 
         structlog.get_logger().info(
             "reupload_swap_retry_succeeded",
@@ -2347,6 +2360,13 @@ async def _apply_reupload_swap(
             attempt=2,
             retry_timeout_seconds=15,
         )
+
+    # fix(#1917): the DDL budget ends here. `set_config(..., true)` is
+    # `SET LOCAL` taking a bind parameter.
+    await session.execute(
+        text("SELECT set_config('lock_timeout', :value, true)"),
+        {"value": pre_swap_lock_timeout},
+    )
 
     # fix(#1373): resolve the geometry type ONCE, from the relation the swap
     # just installed, and use that one value everywhere below.
@@ -2382,10 +2402,9 @@ async def _apply_reupload_swap(
 
         await ensure_geom_4326_gist_index(session, table_name, schema=_tenant_schema)
 
-    # Update dataset metadata in the same transaction as swap
-    # fix(#1847): the catalog writes start here, and this function dirties both
-    # rows. `lock_timeout=None` so SET LOCAL does not clamp an ingest swap to a
-    # request's budget.
+    # fix(#1847, #1917): the catalog writes start here and dirty both rows.
+    # `lock_timeout=None` issues no SET LOCAL, and the swap's DDL budget was
+    # put back above, so this wait carries no request-sized clamp.
     from app.platform.catalog_locks import bump_tile_cache_version_on, lock_catalog_rows
     from app.platform.extensions import get_processing_port
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3607,7 +3607,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): the cache-bump docstring states its contract. Cap 2601 -> 2596.
     # fix(#1902): the atomic bump moved to platform/catalog_locks. Cap 2596 -> 2559.
     # fix(#1911): the reupload swap bumps atomically under the lock. Cap 2559 -> 2558.
-    "backend/app/processing/ingest/tasks_common.py": 2558,
+    # fix(#1917): +19 — the swap DDL's lock_timeout is captured before the
+    # savepoint and put back after it, so it stops clamping the catalog-lock
+    # wait; its three budget constants moved to module scope to be testable.
+    # Cap 2558 -> 2577, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2577,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3607,10 +3607,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): the cache-bump docstring states its contract. Cap 2601 -> 2596.
     # fix(#1902): the atomic bump moved to platform/catalog_locks. Cap 2596 -> 2559.
     # fix(#1911): the reupload swap bumps atomically under the lock. Cap 2559 -> 2558.
-    # fix(#1917): +19 — the swap DDL's lock_timeout is captured before the
-    # savepoint and put back after it, so it stops clamping the catalog-lock
-    # wait; its three budget constants moved to module scope to be testable.
-    # Cap 2558 -> 2577, exact.
+    # fix(#1917): +19 — the swap restores the lock_timeout it installed, so it
+    # stops clamping the catalog-lock wait; its budget constants moved to
+    # module scope to be testable. Cap 2558 -> 2577, exact.
     "backend/app/processing/ingest/tasks_common.py": 2577,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features

--- a/backend/tests/test_swap_lock_timeout_scope_1917.py
+++ b/backend/tests/test_swap_lock_timeout_scope_1917.py
@@ -1,0 +1,193 @@
+"""The reupload swap's DDL lock_timeout does not outlive its savepoint (#1917).
+
+PostgreSQL keeps a ``SET LOCAL`` across ``RELEASE SAVEPOINT`` — only
+``ROLLBACK TO`` reverts it. ``_apply_reupload_swap`` installs one for its
+``ALTER TABLE`` renames, so on the success path it has to put the previous
+value back; otherwise the ``lock_catalog_rows(lock_timeout=None)`` wait that
+follows runs on the swap's budget and fails on contention it must wait out.
+
+The DB-backed tests require the Docker test database.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.catalog_locks import CatalogLockConflict
+from app.processing.ingest import tasks_common
+from app.processing.ingest.tasks_common import _apply_reupload_swap
+
+from tests.factories import get_user_id
+from tests.test_feature_lock_order_1847 import _await_lock_wait
+from tests.test_reupload_swap_lock_retry import (
+    _make_dataset_stub,
+    _make_port,
+    _minimal_metadata,
+)
+
+pytestmark = pytest.mark.anyio
+
+# The swap's DDL budget for these tests, shrunk so the contended wait below
+# outlasts it in about a second instead of the production five.
+_TEST_SWAP_MS = 500
+_TEST_SWAP_TIMEOUT = f"{_TEST_SWAP_MS}ms"
+_PAST_THE_CLAMP_SECONDS = (_TEST_SWAP_MS / 1000.0) * 3
+
+
+@pytest.fixture
+async def swap_target(client, test_db_session):
+    """A committed dataset row and the live/staging table pair its swap renames."""
+    suffix = uuid.uuid4().hex[:8]
+    live = f"swap_scope_{suffix}"
+    staging = f"swap_scopes_{suffix}"
+    for table in (live, staging):
+        await test_db_session.execute(
+            text(
+                f'CREATE TABLE data."{table}" '
+                "(id serial PRIMARY KEY, name text, geom geometry(Point, 4326))"
+            )
+        )
+        await test_db_session.execute(
+            text(f"INSERT INTO data.\"{table}\" (name) VALUES ('row')")
+        )
+    admin_id = await get_user_id(test_db_session, "admin")
+    record = Record(
+        title=f"Swap scope {suffix}",
+        summary="Fixture layer",
+        theme_category=["test"],
+        visibility="private",
+        record_status="published",
+        created_by=admin_id,
+    )
+    test_db_session.add(record)
+    await test_db_session.flush()
+    dataset = Dataset(
+        record_id=record.id,
+        table_name=live,
+        srid=4326,
+        geometry_type="POINT",
+        feature_count=1,
+        column_info=[{"name": "name", "type": "text"}],
+        source_format="csv",
+    )
+    test_db_session.add(dataset)
+    await test_db_session.commit()
+    await test_db_session.refresh(dataset)
+
+    stub = _make_dataset_stub(live)
+    stub.id = dataset.id
+    stub.record_id = dataset.record_id
+    yield stub, staging
+
+    await test_db_session.execute(
+        text("DELETE FROM catalog.records WHERE id = :record_id"),
+        {"record_id": stub.record_id},
+    )
+    for table in (live, staging, f"{live}_old"):
+        await test_db_session.execute(
+            text(f'DROP TABLE IF EXISTS data."{table}" CASCADE')
+        )
+    await test_db_session.commit()
+
+
+def _stub_downstream(monkeypatch, session) -> None:
+    """Neutralize the metadata/audit writes the swap makes after its lock."""
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    async def _noop_quality(*args, **kwargs):
+        return {"score": 0.0, "issues": []}
+
+    monkeypatch.setattr(
+        "app.processing.ingest.metadata.refresh_attribute_metadata", _noop
+    )
+    monkeypatch.setattr(
+        "app.processing.ingest.metadata.compute_quality_score", _noop_quality
+    )
+    monkeypatch.setattr("app.modules.audit.service.audit_emit", _noop)
+    monkeypatch.setattr("app.platform.extensions.get_processing_port", _make_port)
+    monkeypatch.setattr(session, "add", lambda *args, **kwargs: None)
+
+
+async def _run_swap(session, stub, staging):
+    return await _apply_reupload_swap(
+        session,
+        dataset=stub,
+        staging_table=staging,
+        metadata=_minimal_metadata(),
+        sample_values={},
+        user_id=str(uuid.uuid4()),
+        source_filename="x.csv",
+        source_format="csv",
+        original_srid=4326,
+    )
+
+
+class TestSwapLockTimeoutScope:
+    async def test_the_swap_restores_the_lock_timeout_it_installed(
+        self, swap_target, monkeypatch
+    ) -> None:
+        """After the swap the transaction is back on the budget it arrived with."""
+        stub, staging = swap_target
+        import app.core.db as db_module
+
+        async with db_module.async_session() as session:
+            _stub_downstream(monkeypatch, session)
+            before = await session.scalar(
+                text("SELECT current_setting('lock_timeout')")
+            )
+            await _run_swap(session, stub, staging)
+            after = await session.scalar(text("SELECT current_setting('lock_timeout')"))
+            await session.rollback()
+
+        assert after == before, (
+            f"the swap left lock_timeout at {after!r} (it was {before!r}). A "
+            "SET LOCAL survives RELEASE SAVEPOINT, so the DDL budget is still "
+            "in force and clamps every wait the rest of this transaction takes."
+        )
+
+    async def test_a_contended_catalog_row_is_waited_out_not_failed(
+        self, swap_target, monkeypatch
+    ) -> None:
+        """A holder past the DDL budget is waited out, not answered with a conflict."""
+        stub, staging = swap_target
+        monkeypatch.setattr(tasks_common, "_SWAP_FIRST_TIMEOUT", _TEST_SWAP_TIMEOUT)
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as api,
+            db_module.async_session() as probe,
+        ):
+            await holder.execute(
+                select(Dataset.id).where(Dataset.id == stub.id).with_for_update()
+            )
+            _stub_downstream(monkeypatch, api)
+            api_pid = await api.scalar(text("SELECT pg_backend_pid()"))
+            swap = asyncio.create_task(_run_swap(api, stub, staging))
+            try:
+                await _await_lock_wait(probe, api_pid)
+                await asyncio.sleep(_PAST_THE_CLAMP_SECONDS)
+                still_waiting = not swap.done()
+            finally:
+                await holder.rollback()
+
+            try:
+                version = await asyncio.wait_for(swap, timeout=30)
+            except CatalogLockConflict as exc:
+                raise AssertionError(
+                    "the swap failed on the contended datasets row instead of "
+                    "waiting for it: the DDL lock_timeout outlived the savepoint "
+                    "that set it and clamped a wait that asked for no clamp"
+                ) from exc
+            await api.rollback()
+
+        assert still_waiting, (
+            "the swap finished before the DDL budget could have clamped its "
+            "wait, so this run proves nothing about the clamp"
+        )
+        assert version is not None

--- a/backend/tests/test_swap_lock_timeout_scope_1917.py
+++ b/backend/tests/test_swap_lock_timeout_scope_1917.py
@@ -26,6 +26,7 @@ from tests.test_reupload_swap_lock_retry import (
     _make_dataset_stub,
     _make_port,
     _minimal_metadata,
+    _stub_atomic_bump,
 )
 
 pytestmark = pytest.mark.anyio
@@ -94,7 +95,7 @@ async def swap_target(client, test_db_session):
 
 
 def _stub_downstream(monkeypatch, session) -> None:
-    """Neutralize the metadata/audit writes the swap makes after its lock."""
+    """Neutralize the metadata, audit and tile-bump writes the swap makes after its lock."""
 
     async def _noop(*args, **kwargs):
         return None
@@ -111,6 +112,8 @@ def _stub_downstream(monkeypatch, session) -> None:
     monkeypatch.setattr("app.modules.audit.service.audit_emit", _noop)
     monkeypatch.setattr("app.platform.extensions.get_processing_port", _make_port)
     monkeypatch.setattr(session, "add", lambda *args, **kwargs: None)
+    # The atomic bump itself is covered by test_worker_swap_bump_after_lock_1911.py.
+    _stub_atomic_bump(monkeypatch)
 
 
 async def _run_swap(session, stub, staging):


### PR DESCRIPTION
Closes #1917

## What changed

`_apply_reupload_swap` runs `SET LOCAL lock_timeout = '5s'` inside a savepoint before its three `ALTER TABLE ... RENAME` statements. PostgreSQL keeps a `SET LOCAL` across `RELEASE SAVEPOINT` — only `ROLLBACK TO` reverts it — so on the success path the value survived into the `lock_catalog_rows(lock_timeout=None)` wait a few lines below. That wait was bounded at 5s (15s if the DDL retry ran) and failed the ingest job with `CatalogLockConflict` on contention it exists to wait out, contradicting the comment above the call.

- `backend/app/processing/ingest/tasks_common.py`: capture `current_setting('lock_timeout')` before the swap and put that value back after it, via `set_config('lock_timeout', :value, true)` (a `SET LOCAL` that takes a bind parameter). Restoring the captured value rather than `DEFAULT` matters because an outer transaction may have installed its own budget; `DEFAULT` would discard it.
- The restore sits after the whole try/except, not in a `finally` inside the savepoint: a failed swap leaves the subtransaction aborted, so a restore statement there would raise over the original lock-timeout error and break the retry. The failure path needs no restore — `ROLLBACK TO` already reverts the setting.
- The three swap budget constants (`_SWAP_FIRST_TIMEOUT`, `_SWAP_RETRY_TIMEOUT`, `_SWAP_RETRY_SLEEP_MS`) move to module scope so the test can shrink the budget instead of holding a row for five seconds.
- Corrected the comment above `lock_catalog_rows`, which claimed `lock_timeout=None` meant no clamp.
- `_MODULE_LOC_CAPS` for `tasks_common.py`: 2559 → 2578, exact, with the note saying what the lines bought.

## Measured, not assumed

Probe against PostgreSQL 18 on the test instance, one session running the same savepoint sequence plus a second connection holding a row for 8s:

| step | `lock_timeout` |
| --- | --- |
| before `SAVEPOINT` | `0` |
| inside the savepoint, after `SET LOCAL '5s'` | `5s` |
| after `RELEASE SAVEPOINT` | `5s` |
| after a nested `SET LOCAL '15s'` + `ROLLBACK TO` | `5s` |

Same result through SQLAlchemy's `session.begin_nested()`. With the row held for 8s by a second connection, the later unclamped wait:

| variant | outcome |
| --- | --- |
| as shipped | SQLSTATE 55P03 at 5.01s |
| with the restore | acquired at 7.95s |

## Every other `SET LOCAL` in `backend/app/`

An AST pass over `backend/app/` collected every function whose body contains a `SET LOCAL` or `set_config(...)` literal, took the transitive closure of functions that can reach one, and looked for calls to any of them lexically inside an `async with ... begin_nested()` block. The only two hits are the swap's own call sites, both fixed here:

- `tasks_common.py` `_swap_with_timeout()` at the first attempt and at the retry — fixed.

The remaining sites are all issued at the top of a transaction that is meant to carry them to its end, so nothing is scoped smaller than it behaves:

- `catalog_locks.py` `_install_lock_timeout` — the deliberate `REQUEST_LOCK_TIMEOUT`, documented as transaction-wide; this is the wait the swap was clamping.
- `tasks_common.py` `_job_phase_session` — bounds the whole phase-bracket transaction.
- `jobs/router.py` `cancel_job` and `maps/service_crud.py` `lock_map_for_asset_write` — a 2s request budget, intended for the request's transaction.
- `analysis/tasks.py` `_materialize` — the CTAS budget ends at an explicit `commit()`, and registration then sets its own.
- `analysis/tasks.py` `_apply_materialize_work_mem`, `embeddings/helpers.py` `set_hnsw_recall`, `tasks_postgis_refresh.py` `_repair_geom_4326` — per-transaction tuning, no savepoint on the path.
- `statement_timeout.py`, `tenant_session.py`, `tiles/pool.py`, `sandbox/executor.py` — the deadline, tenant GUC, and `SET LOCAL ROLE` / `search_path` bindings, all of which must hold for the whole transaction by design.
- `tenant_adoption_sql.py` — inside a SQL function body, not a savepoint.

## Tests

`backend/tests/test_swap_lock_timeout_scope_1917.py`, two cases:

- the swap leaves `lock_timeout` at the value the transaction arrived with;
- a second connection holds the dataset's catalog row past the swap's DDL budget (shrunk to 500ms via the module constant), and the swap waits it out and completes instead of raising `CatalogLockConflict`. The wait is reached through the `pg_stat_activity` barrier the #1847 suite already uses, and a vacuity guard fails the test if the holder released before the budget could have clamped anything.

Counterfactual: with the restore removed, both fail with their named messages (`the swap left lock_timeout at '5s' (it was '0')` and `the swap failed on the contended datasets row instead of waiting for it`).

Both cases drive the swap with the shared `SimpleNamespace` stub, so they reuse `_stub_atomic_bump` from the sibling suite for the `bump_tile_cache_version_on` call #1916 added — that helper builds an UPDATE against `type(dataset)`, which a stub cannot satisfy. The bump itself is covered by `test_worker_swap_bump_after_lock_1911.py`; the shared stub is left alone.

## Verification

```
uv run pytest tests/test_swap_lock_timeout_scope_1917.py tests/test_worker_swap_bump_after_lock_1911.py \
  tests/test_reupload_swap_lock_retry.py tests/test_layering.py
# 64 passed
uv run ruff check . && uv run ruff format --check .
# All checks passed
```

Before the rebase the same change plus `tests/test_dataset_refresh_runs.py` ran 137 passed.

## Rebase note

#1916 landed on the same function and this branch is rebased onto it. The conflicts were the CHANGELOG (all four entries kept), the `tasks_common` LOC cap (now 2558 -> 2577, matching `wc -l` exactly), and the catalog-locks import line, which keeps `bump_tile_cache_version_on` alongside `lock_catalog_rows` and takes the corrected comment. The lock-timeout fix and #1916's bump are independent: this one touches the savepoint block and the comment above `lock_catalog_rows`, not the bump.


## What this widens, deliberately

Restoring the captured value means the `lock_catalog_rows` wait below the swap is bounded by whatever the session arrived with, which on a default install is `0`. That is the historical behaviour and what the call site's comment always claimed, but it is worth stating rather than leaving for a reader to derive: the transaction holds `AccessExclusiveLock` on the table it just renamed across that wait, so the wait's duration is the window in which the dataset's live table is not readable. The leaked 5s budget was bounding that window by accident while failing the job. Giving the wait a deliberate bound, with its own error mapping, is a separate design call and is filed as #1921 rather than folded in here.

One thing deliberately left alone: in the contention log, `first_timeout_seconds` and `retry_timeout_seconds` stay integer literals while `sleep_ms` reads the module constant. The two timeout constants are duration strings (`"5s"`), those log fields are integers pinned by `test_reupload_swap_lock_retry.py`, and there is no honest conversion once a test patches one to `"500ms"`. Making all three read their constants would mean changing the log's field types and the assertions on them, which is a different change from this one.

