### PR TITLE
fix(api): give a schema-layer credential refusal the door's error code (#1924)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and releases use semantic versioning.
 - The import-commit door accepted a service token with no length limit of its own, while every
   other service door caps one at 1000 characters. An over-long token is now refused with 422
   before anything is reserved or staged. (#1923)
+- A service token refused for control characters or whitespace now answers with the same
+  `invalid_service_token` code the other credential refusals carry, so the app and the CLI show
+  the token-specific message on every service door instead of a generic validation error. (#1924)
 
 ## [1.18.1] - 2026-09-05
 

--- a/backend/app/core/coded_errors.py
+++ b/backend/app/core/coded_errors.py
@@ -1,0 +1,19 @@
+"""A validator refusal that carries the error code its response publishes.
+
+In ``core/`` for the reason ``upload_errors.py`` is: the raiser lives in
+``platform/``, the renderer in ``standards/``, and neither may import the other.
+"""
+
+
+class CodedValueError(ValueError):
+    """A field refusal whose ``code`` reaches the body beside its ``message``.
+
+    ``message`` is published, so it states the policy and never the rejected
+    value. Pydantic keeps the raised instance under ``ctx["error"]``, which is
+    where the 422 handler reads the code back.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message

--- a/backend/app/core/coded_errors.py
+++ b/backend/app/core/coded_errors.py
@@ -1,7 +1,7 @@
 """A validator refusal that carries the error code its response publishes.
 
-In ``core/`` for the reason ``upload_errors.py`` is: the raiser lives in
-``platform/``, the renderer in ``standards/``, and neither may import the other.
+In ``core/`` because it is layer-neutral: the raiser is in ``platform/``, the
+renderer in ``standards/``, and the type carries no logic from either.
 """
 
 

--- a/backend/app/platform/service_auth.py
+++ b/backend/app/platform/service_auth.py
@@ -40,6 +40,7 @@ from typing import Any, Literal
 from fastapi import HTTPException, status
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from app.core.coded_errors import CodedValueError
 from app.core.service_tokens import (
     BASIC_USERNAME_POLICY,
     CREDENTIAL_METHOD_POLICY,
@@ -338,15 +339,20 @@ def _validate_safe_token(v: str | None) -> str | None:
     additional outbound HTTP headers through the libcurl pipeline. Legitimate
     JWT / base64url / ArcGIS tokens never contain control characters or
     whitespace, so reject them at the API boundary (422).
+
+    The refusal carries ``invalid_service_token``, the code a door-layer
+    refusal returns and the clients map, so a caller reads the same message
+    whichever layer judges the credential.
     """
     if v is None:
         return v
     if not v.isprintable():
-        raise ValueError(
-            "token contains control characters (possible header injection)"
+        raise CodedValueError(
+            INVALID_SERVICE_TOKEN_CODE,
+            "token contains control characters (possible header injection)",
         )
     if any(c.isspace() for c in v):
-        raise ValueError("token contains whitespace")
+        raise CodedValueError(INVALID_SERVICE_TOKEN_CODE, "token contains whitespace")
     return v
 
 

--- a/backend/app/standards/ogc/errors.py
+++ b/backend/app/standards/ogc/errors.py
@@ -258,17 +258,19 @@ def _allow_header_with_head(headers: dict[str, str] | None) -> dict[str, str] | 
 def _coded_detail(exc: RequestValidationError) -> dict[str, str] | None:
     """The ``{"code", "message"}`` detail a coded field refusal answers with.
 
-    None unless the coded refusal is the request's only error: a door judges a
-    credential once the whole body validated, so a request carrying other field
-    errors keeps the flattened list instead. Never reads pydantic's ``input``.
+    None unless every error is coded and they agree on code and message — one
+    mistake spelled on two fields. Anything else keeps the flattened list, so a
+    caller is still told about each distinct thing. Never reads ``input``.
     """
-    errors = exc.errors()
-    if len(errors) != 1:
+    causes = [(error.get("ctx") or {}).get("error") for error in exc.errors()]
+    if not causes or not all(isinstance(cause, CodedValueError) for cause in causes):
         return None
-    cause = (errors[0].get("ctx") or {}).get("error")
-    if not isinstance(cause, CodedValueError):
+    first = causes[0]
+    if any(
+        cause.code != first.code or cause.message != first.message for cause in causes
+    ):
         return None
-    return {"code": cause.code, "message": cause.message}
+    return {"code": first.code, "message": first.message}
 
 
 def register_error_handlers(app: FastAPI) -> None:

--- a/backend/app/standards/ogc/errors.py
+++ b/backend/app/standards/ogc/errors.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from app.core.coded_errors import CodedValueError
 from app.core.logging_config import safe_access_log_path
 from app.core.url_redaction import redact_query_credentials
 from app.standards.ogc.utils import standards_api_path
@@ -254,6 +255,22 @@ def _allow_header_with_head(headers: dict[str, str] | None) -> dict[str, str] | 
     return updated
 
 
+def _coded_detail(exc: RequestValidationError) -> dict[str, str] | None:
+    """The ``{"code", "message"}`` detail a coded field refusal answers with.
+
+    None unless the coded refusal is the request's only error: a door judges a
+    credential once the whole body validated, so a request carrying other field
+    errors keeps the flattened list instead. Never reads pydantic's ``input``.
+    """
+    errors = exc.errors()
+    if len(errors) != 1:
+        return None
+    cause = (errors[0].get("ctx") or {}).get("error")
+    if not isinstance(cause, CodedValueError):
+        return None
+    return {"code": cause.code, "message": cause.message}
+
+
 def register_error_handlers(app: FastAPI) -> None:
     @app.exception_handler(HTTPException)
     async def http_exception_handler(
@@ -303,9 +320,14 @@ def register_error_handlers(app: FastAPI) -> None:
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
         status_code = 400 if _is_standards_path(request) else 422
-        detail = "; ".join(
-            f"{'.'.join(str(loc) for loc in e['loc'])}: {e['msg']}"
-            for e in exc.errors()
+        coded = _coded_detail(exc)
+        detail: str | dict[str, str] = (
+            coded
+            if coded is not None
+            else "; ".join(
+                f"{'.'.join(str(loc) for loc in e['loc'])}: {e['msg']}"
+                for e in exc.errors()
+            )
         )
         return JSONResponse(
             status_code=status_code,

--- a/backend/app/standards/ogc/errors.py
+++ b/backend/app/standards/ogc/errors.py
@@ -258,18 +258,29 @@ def _allow_header_with_head(headers: dict[str, str] | None) -> dict[str, str] | 
 def _coded_detail(exc: RequestValidationError) -> dict[str, str] | None:
     """The ``{"code", "message"}`` detail a coded field refusal answers with.
 
-    None unless every error is coded and they agree on code and message — one
-    mistake spelled on two fields. Anything else keeps the flattened list, so a
-    caller is still told about each distinct thing. Never reads ``input``.
+    None unless every error is coded and they agree on code, message and the
+    value refused — one mistake spelled on two fields. Anything else keeps the
+    flattened list, so a caller is still told about each distinct thing.
+
+    Two refused values are compared in memory; only the code and the policy
+    reach the body.
     """
-    causes = [(error.get("ctx") or {}).get("error") for error in exc.errors()]
-    if not causes or not all(isinstance(cause, CodedValueError) for cause in causes):
+    errors = exc.errors()
+    if not errors:
         return None
-    first = causes[0]
-    if any(
-        cause.code != first.code or cause.message != first.message for cause in causes
-    ):
+    first = (errors[0].get("ctx") or {}).get("error")
+    if not isinstance(first, CodedValueError):
         return None
+    first_input = errors[0].get("input")
+    for error in errors[1:]:
+        cause = (error.get("ctx") or {}).get("error")
+        if (
+            not isinstance(cause, CodedValueError)
+            or cause.code != first.code
+            or cause.message != first.message
+            or error.get("input") != first_input
+        ):
+            return None
     return {"code": first.code, "message": first.message}
 
 

--- a/backend/tests/test_1755_token_validator_consolidation.py
+++ b/backend/tests/test_1755_token_validator_consolidation.py
@@ -197,16 +197,16 @@ async def _arcgis_job(session, *, created_by: uuid.UUID, dataset_id=None) -> Ing
     return job
 
 
-def _assert_refused_without_the_token(resp, secret: str, *, loc: str) -> None:
-    """422 naming the token field, and the credential absent from the body.
-
-    ``loc`` differs by door: the import-commit refusal is re-raised by the
-    handler from a subclass validation, so it has no ``body`` prefix.
-    """
+def _assert_refused_without_the_token(resp, secret: str) -> None:
+    """422 carrying the shared refusal code, and the credential absent."""
     assert resp.status_code == 422, resp.text
-    assert resp.json()["detail"].startswith(f"{loc}:")
-    # `ValidationError.errors()` carries the raw input; the 422 flattener in
-    # standards/ogc/errors.py renders `loc` and `msg` and drops it.
+    detail = resp.json()["detail"]
+    # fix(#1924): a schema-layer refusal publishes the same code a door-layer
+    # one does — the frontend banner and the CLI sentence key on it.
+    assert detail["code"] == "invalid_service_token"
+    assert "whitespace" in detail["message"]
+    # `ValidationError.errors()` carries the raw input; the handler in
+    # standards/ogc/errors.py renders the code and policy and drops it.
     assert secret not in resp.text
 
 
@@ -231,7 +231,7 @@ class TestTheCommitDoorsRefuseOverHttp:
                 headers=admin_auth_header,
             )
 
-        _assert_refused_without_the_token(resp, _UNSAFE_TOKEN_OVER_HTTP, loc="token")
+        _assert_refused_without_the_token(resp, _UNSAFE_TOKEN_OVER_HTTP)
         task.defer_async.assert_not_awaited()
 
     async def test_the_import_commit_door_refuses_a_token_past_the_cap(
@@ -240,6 +240,7 @@ class TestTheCommitDoorsRefuseOverHttp:
         admin_auth_header: dict,
         test_db_session,
     ) -> None:
+        """The cap is not a coded refusal, so it answers with the field list."""
         admin_id = await get_user_id(test_db_session, "admin")
         job = await _arcgis_job(test_db_session, created_by=admin_id)
         over_cap = "a" * (_TOKEN_MAX_LENGTH + 1)
@@ -251,7 +252,11 @@ class TestTheCommitDoorsRefuseOverHttp:
                 headers=admin_auth_header,
             )
 
-        _assert_refused_without_the_token(resp, over_cap, loc="token")
+        assert resp.status_code == 422, resp.text
+        detail = resp.json()["detail"]
+        assert isinstance(detail, str)
+        assert detail.startswith("token:")
+        assert over_cap not in resp.text
         task.defer_async.assert_not_awaited()
 
     async def test_the_reupload_commit_door_refuses_and_never_echoes_the_token(
@@ -281,7 +286,40 @@ class TestTheCommitDoorsRefuseOverHttp:
                 headers=admin_auth_header,
             )
 
-        _assert_refused_without_the_token(
-            resp, _UNSAFE_TOKEN_OVER_HTTP, loc="body.token"
+        _assert_refused_without_the_token(resp, _UNSAFE_TOKEN_OVER_HTTP)
+        task.defer_async.assert_not_awaited()
+
+    async def test_a_second_field_error_keeps_the_flattened_list(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        """fix(#1924): a second field error keeps the flattened list."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="ArcGIS Reupload Dataset Two",
+            visibility="public",
+            feature_count=100,
+            source_filename="original.geojson",
+            source_url=_ARCGIS_URL,
         )
+        job = await _arcgis_job(
+            test_db_session, created_by=admin_id, dataset_id=dataset.id
+        )
+
+        async with _reupload_harness() as task:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+                json={"token": _UNSAFE_TOKEN_OVER_HTTP, "srid_override": 0},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 422, resp.text
+        detail = resp.json()["detail"]
+        assert isinstance(detail, str)
+        assert "body.token:" in detail and "body.srid_override:" in detail
+        assert _UNSAFE_TOKEN_OVER_HTTP not in resp.text
         task.defer_async.assert_not_awaited()

--- a/backend/tests/test_1755_token_validator_consolidation.py
+++ b/backend/tests/test_1755_token_validator_consolidation.py
@@ -6,13 +6,16 @@ one shared function, and the door-side header-token policy is unchanged.
 
 from __future__ import annotations
 
+import inspect
 import uuid
 
 import pytest
 from fastapi import HTTPException
+from fastapi.exceptions import RequestValidationError
 from httpx import AsyncClient
 from pydantic import ValidationError
 
+from app.core.coded_errors import CodedValueError
 from app.core.service_tokens import (
     ARCGIS_SERVICE_FORMAT,
     CredentialMethod,
@@ -26,11 +29,13 @@ from app.modules.catalog.datasets.domain.schemas import (
 from app.modules.catalog.sources.schemas import ProbeRequest, ServicePreviewRequest
 from app.platform.jobs.models import IngestJob
 from app.platform.service_auth import (
+    INVALID_SERVICE_TOKEN_CODE,
     ServiceAuthRequest,
     _validate_safe_token,
     credential_or_422,
 )
 from app.processing.ingest.schemas import ServiceCommitRequest
+from app.standards.ogc.errors import _coded_detail
 from tests.factories import create_dataset, get_user_id
 
 # The dispatch harnesses #1676 built for these two doors, reused so this suite
@@ -124,6 +129,41 @@ def test_every_service_credential_door_uses_the_one_shared_rule(door):
         assert validators[name].func is _validate_safe_token, (
             f"{door} judges its token by a second copy of the rule"
         )
+
+
+def test_the_shared_rule_never_interpolates_the_token():
+    """fix(#1924): its messages reach a response body, so they carry no brace."""
+    assert "{" not in inspect.getsource(_validate_safe_token)
+
+
+def test_two_coded_refusals_that_disagree_fall_back_to_the_field_list():
+    """fix(#1924): two different defects are two things to tell the caller."""
+    whitespace = CodedValueError(
+        INVALID_SERVICE_TOKEN_CODE, "token contains whitespace"
+    )
+    control = CodedValueError(
+        INVALID_SERVICE_TOKEN_CODE, "token contains control chars"
+    )
+    errors = [
+        {
+            "loc": ("body", "token"),
+            "msg": "",
+            "type": "value_error",
+            "ctx": {"error": whitespace},
+        },
+        {
+            "loc": ("body", "auth", "token"),
+            "msg": "",
+            "type": "value_error",
+            "ctx": {"error": control},
+        },
+    ]
+
+    assert _coded_detail(RequestValidationError(errors)) is None
+    assert _coded_detail(RequestValidationError(errors[:1])) == {
+        "code": INVALID_SERVICE_TOKEN_CODE,
+        "message": whitespace.message,
+    }
 
 
 class TestTheStrictHeaderTokenPolicyIsUnchanged:
@@ -322,4 +362,38 @@ class TestTheCommitDoorsRefuseOverHttp:
         assert isinstance(detail, str)
         assert "body.token:" in detail and "body.srid_override:" in detail
         assert _UNSAFE_TOKEN_OVER_HTTP not in resp.text
+        task.defer_async.assert_not_awaited()
+
+    async def test_both_spellings_of_one_bad_token_keep_the_code(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+    ) -> None:
+        """fix(#1924): the flat and nested spellings are one mistake, not two."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=admin_id,
+            name="ArcGIS Reupload Dataset Three",
+            visibility="public",
+            feature_count=100,
+            source_filename="original.geojson",
+            source_url=_ARCGIS_URL,
+        )
+        job = await _arcgis_job(
+            test_db_session, created_by=admin_id, dataset_id=dataset.id
+        )
+
+        async with _reupload_harness() as task:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/reupload/{job.id}/commit",
+                json={
+                    "token": _UNSAFE_TOKEN_OVER_HTTP,
+                    "auth": {"method": "bearer", "token": _UNSAFE_TOKEN_OVER_HTTP},
+                },
+                headers=admin_auth_header,
+            )
+
+        _assert_refused_without_the_token(resp, _UNSAFE_TOKEN_OVER_HTTP)
         task.defer_async.assert_not_awaited()

--- a/backend/tests/test_1755_token_validator_consolidation.py
+++ b/backend/tests/test_1755_token_validator_consolidation.py
@@ -132,38 +132,52 @@ def test_every_service_credential_door_uses_the_one_shared_rule(door):
 
 
 def test_the_shared_rule_never_interpolates_the_token():
-    """fix(#1924): its messages reach a response body, so they carry no brace."""
+    """Its messages reach a response body, so they carry no brace."""
     assert "{" not in inspect.getsource(_validate_safe_token)
 
 
-def test_two_coded_refusals_that_disagree_fall_back_to_the_field_list():
-    """fix(#1924): two different defects are two things to tell the caller."""
-    whitespace = CodedValueError(
-        INVALID_SERVICE_TOKEN_CODE, "token contains whitespace"
-    )
-    control = CodedValueError(
-        INVALID_SERVICE_TOKEN_CODE, "token contains control chars"
-    )
-    errors = [
+_WHITESPACE_POLICY = "token contains whitespace"
+_CONTROL_POLICY = "token contains control characters"
+
+
+def _coded_errors(*refusals: tuple[str, str]) -> list[dict]:
+    """One coded error per refusal, on the flat then the nested token field."""
+    locs = (("body", "token"), ("body", "auth", "token"))
+    return [
         {
-            "loc": ("body", "token"),
+            "loc": loc,
             "msg": "",
             "type": "value_error",
-            "ctx": {"error": whitespace},
-        },
-        {
-            "loc": ("body", "auth", "token"),
-            "msg": "",
-            "type": "value_error",
-            "ctx": {"error": control},
-        },
+            "ctx": {"error": CodedValueError(INVALID_SERVICE_TOKEN_CODE, policy)},
+            "input": value,
+        }
+        for loc, (policy, value) in zip(locs, refusals)
     ]
 
-    assert _coded_detail(RequestValidationError(errors)) is None
-    assert _coded_detail(RequestValidationError(errors[:1])) == {
+
+def test_the_coded_detail_collapses_only_one_mistake_spelled_twice():
+    """Same policy and same refused value collapse; anything else does not."""
+    one_paste = _coded_errors(
+        (_WHITESPACE_POLICY, "aaa bbb"), (_WHITESPACE_POLICY, "aaa bbb")
+    )
+    detail = _coded_detail(RequestValidationError(one_paste))
+    assert detail == {
         "code": INVALID_SERVICE_TOKEN_CODE,
-        "message": whitespace.message,
+        "message": _WHITESPACE_POLICY,
     }
+    # The collapsed detail publishes the policy alone. Comparing the two
+    # refused values never carries either of them out of memory.
+    assert "aaa bbb" not in str(detail)
+
+    two_defects = _coded_errors(
+        (_WHITESPACE_POLICY, "aaa bbb"), (_CONTROL_POLICY, "aaa bbb")
+    )
+    assert _coded_detail(RequestValidationError(two_defects)) is None
+
+    two_values = _coded_errors(
+        (_WHITESPACE_POLICY, "aaa bbb"), (_WHITESPACE_POLICY, "ccc ddd")
+    )
+    assert _coded_detail(RequestValidationError(two_values)) is None
 
 
 class TestTheStrictHeaderTokenPolicyIsUnchanged:
@@ -335,7 +349,7 @@ class TestTheCommitDoorsRefuseOverHttp:
         admin_auth_header: dict,
         test_db_session,
     ) -> None:
-        """fix(#1924): a second field error keeps the flattened list."""
+        """A second field error keeps the flattened list."""
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await create_dataset(
             test_db_session,
@@ -370,7 +384,7 @@ class TestTheCommitDoorsRefuseOverHttp:
         admin_auth_header: dict,
         test_db_session,
     ) -> None:
-        """fix(#1924): the flat and nested spellings are one mistake, not two."""
+        """The flat and nested spellings are one mistake, not two."""
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await create_dataset(
             test_db_session,

--- a/backend/tests/test_service_auth_contract_1746.py
+++ b/backend/tests/test_service_auth_contract_1746.py
@@ -1142,8 +1142,8 @@ class TestABlankValueIsNotACredential:
     ) -> None:
         """Refused by `_validate_safe_token`, which runs ahead of the shape rule.
 
-        fix(#1924): the nested `auth.token` spelling publishes the same coded
-        refusal the flat `token` one does.
+        The nested `auth.token` spelling publishes the same coded refusal the
+        flat `token` one does.
         """
         resp, probe = await self._probe(
             client, admin_auth_header, {"auth": {"method": "bearer", "token": "   "}}

--- a/backend/tests/test_service_auth_contract_1746.py
+++ b/backend/tests/test_service_auth_contract_1746.py
@@ -1140,18 +1140,16 @@ class TestABlankValueIsNotACredential:
     async def test_a_whitespace_bearer_token_is_refused(
         self, client: AsyncClient, admin_auth_header: dict
     ) -> None:
-        """Refused by `_validate_safe_token`, which runs before the shape rule.
+        """Refused by `_validate_safe_token`, which runs ahead of the shape rule.
 
-        Field validators run ahead of the model validator, so a token of spaces
-        is answered by the whitespace rule that has always applied to this
-        field rather than by the blank rule above. Recorded rather than
-        asserted as the shape message, because which of the two answers first
-        is a pydantic ordering detail and both are refusals.
+        fix(#1924): the nested `auth.token` spelling publishes the same coded
+        refusal the flat `token` one does.
         """
         resp, probe = await self._probe(
             client, admin_auth_header, {"auth": {"method": "bearer", "token": "   "}}
         )
         assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["code"] == "invalid_service_token"
         assert UNSUPPORTED_AUTH_METHOD_POLICY not in resp.text
         probe.assert_not_awaited()
 


### PR DESCRIPTION
## What this PR resolves

Closes #1924. A service-credential token refused by the request schema reached
the caller as a flat validation string with no `code`, so the two clients that
build a message from `invalid_service_token` fell back to a generic 422:
`frontend/src/lib/error-map.ts:449` (which interpolates the server message into
`errors.refreshInvalidServiceToken`, present in all four locales) and
`cli/geolens_cli/refresh.py:86`. `cli/geolens_cli/replace.py:325` maps the same
code for the re-upload path. All three read `detail.code` — the CLI through
`_problem_detail`, which already accepts a mapping or a string — so they need
nothing on their side; I read each of them rather than assuming.

Now `_validate_safe_token` raises `CodedValueError(INVALID_SERVICE_TOKEN_CODE, …)`
and the `RequestValidationError` handler renders that as
`{"code": "invalid_service_token", "message": <policy>}`, the same detail a
door-layer refusal already returns.

The status is 422 either way, and the two refusal messages are unchanged text.
What changes is that the refusal is structured again.

## Which option, and why not the other

The issue named two: a custom error type the validation handler recognises, or a
field-name → code map in the handler. This is the first.

A field-name map cannot say **which rule** failed. `max_length=1000` and a wrong
JSON type fail on the same `token` field name as the credential rule, so keyed on
the name all of them would be labelled `invalid_service_token`. It also has to be
maintained in a second place from the rule it describes, and the `loc` it would
match has three shapes: `body.auth.token` on the five models carrying a
structured credential, `body.token` on the deprecated flat spelling, and a bare
`token` on the import-commit path, where the handler re-validates
`ServiceCommitRequest` itself and re-raises without FastAPI's `body` prefix.
Carrying the code on the exception means the site that knows what was refused is
the site that names it.

`CodedValueError` lives in `backend/app/core/coded_errors.py` because it is
layer-neutral: raised in `platform/`, rendered in `standards/`, carrying no logic
from either.

## When the coded detail answers

`_coded_detail` returns the dict when **every** error in the request is a
`CodedValueError` and they all agree on code, message **and** the value refused.
Two shapes reach it:

- One coded refusal alone. This is the shape a door refusal always has, since a
  door judges a credential only after the whole body validated.
- The same refusal of the same value on two fields — a caller who pastes one bad
  token into both the deprecated flat `token` and the `auth` object. Pydantic
  skips the model-level conflict validator when a field validator has already
  failed, so that body arrives as two errors with identical code, message and
  input. It is one mistake, and answering it with the field list would be the
  same degradation this issue is about, on a body a real caller produces.

Everything else falls back to the flattened field list, which is what those
requests got before:

- A coded refusal beside an unrelated error (a missing required field, a bad
  `srid_override`). The caller keeps being told about both.
- Two coded refusals that **disagree on the policy** — whitespace on one field, a
  control character on the other.
- Two coded refusals with the same policy but **different values** — two bad
  tokens pasted into the two spellings. The code and message are identical there,
  so without the input comparison this case would collapse and hide that both
  fields failed.

The two values are compared in memory only; the detail publishes the code and
the policy, and nothing on this path puts a rejected credential into a body or a
log line. That is asserted at both levels — the HTTP tests check the whole
response text, the unit test checks the returned detail.

That keeps the change strictly non-regressive: no request that used to be told
about two distinct problems is now told about one.

## Verification

One test per door asserting the code survives, both already round-tripping over
HTTP in `backend/tests/test_1755_token_validator_consolidation.py`; their shared
helper now asserts the code instead of the flat string's `loc` prefix. Both use
an **ArcGIS** job deliberately: for ArcGIS the schema rule is the only rule, so
the assertion cannot pass vacuously through the door-layer check the way a WFS
body would. Both keep asserting the rejected value is absent from the whole
response body, not just from the message. Added beside them:

- the both-spellings body (verified to arrive as two identical coded errors, so
  it fails under a sole-error rule);
- the mixed coded/uncoded fallback, over HTTP;
- the two collapse-refusing cases — different policies, and the same policy with
  different values — against `_coded_detail` directly, which also asserts that
  neither value appears in the detail it returns;
- a brace pin on `_validate_safe_token`'s source. The two messages are inline
  literals rather than `*_POLICY` constants, so the existing no-brace assertion
  in `test_service_refresh_1220.py` does not reach them, and this PR promotes
  them from a flattened `msg` fragment to text a client renders directly;
- the nested `auth.token` spelling, in
  `test_service_auth_contract_1746.py::test_a_whitespace_bearer_token_is_refused`,
  which already posted the right body and asserted only the status.

```
tests/test_1755_token_validator_consolidation.py
tests/test_service_auth_contract_1746.py
tests/test_door_token_policy_1746.py
tests/test_layering.py                                   181 passed
tests/test_preview_token_sec021.py
tests/test_service_refresh_1220.py
tests/test_import_token_lease_1676.py
tests/test_service_auth_transport_1746.py
tests/test_services_endpoints.py
tests/test_api_contract_openapi.py                       562 passed
tests/test_ingest.py -k "422 or validation or commit"    7 passed, 38 deselected
uv run ruff check .                                      All checks passed!
uv run ruff format --check .                             1185 files already formatted
```

## Interaction with #1930's token cap

Rebased onto `36e787c0e`. #1930 gave `ServiceCommitRequest.token` a
`max_length=1000`, which lands on the same field this PR changes the rendering
of, so the two were checked together rather than reasoned about: an over-long
token fails the field constraint before `_validate_safe_token` runs, producing a
`string_too_long` error whose cause is not a `CodedValueError`, and
`_coded_detail` returns None for it. A token that is both over the cap and
whitespace-bearing takes the same branch — pydantic's field constraint
short-circuits the `after` validator, so there is no shape in which a capped
token collects a credential code it did not earn. `test_the_import_commit_door_refuses_a_token_past_the_cap`
(#1930's) now asserts that fallback explicitly: 422, a string `detail`, and the
token absent from the body.

## No contract change

`cd backend && PYTHONPATH=. uv run python scripts/dump_openapi.py --check` exits
0 — `ProblemDetail.detail` is already `str | dict | list`, and no route signature
moved — so `backend/openapi.json`, the two OpenAPI snapshots and the SDKs are
untouched.

Nothing under `sdks/`, `mcp/` or any docs surface keys on `invalid_service_token`
(`grep -rn invalid_service_token .` over the tree returns only `frontend/src`,
`backend/app`, `backend/tests` and `cli/`), so the frontend and the CLI are the
whole client surface for it.

## Not changed

The `auth` object's shape refusals (`SERVICE_AUTH_BEARER_POLICY` and its two
siblings) stay plain `ValueError`s. They have never had a door-layer counterpart
carrying a code and no client maps one for them, so giving them codes would be a
new taxonomy rather than the parity this issue asks for.
