### PR TITLE
fix(sources): judge every service-credential token by the one shared rule (#1755 item 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ and releases use semantic versioning.
   briefly held the dataset's catalog row. The lock budget the table swap sets for its own DDL no
   longer carries over to the wait that follows it. (#1917)
 - The import-commit and re-upload-commit doors accepted a service token containing control
-  characters or whitespace, which every other service door already refused. Both now answer 422
-  before the commit reserves or stages anything. (#1755)
+  characters or whitespace when the job was an ArcGIS one, or one whose service type was not
+  recorded. Both now answer 422 before anything is reserved or staged. WFS and OGC API Features
+  commits already refused such a token at the door and are unchanged. (#1755)
 
 ## [1.18.1] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and releases use semantic versioning.
 - A reupload could fail with a catalog-lock conflict instead of waiting when another operation
   briefly held the dataset's catalog row. The lock budget the table swap sets for its own DDL no
   longer carries over to the wait that follows it. (#1917)
+- The import-commit and re-upload-commit doors accepted a service token containing control
+  characters or whitespace, which every other service door already refused. Both now answer 422
+  before the commit reserves or stages anything. (#1755)
 
 ## [1.18.1] - 2026-09-05
 

--- a/backend/app/modules/catalog/datasets/domain/schemas.py
+++ b/backend/app/modules/catalog/datasets/domain/schemas.py
@@ -26,6 +26,10 @@ from app.modules.catalog.sources.schemas import (
 from app.platform.analysis_sql import MAX_SPATIAL_JOIN_FIELDS
 from app.platform.dataset_origin import OriginKind
 
+# fix(#1755 item 3): the shared rule, not a second copy of it. Every request
+# model carrying a service-credential token judges it by this one function.
+from app.platform.service_auth import _validate_safe_token
+
 
 # feat(#1222): built from the probe's own closed vocabulary rather than
 # retyped, so the two cannot drift. The wording matters as much as the list:
@@ -92,16 +96,6 @@ def _validate_http_url_without_credentials(v: str) -> str:
         raise ValueError(
             "url must not include credential query parameters; use the token field instead"
         )
-    return v
-
-
-def _validate_safe_service_token(v: str | None) -> str | None:
-    if v is None:
-        return v
-    if not v.isprintable():
-        raise ValueError("token contains control characters")
-    if any(c.isspace() for c in v):
-        raise ValueError("token contains whitespace")
     return v
 
 
@@ -786,7 +780,7 @@ class ReuploadServicePreviewRequest(BaseModel):
     token: str | None = Field(
         default=None, max_length=1000, description=DEPRECATED_TOKEN_SUFFIX.strip()
     )
-    _validate_token = field_validator("token")(_validate_safe_service_token)
+    _validate_token = field_validator("token")(_validate_safe_token)
     object_id_field: str | None = Field(default=None, max_length=200)
     # feat(#1746): the fifth model to carry the structured credential. #1760
     # left it out because nothing composed a header for the methods it adds;
@@ -826,6 +820,7 @@ class ReuploadCommitRequest(BaseModel):
     token: str | None = Field(
         default=None, max_length=1000, description=DEPRECATED_TOKEN_SUFFIX.strip()
     )
+    _validate_token = field_validator("token")(_validate_safe_token)
     # GPKG-01 Phase 1058: user-chosen layer for multi-layer GPKG files
     layer_name: str | None = Field(default=None, max_length=500)
     auth: ServiceAuthRequest | None = Field(
@@ -859,7 +854,7 @@ class DatasetRefreshRequest(BaseModel):
             "claimed. A retry needs a new token." + DEPRECATED_TOKEN_SUFFIX
         ),
     )
-    _validate_token = field_validator("token")(_validate_safe_service_token)
+    _validate_token = field_validator("token")(_validate_safe_token)
     auth: ServiceAuthRequest | None = Field(
         default=None, description=SERVICE_AUTH_FIELD_DESCRIPTION
     )

--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -4,11 +4,12 @@ import uuid
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.platform.service_auth import (
     SERVICE_AUTH_FIELD_DESCRIPTION,
     ServiceAuthRequest,
+    _validate_safe_token,
     reject_service_auth_conflict,
 )
 
@@ -241,6 +242,9 @@ class ServiceCommitRequest(BaseCommitRequest):
             "the database. Deprecated: use the auth object with method bearer."
         ),
     )
+    # fix(#1755 item 3): the deprecated flat spelling of a credential is held
+    # to the same rule as the `auth` object beside it on this door.
+    _validate_token = field_validator("token")(_validate_safe_token)
     # feat(#1746 B2b): declared LAST, like every other model that gained this
     # field, because the generated Python SDK gives each field a positional
     # slot in declaration order and appending cannot move a slot that already

--- a/backend/tests/test_1755_token_validator_consolidation.py
+++ b/backend/tests/test_1755_token_validator_consolidation.py
@@ -1,26 +1,16 @@
 """fix(#1755 item 3): one rule for a service-credential token, on every door.
 
-Item 3 asked whether ``_validate_safe_token`` (printable, no whitespace) could
-be folded into the strict header-token policy. It cannot. ``credential_or_422``
-reaches that policy only when ``requires_header_token_policy`` is true, so an
-ArcGIS credential never meets it, and neither does a probe, which has no service
-format yet. On that path the schema rule is the only rule.
-
-What WAS duplicated is the schema rule itself. ``datasets/domain/schemas.py``
-carried a byte-identical private copy under a second name, and while there were
-two copies ``ReuploadCommitRequest.token`` and ``ServiceCommitRequest.token``
-carried neither, so the deprecated flat spelling of a credential was laxer than
-the ``auth`` object beside it on the same door.
-
-These tests pin the consolidated state: every request model that accepts a
-service credential judges its flat ``token`` by the one shared function, and
-the strict header-token policy is unchanged in both directions.
+Every request model accepting a service credential judges its flat ``token`` by
+one shared function, and the door-side header-token policy is unchanged.
 """
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from fastapi import HTTPException
+from httpx import AsyncClient
 from pydantic import ValidationError
 
 from app.core.service_tokens import (
@@ -34,12 +24,21 @@ from app.modules.catalog.datasets.domain.schemas import (
     ReuploadServicePreviewRequest,
 )
 from app.modules.catalog.sources.schemas import ProbeRequest, ServicePreviewRequest
+from app.platform.jobs.models import IngestJob
 from app.platform.service_auth import (
     ServiceAuthRequest,
     _validate_safe_token,
     credential_or_422,
 )
 from app.processing.ingest.schemas import ServiceCommitRequest
+from tests.factories import create_dataset, get_user_id
+
+# The dispatch harnesses #1676 built for these two doors, reused so this suite
+# answers to the same model of a door that the door-policy suite does.
+from tests.test_import_token_lease_1676 import (  # noqa: F401
+    _import_harness,
+    _reupload_harness,
+)
 
 _URL = "https://services.example.test/geoserver/wfs"
 _HEADER_AUTH_FORMAT = "wfs"
@@ -63,12 +62,11 @@ _TOKEN_DOORS = {
     "structured auth": (ServiceAuthRequest, {"method": "bearer"}),
 }
 
-# The rule is printable and whitespace-free, so these are what it refuses. CR
-# and LF are the header-smuggling primitive SEC-021 named.
-# A token holding the two characters base64url refuses, so the schema layer's
-# wider vocabulary is visible. Deliberately low-entropy and obviously synthetic.
+# The two characters base64url refuses, as a low-entropy synthetic value.
 _WIDE_VOCABULARY_TOKEN = "aaaa+bbbb/cccc="
 
+# The rule is printable and whitespace-free, so these are what it refuses.
+# CR and LF are the header-smuggling primitive SEC-021 named.
 _REFUSED_TOKENS = {
     "carriage return": "tok\rX-Injected: yes",
     "line feed": "tok\nX-Injected: yes",
@@ -148,3 +146,108 @@ class TestTheStrictHeaderTokenPolicyIsUnchanged:
         bound = credential_or_422(credential, service_format=service_format)
 
         assert bound is not None
+
+
+# ---------------------------------------------------------------------------
+# The same rule over HTTP, at the two doors this change converted
+# ---------------------------------------------------------------------------
+
+_ARCGIS_URL = "https://example.arcgis.test/rest/services/P/FeatureServer/0"
+
+# Whitespace rather than a control character, so `secret not in resp.text` is a
+# real assertion: JSON escapes a CR, and the raw byte would never appear anyway.
+_UNSAFE_TOKEN_OVER_HTTP = "aaaa bbbb cccc"
+
+
+async def _arcgis_job(session, *, created_by: uuid.UUID, dataset_id=None) -> IngestJob:
+    """A pending ArcGIS service job, bound to a dataset when one is given."""
+    metadata: dict = {"service_type": "ArcGIS FeatureServer", "layer_id": 0}
+    if dataset_id is not None:
+        metadata |= {
+            "reupload": True,
+            "dataset_id": str(dataset_id),
+            "source_type": "service_url",
+        }
+    job = IngestJob(
+        dataset_id=dataset_id,
+        source_filename="Parcels",
+        source_url=_ARCGIS_URL,
+        source_layer="0",
+        created_by=created_by,
+        status="pending",
+        user_metadata=metadata,
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+def _assert_refused_without_the_token(resp, secret: str, *, loc: str) -> None:
+    """422 naming the token field, and the credential absent from the body.
+
+    ``loc`` differs by door: the import-commit refusal is re-raised by the
+    handler from a subclass validation, so it has no ``body`` prefix.
+    """
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"].startswith(f"{loc}:")
+    # `ValidationError.errors()` carries the raw input; the 422 flattener in
+    # standards/ogc/errors.py renders `loc` and `msg` and drops it.
+    assert secret not in resp.text
+
+
+class TestTheCommitDoorsRefuseOverHttp:
+    """The refusal the schema rule newly performs, exercised end to end."""
+
+    pytestmark = pytest.mark.anyio
+
+    async def test_the_import_commit_door_refuses_and_never_echoes_the_token(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = await _arcgis_job(test_db_session, created_by=admin_id)
+
+        async with _import_harness() as task:
+            resp = await client.post(
+                f"/ingest/commit/{job.id}",
+                json={"title": "Parcels", "token": _UNSAFE_TOKEN_OVER_HTTP},
+                headers=admin_auth_header,
+            )
+
+        _assert_refused_without_the_token(resp, _UNSAFE_TOKEN_OVER_HTTP, loc="token")
+        task.defer_async.assert_not_awaited()
+
+    async def test_the_reupload_commit_door_refuses_and_never_echoes_the_token(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="ArcGIS Reupload Dataset",
+            visibility="public",
+            feature_count=100,
+            source_filename="original.geojson",
+            source_url=_ARCGIS_URL,
+        )
+        job = await _arcgis_job(
+            test_db_session, created_by=admin_id, dataset_id=dataset.id
+        )
+
+        async with _reupload_harness() as task:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+                json={"token": _UNSAFE_TOKEN_OVER_HTTP},
+                headers=admin_auth_header,
+            )
+
+        _assert_refused_without_the_token(
+            resp, _UNSAFE_TOKEN_OVER_HTTP, loc="body.token"
+        )
+        task.defer_async.assert_not_awaited()

--- a/backend/tests/test_1755_token_validator_consolidation.py
+++ b/backend/tests/test_1755_token_validator_consolidation.py
@@ -1,0 +1,150 @@
+"""fix(#1755 item 3): one rule for a service-credential token, on every door.
+
+Item 3 asked whether ``_validate_safe_token`` (printable, no whitespace) could
+be folded into the strict header-token policy. It cannot. ``credential_or_422``
+reaches that policy only when ``requires_header_token_policy`` is true, so an
+ArcGIS credential never meets it, and neither does a probe, which has no service
+format yet. On that path the schema rule is the only rule.
+
+What WAS duplicated is the schema rule itself. ``datasets/domain/schemas.py``
+carried a byte-identical private copy under a second name, and while there were
+two copies ``ReuploadCommitRequest.token`` and ``ServiceCommitRequest.token``
+carried neither, so the deprecated flat spelling of a credential was laxer than
+the ``auth`` object beside it on the same door.
+
+These tests pin the consolidated state: every request model that accepts a
+service credential judges its flat ``token`` by the one shared function, and
+the strict header-token policy is unchanged in both directions.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.core.service_tokens import (
+    ARCGIS_SERVICE_FORMAT,
+    CredentialMethod,
+    ServiceCredential,
+)
+from app.modules.catalog.datasets.domain.schemas import (
+    DatasetRefreshRequest,
+    ReuploadCommitRequest,
+    ReuploadServicePreviewRequest,
+)
+from app.modules.catalog.sources.schemas import ProbeRequest, ServicePreviewRequest
+from app.platform.service_auth import (
+    ServiceAuthRequest,
+    _validate_safe_token,
+    credential_or_422,
+)
+from app.processing.ingest.schemas import ServiceCommitRequest
+
+_URL = "https://services.example.test/geoserver/wfs"
+_HEADER_AUTH_FORMAT = "wfs"
+
+# Every request model whose `token` is a service credential, with the fields it
+# requires. `CommitRequest` is absent because it is the flat wire union, and the
+# route re-validates against `ServiceCommitRequest` before reading a credential.
+_TOKEN_DOORS = {
+    "probe": (ProbeRequest, {"url": _URL}),
+    "service preview": (
+        ServicePreviewRequest,
+        {"url": _URL, "service_type": "WFS 2.0.0", "layer_name": "topp:parcels"},
+    ),
+    "reupload service preview": (
+        ReuploadServicePreviewRequest,
+        {"url": _URL, "service_type": "WFS 2.0.0", "layer_name": "topp:parcels"},
+    ),
+    "reupload commit": (ReuploadCommitRequest, {}),
+    "refresh": (DatasetRefreshRequest, {}),
+    "import commit": (ServiceCommitRequest, {"title": "Parcels"}),
+    "structured auth": (ServiceAuthRequest, {"method": "bearer"}),
+}
+
+# The rule is printable and whitespace-free, so these are what it refuses. CR
+# and LF are the header-smuggling primitive SEC-021 named.
+# A token holding the two characters base64url refuses, so the schema layer's
+# wider vocabulary is visible. Deliberately low-entropy and obviously synthetic.
+_WIDE_VOCABULARY_TOKEN = "aaaa+bbbb/cccc="
+
+_REFUSED_TOKENS = {
+    "carriage return": "tok\rX-Injected: yes",
+    "line feed": "tok\nX-Injected: yes",
+    "embedded space": "tok en",
+    "tab": "tok\ttab",
+    "null": "tok\x00",
+}
+
+
+@pytest.mark.parametrize("door", sorted(_TOKEN_DOORS))
+@pytest.mark.parametrize("kind", sorted(_REFUSED_TOKENS))
+def test_every_service_credential_door_refuses_an_unsafe_token(door, kind):
+    model, required = _TOKEN_DOORS[door]
+    with pytest.raises(ValidationError) as exc_info:
+        model(**required, token=_REFUSED_TOKENS[kind])
+
+    fields = {error["loc"][0] for error in exc_info.value.errors()}
+    assert "token" in fields, f"{door} refused the body, but not on the token field"
+
+
+@pytest.mark.parametrize("door", sorted(_TOKEN_DOORS))
+def test_every_service_credential_door_keeps_the_wider_vocabulary(door):
+    """A token outside base64url passes the schema layer. Narrowing it is the
+    door's job, and only where the credential becomes a header line."""
+    model, required = _TOKEN_DOORS[door]
+    model(**required, token=_WIDE_VOCABULARY_TOKEN)
+
+
+@pytest.mark.parametrize("door", sorted(_TOKEN_DOORS))
+def test_every_service_credential_door_uses_the_one_shared_rule(door):
+    model, _ = _TOKEN_DOORS[door]
+    validators = model.__pydantic_decorators__.field_validators
+    on_token = [
+        name
+        for name, decorator in validators.items()
+        if "token" in decorator.info.fields
+    ]
+
+    assert on_token, f"{door} has no validator on its token field"
+    for name in on_token:
+        assert validators[name].func is _validate_safe_token, (
+            f"{door} judges its token by a second copy of the rule"
+        )
+
+
+class TestTheStrictHeaderTokenPolicyIsUnchanged:
+    """The door-side half, which the schema rule neither replaces nor
+    duplicates."""
+
+    def test_a_header_auth_format_still_refuses_a_token_outside_base64url(self):
+        credential = ServiceCredential(
+            method=CredentialMethod.BEARER, token=_WIDE_VOCABULARY_TOKEN
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            credential_or_422(credential, service_format=_HEADER_AUTH_FORMAT)
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["code"] == "invalid_service_token"
+
+    def test_arcgis_still_accepts_a_token_outside_base64url(self):
+        credential = ServiceCredential(
+            method=CredentialMethod.BEARER, token=_WIDE_VOCABULARY_TOKEN
+        )
+        bound = credential_or_422(credential, service_format=ARCGIS_SERVICE_FORMAT)
+
+        assert bound is not None and bound.token == _WIDE_VOCABULARY_TOKEN
+
+    @pytest.mark.parametrize("service_format", [ARCGIS_SERVICE_FORMAT, None])
+    def test_a_url_query_transport_never_reaches_the_strict_policy(
+        self, service_format
+    ):
+        """A URL-query transport admits a control character, so the schema rule
+        is the only one standing on this path."""
+        credential = ServiceCredential(
+            method=CredentialMethod.BEARER, token="tok\rX-Injected: yes"
+        )
+        bound = credential_or_422(credential, service_format=service_format)
+
+        assert bound is not None

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5352,7 +5352,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): +5. BulkDeleteResultItem gained an optional `code`, so a
     # per-item conflict is machine-readable with the same code the
     # single-delete 409 carries. Cap 1536 -> 1540, exact.
-    "backend/app/modules/catalog/datasets/domain/schemas.py": 1540,
+    # fix(#1755 item 3): -5. The module-local copy of the token rule is gone;
+    # the three models import the shared one. Cap 1540 -> 1535, exact.
+    "backend/app/modules/catalog/datasets/domain/schemas.py": 1535,
     # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
     # tasks.py crossed 1000 for the first time here because the four operations
     # are deliberately concentrated rather than spread: it grows by one branch


### PR DESCRIPTION
## What this PR resolves

Refs #1755. The lane was scoped to the backend-hygiene items 8, 10, 11, 14 and 3.
Four of the five are already on `main` at `baa6e296a`, verified file by file rather
than from the issue's triage comment, which is stale. Only item 3 needed work.

- [ ] **Item 8** — `alembic/env.py` `fileConfig(disable_existing_loggers=False)`.
      Already on `main` (#1883), with `backend/tests/test_1755_alembic_logger_flag.py`
      pinning both the flag and the end-to-end effect. Green on this branch.
      `test_1746_stdlib_log_redaction.py` no longer resets `.disabled` — that reset went
      with #1883, so there is nothing left to remove.
- [ ] **Item 10** — the defer-failure cause. Already on `main` (#1833). `DeferFailed`
      carries `cause_class` (`type(cause).__name__`, an identifier and never the
      exception's message), so a bug inside a defer closure no longer reads identically
      to a queue outage. Four tests in `test_defer_orphan_guard.py` cover it. Note this
      landed as a coded field in the 503 body rather than as a log line; the merged design
      argues the class name is safe to return and the raw message is not, and I did not
      re-litigate it.
- [ ] **Item 11** — the `finally`-block cleanups. Already on `main` (#1883) as one
      `cleanup_step` async context manager, applied at 36 sites across seven task modules
      including both named ones. The helper itself lives in `tasks_common.py`, so per the
      lane brief nothing here touches that file.
- [ ] **Item 14** — `enrich_arcgis_feature_counts` folded into `build_arcgis_count_query_url`.
      Already on `main` (#1840). The encoding change is called out in the function's
      docstring, and `TestTheCountQueryHasOneProducer` in `test_arcgis_header_transport_c2.py`
      pins both halves, including a synthetic token holding reserved characters.
- [x] **Item 3** — done here.

## Item 3: what the consolidation turned out to be

The issue asked whether `_validate_safe_token` (printable, no whitespace) could be
folded into the strict header-token policy now that the policy runs at every door.
**It cannot.** `credential_or_422` reaches that policy only when
`requires_header_token_policy(service_format)` is true. An ArcGIS credential is a
URL-query transport and is not in that set, and a probe has no service format at all
yet, so on both paths `credential_or_422` checks only that a bearer token is non-blank.
The schema rule is the only rule there. Folding it away would leave a control character
judged nowhere until the credential had already been spent at the origin.

What *was* duplicated is the schema rule itself.
`backend/app/modules/catalog/datasets/domain/schemas.py` carried a private copy of it
under a second name, `_validate_safe_service_token`. The two agree on every behaviour
that matters — `None` passthrough, check order, exception type, no stripping, the same
pydantic hook — but they are not byte-identical: the shared rule's control-character
message names header injection and the copy's did not. Nothing in the tree pinned
either string, so deleting the copy changes no test. And while there were two copies of
the rule, two request models carried neither:

| Request model | Before | After |
| --- | --- | --- |
| `ReuploadCommitRequest.token` | no rule | shared rule |
| `ServiceCommitRequest.token` | no rule | shared rule |
| `ReuploadServicePreviewRequest.token` | local copy | shared rule |
| `DatasetRefreshRequest.token` | local copy | shared rule |
| `ProbeRequest` / `ServicePreviewRequest` / `ServiceAuthRequest` | shared rule | unchanged |

So on the import-commit and re-upload-commit doors the deprecated flat `token` was
laxer than the `auth` object sitting beside it on the same body: a credential holding
a control character or whitespace was accepted where every sibling door answered 422.
That is the user-visible half and the CHANGELOG entry.

`CommitRequest`, the flat wire union for `POST /ingest/commit/{job_id}`, is deliberately
left alone. Its `token` is documented as a preview confirmation token, and the route
re-validates the body against `ServiceCommitRequest` before it reads a credential, so
the service path is covered by the subclass and the refusal still arrives through
FastAPI's 422 envelope before any write.

## The refusal's shape changes for WFS and OGC API Features

Worth calling out because it is user-visible, and it is not what this PR set out to
change. For a WFS or OAPIF commit carrying a whitespace or control-character token, the
refusal now happens at the schema layer instead of at the door, because the schema rule
runs first. The status is 422 either way, but `detail` goes from
`{"code": "invalid_service_token", "message": ...}` to a flat validation string with no
`code` key. The frontend maps that code to a translated banner
(`frontend/src/lib/error-map.ts:449`) and the CLI maps it to its own sentence
(`cli/geolens_cli/refresh.py:86`); for exactly these inputs both now fall back to a
generic 422. Every other refused input keeps the structured code. Restoring a structured
code at the schema layer is #1924, not this PR.

## Not changed

The strict header-token policy is untouched in both directions, and the tests assert
it: a WFS credential outside base64url is still refused at the door with
`invalid_service_token`, and ArcGIS still keeps its wider vocabulary. No API contract
change — `python scripts/dump_openapi.py --check` is clean, so no SDK or CLI regeneration.

Two things deliberately left for their own PRs:

- **#1923** — `ServiceCommitRequest.token` still has no `max_length`, unlike its six
  siblings. Adding one changes the JSON Schema and would drag `openapi.json` plus SDK
  regeneration into a validator PR.
- **#1924** — a schema-layer credential refusal should carry the same structured
  `invalid_service_token` code a door-layer one does, which is the code the frontend
  banner and the CLI message are built from. See the section above.

`CommitRequest.token` is untouched: despite the name it is the preview confirmation
token, not a service credential, and it is out of this PR's scope.

`backend/app/modules/catalog/datasets/domain/schemas.py` shrank by 5 lines; its
`_MODULE_LOC_CAPS` entry is lowered to match in the same commit.

## Door-level coverage

The suite now also exercises both converted doors over HTTP, on an ArcGIS job — the path
where the strict policy never ran. Each asserts 422, that the response body names the
token field, and that the credential appears nowhere in the body. That last assertion is
the point: `ValidationError.errors()` carries the raw input, and the only thing keeping
it out of the response is the 422 flattener in `backend/app/standards/ogc/errors.py`
rendering `loc` and `msg` and dropping `input`. Nothing pinned that before. The two doors
render a different `loc` for the same refusal, so the helper takes it — the re-upload
door refuses at the FastAPI signature (`body.token`), the import door through
`commit_import`'s own `RequestValidationError` re-raise (`token`), a branch whose comment
said it would fire only once a subclass added stricter per-field rules. This is that phase.

## Verification

```
cd backend && uv run ruff check .            # All checks passed!
cd backend && uv run ruff format --check .   # 1182 files already formatted

# tests/test_1755_token_validator_consolidation.py tests/test_layering.py
# tests/test_commit_request_schemas.py tests/test_service_auth_contract_1746.py
# tests/test_service_auth_transport_1746.py tests/test_door_token_policy_1746.py
# tests/test_1755_alembic_logger_flag.py tests/test_1755_cleanup_step.py
# tests/test_defer_orphan_guard.py
577 passed

# tests/test_reupload.py tests/test_reupload_service.py
# tests/test_reupload_expected_origin_1768.py tests/test_job_cancel_reupload_commit.py
# tests/test_import_token_lease_1676.py tests/test_dataset_refresh_runs.py
# tests/test_reupload_idor.py
164 passed

# tests/test_ingest.py tests/test_ingest_fan_out.py tests/test_ingest_layer_name_guard.py
# tests/test_1184_body_limit_per_route.py
138 passed

cd backend && PYTHONPATH=. uv run python scripts/dump_openapi.py --check   # exit 0
```

The suite was run against a counterfactual with both new validator lines removed: 14 of
its 55 cases fail there, on exactly the two doors that changed, across the model-level
assertions, the one-shared-function assertion, and both door-level cases, which answer
202 without the change.
