### PR TITLE
fix(ingest): bound the reupload swap's post-swap catalog wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and releases use semantic versioning.
 - A service token refused for control characters or whitespace now answers with the same
   `invalid_service_token` code the other credential refusals carry, so the app and the CLI show
   the token-specific message on every service door instead of a generic validation error. (#1924)
+- A reupload whose table swap was finished but whose catalog row was held by another operation
+  could wait indefinitely, leaving the dataset's table unreadable for as long as the hold lasted.
+  That wait is now capped at 60 seconds, and a reupload that gives up reports lock contention and
+  logs how long it waited, having rolled the swap back whole. (#1921)
 
 ## [1.18.1] - 2026-09-05
 

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -8,6 +8,7 @@ and reupload workflows.
 
 import asyncio
 import functools
+import time
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -2213,6 +2214,11 @@ _SWAP_FIRST_TIMEOUT = "5s"
 _SWAP_RETRY_TIMEOUT = "15s"
 _SWAP_RETRY_SLEEP_MS = 200
 
+# fix(#1921): the budget for the catalog wait that FOLLOWS the swap. The
+# transaction holds AccessExclusiveLock on the table it just installed across
+# that wait, so its duration is the dataset's unreadable window.
+_POST_SWAP_CATALOG_TIMEOUT = "60s"
+
 
 async def _apply_reupload_swap(
     session,
@@ -2402,20 +2408,53 @@ async def _apply_reupload_swap(
 
         await ensure_geom_4326_gist_index(session, table_name, schema=_tenant_schema)
 
-    # fix(#1847, #1917): the catalog writes start here and dirty both rows.
-    # `lock_timeout=None` issues no SET LOCAL, and the swap's DDL budget was
-    # put back above, so this wait carries no request-sized clamp.
-    from app.platform.catalog_locks import bump_tile_cache_version_on, lock_catalog_rows
+    # fix(#1847, #1917, #1921): the catalog writes start here and dirty both
+    # rows. The swap's DDL budget was put back above; this wait gets its own,
+    # and the value the transaction arrived with is restored after it.
+    from app.platform.catalog_locks import (
+        CatalogLockConflict,
+        bump_tile_cache_version_on,
+        lock_catalog_rows,
+    )
     from app.platform.extensions import get_processing_port
 
     _port = get_processing_port()
-    await lock_catalog_rows(
-        session,
-        dataset_cls=_port.get_dataset_orm_class(),
-        record_cls=_port.get_record_orm_class(),
-        dataset_id=dataset.id,
-        record_id=dataset.record_id,
-        lock_timeout=None,
+    _wait_started = time.perf_counter()
+    try:
+        await lock_catalog_rows(
+            session,
+            dataset_cls=_port.get_dataset_orm_class(),
+            record_cls=_port.get_record_orm_class(),
+            dataset_id=dataset.id,
+            record_id=dataset.record_id,
+            lock_timeout=_POST_SWAP_CATALOG_TIMEOUT,
+        )
+    except CatalogLockConflict:
+        structlog.get_logger().warning(
+            "reupload_swap_catalog_lock_timeout",
+            dataset_id=str(dataset.id),
+            table_name=table_name,
+            waited_ms=round((time.perf_counter() - _wait_started) * 1000),
+            budget=_POST_SWAP_CATALOG_TIMEOUT,
+            hint=(
+                "The post-swap catalog wait expired; the whole swap rolled "
+                "back, so no half-swapped table is left. Find the holder of "
+                "this dataset's catalog.datasets row in pg_stat_activity."
+            ),
+        )
+        raise
+
+    structlog.get_logger().info(
+        "reupload_swap_catalog_lock_acquired",
+        dataset_id=str(dataset.id),
+        table_name=table_name,
+        waited_ms=round((time.perf_counter() - _wait_started) * 1000),
+        budget=_POST_SWAP_CATALOG_TIMEOUT,
+    )
+    # fix(#1921): this wait's budget ends here, like the DDL's above it.
+    await session.execute(
+        text("SELECT set_config('lock_timeout', :value, true)"),
+        {"value": pre_swap_lock_timeout},
     )
 
     dataset.srid = metadata["srid"]

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2219,6 +2219,26 @@ _SWAP_RETRY_SLEEP_MS = 200
 # it, so a holder that outlasts this is stuck, not working.
 _POST_SWAP_CATALOG_TIMEOUT = "60s"
 
+# fix(#1921): `lock_catalog_rows` reports an expired budget and a lost
+# deadlock alike, and the two send an operator looking for different things.
+_POST_SWAP_WAIT_FAILURES = {
+    "55P03": (
+        "reupload_swap_catalog_lock_timeout",
+        "The post-swap catalog wait expired. Find the holder of this "
+        "dataset's catalog.datasets row in pg_stat_activity.",
+    ),
+    "40P01": (
+        "reupload_swap_catalog_deadlock",
+        "PostgreSQL chose this swap as the deadlock victim. Look for the "
+        "other side of the cycle: a transaction holding this dataset's "
+        "catalog row and waiting on its live table.",
+    ),
+}
+_POST_SWAP_WAIT_UNKNOWN = (
+    "reupload_swap_catalog_lock_failed",
+    "The post-swap catalog wait failed and reported no SQLSTATE.",
+)
+
 
 async def _apply_reupload_swap(
     session,
@@ -2411,12 +2431,14 @@ async def _apply_reupload_swap(
     # fix(#1847, #1917, #1921): the catalog writes start here and dirty both
     # rows. The swap's DDL budget was put back above; this wait gets its own,
     # and the value the transaction arrived with is restored after it.
+    from app.core.db.sqlstate import sqlstate
     from app.platform.catalog_locks import (
         CatalogLockConflict,
         bump_tile_cache_version_on,
         lock_catalog_rows,
     )
     from app.platform.extensions import get_processing_port
+    from sqlalchemy.exc import DBAPIError
 
     _port = get_processing_port()
     # fix(#1921): lock_catalog_rows rolls back before it raises, and a
@@ -2432,17 +2454,19 @@ async def _apply_reupload_swap(
             record_id=dataset.record_id,
             lock_timeout=_POST_SWAP_CATALOG_TIMEOUT,
         )
-    except CatalogLockConflict:
+    except CatalogLockConflict as conflict:
+        cause = conflict.__cause__
+        code = sqlstate(cause) if isinstance(cause, DBAPIError) else None
+        event, hint = _POST_SWAP_WAIT_FAILURES.get(code, _POST_SWAP_WAIT_UNKNOWN)
         structlog.get_logger().warning(
-            "reupload_swap_catalog_lock_timeout",
+            event,
             dataset_id=_log_dataset_id,
             table_name=table_name,
             waited_ms=round((time.perf_counter() - _wait_started) * 1000),
             budget=_POST_SWAP_CATALOG_TIMEOUT,
+            sqlstate=code,
             hint=(
-                "The post-swap catalog wait expired; the whole swap rolled "
-                "back, so no half-swapped table is left. Find the holder of "
-                "this dataset's catalog.datasets row in pg_stat_activity."
+                f"{hint} The whole swap rolled back, so no half-swapped table is left."
             ),
         )
         raise

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -2216,7 +2216,7 @@ _SWAP_RETRY_SLEEP_MS = 200
 
 # fix(#1921): the budget for the catalog wait that FOLLOWS the swap. The
 # transaction holds AccessExclusiveLock on the table it just installed across
-# that wait, so its duration is the dataset's unreadable window.
+# it, so a holder that outlasts this is stuck, not working.
 _POST_SWAP_CATALOG_TIMEOUT = "60s"
 
 
@@ -2419,6 +2419,9 @@ async def _apply_reupload_swap(
     from app.platform.extensions import get_processing_port
 
     _port = get_processing_port()
+    # fix(#1921): lock_catalog_rows rolls back before it raises, and a
+    # rolled-back session expires every loaded instance.
+    _log_dataset_id = str(dataset.id)
     _wait_started = time.perf_counter()
     try:
         await lock_catalog_rows(
@@ -2432,7 +2435,7 @@ async def _apply_reupload_swap(
     except CatalogLockConflict:
         structlog.get_logger().warning(
             "reupload_swap_catalog_lock_timeout",
-            dataset_id=str(dataset.id),
+            dataset_id=_log_dataset_id,
             table_name=table_name,
             waited_ms=round((time.perf_counter() - _wait_started) * 1000),
             budget=_POST_SWAP_CATALOG_TIMEOUT,
@@ -2446,7 +2449,7 @@ async def _apply_reupload_swap(
 
     structlog.get_logger().info(
         "reupload_swap_catalog_lock_acquired",
-        dataset_id=str(dataset.id),
+        dataset_id=_log_dataset_id,
         table_name=table_name,
         waited_ms=round((time.perf_counter() - _wait_started) * 1000),
         budget=_POST_SWAP_CATALOG_TIMEOUT,

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -11,6 +11,10 @@ from sqlalchemy import select, update
 from app.core.db.tenant_session import tenant_task
 from app.core.url_redaction import scrub_secret_from_exception
 from app.platform.cache.tiles import invalidate_catalog_cache
+from app.platform.catalog_locks import (
+    CATALOG_LOCK_CONFLICT_CODE,
+    CatalogLockConflict,
+)
 from app.platform.dataset_origin import classify_origin, service_layer_identity
 from app.platform.jobs.heartbeat import (
     attempt_scoped_staging_table,
@@ -561,7 +565,7 @@ async def reupload_file(
             await record_refresh_failure(
                 err_session,
                 ingest_job_id=job_uuid,
-                error_code="file_refresh_failed",
+                error_code=_file_refresh_error_code(exc),
                 error_message=str(exc),
                 contacted_origin=False,
             )
@@ -666,16 +670,27 @@ async def _record_failed_origin_contact(
         await invalidate_catalog_cache()
 
 
+def _file_refresh_error_code(exc: BaseException) -> str:
+    """Map a file-reupload failure onto its run ``error_code``.
+
+    A contended catalog row reports as contention: nothing was written, and
+    the reader's next step is to find the holder, not to inspect the file.
+    """
+    if isinstance(exc, CatalogLockConflict):
+        return CATALOG_LOCK_CONFLICT_CODE
+    return "file_refresh_failed"
+
+
 def _service_refresh_error_code(exc: BaseException) -> str:
     """Map a service-refresh failure onto its run ``error_code``.
 
-    feat(#1220). Three codes, because they send the reader to three different
-    places: a spent or expired credential needs a fresh token, an unreachable
-    credential store needs an operator, and everything else is the origin or
-    the pipeline. ``error_code`` is a closed vocabulary the history UI reads,
-    so the mapping lives in one function rather than as a conditional inside
-    the failure handler where a fourth case would grow another branch.
+    Four codes, because they send the reader to four different places: the
+    holder of a contended catalog row, a fresh token, an operator for an
+    unreachable credential store, or the origin. ``error_code`` is a closed
+    vocabulary the history UI reads, so the mapping lives in one function.
     """
+    if isinstance(exc, CatalogLockConflict):
+        return CATALOG_LOCK_CONFLICT_CODE
     if isinstance(exc, CredentialExpiredError):
         return "credential_expired"
     if isinstance(exc, CredentialStoreUnavailable):

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -2450,10 +2450,10 @@ class TestWorkerDoorsAcquireBeforeTheirWrites:
             )
 
     def test_worker_doors_do_not_clamp_their_transaction(self):
-        """`lock_timeout=None` at each, and nowhere on a request path.
+        """`lock_timeout=None` appears at worker doors only, never on a request path.
 
-        `SET LOCAL` applies for the rest of the transaction. A worker that
-        inherited the request budget would fail a multi-minute ingest on
+        `SET LOCAL` applies for the rest of the transaction, so a worker
+        carrying the request budget would fail a multi-minute ingest on
         contention it is supposed to wait out.
         """
         import ast
@@ -2476,12 +2476,12 @@ class TestWorkerDoorsAcquireBeforeTheirWrites:
                         if kw.value.value is None:
                             none_sites.append(str(path.relative_to(app_dir.parent)))
         assert sorted(set(none_sites)) == [
-            "app/processing/ingest/tasks_common.py",
             "app/processing/ingest/tasks_raster_replace.py",
             "app/processing/ingest/tasks_vrt.py",
         ], (
-            "lock_timeout=None belongs to worker tasks only. A request path "
-            f"that passes it waits forever on a contended row. Found: {none_sites}"
+            "lock_timeout=None belongs to worker tasks only, and never to the "
+            "reupload swap, which holds AccessExclusiveLock across its wait and "
+            f"names its own budget (#1921). Found: {none_sites}"
         )
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3611,10 +3611,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1917): +19 — the swap restores the lock_timeout it installed, so it
     # stops clamping the catalog-lock wait; its budget constants moved to
     # module scope to be testable. Cap 2558 -> 2577, exact.
-    # fix(#1921): +42 — the post-swap catalog wait gets its own budget, a
+    # fix(#1921): +66 — the post-swap catalog wait gets its own budget, a
     # restore of its own, and a log line carrying how long it waited, off an
-    # id captured before the rollback. Cap 2577 -> 2619, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2619,
+    # id captured before the rollback; an expired budget and a lost deadlock
+    # get separate events. Cap 2577 -> 2643, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2643,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3611,10 +3611,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1917): +19 — the swap restores the lock_timeout it installed, so it
     # stops clamping the catalog-lock wait; its budget constants moved to
     # module scope to be testable. Cap 2558 -> 2577, exact.
-    # fix(#1921): +39 — the post-swap catalog wait gets its own budget, a
-    # restore of its own, and a log line carrying how long it waited.
-    # Cap 2577 -> 2616, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2616,
+    # fix(#1921): +42 — the post-swap catalog wait gets its own budget, a
+    # restore of its own, and a log line carrying how long it waited, off an
+    # id captured before the rollback. Cap 2577 -> 2619, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2619,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3612,9 +3612,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # stops clamping the catalog-lock wait; its budget constants moved to
     # module scope to be testable. Cap 2558 -> 2577, exact.
     # fix(#1921): +66 — the post-swap catalog wait gets its own budget, a
-    # restore of its own, and a log line carrying how long it waited, off an
-    # id captured before the rollback; an expired budget and a lost deadlock
-    # get separate events. Cap 2577 -> 2643, exact.
+    # restore, and events telling an expired budget from a lost deadlock.
+    # Cap 2577 -> 2643, exact.
     "backend/app/processing/ingest/tasks_common.py": 2643,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3611,7 +3611,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1917): +19 — the swap restores the lock_timeout it installed, so it
     # stops clamping the catalog-lock wait; its budget constants moved to
     # module scope to be testable. Cap 2558 -> 2577, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2577,
+    # fix(#1921): +39 — the post-swap catalog wait gets its own budget, a
+    # restore of its own, and a log line carrying how long it waited.
+    # Cap 2577 -> 2616, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2616,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -3712,7 +3715,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # shorter at every call site than passing a coroutine, and `reupload_file`
     # gained the same treatment its service sibling already had (5 steps).
     # Cap 1333 -> 1310, exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1310,
+    # fix(#1921): +15 — the file path gets the exception-to-error_code mapper
+    # its service sibling already had, and both name a contended catalog row.
+    # Cap 1310 -> 1325, exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1325,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is

--- a/backend/tests/test_swap_catalog_wait_bound_1921.py
+++ b/backend/tests/test_swap_catalog_wait_bound_1921.py
@@ -1,0 +1,195 @@
+"""The reupload swap's post-swap catalog wait carries an explicit budget (#1921).
+
+The swap holds AccessExclusiveLock on the table it installed across that wait,
+so its duration is the dataset's unreadable window. Expiry rolls the whole swap
+back and reports as contention. The DB tests need the Docker test database.
+"""
+
+import asyncio
+
+import pytest
+import structlog
+from sqlalchemy import select, text
+
+from app.modules.catalog.datasets.domain.models import Dataset
+from app.platform.catalog_locks import (
+    CATALOG_LOCK_CONFLICT_CODE,
+    CatalogLockConflict,
+)
+from app.processing.ingest import tasks_common
+from app.processing.ingest.tasks_reupload import (
+    _file_refresh_error_code,
+    _service_refresh_error_code,
+)
+
+from tests.test_swap_lock_timeout_scope_1917 import (
+    _run_swap,
+    _stub_downstream,
+    make_swap_target,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+async def swap_target(client, test_db_session):
+    async for target in make_swap_target(client, test_db_session):
+        yield target
+
+
+# Short enough that a held row outlasts it in under a second.
+_TEST_BUDGET = "500ms"
+_TEST_BUDGET_MS = 500
+
+
+class TestPostSwapCatalogWaitBudget:
+    async def test_the_wait_runs_on_the_swaps_own_budget(
+        self, swap_target, monkeypatch
+    ) -> None:
+        """A budget is in force for the duration of the catalog acquisition."""
+        stub, staging = swap_target
+        import app.core.db as db_module
+        import app.platform.catalog_locks as locks_module
+
+        observed: dict[str, object] = {}
+        real_lock = locks_module.lock_catalog_rows
+
+        async def _recording_lock(session, **kwargs):
+            observed["lock_timeout"] = kwargs.get("lock_timeout")
+            await real_lock(session, **kwargs)
+            observed["in_force"] = await session.scalar(
+                text("SELECT current_setting('lock_timeout')")
+            )
+
+        async with db_module.async_session() as session:
+            _stub_downstream(monkeypatch, session)
+            arrived_with = await session.scalar(
+                text("SELECT current_setting('lock_timeout')")
+            )
+            monkeypatch.setattr(locks_module, "lock_catalog_rows", _recording_lock)
+            await _run_swap(session, stub, staging)
+            await session.rollback()
+
+        assert observed["lock_timeout"] == tasks_common._POST_SWAP_CATALOG_TIMEOUT, (
+            "the swap asked for "
+            f"{observed['lock_timeout']!r}, not the module's post-swap budget. "
+            "An unbounded wait here is an unbounded outage: the transaction "
+            "holds AccessExclusiveLock on the table it just installed."
+        )
+        assert observed["in_force"] != arrived_with, (
+            f"lock_timeout was still {arrived_with!r} inside the acquisition, "
+            "so the budget the call asked for never reached PostgreSQL."
+        )
+
+    async def test_an_uncontended_wait_is_recorded(
+        self, swap_target, monkeypatch
+    ) -> None:
+        """The swap logs how long the acquisition took, waited or not."""
+        stub, staging = swap_target
+        import app.core.db as db_module
+
+        async with db_module.async_session() as session:
+            _stub_downstream(monkeypatch, session)
+            with structlog.testing.capture_logs() as captured:
+                await _run_swap(session, stub, staging)
+            await session.rollback()
+
+        acquired = [
+            r
+            for r in captured
+            if r.get("event") == "reupload_swap_catalog_lock_acquired"
+        ]
+        assert len(acquired) == 1, (
+            f"expected one reupload_swap_catalog_lock_acquired event; got {captured}"
+        )
+        assert acquired[0]["log_level"] == "info"
+        assert acquired[0]["table_name"] == stub.table_name
+        assert acquired[0]["budget"] == tasks_common._POST_SWAP_CATALOG_TIMEOUT
+        assert isinstance(acquired[0]["waited_ms"], int)
+
+    async def test_a_holder_past_the_budget_fails_the_swap_as_contention(
+        self, swap_target, monkeypatch, test_db_session
+    ) -> None:
+        """Expiry rolls the rename back whole and reports lock contention."""
+        stub, staging = swap_target
+        await test_db_session.execute(
+            text(f"UPDATE data.\"{staging}\" SET name = 'new_data'")
+        )
+        await test_db_session.commit()
+
+        monkeypatch.setattr(tasks_common, "_POST_SWAP_CATALOG_TIMEOUT", _TEST_BUDGET)
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as api,
+        ):
+            await holder.execute(
+                select(Dataset.id).where(Dataset.id == stub.id).with_for_update()
+            )
+            _stub_downstream(monkeypatch, api)
+            with structlog.testing.capture_logs() as captured:
+                with pytest.raises(CatalogLockConflict):
+                    await asyncio.wait_for(_run_swap(api, stub, staging), timeout=30)
+            await holder.rollback()
+
+        expired = [
+            r
+            for r in captured
+            if r.get("event") == "reupload_swap_catalog_lock_timeout"
+        ]
+        assert len(expired) == 1, (
+            f"expected one reupload_swap_catalog_lock_timeout event; got {captured}"
+        )
+        assert expired[0]["log_level"] == "warning"
+        assert expired[0]["budget"] == _TEST_BUDGET
+        assert expired[0]["waited_ms"] >= _TEST_BUDGET_MS * 0.8, (
+            f"the swap gave up after {expired[0]['waited_ms']}ms against a "
+            f"{_TEST_BUDGET} budget, so this run proves nothing about the wait"
+        )
+
+        live_row = await test_db_session.scalar(
+            text(f'SELECT name FROM data."{stub.table_name}"')
+        )
+        assert live_row == "row", (
+            f"the live table holds {live_row!r}: the renames were not rolled "
+            "back with the failed wait, leaving a half-swapped dataset"
+        )
+        staging_survived = await test_db_session.scalar(
+            text(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema='data' AND table_name=:tn)"
+            ),
+            {"tn": staging},
+        )
+        assert staging_survived is True
+        await test_db_session.rollback()
+
+
+class TestReuploadErrorCodes:
+    """Pure mapping — no DB."""
+
+    def test_a_contended_catalog_row_maps_to_its_own_code(self) -> None:
+        exc = CatalogLockConflict("held")
+        assert _file_refresh_error_code(exc) == CATALOG_LOCK_CONFLICT_CODE
+        assert _service_refresh_error_code(exc) == CATALOG_LOCK_CONFLICT_CODE
+
+    def test_everything_else_keeps_its_path_code(self) -> None:
+        exc = RuntimeError("ogr2ogr fell over")
+        assert _file_refresh_error_code(exc) == "file_refresh_failed"
+        assert _service_refresh_error_code(exc) == "service_refresh_failed"
+
+    def test_the_credential_codes_are_unchanged(self) -> None:
+        from app.platform.refresh.credentials import (
+            CredentialExpiredError,
+            CredentialStoreUnavailable,
+        )
+
+        assert (
+            _service_refresh_error_code(CredentialExpiredError("spent"))
+            == "credential_expired"
+        )
+        assert (
+            _service_refresh_error_code(CredentialStoreUnavailable("down"))
+            == "credential_store_unavailable"
+        )

--- a/backend/tests/test_swap_catalog_wait_bound_1921.py
+++ b/backend/tests/test_swap_catalog_wait_bound_1921.py
@@ -6,12 +6,15 @@ back and reports as contention. The DB tests need the Docker test database.
 """
 
 import asyncio
+import uuid
 
 import pytest
 import structlog
 from sqlalchemy import select, text
+from sqlalchemy.orm import joinedload
 
 from app.modules.catalog.datasets.domain.models import Dataset
+from app.processing.ingest.tasks_common import _apply_reupload_swap
 from app.platform.catalog_locks import (
     CATALOG_LOCK_CONFLICT_CODE,
     CatalogLockConflict,
@@ -22,6 +25,7 @@ from app.processing.ingest.tasks_reupload import (
     _service_refresh_error_code,
 )
 
+from tests.test_reupload_swap_lock_retry import _minimal_metadata
 from tests.test_swap_lock_timeout_scope_1917 import (
     _run_swap,
     _stub_downstream,
@@ -41,6 +45,10 @@ async def swap_target(client, test_db_session):
 _TEST_BUDGET = "500ms"
 _TEST_BUDGET_MS = 500
 
+_POST_SWAP_BUDGET = tasks_common._POST_SWAP_CATALOG_TIMEOUT
+# What `current_setting` reports back for the constant above.
+_NORMALIZED_BUDGET = "1min"
+
 
 class TestPostSwapCatalogWaitBudget:
     async def test_the_wait_runs_on_the_swaps_own_budget(
@@ -56,6 +64,10 @@ class TestPostSwapCatalogWaitBudget:
 
         async def _recording_lock(session, **kwargs):
             observed["lock_timeout"] = kwargs.get("lock_timeout")
+            # fix(#1919): the DDL budget is gone by the time this wait starts.
+            observed["on_entry"] = await session.scalar(
+                text("SELECT current_setting('lock_timeout')")
+            )
             await real_lock(session, **kwargs)
             observed["in_force"] = await session.scalar(
                 text("SELECT current_setting('lock_timeout')")
@@ -76,9 +88,15 @@ class TestPostSwapCatalogWaitBudget:
             "An unbounded wait here is an unbounded outage: the transaction "
             "holds AccessExclusiveLock on the table it just installed."
         )
-        assert observed["in_force"] != arrived_with, (
-            f"lock_timeout was still {arrived_with!r} inside the acquisition, "
-            "so the budget the call asked for never reached PostgreSQL."
+        assert observed["on_entry"] == arrived_with, (
+            f"the wait started on {observed['on_entry']!r}, not the "
+            f"{arrived_with!r} the transaction arrived with: the swap's DDL "
+            "budget leaked past the savepoint that set it (#1919)."
+        )
+        assert observed["in_force"] == _NORMALIZED_BUDGET, (
+            f"lock_timeout read {observed['in_force']!r} inside the "
+            f"acquisition, not the {_NORMALIZED_BUDGET!r} PostgreSQL "
+            f"normalizes {_POST_SWAP_BUDGET!r} to."
         )
 
     async def test_an_uncontended_wait_is_recorded(
@@ -163,6 +181,59 @@ class TestPostSwapCatalogWaitBudget:
             {"tn": staging},
         )
         assert staging_survived is True
+        await test_db_session.rollback()
+
+    async def test_the_expiry_handler_survives_the_rollback_that_precedes_it(
+        self, swap_target, monkeypatch, test_db_session
+    ) -> None:
+        """A real ORM instance still reports contention, not a greenlet error."""
+        stub, staging = swap_target
+        monkeypatch.setattr(tasks_common, "_POST_SWAP_CATALOG_TIMEOUT", _TEST_BUDGET)
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as api,
+        ):
+            await holder.execute(
+                select(Dataset.id).where(Dataset.id == stub.id).with_for_update()
+            )
+            _stub_downstream(monkeypatch, api)
+            loaded = (
+                await api.execute(
+                    select(Dataset)
+                    .options(joinedload(Dataset.record))
+                    .where(Dataset.id == stub.id)
+                )
+            ).scalar_one()
+            with structlog.testing.capture_logs() as captured:
+                with pytest.raises(CatalogLockConflict):
+                    await asyncio.wait_for(
+                        _apply_reupload_swap(
+                            api,
+                            dataset=loaded,
+                            staging_table=staging,
+                            metadata=_minimal_metadata(),
+                            sample_values={},
+                            user_id=str(uuid.uuid4()),
+                            source_filename="x.csv",
+                            source_format="csv",
+                            original_srid=4326,
+                        ),
+                        timeout=30,
+                    )
+            await holder.rollback()
+
+        expired = [
+            r
+            for r in captured
+            if r.get("event") == "reupload_swap_catalog_lock_timeout"
+        ]
+        assert len(expired) == 1, (
+            "the expiry warning never emitted, so the handler raised on its "
+            f"own before reaching the log. Captured: {captured}"
+        )
+        assert expired[0]["dataset_id"] == str(stub.id)
         await test_db_session.rollback()
 
 

--- a/backend/tests/test_swap_catalog_wait_bound_1921.py
+++ b/backend/tests/test_swap_catalog_wait_bound_1921.py
@@ -10,7 +10,9 @@ import uuid
 
 import pytest
 import structlog
+from asyncpg.exceptions import DeadlockDetectedError
 from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import joinedload
 
 from app.modules.catalog.datasets.domain.models import Dataset
@@ -161,6 +163,10 @@ class TestPostSwapCatalogWaitBudget:
         )
         assert expired[0]["log_level"] == "warning"
         assert expired[0]["budget"] == _TEST_BUDGET
+        assert expired[0]["sqlstate"] == "55P03", (
+            f"the handler read {expired[0]['sqlstate']!r} off the conflict's "
+            "cause, so it cannot tell an expired budget from a deadlock."
+        )
         assert expired[0]["waited_ms"] >= _TEST_BUDGET_MS * 0.8, (
             f"the swap gave up after {expired[0]['waited_ms']}ms against a "
             f"{_TEST_BUDGET} budget, so this run proves nothing about the wait"
@@ -235,6 +241,51 @@ class TestPostSwapCatalogWaitBudget:
         )
         assert expired[0]["dataset_id"] == str(stub.id)
         await test_db_session.rollback()
+
+    @pytest.mark.parametrize(
+        ("cause", "event", "code", "needle"),
+        [
+            (
+                DBAPIError("stmt", {}, DeadlockDetectedError("cycle")),
+                "reupload_swap_catalog_deadlock",
+                "40P01",
+                "deadlock victim",
+            ),
+            (None, "reupload_swap_catalog_lock_failed", None, "no SQLSTATE"),
+        ],
+        ids=["deadlock", "no_sqlstate"],
+    )
+    async def test_the_cause_picks_the_event(
+        self, swap_target, monkeypatch, cause, event, code, needle
+    ) -> None:
+        """A lost deadlock and an unreadable cause are not reported as expiry."""
+        stub, staging = swap_target
+        import app.core.db as db_module
+        import app.platform.catalog_locks as locks_module
+
+        async def _raise_conflict(session, **kwargs):
+            conflict = CatalogLockConflict("held")
+            conflict.__cause__ = cause
+            raise conflict
+
+        monkeypatch.setattr(locks_module, "lock_catalog_rows", _raise_conflict)
+        async with db_module.async_session() as session:
+            _stub_downstream(monkeypatch, session)
+            with structlog.testing.capture_logs() as captured:
+                with pytest.raises(CatalogLockConflict):
+                    await _run_swap(session, stub, staging)
+            await session.rollback()
+
+        assert [
+            r.get("event")
+            for r in captured
+            if r.get("event", "").startswith("reupload_swap_catalog")
+        ] == [event]
+        logged = next(r for r in captured if r.get("event") == event)
+        assert logged["log_level"] == "warning"
+        assert logged["sqlstate"] == code
+        assert needle in logged["hint"]
+        assert isinstance(logged["waited_ms"], int)
 
 
 class TestReuploadErrorCodes:

--- a/backend/tests/test_swap_lock_timeout_scope_1917.py
+++ b/backend/tests/test_swap_lock_timeout_scope_1917.py
@@ -38,9 +38,11 @@ _TEST_SWAP_TIMEOUT = f"{_TEST_SWAP_MS}ms"
 _PAST_THE_CLAMP_SECONDS = (_TEST_SWAP_MS / 1000.0) * 3
 
 
-@pytest.fixture
-async def swap_target(client, test_db_session):
-    """A committed dataset row and the live/staging table pair its swap renames."""
+async def make_swap_target(client, test_db_session):
+    """A committed dataset row and the live/staging table pair its swap renames.
+
+    An async generator so a sibling suite can wrap it in its own fixture.
+    """
     suffix = uuid.uuid4().hex[:8]
     live = f"swap_scope_{suffix}"
     staging = f"swap_scopes_{suffix}"
@@ -92,6 +94,12 @@ async def swap_target(client, test_db_session):
             text(f'DROP TABLE IF EXISTS data."{table}" CASCADE')
         )
     await test_db_session.commit()
+
+
+@pytest.fixture
+async def swap_target(client, test_db_session):
+    async for target in make_swap_target(client, test_db_session):
+        yield target
 
 
 def _stub_downstream(monkeypatch, session) -> None:

--- a/backend/tests/test_swap_lock_timeout_scope_1917.py
+++ b/backend/tests/test_swap_lock_timeout_scope_1917.py
@@ -39,10 +39,7 @@ _PAST_THE_CLAMP_SECONDS = (_TEST_SWAP_MS / 1000.0) * 3
 
 
 async def make_swap_target(client, test_db_session):
-    """A committed dataset row and the live/staging table pair its swap renames.
-
-    An async generator so a sibling suite can wrap it in its own fixture.
-    """
+    """A committed dataset row and the live/staging table pair its swap renames."""
     suffix = uuid.uuid4().hex[:8]
     live = f"swap_scope_{suffix}"
     staging = f"swap_scopes_{suffix}"


### PR DESCRIPTION
Closes #1921

## What changed

`_apply_reupload_swap` runs three `ALTER TABLE ... RENAME` statements and then, still inside the same transaction and therefore still holding `AccessExclusiveLock` on the table it just installed, waits for the dataset's catalog rows. That wait asked for `lock_timeout=None`, which issues no `SET LOCAL`, so it inherited the worker session's value — `0` on a default install, with `statement_timeout` and `idle_in_transaction_session_timeout` also `0`, and no phase budget on `tasks_reupload.py`'s plain `async_session()`. Nothing bounded it, and its duration is the window in which the dataset's live table is not readable.

- `backend/app/processing/ingest/tasks_common.py`: the wait runs on `_POST_SWAP_CATALOG_TIMEOUT = "60s"`, a new module constant. The value the transaction arrived with is restored immediately after the acquisition, through the same `set_config('lock_timeout', :value, true)` spelling #1919 uses for the DDL budget, so the swap still leaves the transaction on the `lock_timeout` it came in with.
- The acquisition is bracketed by `time.perf_counter()`. Success logs `reupload_swap_catalog_lock_acquired` at info with `waited_ms` and `budget`; expiry logs `reupload_swap_catalog_lock_timeout` at warning with the same two fields plus a hint pointing at `pg_stat_activity`, then re-raises.
- `backend/app/processing/ingest/tasks_reupload.py`: `_file_refresh_error_code`, the file path's first exception-to-code mapper, and a `CatalogLockConflict` branch on the service path's existing `_service_refresh_error_code`. Both answer `catalog_lock_conflict` — the constant `platform/catalog_locks.py` already exports for the 409 body and for a bulk-delete item that carries its conflict.

## The number, and why 60s

Sized against how long a holder may legitimately keep the pair, which is not the same as how long a reupload runs. The lock order (#1847, #1848) puts every long step — GDAL, object storage, HTTP — *before* the acquisition, at all five acquisition sites.

Every holder that could hold the pair past 60s also touches the live table, which this transaction holds `AccessExclusiveLock` on while it waits — those pairings deadlock at `deadlock_timeout` (~1s, 40P01, already mapped to `CatalogLockConflict`) rather than waiting. What remains is catalog-only and short, so 60s is a ceiling nothing legitimate reaches; past it the holder is stuck or idle-in-transaction.

It is deliberately unrelated to `REQUEST_LOCK_TIMEOUT` (2s), which is what a *request* is willing to spend rather than what a worker may need to absorb. Every further second past the ceiling is another second of an unreadable table for a swap that is already finished.

## The error mapping

The whole swap is one transaction, so expiry costs nothing structural: `lock_catalog_rows` rolls back before raising, which reverts the three renames along with everything else. The job fails with no half-swapped table. Verified rather than assumed — after the failure the live table still holds its pre-swap row and the staging table is still there.

What was generic was the *code*. The message already came from the one place that raises it ("Another operation is updating this dataset's catalog entry."), but both reupload paths recorded the run under `file_refresh_failed` / `service_refresh_failed`, which sends a reader to inspect the file or the origin. Following the sibling mapping in this file — `_service_refresh_error_code`, added by #1220 for exactly this reason — a contended row now reports `catalog_lock_conflict`.

Retry disposition needed no change and got none: `_retry_capability` already refuses reupload jobs with "Dataset replacement jobs cannot be replayed as ordinary imports. Start the reupload again," which is the correct disposition for a contention failure, where nothing was written and a fresh attempt lands after the holder commits.

## An expired budget and a lost deadlock are different events

Raised in review. `lock_catalog_rows` maps 40P01 to `CatalogLockConflict` alongside 55P03, so a single `reupload_swap_catalog_lock_timeout` event told an operator the 60-second wait had run out, and its hint sent them to find a holder in `pg_stat_activity`, when PostgreSQL may have aborted this transaction as a deadlock victim about a second in.

That is not an edge case here — it is what the justification above predicts. If every holder that could outlast 60s also touches the live table this transaction holds `AccessExclusiveLock` on, then 40P01 is the *expected* outcome for exactly the contention the bound exists to handle, and labelling it as expiry is wrong for the main case rather than a rare one.

The handler now reads the SQLSTATE off the conflict's `__cause__` — `_raise_rolled_back_conflict` does `raise CatalogLockConflict(...) from exc`, so the `DBAPIError` and its code are there — and picks one of three events:

| SQLSTATE | event | hint points at |
| --- | --- | --- |
| `55P03` | `reupload_swap_catalog_lock_timeout` | the holder of the catalog row, in `pg_stat_activity` |
| `40P01` | `reupload_swap_catalog_deadlock` | the other side of the cycle — a transaction holding the catalog row and waiting on the live table |
| unreadable | `reupload_swap_catalog_lock_failed` | neither; it asserts no cause |

`waited_ms`, `budget` and the rolled-back-whole assurance stay on all three, and the code itself is now a `sqlstate` field. A `waited_ms` near 1s against a 60s budget tells the two apart at a glance.

`lock_catalog_rows` is untouched — no widening of what it raises, no change to its mapping (#1864 is the recorded cost of reaching past a lock helper's brief).

## The expiry handler had to stop reading the ORM instance

Caught in review, and it made the whole feature inert in production while every test passed. `lock_catalog_rows` raises only through `_raise_rolled_back_conflict`, which rolls the session back first — and a rolled-back session expires every loaded instance. `dataset_id=str(dataset.id)` inside `except CatalogLockConflict:` was that read. Reproduced against the dev database with a real `Dataset`, a real holder and a real conflict:

```
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called
  (raised from the except block, over app.platform.catalog_locks.CatalogLockConflict)
```

The cascade: the warning never emitted, so this PR's observability half was dead; the bare `raise` never ran, so `MissingGreenlet` propagated in place of the conflict; both error-code mappers then saw the wrong exception type and returned the generic code, so the error-mapping half was dead too; and `record_refresh_failure(..., error_message=str(exc))` wrote the raw SQLAlchemy greenlet string into run history a user reads. Newly exposed by this PR — under `lock_timeout=None` the conflict was reachable only via a 40P01 deadlock, and the 60s budget makes it routine.

The id is now captured beside `table_name` before the acquisition and used at both log calls. The success-path line has no exposure, but reads the same local so the two cannot drift.

No other post-rollback ORM read exists on the path: `table_name` is a local, the conflict path leaves via `raise`, every `dataset.*` read at the callers is success-path only, both `finally:` blocks use locals, and the broad handler opens a fresh session.

Why nothing caught it: the DB fixture builds a real `Dataset` and then yields `_make_dataset_stub(live)`, a `types.SimpleNamespace`, which has no expiry semantics and answers `stub.id` happily after a rollback. The new case drives the real instance.

## #1919 is untouched, and now actually guarded

The DDL capture/restore is byte-identical; the new budget gets a *second* restore rather than reusing or displacing the first.

The first revision of this PR claimed `test_the_swap_restores_the_lock_timeout_it_installed` was the evidence for that. It is not: it compares `lock_timeout` before and after the whole swap, and the new second restore writes the same `pre_swap_lock_timeout`, so deleting #1919's restore leaves it green. The sibling case does not close the gap either — `_install_lock_timeout` issues its own `SET LOCAL` whenever `lock_timeout` is not None, overriding anything leaked.

The budget case now reads `lock_timeout` on *entry* to the acquisition, before delegating, and asserts it equals what the transaction arrived with. Counterfactual, with #1919's restore deleted:

```
E   AssertionError: the wait started on '5s', not the '0' the transaction
    arrived with: the swap's DDL budget leaked past the savepoint that set it (#1919).
FAILED test_the_wait_runs_on_the_swaps_own_budget
1 failed, 8 passed
```

Both 1917 cases are among the 8 that passed, which is the point: this is the only case that sees it.

The in-force assertion is also tightened from "differs from the session default" — which a leaked `5s` satisfies — to `== "1min"`, what PostgreSQL normalizes `'60s'` to.

One consequence worth stating rather than leaving to be derived: `_install_lock_timeout` also sets the `catalog_timeout_installed` ContextVar, and the restore does not clear it. That marker is read only by the FastAPI 409 boundary handler, which no worker transaction reaches, so it stays inert here; leaving it alone keeps the request path's behaviour exactly as it is.

## The two sibling worker doors are filed, not overlooked

`tasks_raster_replace.py` and `tasks_vrt.py` still pass `lock_timeout=None`, tracked as #1937 and #1938. Neither holds DDL across its wait, so the exposure there is a hung job rather than an unreadable table, and the shape in this PR is the wrong fix for them: raster replace wants a `lock_and_statement_timeout_ms` phase budget covering its transaction, not a per-call clamp. Deliberately not copied here.

## Structural gate updated

`test_feature_lock_order_1847.py::test_worker_doors_do_not_clamp_their_transaction` asserts the exact set of files passing `lock_timeout=None`. `tasks_common.py` leaves that set. Removing it strengthens the gate for this file: re-introducing an unbounded wait in the swap now fails the test.

## Tests

`backend/tests/test_swap_catalog_wait_bound_1921.py`, ten cases:

- the acquisition asks for the module budget; `lock_timeout` on entry is what the transaction arrived with (the #1919 guard above); and inside the lock it reads `1min`, so the value reached PostgreSQL rather than merely being passed;
- an uncontended swap emits `reupload_swap_catalog_lock_acquired` with an integer `waited_ms` and the budget;
- a second connection holds the datasets row past a budget shrunk to 500ms: the swap raises `CatalogLockConflict`, logs `reupload_swap_catalog_lock_timeout` with `waited_ms` at least 80% of the budget (the vacuity guard — a run that gave up early would prove nothing), and the renames are gone, with the live table on its old row and the staging table still present;
- the same contention against a **real** `Dataset` loaded in the swap's own session: the warning emits and `CatalogLockConflict` is what escapes. This one fails with `MissingGreenlet` without the capture above;
- the deadlock and no-SQLSTATE branches, parametrized;
- the three mapping cases: a contended row through both mappers, the fall-through codes, and the two credential codes unchanged.

**Which of the three branches is exercised end to end, and which is not.** The `55P03` branch is: the contention cases drive a real expiry against a real second connection, and one of them asserts `sqlstate == "55P03"`, so the extraction from a real `DBAPIError` cause is proven rather than assumed. The `40P01` and no-SQLSTATE branches are driven by a **constructed** cause — a `CatalogLockConflict` whose `__cause__` is a `DBAPIError` wrapping `asyncpg`'s `DeadlockDetectedError`, or no cause at all. Provoking a real deadlock here means racing two sessions into a cycle and betting on which one PostgreSQL picks as the victim, which is a flaky test rather than a stronger one. Read those two as covering the dispatch, not the end-to-end path.

Counterfactual on the event split, with the dispatch collapsed back to the single timeout entry:

```
E   AssertionError: assert ['reupload_swap_catalog_lock_timeout'] == ['reupload_swap_catalog_deadlock']
E   AssertionError: assert ['reupload_swap_catalog_lock_timeout'] == ['reupload_swap_catalog_lock_failed']
2 failed, 7 passed
```

Counterfactual on the budget itself, with `lock_timeout=_POST_SWAP_CATALOG_TIMEOUT` put back to `None`:

```
FAILED test_the_wait_runs_on_the_swaps_own_budget
FAILED test_a_holder_past_the_budget_fails_the_swap_as_contention
2 failed, 4 passed
```

The second failure is a `TimeoutError` at the test's own 30s ceiling — the wait never ends, which is the defect.

The DB-backed cases reuse the 1917 suite's fixture rather than copying it: its body became the plain async generator `make_swap_target`, wrapped by a three-line `@pytest.fixture` in each of the two modules. `_make_dataset_stub`, `_stub_atomic_bump`, `_stub_downstream` and `_run_swap` are used as they are.

## Verification

```
uv run pytest tests/test_swap_catalog_wait_bound_1921.py tests/test_swap_lock_timeout_scope_1917.py \
  tests/test_worker_swap_bump_after_lock_1911.py tests/test_reupload_swap_lock_retry.py \
  tests/test_feature_lock_order_1847.py tests/test_job_cancel_no_swap.py tests/test_layering.py
# 157 passed, 1 skipped

uv run pytest tests/test_dataset_refresh_runs.py tests/test_service_refresh_1220.py tests/test_reupload.py \
  tests/test_reupload_service.py tests/test_reupload_completion_contract_1207.py \
  tests/test_failed_job_token_purge_1746.py tests/test_worker_tile_cache_1315.py tests/test_refresh_gate_1269.py
# 257 passed, 3 skipped

uv run ruff check . && uv run ruff format --check .
# All checks passed / 1185 files already formatted
```

## LOC caps

- `tasks_common.py` 2577 -> 2643, exact.
- `tasks_reupload.py` 1310 -> 1325, exact.
