### PR TITLE
fix(ingest): cap the import-commit service token like its six siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and releases use semantic versioning.
   characters or whitespace when the job was an ArcGIS one, or one whose service type was not
   recorded. Both now answer 422 before anything is reserved or staged. WFS and OGC API Features
   commits already refused such a token at the door and are unchanged. (#1755)
+- The import-commit door accepted a service token with no length limit of its own, while every
+  other service door caps one at 1000 characters. An over-long token is now refused with 422
+  before anything is reserved or staged. (#1923)
 
 ## [1.18.1] - 2026-09-05
 

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -1912,10 +1912,9 @@ async def commit_import(
     try:
         commit = Subclass.model_validate(request.model_dump())
     except ValidationError as e:
-        # Preserve FastAPI's standard 422 envelope. Currently a safety net:
-        # the flat CommitRequest already validated 'title' at the signature
-        # level. This branch only fires if a subclass adds stricter
-        # per-field rules in a future phase.
+        # fix(#1755, #1923): the only enforcement of the import-commit door's
+        # stricter token rules — the flat CommitRequest declares neither the
+        # shared safe-token rule nor the 1000-character cap.
         raise RequestValidationError(errors=e.errors())
 
     # fix(#823): dash-guard + all_layers membership check for the commit's

--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -237,6 +237,7 @@ class ServiceCommitRequest(BaseCommitRequest):
 
     token: str | None = Field(
         default=None,
+        max_length=1000,
         description=(
             "Optional auth token for protected services. Never persisted to "
             "the database. Deprecated: use the auth object with method bearer."

--- a/backend/tests/test_1755_token_validator_consolidation.py
+++ b/backend/tests/test_1755_token_validator_consolidation.py
@@ -65,6 +65,8 @@ _TOKEN_DOORS = {
 # The two characters base64url refuses, as a low-entropy synthetic value.
 _WIDE_VOCABULARY_TOKEN = "aaaa+bbbb/cccc="
 
+_TOKEN_MAX_LENGTH = 1000
+
 # The rule is printable and whitespace-free, so these are what it refuses.
 # CR and LF are the header-smuggling primitive SEC-021 named.
 _REFUSED_TOKENS = {
@@ -93,6 +95,18 @@ def test_every_service_credential_door_keeps_the_wider_vocabulary(door):
     door's job, and only where the credential becomes a header line."""
     model, required = _TOKEN_DOORS[door]
     model(**required, token=_WIDE_VOCABULARY_TOKEN)
+
+
+@pytest.mark.parametrize("door", sorted(_TOKEN_DOORS))
+def test_every_service_credential_door_caps_its_token(door):
+    model, required = _TOKEN_DOORS[door]
+    model(**required, token="a" * _TOKEN_MAX_LENGTH)
+
+    with pytest.raises(ValidationError) as exc_info:
+        model(**required, token="a" * (_TOKEN_MAX_LENGTH + 1))
+
+    fields = {error["loc"][0] for error in exc_info.value.errors()}
+    assert "token" in fields, f"{door} refused the body, but not on the token field"
 
 
 @pytest.mark.parametrize("door", sorted(_TOKEN_DOORS))
@@ -218,6 +232,26 @@ class TestTheCommitDoorsRefuseOverHttp:
             )
 
         _assert_refused_without_the_token(resp, _UNSAFE_TOKEN_OVER_HTTP, loc="token")
+        task.defer_async.assert_not_awaited()
+
+    async def test_the_import_commit_door_refuses_a_token_past_the_cap(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        admin_id = await get_user_id(test_db_session, "admin")
+        job = await _arcgis_job(test_db_session, created_by=admin_id)
+        over_cap = "a" * (_TOKEN_MAX_LENGTH + 1)
+
+        async with _import_harness() as task:
+            resp = await client.post(
+                f"/ingest/commit/{job.id}",
+                json={"title": "Parcels", "token": over_cap},
+                headers=admin_auth_header,
+            )
+
+        _assert_refused_without_the_token(resp, over_cap, loc="token")
         task.defer_async.assert_not_awaited()
 
     async def test_the_reupload_commit_door_refuses_and_never_echoes_the_token(

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3377,8 +3377,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # first meets a whole-file check. Cap 2602 -> 2616, exact.
     # fix(#1848): +50. `upload_file` commits the job before the spooled body
     # is staged and binds through a guarded UPDATE that stamps `staged_at`; the
-    # lines are the guard helper, the two guarded writes and the 409. To 2666.
-    "backend/app/processing/ingest/router.py": 2666,
+    # lines are the guard helper, the two guarded writes and the 409.
+    "backend/app/processing/ingest/router.py": 2665,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901


### PR DESCRIPTION
## What changed

`ServiceCommitRequest.token` in `backend/app/processing/ingest/schemas.py` now carries `max_length=1000`, the same constraint its six sibling models already declare on the flat service-credential field: `ProbeRequest`, `ServicePreviewRequest`, `ReuploadServicePreviewRequest`, `ReuploadCommitRequest`, `DatasetRefreshRequest` and `ServiceAuthRequest`. Same spelling, same error behaviour — a 422 naming the `token` field.

## Why

The import-commit door was the one service door with no bound of its own on the credential it accepts. Only the body-size middleware stood between a caller and a 200 000-character token, so an absurd length failed at the service it was eventually sent to instead of at the door that owns the rule.

## The snapshot and the SDKs did not change

The issue expected this to move `backend/openapi.json` and pull an SDK regeneration. It does not, and that is worth recording rather than assuming next time.

`ServiceCommitRequest` is not an OpenAPI component. The published body schema for `POST /ingest/commit/{job_id}` is the flat `CommitRequest` union; the route picks a subclass with `_pick_commit_subclass(job)` and re-validates against it, so the constraint lives entirely on that internal re-validation. All four regeneration artifacts were refreshed anyway and every one is byte-identical to `main`:

| artifact | gate | result |
| --- | --- | --- |
| `backend/openapi.json` | `dump_openapi.py --check` | exit 0, no diff |
| `sdks/python`, `sdks/typescript` | `make sdks-check` (full regen + `tsc` + SDK tests) | exit 0, no diff |
| `frontend/src/types/api.generated.ts` | `npm run types:check` | exit 0, no diff |

Because the cap is invisible in the published contract, the new tests prove it reaches a caller: `test_the_import_commit_door_refuses_a_token_past_the_cap` posts a 1001-character token to the live commit route and asserts 422, the token absent from the response body, and nothing deferred to the queue.

## The re-validation branch is no longer a hypothetical

That same branch in `commit_import` carried a comment calling itself a safety net that "only fires if a subclass adds stricter per-field rules in a future phase". The future phase arrived: since #1755 it is the only enforcement of the shared safe-token rule at this door, and after this PR the only enforcement of the cap, because the flat `CommitRequest` declares neither. The comment now names that invariant, so the branch does not read as dead code to whoever passes through next.

The `_MODULE_LOC_CAPS` entry for `router.py` ratchets 2666 → 2665 to match: the replacement comment is one line shorter, and the ratchet is exact in both directions. Its stale running total came off with it, leaving the `#1848` ledger entry accurate.

## `CommitRequest.token` — unchanged, tracked as #1931

Left alone as the issue asked, but the reasoning behind that instruction does not hold and #1931 now records why. The field is not a preview confirmation token; that concept lives elsewhere in the tree (`preview_token`, on the config-import surface). On the service path the route reads this very wire field as the credential, and the ArcGIS sign-in response tells callers to do exactly that — "Put that token in the `token` field on probe, preview, commit and refresh" (`backend/app/modules/catalog/sources/router.py:1751`).

Nothing is broken by that: the subclass re-validation applies both the shared safe-token rule and now the cap before the value is read. The published contract simply documents neither constraint, and the field's description is wrong. Capping and re-describing it is a contract change with a real snapshot and SDK diff, so it belongs in #1931 rather than riding along here.

## Verification

```
cd backend && uv run ruff check .                        # All checks passed!
cd backend && uv run ruff format --check .               # 1184 files already formatted
pytest tests/test_1755_token_validator_consolidation.py \
       tests/test_commit_request_schemas.py \
       tests/test_layering.py -q                         # 134 passed
pytest tests/test_sdks_round_trip.py \
       tests/test_service_auth_contract_1746.py          # 92 passed (with the schema suite)
make sdks-check                                          # exit 0
cd frontend && npm run types:check                       # exit 0
JWT_SECRET_KEY=… PYTHONPATH=. \
  uv run python scripts/dump_openapi.py --check          # exit 0
```

Positive control: with the `max_length` line removed, `test_every_service_credential_door_caps_its_token` fails on the `import commit` parameter alone and the other six doors pass.

Closes #1923
Refs #1931
