### PR TITLE
chore(backend): trim review-history comments in tenant_adoption, service_items and analysis tasks

### DIFF
--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -461,8 +461,8 @@ async def list_tenants(conn) -> list[str]:
 
 
 #: ``inherit_option``/``set_option`` arrived in PostgreSQL 16 and GeoLens
-#: supports 13 up, so they are read back out of the row as jsonb.  Before 16 the
-#: guard is ``admin_option`` alone, NOINHERIT's own SET-only guarantee.
+#: supports 13 up, so they are read back out of the row as jsonb.  Before 16
+#: ``admin_option`` alone is correct: NOINHERIT gateway roles are SET-only.
 _MEMBER_OPTIONS_PRESENT = "jsonb_exists(to_jsonb(membership), 'set_option')"
 _MEMBER_INHERIT = "(to_jsonb(membership) ->> 'inherit_option')::boolean"
 _MEMBER_SET = "(to_jsonb(membership) ->> 'set_option')::boolean"

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -1049,9 +1049,8 @@ async def ensure_cluster_roles(conn) -> bool:
     await conn.execute(text(PROVISIONER_DATABASE_GRANT_SQL))
     await conn.execute(text(f"GRANT USAGE ON SCHEMA catalog TO {PROVISIONER}"))
     await conn.execute(text(f"GRANT SELECT ON TABLE catalog.tenants TO {PROVISIONER}"))
-    # fix(#998 codex r45): a grantable entry some third role issued survives
-    # the plain revokes below; refuse it with the grantor named before
-    # pretending to rewrite it.
+    # fix(#998): a grantable entry some third role issued survives the plain revokes
+    # below; refuse it with the grantor named before pretending to rewrite it.
     await conn.execute(text(PROVISIONER_GRANT_OPTION_GUARD_SQL))
     # A re-GRANT adds the privilege and leaves an existing GRANT OPTION alone.
     # These are no-ops on a database that never had one.

--- a/backend/app/core/db/tenant_adoption.py
+++ b/backend/app/core/db/tenant_adoption.py
@@ -1,40 +1,24 @@
 """Forward-only tenant-ownership adoption at the current schema head.
 
-Migration ``0019_tenant_provisioning_boundary`` is the only place that has ever
-moved restored tenant schemas, roles, and relations under the least-privilege
-provisioning boundary.  Reaching it again meant ``alembic downgrade 0016``,
-which walks back through migrations that either refuse on data the current
-schema legitimately holds or discard state the re-upgrade cannot rebuild.  On a
-populated cluster that is a data-loss event, not a recovery procedure (#998).
+Reconstructs the ownership migration ``0019_tenant_provisioning_boundary``
+installs, against the **current head schema**, so a restored dump never needs
+``alembic downgrade 0016`` to reach the least-privilege provisioning boundary.
 
-This module reconstructs the same ownership against the **current head schema**,
-so the downgrade is never required.  It is deliberately not a replay of 0019:
-
-- 0019 installs its SECURITY DEFINER functions with plain ``CREATE FUNCTION``,
-  which collides with the functions a restored dump already carries.  Adoption
-  never installs a function body.  The migrations own that body; adoption
-  verifies the two functions are present, ``SECURITY DEFINER``, and
-  ``search_path``-pinned, and repairs only the owner and the ACL that
-  ``pg_restore --no-owner --no-acl`` strips.  That repair matters on its own:
-  PostgreSQL's default function ACL is ``EXECUTE`` to ``PUBLIC``, so a restored
-  ``catalog.provision_tenant_data_schema`` is a SECURITY DEFINER function owned
-  by the restoring superuser and callable by every login in the database.
-- 0019 parked tenant relations on the provisioner so its provisioning function
-  could rewrite their ACLs.  Migration 0024 removed that object-ACL pass, so at
-  head the relations move straight to the per-tenant writer and the reader's
-  per-relation ``SELECT`` is granted by the writer itself — the same contract
-  ingest follows.
+Function bodies belong to the migrations and are never installed here.
+Adoption verifies both boundary functions are present, ``SECURITY DEFINER`` and
+``search_path``-pinned, and repairs the owner and the ACL that ``pg_restore
+--no-owner --no-acl`` strips: PostgreSQL's default function ACL is ``EXECUTE``
+to ``PUBLIC``, so a restored ``catalog.provision_tenant_data_schema`` is a
+SECURITY DEFINER function owned by the restoring superuser and callable by
+every login in the database.
 
 Idempotence is keyed on database state, never on a marker or a timestamp: each
-step reads what the cluster currently holds and issues DDL only for the gap.  A
-second run over an adopted tenant issues no DDL at all, and a run interrupted
-partway is resumed by running it again — every tenant is adopted in its own
-transaction, so completed tenants stay completed.
+step reads what the cluster currently holds and issues DDL only for the gap.
+Every tenant is adopted in its own transaction, so a run interrupted partway is
+resumed by running it again.
 
-Adoption rewrites only the grants it is itself the grantor of.  A pre-existing
-anomaly — a membership some third party granted, a duplicate row behind a
-canonical one, a default-privilege entry owned by a role this credential cannot
-assume — is reported with the exact statement to run and the role to run it as,
+Adoption rewrites only the grants it is itself the grantor of.  Any other
+anomaly is reported with the exact statement to run and the role to run it as,
 and the tenant is left for the next run.  See the repair boundary in
 :mod:`app.core.db.tenant_adoption_sql`.
 
@@ -99,13 +83,12 @@ logger = structlog.stdlib.get_logger(__name__)
 async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
     """Read the tenant boundary from the database, never from a constant.
 
-    The boundary is whatever currently carries 0018's insert-stamping trigger.
-    Migration 0018 froze a six-table tuple by design and later migrations
-    widened the live set, so any enumeration copied from a migration is stale
-    the moment a table joins.  Tables holding a ``tenant_id`` column *without*
-    the trigger are reported too: 0037's ``dataset_refresh_runs`` is a
-    deliberately dormant column, and an accidental one should look the same
-    here so it can be told apart on purpose rather than by omission.
+    The boundary is whatever currently carries 0018's insert-stamping trigger,
+    so an enumeration copied from a migration is stale the moment a table
+    joins.  Tables holding a ``tenant_id`` column *without* the trigger are
+    reported too, so a deliberately dormant column (0037's
+    ``dataset_refresh_runs``) and an accidental one are told apart on purpose
+    rather than by omission.
     """
     result = await conn.execute(
         text(
@@ -213,12 +196,9 @@ async def live_tenant_boundary(conn) -> list[BoundaryTableState]:
     ]
 
 
-#: ``prosrc`` with SQL comments removed.  The markers below say what a body
-#: still *does*, and a substituted body could otherwise carry them in a comment
-#: and satisfy the check while executing something else.  Dead code can still
-#: defeat it — see ``BoundaryFunctionState.migration_shaped`` for why this is a
-#: structural check and not a provenance one, and why the residual exposure only
-#: runs in the safe direction.
+#: ``prosrc`` with SQL comments removed: a substituted body could otherwise
+#: carry the markers below in a comment and satisfy the check while executing
+#: something else.  Structural, not provenance — see ``migration_shaped``.
 _EXECUTABLE_BODY = (
     "regexp_replace("
     "regexp_replace(routine.prosrc, '/\\*.*?\\*/', ' ', 'gs'),"
@@ -301,10 +281,9 @@ async def boundary_function_states(conn) -> list[BoundaryFunctionState]:
 async def stamping_function_shape(conn) -> str | None:
     """Why ``catalog.stamp_current_tenant_on_insert`` is not 0018's, if it is not.
 
-    Checking only that a trigger points at this name proves nothing: replace the
-    body with one that returns ``NEW`` untouched and every insert lands
-    tenantless while every structural check still passes.  Same structural
-    approach, and the same honest limits, as
+    A trigger pointing at this name proves nothing on its own: a body that
+    returns ``NEW`` untouched lands every insert tenantless while every
+    structural check passes.  Same structural limits as
     ``BoundaryFunctionState.migration_shaped``.
     """
     result = await conn.execute(
@@ -391,8 +370,8 @@ async def cluster_topology_error(engine) -> str | None:
     """Would ``--apply`` refuse this cluster's fixed role topology?
 
     Runs the identical guard ``ensure_cluster_roles`` runs, minus the half that
-    creates anything, rather than a read-only paraphrase of it that could drift.
-    A raise aborts the transaction, so it gets a connection of its own.
+    creates anything.  A raise aborts the transaction, so it gets a connection
+    of its own.
     """
     try:
         async with engine.begin() as conn:
@@ -405,8 +384,7 @@ async def cluster_topology_error(engine) -> str | None:
 async def missing_provisioner_grants(conn) -> list[str]:
     """Object privileges ``ensure_cluster_roles`` grants and a restore drops.
 
-    Replaying globals brings the role back; it brings none of these with it, and
-    without them ``catalog.provision_tenant_data_schema`` cannot see
+    Without them ``catalog.provision_tenant_data_schema`` cannot see
     ``catalog.tenants`` or create a tenant schema.  Call only once
     :func:`cluster_topology_error` has confirmed the role exists — the
     ``has_*_privilege`` family errors on a role name that is not there.
@@ -482,12 +460,9 @@ async def list_tenants(conn) -> list[str]:
     return [row[0] for row in result]
 
 
-#: ``pg_auth_members.inherit_option``/``set_option`` arrived in PostgreSQL 16 and
-#: GeoLens supports 13 and up (README), so naming those columns directly would be
-#: a parse error on an older server.  Reading them back out of the row as jsonb
-#: parses everywhere, and the guard degrades to ``admin_option`` alone before 16 —
-#: which is correct, because that is where NOINHERIT on the fixed gateway roles
-#: carries the same SET-only guarantee.
+#: ``inherit_option``/``set_option`` arrived in PostgreSQL 16 and GeoLens
+#: supports 13 up, so they are read back out of the row as jsonb.  Before 16 the
+#: guard is ``admin_option`` alone, NOINHERIT's own SET-only guarantee.
 _MEMBER_OPTIONS_PRESENT = "jsonb_exists(to_jsonb(membership), 'set_option')"
 _MEMBER_INHERIT = "(to_jsonb(membership) ->> 'inherit_option')::boolean"
 _MEMBER_SET = "(to_jsonb(membership) ->> 'set_option')::boolean"
@@ -505,10 +480,10 @@ def _role_secure_sql(
     """SQL for "this per-tenant role has the shape ``--apply`` enforces".
 
     Every clause mirrors a refusal in ``ADOPT_TENANT_SQL`` or in
-    ``catalog.provision_tenant_data_schema``, so a dry run cannot call a topology
-    adopted that ``--apply`` would reject or repair.  Role existence and
-    effective privileges are not enough on their own: a reader carrying
-    ``SUPERUSER`` satisfies every ``has_table_privilege`` check by fiat.
+    ``catalog.provision_tenant_data_schema``, so a dry run cannot call a
+    topology adopted that ``--apply`` would reject or repair.  Effective
+    privileges are not enough on their own: a reader carrying ``SUPERUSER``
+    satisfies every ``has_table_privilege`` check by fiat.
 
     Role names come from the module constants above, never from a caller.
     """
@@ -1064,10 +1039,9 @@ async def ensure_cluster_roles(conn) -> bool:
     """Create the fixed role topology if absent, and refuse an unsafe one.
 
     Returns whether *this* run had to take a usable membership in the
-    provisioner, which is what decides whether the run gives one back.  An
-    operator may have granted the migrator that role by hand — especially before
-    PostgreSQL 16, where CREATEROLE leaves no automatic membership to compare
-    against — and revoking somebody else's grant is not this tool's business.
+    provisioner, which is what decides whether the run gives one back.  A
+    membership an operator granted by hand is left alone: revoking somebody
+    else's grant is not this tool's business.
     """
     held_before = await _holds_provisioner_privileges(conn)
     await conn.execute(text(CLUSTER_ROLE_CREATE_SQL))
@@ -1097,11 +1071,11 @@ async def ensure_cluster_roles(conn) -> bool:
 async def secure_boundary_functions(conn) -> list[BoundaryFunctionState]:
     """Re-own and re-restrict the two functions a restore left wide open.
 
-    The bodies belong to the migrations and are never rewritten here.  What a
+    The bodies belong to the migrations and are never rewritten here.  What
     ``pg_restore --no-owner --no-acl`` strips is the owner and the ACL, and the
-    PostgreSQL default for a function with no ACL is ``EXECUTE`` to ``PUBLIC``.
-    A SECURITY DEFINER function owned by the restoring superuser and callable by
-    everyone is the state this repairs.
+    PostgreSQL default for a function with no ACL is ``EXECUTE`` to ``PUBLIC``,
+    so the state this repairs is a SECURITY DEFINER function owned by the
+    restoring superuser and callable by everyone.
     """
     states = {state.name: state for state in await boundary_function_states(conn)}
     missing = [name for name in BOUNDARY_FUNCTIONS if name not in states]
@@ -1135,10 +1109,10 @@ async def release_bootstrap_membership(engine, *, took_provisioner_edge: bool) -
 
     From PostgreSQL 16 this runs whatever the flag says: the predicate — granted
     by the current role, carrying no ADMIN — describes the edge adoption takes
-    and nothing an operator would set up by hand, and running it unconditionally
-    is what recovers one a previous run was SIGKILLed before returning.  Before
-    16 there is a single row per pair and no way to tell those apart, so there
-    the flag is the only evidence there is.
+    and nothing an operator would set up by hand, so running it unconditionally
+    also recovers one a previous run was killed before returning.  Before 16
+    there is a single row per pair and no way to tell those apart, so there the
+    flag is the only evidence there is.
     """
     async with engine.begin() as conn:
         modern = await conn.execute(
@@ -1218,9 +1192,9 @@ async def run_adoption(engine, *, apply: bool) -> AdoptionReport:
                     "tenant_adoption: tenant failed", tenant_id=tenant_id, exc_info=True
                 )
     finally:
-        # A bare finally, so a Ctrl-C (CancelledError, a BaseException) hands the
-        # edge back too. From PostgreSQL 16 even a SIGKILL is recoverable: the
-        # next run releases the edge whether or not it took one.
+        # A bare finally, so a Ctrl-C (CancelledError, a BaseException) hands
+        # the edge back too. From PostgreSQL 16 even a SIGKILL is recoverable:
+        # the next run releases the edge whether or not it took one.
         await release_bootstrap_membership(
             engine, took_provisioner_edge=took_provisioner_edge
         )

--- a/backend/app/platform/service_items.py
+++ b/backend/app/platform/service_items.py
@@ -89,11 +89,14 @@ PAGE_SIZE = 1000
 class MaterialisedCollection(NamedTuple):
     """A local extract, and what is known about the collection behind it.
 
+    ``features`` is the number of features written to the local extract. A full
+    walk writes the whole collection, so it equals ``total``; a sampled or
+    truncated read writes fewer.
+
     ``total`` is the collection's own size when it can be known: the service's
     ``numberMatched`` if it published one, otherwise the features written when
     the walk ran to the end. ``None`` when the walk stopped at a sample limit
-    and the service said nothing, so ``features`` is never the collection's row
-    count.
+    and the service said nothing.
     """
 
     path: str

--- a/backend/app/platform/service_items.py
+++ b/backend/app/platform/service_items.py
@@ -266,12 +266,11 @@ def _advertised_items_href(document: dict, base: str) -> str | None:
         candidates[0],
     )
     try:
-        # fix(#1770 round 47 P1): length-gated before `urljoin`, and again
-        # inside `_with_page_size`, both raising the SAME `ValueError` this
-        # except clause already exists to catch.
+        # fix(#1770): length-gated before `urljoin`, and again inside `_with_page_size`,
+        # both raising the SAME `ValueError` this except clause already exists to catch.
         return urljoin(base, bounded_service_url(str(chosen["href"]), what="items"))
     except HrefTooLongError:
-        # fix(#1770 round 47b): its own wording, matching
+        # fix(#1770): its own wording, matching
         # `service_endpoints.py::_assert_same_origin`.
         raise ItemFetchFailedError("items link exceeds the length limit") from None
     except ValueError:
@@ -320,20 +319,20 @@ def _next_href(document: object, base: str) -> str | None:
     for link in document.get("links", []) or []:
         if isinstance(link, dict) and link.get("rel") == "next" and link.get("href"):
             try:
-                # fix(#1770 round 47 P1): the same length gate
-                # `service_endpoints.py::_next_page` applies, before `urljoin`.
+                # fix(#1770): the same length gate `service_endpoints.py::_next_page`
+                # applies, before `urljoin`.
                 return urljoin(
                     base, bounded_service_url(str(link["href"]), what="next")
                 )
             except HrefTooLongError:
-                # fix(#1770 round 47b): its own wording.
+                # fix(#1770): its own wording.
                 raise ItemFetchFailedError(
                     "next link exceeds the length limit"
                 ) from None
             except ValueError:
-                # fix(#1746 B2b review r16): an address that will not parse
-                # cannot be shown to stay on the origin, so it is refused
-                # rather than read as the end of the chain. Never echoed.
+                # fix(#1746): an address that will not parse cannot be shown to stay on
+                # the origin, so it is refused rather than read as the end of the chain.
+                # Never echoed.
                 raise ItemFetchFailedError("unparseable next page") from None
     return None
 
@@ -358,9 +357,9 @@ async def _fetch_page(
         client,
         url,
         headers,
-        # fix(#1746 B2b review r25): the same Accept the probe and the
-        # endpoint check send, so a service serving HTML for `*/*` cannot
-        # answer one of the three reads differently from the other two.
+        # fix(#1746): the same Accept the probe and the endpoint check send, so a
+        # service serving HTML for `*/*` cannot answer one of the three reads
+        # differently from the other two.
         accept=OGC_JSON_ACCEPT,
         budget=budget,
         # Read at call time for the same reason `fetch_document` does it: a
@@ -372,9 +371,9 @@ async def _fetch_page(
     try:
         return json.loads(body), len(body), final_url
     except (ValueError, RecursionError) as exc:
-        # fix(#1770 round 44 P2): a JSON depth bomb is under both the byte
-        # cap and MAX_STRUCTURAL_TOKENS (which counts brackets, not depth) and
-        # raises RecursionError rather than ValueError.
+        # fix(#1770): a JSON depth bomb is under both the byte cap and
+        # MAX_STRUCTURAL_TOKENS (which counts brackets, not depth) and raises
+        # RecursionError rather than ValueError.
         raise ItemFetchFailedError(str(exc)) from None
 
 
@@ -417,13 +416,13 @@ async def _resolve_items_url(
         # be paid with this credential.
         raise ItemFetchFailedError("items link leaves the origin")
     try:
-        # fix(#1770 round 47 P1): `_with_page_size` re-parses `href`'s query to
-        # replace `limit`, and bounds both its length and its field count; only
-        # a query packed with many short pairs reaches this except in practice.
+        # fix(#1770): `_with_page_size` re-parses `href`'s query to replace `limit`, and
+        # bounds both its length and its field count; only a query packed with many
+        # short pairs reaches this except in practice.
         return _with_page_size(href), size
     except HrefTooLongError:
-        # fix(#1770 round 47b): its own wording, kept for the same reason that
-        # check is defence in depth rather than trusted alone.
+        # fix(#1770): its own wording, kept for the same reason that check is defence in
+        # depth rather than trusted alone.
         raise ItemFetchFailedError("items link exceeds the length limit") from None
     except ValueError:
         raise ItemFetchFailedError("unparseable items link") from None
@@ -521,9 +520,9 @@ def _end_of_chain(
         # different service to be paid with this credential.
         raise ItemFetchFailedError("next page leaves the origin")
     if following is None and feature_limit is None and pages == 1:
-        # fix(#1770 round 41 P1): a FULL walk ending on the FIRST page with
-        # no `next` must be able to PROVE it -- see `_page_proves_complete`.
-        # `has_next=False`: this branch needs `following is None`.
+        # fix(#1770): a FULL walk ending on the FIRST page with no `next` must be able
+        # to PROVE it -- see `_page_proves_complete`. `has_next=False`: this branch
+        # needs `following is None`.
         provably_complete = _page_proves_complete(
             document, has_next=False, observed=observed, number_matched=number_matched
         )
@@ -531,9 +530,9 @@ def _end_of_chain(
             raise ItemFetchFailedError("collection may not be complete")
         return following, truncated
     if following is None and feature_limit is not None:
-        # fix(#1770 round 42): the SAMPLED-walk mirror of the branch above.
-        # Never refuses -- a preview stays usable -- but the total it reports
-        # is honest only where `_page_proves_complete` proves it.
+        # fix(#1770): the SAMPLED-walk mirror of the branch above. Never refuses -- a
+        # preview stays usable -- but the total it reports is honest only where
+        # `_page_proves_complete` proves it.
         return following, _sample_truncated(
             document,
             landed_mid_page=False,
@@ -591,20 +590,19 @@ async def _walk_pages(
     verify it declines.
     """
     written = 0
-    # fix(#1746 B2b round 34): every page counted whole, before
-    # `feature_limit` truncates what gets written -- `written` under-reports a
-    # page's real size once a sample cuts it short.
+    # fix(#1746): every page counted whole, before `feature_limit` truncates what gets
+    # written -- `written` under-reports a page's real size once a sample cuts it short.
     observed = 0
     pages = 0
     on_disk = 0
     number_matched: int | None = None
-    # fix(#1770 round 42): whether the walk STOPPED SHORT, tri-state. Only the
-    # site that breaks out of the loop knows, a FULL walk never touches it, and
-    # `None` means the page proved neither, so the total is unknown.
+    # fix(#1770): whether the walk STOPPED SHORT, tri-state. Only the site that breaks
+    # out of the loop knows, a FULL walk never touches it, and `None` means the page
+    # proved neither, so the total is unknown.
     truncated: bool | None = False
-    # fix(#1746 B2b review r23): the origin is contacted HERE, not by the
-    # subprocess, so this is the moment a caller that dates origin contacts
-    # hears about. `fire_once` means no loop tracks which pass it is on.
+    # fix(#1746): the origin is contacted HERE, not by the subprocess, so this is the
+    # moment a caller that dates origin contacts hears about. `fire_once` means no loop
+    # tracks which pass it is on.
     arm = fire_once(on_first_request)
     first_page, downloaded = await _resolve_items_url(
         client, url=url, collection=collection, headers=headers, on_first_request=arm
@@ -628,40 +626,39 @@ async def _walk_pages(
         # may stop partway through it.
         observed += len(features)
         if "numberMatched" in document:
-            # fix(#1746 B2b review r30): the whole query's match count, read
-            # from EVERY page. Two pages giving different answers describe two
-            # different queries and neither can be checked against the walk.
+            # fix(#1746): the whole query's match count, read from EVERY page. Two pages
+            # giving different answers describe two different queries and neither can be
+            # checked against the walk.
             reported = document["numberMatched"]
             if number_matched is None:
                 number_matched = reported
             elif reported != number_matched:
                 raise ItemFetchFailedError("pages disagree about the size")
         for index, feature in enumerate(features):
-            # fix(#1746 B2b review r19): `ensure_ascii=False` and a binary
-            # file, so non-Latin text is not tripled on disk; what is written
-            # is then counted rather than inferred from the download (r20).
+            # fix(#1746): `ensure_ascii=False` and a binary file, so non-Latin text is
+            # not tripled on disk; what is written is then counted rather than inferred
+            # from the download.
             try:
-                # fix(#1770 round 47 P2): a JSON escape for an unpaired
-                # surrogate is legal and has no UTF-8 encoding, so this
-                # refuses rather than writing bytes GDAL cannot read back.
+                # fix(#1770): a JSON escape for an unpaired surrogate is legal and has
+                # no UTF-8 encoding, so this refuses rather than writing bytes GDAL
+                # cannot read back.
                 encoded = json.dumps(
                     feature, separators=(",", ":"), ensure_ascii=False
                 ).encode("utf-8")
             except UnicodeEncodeError as exc:
                 raise ItemFetchFailedError(f"unencodable feature: {exc}") from None
             chunk = b"," + encoded if written else encoded
-            # fix(#1746 B2b review r21): compared BEFORE the write. Checking
-            # after admits one expanded feature past the cap, which on this
-            # path is the value that expands unboundedly.
+            # fix(#1746): compared BEFORE the write. Checking after admits one expanded
+            # feature past the cap, which on this path is the value that expands
+            # unboundedly.
             if on_disk + len(chunk) > MAX_BYTES:
                 raise ItemFetchFailedError("collection exceeds the cap on disk")
             out.write(chunk)
             on_disk += len(chunk)
             written += 1
             if feature_limit is not None and written >= feature_limit:
-                # fix(#1770 round 42): landing exactly on the page's last
-                # feature asks the same completeness predicate a full walk's
-                # natural end does.
+                # fix(#1770): landing exactly on the page's last feature asks the same
+                # completeness predicate a full walk's natural end does.
                 truncated = _sample_truncated(
                     document,
                     landed_mid_page=index + 1 < len(features),
@@ -682,19 +679,19 @@ async def _walk_pages(
                 truncated=truncated,
             )
     if page_url is not None:
-        # fix(#1746 B2b review r18): the page cap is reached with more to
-        # come. Closing the array here returns a prefix that reads as a
-        # complete collection, and the worker imports it over a dataset.
+        # fix(#1746): the page cap is reached with more to come. Closing the array here
+        # returns a prefix that reads as a complete collection, and the worker imports
+        # it over a dataset.
         raise ItemFetchFailedError("collection exceeds the page cap")
     if number_matched is not None:
-        # fix(#1746 B2b review r31): SAMPLING CAN PRODUCE FEWER ROWS THAN THE
-        # TOTAL, NEVER MORE, so this half holds on every walk. `observed`, not
-        # `written`: a sample masks the page's real size from this check.
+        # fix(#1746): SAMPLING CAN PRODUCE FEWER ROWS THAN THE TOTAL, NEVER MORE, so
+        # this half holds on every walk. `observed`, not `written`: a sample masks the
+        # page's real size from this check.
         if observed > number_matched:
             raise ItemFetchFailedError("more features than the service reported")
-        # fix(#1746 B2b review r30): the chain ends short of the count the
-        # service gives for itself. Equality is a FULL-walk claim only -- a
-        # sampled read is short by design, and `truncated` carries that.
+        # fix(#1746): the chain ends short of the count the service gives for itself.
+        # Equality is a FULL-walk claim only -- a sampled read is short by design, and
+        # `truncated` carries that.
         if feature_limit is None and observed != number_matched:
             raise ItemFetchFailedError("collection is shorter than reported")
     out.write(b"]}")
@@ -738,8 +735,8 @@ async def materialise_oapif_items(
     one over an existing dataset.
     """
     headers = credential_headers(credential_line)
-    # fix(#1746 B2b review r28): prefix and suffix come from the module that
-    # sweeps them, so a file this writes is one that sweep recognises.
+    # fix(#1746): prefix and suffix come from the module that sweeps them, so a file
+    # this writes is one that sweep recognises.
     handle, path = tempfile.mkstemp(
         prefix=OAPIF_ITEMS_SCRATCH_PREFIX,
         suffix=OAPIF_ITEMS_SCRATCH_SUFFIX,
@@ -791,9 +788,9 @@ async def materialise_oapif_items(
         features=written,
     )
     if number_matched is None and truncated is not False:
-        # fix(#1770 round 42): `is not False`. The walk stopped short (`True`)
-        # or the page proved neither (`None`), and neither can name the total,
-        # so it stays unknown rather than reporting the sample size.
+        # fix(#1770): `is not False`. The walk stopped short (`True`) or the page proved
+        # neither (`None`), and neither can name the total, so it stays unknown rather
+        # than reporting the sample size.
         total: int | None = None
     else:
         total = number_matched if number_matched is not None else written

--- a/backend/app/platform/service_items.py
+++ b/backend/app/platform/service_items.py
@@ -1,52 +1,30 @@
-"""Read a protected OGC API collection ourselves, so GDAL never holds the key.
+"""Read a protected OGC API collection here, so GDAL never holds the key.
 
-fix(#1746 B2b review r16). An OGC API items response chooses the next one: each
-page carries a ``rel=next`` link, and GDAL's OAPIF driver follows it. Because
-``GDAL_HTTP_HEADER_FILE`` applies to every request the process makes, a
-collection whose first page is same-origin can hand the credential to any origin
-it likes on page two, with no redirect and nothing for a redirect hook to see.
+An OAPIF items chain is chosen by the service one page at a time, and
+``GDAL_HTTP_HEADER_FILE`` applies to every request the process makes, so a
+collection whose first page is same-origin can hand the credential to any
+origin it names on page two, with no redirect for a redirect hook to see. GDAL
+offers no scope that would confine it: on 3.10.3 a ``[credentials]`` ``path=``
+prefix applies to nothing at all for http(s) URLs, including the origin it
+names, because ``CPLHTTPFetch`` consults path-specific options only for the
+``/vsi*`` handlers.
 
-Validating the description up front cannot bound that, because the chain is
-chosen at run time, one page at a time. Two ways out, and the first was measured
-before the second was written.
+So the pages are read here instead, with the bounded client that revalidates
+SSRF and refuses to leave the origin, streamed to a local GeoJSON file that
+GDAL is handed in place of the OAPIF source. It follows nothing, because there
+is nothing left to follow.
 
-GDAL 3.10.3, the version in the worker image, was tested for a path-scoped
-header option: two local servers, the credential configured for the first only,
-`ogr2ogr` run against an OAPIF endpoint whose `next` pointed at the second. A
-``[configoptions]`` section of a ``GDAL_CONFIG_FILE`` applied the option and
-proved the file is read; every ``[credentials]`` ``path=`` prefix applied it to
-nothing at all, including the origin it named. ``CPLHTTPFetch``, which both the
-WFS and OAPIF drivers use, does not consult path-specific options for http(s)
-URLs; that section serves the ``/vsi*`` handlers. So the scope does not exist
-and the credential cannot be confined inside GDAL.
+WFS needs none of this: that driver pages by ``STARTINDEX``/``COUNT`` against
+the GetFeature endpoint the capabilities advertise, which is the endpoint
+``service_endpoints`` already validates.
 
-Therefore GDAL is not given the credential for this path at all. The pages are
-read here, with the bounded client that revalidates SSRF and refuses to leave
-the origin, streamed to a local GeoJSON file, and GDAL is handed that file. It
-follows nothing, because there is nothing left to follow.
-
-WFS needs none of this, and that was measured too rather than assumed: served a
-``wfs:FeatureCollection`` carrying ``next="http://other-origin/"``, GDAL fetched
-it never. The WFS driver pages by ``STARTINDEX``/``COUNT`` against the
-GetFeature endpoint the capabilities advertise, which is exactly the endpoint
-``service_endpoints`` validates, so that driver is bounded by the description
-check already.
-
-What a service is allowed to cost, since the whole chain is its to choose:
-
-``MAX_PAGES`` (10,000) requests, ``MAX_BYTES`` (2 GiB) downloaded and the same
-again written to the staging volume, ``MAX_PAGE_BYTES`` (16 MiB) on the wire
-for any one page, and ``MAX_STRUCTURAL_TOKENS`` (2,000,000) values or
-containers in any one page once decoded. Reaching any of them is a refusal,
-never a short answer: a caller cannot tell a prefix from a collection, and the
-worker would import one over an existing dataset.
-
-The last of those is the least obvious and the reason the others are not
-enough. A byte cap bounds the wire, not the object graph, and compact JSON
-expands 4x to 31x depending on shape (measured; the figures are beside the
-constant). The token bound is counted on the raw bytes before anything is
-decoded, so it costs three ``bytes.count`` passes and refuses before the
-memory would have been spent.
+What a collection may cost, since the whole chain is the service's to choose:
+``MAX_PAGES`` requests, ``MAX_BYTES`` downloaded and the same again written to
+the staging volume, ``MAX_PAGE_BYTES`` on the wire for any one page, and
+``MAX_STRUCTURAL_TOKENS`` values or containers in any one page once decoded.
+Reaching any of them is a refusal, never a short answer: a caller cannot tell a
+prefix from a collection, and the worker would import one over an existing
+dataset.
 """
 
 from __future__ import annotations
@@ -88,65 +66,20 @@ from app.platform.service_endpoints import (
 
 logger = structlog.stdlib.get_logger(__name__)
 
-# What one collection may cost. A page chain is chosen by the service, so it is
-# bounded here rather than trusted: an endpoint that keeps answering `next`
-# forever would otherwise be an unbounded fetch holding a credential.
-#
-# Reaching either is a refusal, never a short answer: see `_walk_pages`.
-#
-# `MAX_BYTES` bounds the bytes DOWNLOADED and, separately, the bytes WRITTEN.
-# r17 added the first because a page is decoded before any feature of it is
-# written, so counting the output missed where the memory goes. r19 then
-# removed a written-bytes counter on the reasoning that compact UTF-8 output
-# is a subset of the pages it came from and so cannot be larger. That was
-# wrong, and r20 caught it: a JSON round trip can GROW. `1e15` is four bytes
-# on the wire and parses to a float whose repr is `1000000000000000.0`, which
-# is eighteen. Python only switches to exponent notation at 1e16, so a page of
-# such numbers expands by more than four times on the way to disk, and a chain
-# comfortably inside the download cap could leave many gigabytes on a staging
-# volume shared with every other import. Both counters exist now, and the
-# written one is a real bound on disk rather than an inference from the wire.
+# What one collection may cost. `MAX_BYTES` bounds the bytes DOWNLOADED and,
+# separately, the bytes WRITTEN: a JSON round trip can GROW (`1e15` is four
+# bytes on the wire and eighteen written), so neither figure bounds the other.
 MAX_PAGES = 10_000
 MAX_BYTES = 2 * 1024 * 1024 * 1024
 
-# What one page may cost on the wire, enforced by the shared reader in
-# `service_endpoints` while it streams and before anything is decoded. A page
-# is held whole in memory to be parsed, so this is a per-request bound the
-# total above cannot substitute for: one oversized response would exhaust the
-# process long before a running total noticed.
-#
-# fix(#1746 B2b review r22): 64 MiB down to 16 MiB. The page size is ours
-# (`limit=`), so a well-behaved service never approaches either figure, and
-# the total budget is on disk rather than in memory. 16 MiB against
-# `PAGE_SIZE` features is ~16 KiB of JSON per feature, still far past any
-# honest geometry, and a service wanting more can paginate.
+# What one page may cost on the wire, streamed and enforced before anything is
+# decoded. A page is held whole in memory to be parsed, so one oversized
+# response exhausts the process before the total above notices.
 MAX_PAGE_BYTES = 16 * 1024 * 1024
 
-# What one page may cost DECODED, bounded before `json.loads` runs.
-#
-# fix(#1746 B2b review r22): the wire cap bounds bytes, not the object graph,
-# and compact JSON expands enormously. Measured on this interpreter against
-# 1 MiB pages:
-#
-#     [1.5,1.5,...]     8.2x    (32.8 bytes per structural token)
-#     [1,1,...]         4.5x    ( 8.9 bytes per token)
-#     [{"a":1},...]    24.1x    (96.4 bytes per token)
-#     [[[1]],...]      30.7x    (61.4 bytes per token)
-#
-# So one 16 MiB page of the worst shape is ~490 MiB decoded, and 64 MiB was
-# ~2 GiB: the whole API container, from a single page, with concurrent
-# previews making it worse.
-#
-# `_structural_tokens` counts commas and opening brackets on the RAW bytes,
-# which is an upper bound on the number of values and containers the decoder
-# will build: every value after the first is preceded by a comma, every
-# container opens with a bracket, and commas inside strings only overcount,
-# which is the safe direction. At the worst measured cost of ~96 bytes per
-# token, two million tokens is ~184 MiB decoded, which is the figure this
-# constant is chosen for. A full page of `PAGE_SIZE` polygon features costs
-# about 22,000 tokens (measured, and pinned in the suite), so the bound is
-# roughly ninety times what an honest service asking for the page size it was
-# given would ever produce.
+# What one page may cost DECODED, bounded before `json.loads` runs: compact JSON
+# expands to ~96 bytes per structural token, so this is ~184 MiB. Counted on the
+# RAW bytes, which only ever overcounts what the decoder builds.
 MAX_STRUCTURAL_TOKENS = 2_000_000
 
 # What a page fetch asks for. The service may answer with fewer.
@@ -156,16 +89,11 @@ PAGE_SIZE = 1000
 class MaterialisedCollection(NamedTuple):
     """A local extract, and what is known about the collection behind it.
 
-    fix(#1746 B2b review r24): the path alone was not enough. A preview asks
-    for a handful of features and gets a file holding exactly that many, so
-    everything downstream read the sample size as the collection's row count:
-    the import preview showed it, and re-upload's schema diff turned it into a
-    row-count delta against the real dataset.
-
     ``total`` is the collection's own size when it can be known: the service's
     ``numberMatched`` if it published one, otherwise the features written when
     the walk ran to the end. ``None`` when the walk stopped at a sample limit
-    and the service said nothing, which is the case that was being guessed at.
+    and the service said nothing, so ``features`` is never the collection's row
+    count.
     """
 
     path: str
@@ -176,10 +104,9 @@ class MaterialisedCollection(NamedTuple):
 class ItemFetchFailedError(EndpointCheckFailedError):
     """A page could not be read, or the chain tried to leave the origin.
 
-    Subclasses the description check's refusal so every door that already
-    answers that one answers this the same way: the caller's request named a
-    URL whose collection cannot be read safely, and the field to change is the
-    same.
+    Subclasses the description check's refusal so every door that answers that
+    one answers this the same way: the caller's request named a URL whose
+    collection cannot be read safely, and the field to change is the same.
     """
 
 
@@ -200,10 +127,9 @@ def _items_url(url: str, collection: str) -> str:
 def _require_object(document: object, what: str) -> dict:
     """The document, or a refusal. Never echoes what came back.
 
-    fix(#1746 B2b review r21): every place a fetched document is interpreted
-    goes through here or through `_require_feature_page` below, so a service
-    that answers 200 with something else is refused once rather than
-    reinterpreted differently at each site.
+    Every place a fetched document is interpreted goes through here or through
+    `_require_feature_page` below, so a service that answers 200 with something
+    else is refused once rather than reinterpreted differently at each site.
     """
     if not isinstance(document, dict):
         raise ItemFetchFailedError(f"malformed {what}")
@@ -213,47 +139,31 @@ def _require_object(document: object, what: str) -> dict:
 def _require_feature_page(document: object, *, first_page: bool) -> list:
     """The features of one items page, or a refusal.
 
-    fix(#1746 B2b review r21): `features or []` read an HTTP 200 JSON error
-    envelope as an empty page, and read `"features": null` and
-    `"features": {}` the same way. A preview then succeeded with zero rows and
-    a refresh or re-upload handed an empty FeatureCollection to ogr2ogr, which
-    replaced existing data with nothing: the silent-truncation class of r18,
-    one level up. A page that does not say what it is does not get to say it
-    is empty.
-
-    fix(#1746 B2b review r29): the same rule, applied to every shape the walker
-    could otherwise read as "this was the last page". MALFORMED MEANS REFUSE,
-    AND NEVER MEANS END-OF-COLLECTION. `_has_next` and `_next_href` both answer
-    None for a shape they cannot read, and None is indistinguishable from a
-    service saying there is no more, so anything they would skip has to be
-    refused before they are asked. Enumerated, because the class is what
-    matters and not the instance:
+    MALFORMED MEANS REFUSE, AND NEVER MEANS END-OF-COLLECTION. `_has_next` and
+    `_next_href` both answer None for a shape they cannot read, and None is
+    indistinguishable from a service saying there is no more, so every shape
+    they would silently skip is refused before they are asked:
 
     * ``links`` present but not a list. Iterating an OBJECT yields its keys,
       which are strings, so no link dict is ever found and the chain looks
-      finished. This is the one r29 reported.
-    * an entry of ``links`` that is not an object. Skipped by the same
+      finished.
+    * an entry of ``links`` that is not an object, skipped by the same
       `isinstance` test, so a ``next`` expressed as a list or a bare string
       disappears.
     * a ``rel=next`` entry whose ``href`` is absent, not a string, or blank.
       A falsy href fails the truthiness test and the link vanishes; a
       non-string one would be coerced by `str()` into an address nobody named.
     * ``links`` missing entirely on a page that is NOT the first. Reaching that
-      page means following a link, so the service does emit them; a page that
-      suddenly has none is a truncated response rather than a last page. OGC
-      API Features requires links on every items response, so this is
-      spec-aligned, but it is only enforced from the second page because a
-      single-page collection that omits them is common and harmless -- nothing
-      is being decided from a link there.
-    * ``numberMatched`` present and not a non-negative integer. Not a
-      truncation risk on its own, but it is the number a preview reports as the
-      collection's size and re-upload turns into a row-count delta, so a
-      service that cannot spell it is not one to take counts from.
-    * ``numberReturned`` present and not equal to the length of ``features``
-      (r31). The page carries the means to check itself, and a page claiming a
-      hundred while carrying ten is a truncated response that everything else
-      here reads as well formed.
-    * ``features`` not a list, from r21.
+      page means following a link, so a page that suddenly has none is a
+      truncated response. Tolerated on the first page, where a single-page
+      collection commonly omits them and nothing is decided from a link.
+    * ``numberMatched`` present and not a non-negative integer. It is the
+      number a preview reports as the collection's size.
+    * ``numberReturned`` present and not equal to the length of ``features``.
+      The page carries the means to check itself, and a page claiming a hundred
+      while carrying ten is a truncated response everything else reads as well
+      formed.
+    * ``features`` not a list.
 
     A legitimately empty page is `{"type": "FeatureCollection", "features": []}`
     and still reads as empty, which is what makes the refusal specific.
@@ -274,14 +184,9 @@ def _require_links(page: dict, *, first_page: bool) -> None:
     links = page.get("links")
     if links is None:
         if "links" in page or not first_page:
-            # An explicit null is malformed either way; an absent one is only
-            # tolerated on the first page, where nothing was followed to get
-            # here and nothing is decided from a link -- decided by THIS
-            # function, that is. Whether an absence this lets through, or an
-            # empty list a few lines down, may be read as "the collection is
-            # complete" is `_walk_pages`'s question (fix(#1770 round 38)): a
-            # shape this function accepts as well-formed can still fail there
-            # for lacking proof, on a full walk, that there was nothing left.
+            # An explicit null is malformed either way; an absent one is
+            # tolerated on the first page only. Whether that absence proves the
+            # collection complete is `_walk_pages`'s question, not this one.
             raise ItemFetchFailedError("malformed items page")
         return
     if not isinstance(links, list):
@@ -313,12 +218,9 @@ def _optional_count(page: dict, member: str) -> int | None:
 def _require_counts(page: dict, features: list) -> None:
     """Refuse the count members a page can contradict itself with.
 
-    fix(#1746 B2b review r31): ``numberReturned`` is the count of features IN
-    THIS RESPONSE, so the page carries the means to check itself. A page saying
-    it returned a hundred while carrying ten is a truncated response, and
-    nothing else in the walk would notice: the features array is well formed,
-    the links are well formed, and a full walk that ends there accepts the ten
-    as the whole collection. It is the per-page twin of the r30 check.
+    ``numberReturned`` is the count of features IN THIS RESPONSE, so a page
+    saying it returned a hundred while carrying ten is a truncated response
+    nothing else in the walk would notice.
 
     ``numberMatched`` is validated as a count here; the cross-page and
     whole-walk comparisons live in `_walk_pages`, which is the only place that
@@ -340,13 +242,10 @@ _ITEMS_MEDIA_TYPE = "application/geo+json"
 def _advertised_items_href(document: dict, base: str) -> str | None:
     """The collection's own ``rel=items`` link, resolved, or None.
 
-    fix(#1746 B2b review r20): fabricating ``/collections/{id}/items`` was a
-    regression against the path this replaced. GDAL followed the advertised
-    link, and `service_endpoints` still treats advertised links as the
-    authoritative statement of where a service keeps things, so a valid service
-    with a non-conventional layout passed the probe and then 404ed at preview
-    and import. What the document says wins; the convention is the fallback for
-    a document that says nothing.
+    What the document says wins, the same way `service_endpoints` treats an
+    advertised link as authoritative; the conventional
+    ``/collections/{id}/items`` layout is the fallback for a document that says
+    nothing.
     """
     candidates = [
         link
@@ -364,14 +263,13 @@ def _advertised_items_href(document: dict, base: str) -> str | None:
         candidates[0],
     )
     try:
-        # fix(#1770 round 47 P1): refused before `urljoin`, and again inside
-        # `_with_page_size` below before that function's own `parse_qsl` --
-        # see `bounded_service_url`'s docstring for why both callers reuse
-        # the SAME `ValueError` this except clause already exists to catch.
+        # fix(#1770 round 47 P1): length-gated before `urljoin`, and again
+        # inside `_with_page_size`, both raising the SAME `ValueError` this
+        # except clause already exists to catch.
         return urljoin(base, bounded_service_url(str(chosen["href"]), what="items"))
     except HrefTooLongError:
-        # fix(#1770 round 47b, low-priority): its own wording -- see
-        # `service_endpoints.py::_assert_same_origin`'s matching site.
+        # fix(#1770 round 47b): its own wording, matching
+        # `service_endpoints.py::_assert_same_origin`.
         raise ItemFetchFailedError("items link exceeds the length limit") from None
     except ValueError:
         # Same rule as `next`: an address that will not parse cannot be shown
@@ -382,17 +280,12 @@ def _advertised_items_href(document: dict, base: str) -> str | None:
 def _with_page_size(href: str) -> str:
     """The advertised link, asking for the page size this module wants.
 
-    Every other parameter the service put on its own link is kept: a
-    `f=json` or a fixed filter is part of where it said the items are.
+    Every other parameter the service put on its own link is kept: a `f=json`
+    or a fixed filter is part of where it said the items are.
 
-    fix(#1770 round 47 P1): `href` already passed `bounded_service_url` in
-    `_advertised_items_href` above, but this is also the module's one
-    `parse_qsl` call site on a service-advertised query string, so it gates
-    its own length again (defence in depth against a future second caller)
-    and bounds the field count directly -- see `bounded_service_url`'s and
-    `bounded_parse_qsl`'s own docstrings. Raises `ValueError`, which
-    `_resolve_items_url` below now catches the same way its sibling calls
-    already do.
+    This is the module's one `parse_qsl` call site on a service-advertised
+    query string, so it gates the href's length itself and bounds the field
+    count directly. Raises `ValueError`, which `_resolve_items_url` catches.
     """
     href = bounded_service_url(href, what="items")
     parts = urlsplit(href)
@@ -406,11 +299,9 @@ def _with_page_size(href: str) -> str:
 def _has_next(document: object) -> bool:
     """Whether the page offers another one, without resolving where.
 
-    fix(#1746 B2b review r28): asked when the walk is stopping at the sample
-    limit and is not going to follow the link, so it must not resolve it, must
-    not judge its origin, and must not refuse an unparseable one -- all three
-    would turn "your preview is complete" into a failure. It answers only the
-    question that decides whether the extract is the whole collection.
+    Asked when the walk is stopping at the sample limit and will not follow the
+    link, so it must not resolve it, judge its origin, or refuse an unparseable
+    one -- all three would turn "your preview is complete" into a failure.
     """
     if not isinstance(document, dict):
         return False
@@ -426,23 +317,20 @@ def _next_href(document: object, base: str) -> str | None:
     for link in document.get("links", []) or []:
         if isinstance(link, dict) and link.get("rel") == "next" and link.get("href"):
             try:
-                # fix(#1770 round 47 P1): the same length gate `service_
-                # endpoints.py::_next_page` applies, before `urljoin`.
+                # fix(#1770 round 47 P1): the same length gate
+                # `service_endpoints.py::_next_page` applies, before `urljoin`.
                 return urljoin(
                     base, bounded_service_url(str(link["href"]), what="next")
                 )
             except HrefTooLongError:
-                # fix(#1770 round 47b, low-priority): its own wording.
+                # fix(#1770 round 47b): its own wording.
                 raise ItemFetchFailedError(
                     "next link exceeds the length limit"
                 ) from None
             except ValueError:
-                # fix(#1746 B2b review r16): the page that named this address
-                # is the one this module exists to distrust, and an address
-                # that will not parse cannot be shown to stay on the origin.
-                # Refused rather than treated as the end of the chain, so a
-                # short read is never mistaken for a complete one. The href is
-                # never echoed.
+                # fix(#1746 B2b review r16): an address that will not parse
+                # cannot be shown to stay on the origin, so it is refused
+                # rather than read as the end of the chain. Never echoed.
                 raise ItemFetchFailedError("unparseable next page") from None
     return None
 
@@ -458,19 +346,18 @@ async def _fetch_page(
 ) -> tuple[object, int, str]:
     """One items page, its wire size and its URL, or a refusal.
 
-    fix(#1746 B2b review r23): the request itself is `fetch_document` in
-    `service_endpoints`, shared with the description reads, so the protections
-    the two paths need cannot diverge again. This adds only what is specific to
-    an items page: the caps it is read under, and the decode.
+    The request itself is `fetch_document` in `service_endpoints`, shared with
+    the description reads, so the protections the two paths need cannot
+    diverge. This adds only what is specific to an items page: the caps it is
+    read under, and the decode.
     """
     body, final_url = await fetch_document(
         client,
         url,
         headers,
-        # fix(#1746 B2b review r25): the same value the probe and the endpoint
-        # check ask for. An items page is an OGC API document like the rest,
-        # and a service that serves HTML for `*/*` must not be able to answer
-        # one of the three reads differently from the other two.
+        # fix(#1746 B2b review r25): the same Accept the probe and the
+        # endpoint check send, so a service serving HTML for `*/*` cannot
+        # answer one of the three reads differently from the other two.
         accept=OGC_JSON_ACCEPT,
         budget=budget,
         # Read at call time for the same reason `fetch_document` does it: a
@@ -482,14 +369,9 @@ async def _fetch_page(
     try:
         return json.loads(body), len(body), final_url
     except (ValueError, RecursionError) as exc:
-        # fix(#1770 round 44 P2): a JSON depth bomb (900,000 nested `[`, 1.8
-        # bytes each) is under both the byte cap and MAX_STRUCTURAL_TOKENS
-        # (which counts brackets, not nesting depth) and raises
-        # RecursionError rather than ValueError -- see
-        # `service_endpoints.py::_parsed_json`'s docstring for the same fix
-        # applied to the OGC API description path. Uncaught here, a worker's
-        # OAPIF item-page walk died unclassified instead of surfacing this
-        # module's own coded refusal.
+        # fix(#1770 round 44 P2): a JSON depth bomb is under both the byte
+        # cap and MAX_STRUCTURAL_TOKENS (which counts brackets, not depth) and
+        # raises RecursionError rather than ValueError.
         raise ItemFetchFailedError(str(exc)) from None
 
 
@@ -509,8 +391,7 @@ async def _resolve_items_url(
     and revalidated for SSRF by `_fetch_page` before it is requested.
 
     A document that advertises no items link falls back to the conventional
-    layout, which is what a service following the usual shape would have
-    advertised anyway.
+    layout.
     """
     document, size, from_url = await _fetch_page(
         client,
@@ -533,18 +414,13 @@ async def _resolve_items_url(
         # be paid with this credential.
         raise ItemFetchFailedError("items link leaves the origin")
     try:
-        # fix(#1770 round 47 P1): `_with_page_size` re-parses `href`'s query
-        # to drop/replace `limit`, and now bounds both its length and its
-        # field count -- see that function's own docstring. `href` already
-        # passed the same length gate once in `_advertised_items_href`
-        # above, so only an adversarial query packed with many short pairs
-        # (comfortably under that length) reaches this except in practice.
+        # fix(#1770 round 47 P1): `_with_page_size` re-parses `href`'s query to
+        # replace `limit`, and bounds both its length and its field count; only
+        # a query packed with many short pairs reaches this except in practice.
         return _with_page_size(href), size
     except HrefTooLongError:
-        # fix(#1770 round 47b, low-priority): its own wording, even though
-        # `_advertised_items_href` above already makes this branch
-        # practically unreachable for `href` itself -- kept for the same
-        # reason that check is defence in depth rather than trusted alone.
+        # fix(#1770 round 47b): its own wording, kept for the same reason that
+        # check is defence in depth rather than trusted alone.
         raise ItemFetchFailedError("items link exceeds the length limit") from None
     except ValueError:
         raise ItemFetchFailedError("unparseable items link") from None
@@ -559,18 +435,11 @@ def _sample_truncated(
 ) -> bool | None:
     """Whether a SAMPLED read that just broke out of its loop stopped short.
 
-    fix(#1770 round 42). Split out of `_walk_pages` to keep the branching in
-    one small function rather than pushing `_walk_pages` itself over the
-    complexity ceiling; see `_page_proves_complete` for the actual proof this
-    delegates to once it is worth asking.
-
-    `landed_mid_page` is unambiguous on its own: more sits right there, on
-    the very page just read, so `True` needs no further proof. Landing
-    exactly on the page's last feature is the one case worth asking
-    `_page_proves_complete` about, using `_has_next` (never raises on an
-    unparseable link) rather than `_next_href` (which can, appropriately,
-    when a link is actually about to be followed) since this link is never
-    going to be followed either way.
+    `landed_mid_page` needs no further proof: more sits right there, on the
+    page just read. Landing exactly on the page's last feature delegates to
+    `_page_proves_complete`, asked with `_has_next` (never raises on an
+    unparseable link) rather than `_next_href`, since this link is never going
+    to be followed either way. `None` when the page proves neither.
     """
     if landed_mid_page:
         return True
@@ -593,18 +462,9 @@ def _page_proves_complete(
     """Whether THIS page, with no next page left to follow, proves the walk
     has reached the true end of the collection.
 
-    fix(#1770 round 42). One predicate, used at both places a walk can reach
-    this question: a FULL walk's natural end (round 38 P1, tightened round
-    40 P1, corrected round 41 P1), and a SAMPLED preview that happens to land
-    exactly on a page's last feature -- the same boundary, reached by a
-    different door. Before round 42 the sampled door asked a weaker,
-    page-local question (`index + 1 < len(features) or _has_next(document)`)
-    that could not see a service which omits BOTH `links` and `numberMatched`
-    on a page that also happens to be no bigger than the sample: nothing
-    stopped there noticing more was possible, so the preview reported
-    `written` as the collection's total and re-upload's schema diff turned
-    that into a delta against the real dataset the next time the service
-    changed size.
+    One predicate, used at both places a walk reaches this question: a FULL
+    walk's natural end, and a SAMPLED preview landing exactly on a page's last
+    feature.
 
     `has_next` True means there is more to follow, definitively -- neither
     proof below can override a service that names a next page. `links`
@@ -614,13 +474,11 @@ def _page_proves_complete(
     nothing was said about pagination at all, so the only proof left is
     `numberMatched` equal to what the walk has actually read (`observed`).
 
-    Callers pass `has_next` rather than resolving it here on purpose: the
-    full walk already validated and resolved the link via `_next_href`
-    (which can raise on an unparseable one, appropriately, since it is about
-    to be followed); a sampled preview that will never follow this link uses
-    `_has_next` instead, which only asks whether one is present and never
-    raises on a malformed href -- refusing a preview over a link it was
-    never going to use would turn "your preview is complete" into a failure.
+    Callers pass `has_next` rather than resolving it here: a full walk has it
+    from `_next_href`, which can raise on an unparseable link it is about to
+    follow, while a sampled preview uses `_has_next`, which never raises --
+    refusing a preview over a link it was never going to use would turn "your
+    preview is complete" into a failure.
     """
     if has_next:
         return False
@@ -643,44 +501,26 @@ def _end_of_chain(
     """The page this walk's `for ... else` reaches without breaking early:
     either another page to fetch, or the genuine end of the chain.
 
-    fix(#1770 round 42): extracted out of `_walk_pages` itself so the
-    branching that decides "was this really the end" lives in one place
-    judged on its own terms, rather than pushing `_walk_pages` over ruff's
-    C901 ceiling -- the same reason `_resolve_conformance` was extracted out
-    of `probe_ogcapi` in #1746; extraction is what this repo does about that
-    rather than another exemption.
-
-    Returns `(page_url, truncated)`. `page_url` is `following` unchanged --
-    the caller's own loop reads it exactly as before. `truncated` is the
-    incoming value, passed straight through, EXCEPT in the one case round 42
-    closes: a SAMPLED walk (`feature_limit is not None`) whose chain has
-    just genuinely ended (`following is None`, meaning the page this
-    function was called for held FEWER rows than `feature_limit`, so the
-    for-loop above exhausted it naturally instead of breaking on the sample
-    limit). There, `truncated` becomes this page's own completeness verdict
-    -- `False` if `_page_proves_complete` proves it, `None` (unknown) if it
-    does not -- rather than staying at whatever an EARLIER page's break
-    might have left it, which is what a preview whose walk crosses several
-    pages before naturally ending on the last one needs: the LAST page
-    decides, not a stale value an intermediate one wrote.
+    Returns `(page_url, truncated)`. `truncated` passes straight through
+    EXCEPT for a SAMPLED walk (`feature_limit is not None`) whose chain has
+    just genuinely ended (`following is None`, so the loop above exhausted the
+    page instead of breaking on the sample limit). There it becomes this page's
+    own completeness verdict -- `False` where `_page_proves_complete` proves
+    it, `None` where it does not. The LAST page decides, not a value an
+    intermediate one left behind.
 
     Raises `ItemFetchFailedError` for a `next` that leaves the origin, or
-    (full walks only, first page only) one that cannot prove it is the last
-    one -- both unchanged from round 41.
+    (full walks only, first page only) one that cannot prove it is the last.
     """
     following = _next_href(document, from_url)
     if following is not None and not same_origin(url, following):
-        # The whole reason this module exists. The page chose the next
-        # address; it does not get to choose a different service to be paid
-        # with this credential.
+        # The page chose the next address; it does not get to choose a
+        # different service to be paid with this credential.
         raise ItemFetchFailedError("next page leaves the origin")
     if following is None and feature_limit is None and pages == 1:
-        # fix(#1770 round 38 P1, tightened round 40 P1, corrected round 41
-        # P1): a FULL walk ending on the FIRST page with no `next` must be
-        # able to PROVE it -- see `_page_proves_complete`'s own docstring
-        # for what counts as proof and why. `has_next=False`: this branch is
-        # reached only when `following is None` (the `if` above), i.e. no
-        # next was found.
+        # fix(#1770 round 41 P1): a FULL walk ending on the FIRST page with
+        # no `next` must be able to PROVE it -- see `_page_proves_complete`.
+        # `has_next=False`: this branch needs `following is None`.
         provably_complete = _page_proves_complete(
             document, has_next=False, observed=observed, number_matched=number_matched
         )
@@ -689,17 +529,8 @@ def _end_of_chain(
         return following, truncated
     if following is None and feature_limit is not None:
         # fix(#1770 round 42): the SAMPLED-walk mirror of the branch above.
-        # Never refuses -- a preview stays usable regardless of what this
-        # page can prove -- but the total this walk eventually reports is
-        # honest only when `_page_proves_complete` actually proves it.
-        # `_sample_truncated` with `landed_mid_page=False`: `following is
-        # None` here means exactly what `_has_next(document)` would answer
-        # too, on the same `links` this page carries. No `pages == 1`
-        # restriction: `_require_links` already refuses an absent `links`
-        # member on every page past the first, so the predicate's
-        # `links`-absent branch is only ever reachable here on page one
-        # regardless, and the `links`-present branch needs no restriction
-        # at all.
+        # Never refuses -- a preview stays usable -- but the total it reports
+        # is honest only where `_page_proves_complete` proves it.
         return following, _sample_truncated(
             document,
             landed_mid_page=False,
@@ -722,24 +553,16 @@ async def _walk_pages(
     """Follow the chain, writing features.
 
     Returns pages read, features written, what the service said the whole
-    collection holds (fix(#1746 B2b review r24): a preview writes
-    ``feature_limit`` features and nothing downstream could tell that apart
-    from a collection that small), and whether the walk stopped SHORT --
-    `True`, `False`, or `None` (fix(#1746 B2b review r28): a collection
-    holding exactly the sample size is complete, and counting features could
-    not say so; fix(#1770 round 42): `None` when the page proves neither --
-    landed exactly on the sample size with nothing on the page to prove one
-    way or the other, so the honest answer is that the total is unknown, not
-    that it stopped short).
+    collection holds, and whether the walk stopped SHORT -- `True`, `False`, or
+    `None` where the last page proved neither, in which case the total is
+    unknown rather than short.
 
     The count-shaped invariants, complete
     -------------------------------------
 
-    fix(#1746 B2b review r31). The OGC items schema has exactly two integer
-    members, ``numberMatched`` and ``numberReturned``; the only other member
-    this walk reads is ``timeStamp``, which it does not, and ``links`` and
-    ``features``, which r29 and r21 cover. So this list is closed rather than
-    the current state of a search:
+    The OGC items schema has exactly two integer members, ``numberMatched`` and
+    ``numberReturned``, so this list is closed rather than the current state of
+    a search:
 
     1. ``numberReturned == len(features)``, per page. The page's claim about
        itself, checked in `_require_counts`.
@@ -750,89 +573,35 @@ async def _walk_pages(
        produce fewer rows than the total; nothing can produce more.
     4. ``observed == numberMatched``, on FULL walks only. A sampled read is
        short by construction, so falling below says nothing there.
-    5. fix(#1770 round 38 P1, tightened round 40 P1, corrected round 41 P1).
-       A FULL walk ending on the FIRST page with no `next` must be able to
-       PROVE it. Two shapes reach this branch, and they prove it two
-       different ways:
-
-       - `links` PRESENT (even `[]`, even one carrying only `self`/
-         `alternate`): the service's own unambiguous statement that it
-         considered pagination and chose not to offer a `next`. OGC API
-         Features Part 1 makes `links` optional but `next`'s absence from a
-         `links` array that exists IS the spec's terminal-page signal, so
-         this proves completeness on its own -- no `numberMatched` required.
-       - `links` ABSENT ENTIRELY: `_require_links` tolerates the shape on the
-         first page (nothing was followed to get here, so nothing was
-         decided from a link), but that tolerance is not itself a
-         completeness claim -- nothing was said about pagination at all, so
-         `numberMatched` equal to `observed` is the only proof, same as (3)
-         and (4).
-
-       Round 38 read the two shapes as one and additionally accepted a page
-       SHORTER than `limit=PAGE_SIZE` as proof by itself, reasoning a server
-       with more to give would have filled it -- wrong, since that assumes
-       the server's own page size is at least `PAGE_SIZE`, which is the
-       server's choice, not a floor this module gets to assume. Round 40
-       removed the length-based proof but then required `numberMatched` on
-       the PRESENT-`links` shape too, refusing every conforming server that
-       states no `next` and has nothing else to say -- most of them. Page
-       length proves nothing on its own, on either side of this check,
-       across all three rounds. A later page follows whatever limit the
-       service's own `next` href encoded, and an ordinary multi-page walk of
-       short pages ending in an empty `links` list is not this finding
-       either way.
-
-       fix(#1770 round 42): the two-shape rule above is now `_page_proves_
-       complete`, a single function -- this branch was its only caller
-       before round 42, and a SAMPLED preview landing on exactly this same
-       boundary asks it too, rather than the page-local, weaker question
-       (`index + 1 < len(features) or _has_next(document)`) round 42's own
-       finding is about. See that function's docstring for the full
-       reasoning; nothing about what counts as proof changed here.
+    5. A FULL walk ending on the FIRST page with no `next` must be able to
+       PROVE it -- see `_page_proves_complete` for the two shapes that do.
+       Page length proves nothing on either side of that check: the server's
+       own page size is its choice, not a floor this module gets to assume.
 
     ``observed`` is the sum of ``len(features)`` across every page this walk
-    read, counted before a sample limit truncates what gets written (fix
-    (#1746 B2b round 34)). ``written`` is bounded by ``feature_limit`` and can
-    fall short of ``observed`` on a sampled read, so ``written <= observed``
-    always; checking the invariants above against ``written`` let a page far
-    larger than the collection the service claims to have pass a preview
-    unnoticed, because the sample cut ``written`` down to size before the
-    comparison ever saw the page's real length.
+    read, counted before a sample limit truncates what gets written, so it is
+    the size the service actually sent rather than the size a sample kept.
+    ``written <= observed`` always.
 
-    Each is a refusal, never a quiet correction, for the reason r29 records:
-    the walk cannot tell a service that has finished from one that has been
-    cut off, so anything it cannot verify it declines.
+    Each is a refusal, never a quiet correction: the walk cannot tell a service
+    that has finished from one that has been cut off, so anything it cannot
+    verify it declines.
     """
     written = 0
-    # fix(#1746 B2b round 34): the cumulative length of every page this walk
-    # read, counted whole and before `feature_limit` truncates what actually
-    # gets written. `written` alone under-reports a page's real size once a
-    # sample cuts it short, and the two `numberMatched` checks below need the
-    # real size to catch a service whose page is bigger than its own claimed
-    # total.
+    # fix(#1746 B2b round 34): every page counted whole, before
+    # `feature_limit` truncates what gets written -- `written` under-reports a
+    # page's real size once a sample cuts it short.
     observed = 0
     pages = 0
     on_disk = 0
     number_matched: int | None = None
-    # fix(#1746 B2b review r28): whether the walk STOPPED SHORT, as opposed to
-    # having written as many features as there are. `written >= feature_limit`
-    # cannot tell those apart: a collection holding exactly the sample size
-    # satisfies it while being complete, and r24 then reported its total as
-    # unknown. Only the site that breaks out of the loop knows which happened.
-    #
-    # fix(#1770 round 42): tri-state. Stays `False` for the whole function
-    # unless the sample limit actually breaks the loop -- a FULL walk
-    # (`feature_limit is None`) never touches it, which is what lets the
-    # total computation below read `feature_limit is None` as implying
-    # `not truncated`. `None` means the break happened but the page proved
-    # neither complete nor short: the honest total there is unknown, not a
-    # guess in either direction.
+    # fix(#1770 round 42): whether the walk STOPPED SHORT, tri-state. Only the
+    # site that breaks out of the loop knows, a FULL walk never touches it, and
+    # `None` means the page proved neither, so the total is unknown.
     truncated: bool | None = False
-    # fix(#1746 B2b review r17, moved r20, made once-ness r23): the origin is
-    # contacted HERE, not by the subprocess, so this is the moment a caller
-    # that dates origin contacts has to hear about. `fire_once` means the
-    # request function can fire it on every read and only the first one lands,
-    # so no loop has to remember which pass it is on.
+    # fix(#1746 B2b review r23): the origin is contacted HERE, not by the
+    # subprocess, so this is the moment a caller that dates origin contacts
+    # hears about. `fire_once` means no loop tracks which pass it is on.
     arm = fire_once(on_first_request)
     first_page, downloaded = await _resolve_items_url(
         client, url=url, collection=collection, headers=headers, on_first_request=arm
@@ -849,24 +618,15 @@ async def _walk_pages(
             on_first_request=arm,
         )
         downloaded += size
-        # Both the first page and every page a `next` named. One rule, one
-        # site, so a malformed page cannot mean different things depending on
-        # where in the chain it arrived.
+        # One rule, one site, so a malformed page cannot mean different
+        # things depending on where in the chain it arrived.
         features = _require_feature_page(document, first_page=pages == 1)
-        # The whole page, before the sample loop below may stop partway
-        # through it. `numberReturned == len(features)` is already enforced
-        # per page by `_require_counts`, so this is the page's own claim about
-        # its size, not a re-derivation.
+        # The page's own claim about its size, before the sample loop below
+        # may stop partway through it.
         observed += len(features)
         if "numberMatched" in document:
-            # OGC API Features part 1: the number of features the whole query
-            # matches, as opposed to the number this page returned. Optional,
-            # and already validated as a non-negative integer by
-            # `_require_feature_page` when it is present at all (r29).
-            #
-            # fix(#1746 B2b review r30): read from EVERY page, not just the
-            # first. It is a statement about the whole query, so two pages
-            # giving different answers means the service is describing two
+            # fix(#1746 B2b review r30): the whole query's match count, read
+            # from EVERY page. Two pages giving different answers describe two
             # different queries and neither can be checked against the walk.
             reported = document["numberMatched"]
             if number_matched is None:
@@ -874,34 +634,13 @@ async def _walk_pages(
             elif reported != number_matched:
                 raise ItemFetchFailedError("pages disagree about the size")
         for index, feature in enumerate(features):
-            # fix(#1746 B2b review r19): `ensure_ascii=False`, and the file
-            # opened in binary. The default escapes every non-ASCII character
-            # to `\uXXXX`, so a collection of non-Latin text wrote roughly
-            # three bytes on disk for each one counted against the download
-            # cap: a chain just under 2 GiB downloaded could leave ~6 GiB on a
-            # staging volume shared with every other import.
-            #
-            # fix(#1746 B2b review r20): and counted, because r19 concluded
-            # from this that the file could not exceed the download and that
-            # was wrong. A JSON round trip can grow: `1e15` is four bytes on
-            # the wire and eighteen written. The bound on disk is measured now
-            # rather than inferred.
+            # fix(#1746 B2b review r19): `ensure_ascii=False` and a binary
+            # file, so non-Latin text is not tripled on disk; what is written
+            # is then counted rather than inferred from the download (r20).
             try:
                 # fix(#1770 round 47 P2): a JSON escape for an unpaired
-                # surrogate (`"\ud800"`) is syntactically legal and
-                # `json.loads` accepts it as a Python `str` containing that
-                # lone surrogate code point -- UTF-8 has no representation
-                # for one, so `.encode("utf-8")` below raises
-                # `UnicodeEncodeError`, uncaught here before this round,
-                # which bypassed the `ItemFetchFailedError` handling every
-                # other malformed page gets: preview 500s, imports die with
-                # an internal exception. Not `errors="surrogatepass"`/
-                # `"surrogateescape"`: either would write bytes GDAL/PostGIS
-                # cannot read back as UTF-8, trading a coded refusal for
-                # silent corruption on disk. A refusal is the correct
-                # answer for a service that emits fundamentally
-                # unrepresentable text, the same as any other malformed
-                # page.
+                # surrogate is legal and has no UTF-8 encoding, so this
+                # refuses rather than writing bytes GDAL cannot read back.
                 encoded = json.dumps(
                     feature, separators=(",", ":"), ensure_ascii=False
                 ).encode("utf-8")
@@ -909,20 +648,17 @@ async def _walk_pages(
                 raise ItemFetchFailedError(f"unencodable feature: {exc}") from None
             chunk = b"," + encoded if written else encoded
             # fix(#1746 B2b review r21): compared BEFORE the write. Checking
-            # afterwards let the extract exceed the cap by one expanded
-            # feature, which on this path is exactly the value that expands
-            # unboundedly, so the bound was one feature short of being one.
+            # after admits one expanded feature past the cap, which on this
+            # path is the value that expands unboundedly.
             if on_disk + len(chunk) > MAX_BYTES:
                 raise ItemFetchFailedError("collection exceeds the cap on disk")
             out.write(chunk)
             on_disk += len(chunk)
             written += 1
             if feature_limit is not None and written >= feature_limit:
-                # fix(#1770 round 42): `_sample_truncated` -- landing
-                # exactly on the page's last feature asks the same
-                # completeness predicate a full walk's natural end does,
-                # rather than the page-local, weaker question this used to
-                # ask on its own.
+                # fix(#1770 round 42): landing exactly on the page's last
+                # feature asks the same completeness predicate a full walk's
+                # natural end does.
                 truncated = _sample_truncated(
                     document,
                     landed_mid_page=index + 1 < len(features),
@@ -943,46 +679,19 @@ async def _walk_pages(
                 truncated=truncated,
             )
     if page_url is not None:
-        # fix(#1746 B2b review r18): the page cap was reached and the service
-        # still had more to give. Closing the array here would return a prefix
-        # that reads as a complete collection, and the worker would import it
-        # over an existing dataset: a silent truncation nothing downstream
-        # could detect. A preview that reached its sample size has already set
-        # `page_url` to None, so this only fires on a genuinely short read.
+        # fix(#1746 B2b review r18): the page cap is reached with more to
+        # come. Closing the array here returns a prefix that reads as a
+        # complete collection, and the worker imports it over a dataset.
         raise ItemFetchFailedError("collection exceeds the page cap")
     if number_matched is not None:
         # fix(#1746 B2b review r31): SAMPLING CAN PRODUCE FEWER ROWS THAN THE
-        # TOTAL, NEVER MORE. r30 gated the whole comparison on a full walk,
-        # which let a sampled read of five features past a `numberMatched` of
-        # two: the extract had five rows and reported a total of two, and
-        # re-upload turned that into a schema delta against a real dataset.
-        # This half holds on every walk, because no way of stopping early can
-        # produce more than there are.
-        #
-        # fix(#1746 B2b round 34): `observed`, not `written`. A hundred-feature
-        # page under a `numberMatched` of ten and a five-row preview left
-        # `written == 5`, which is `<= 10` and passed: the sample masked the
-        # page's real size from the one check that exists to catch it.
-        # `observed` is that page counted whole, so this now compares the size
-        # the service actually sent against the size it claims the collection
-        # is, regardless of how much of it a sample kept.
+        # TOTAL, NEVER MORE, so this half holds on every walk. `observed`, not
+        # `written`: a sample masks the page's real size from this check.
         if observed > number_matched:
             raise ItemFetchFailedError("more features than the service reported")
-        # fix(#1746 B2b review r30): and the chain ran out where the service's
-        # own count says it should not have. A `next` link missing when there
-        # are more features to come is the truncation r18 and r29 refuse in
-        # their own ways, in the form the response itself proves: nothing about
-        # the document is malformed, the walk just ended early. Accepting it
-        # handed a re-upload ten features to replace a hundred with.
-        #
-        # Equality is a FULL-walk claim only. A sampled read stops deliberately
-        # and is expected to be short, so falling below the count says nothing
-        # there; `truncated` from r28 carries that judgement instead.
-        # `feature_limit is None` also implies `not truncated`, since only the
-        # sample limit breaks out of the loop. `observed`, for the same reason
-        # as the check above; on a full walk nothing ever breaks a page early,
-        # so `observed == written` there and this is the same comparison
-        # stated in the term the invariant is actually about.
+        # fix(#1746 B2b review r30): the chain ends short of the count the
+        # service gives for itself. Equality is a FULL-walk claim only -- a
+        # sampled read is short by design, and `truncated` carries that.
         if feature_limit is None and observed != number_matched:
             raise ItemFetchFailedError("collection is shorter than reported")
     out.write(b"]}")
@@ -1010,12 +719,9 @@ async def materialise_oapif_items(
 
     ``deadline`` is a :func:`time.monotonic` stamp by which the whole
     materialisation must be done, and it wraps every page rather than every
-    request. fix(#1746 B2b review r17): the client's own timeout is per
-    inactivity, so a service that answers slowly but never stops answering
-    passes it forever, and this loop ran BEFORE the caller's own clock started
-    in both callers. Ten thousand pages of a service trickling inside the read
-    timeout is hours of an API request or an ingest worker. ``None`` means no
-    caller deadline, which is the direct-call and offline case.
+    request, because the client's own timeout is per inactivity and a service
+    that answers slowly but never stops answering passes that forever. ``None``
+    means no caller deadline, which is the direct-call and offline case.
 
     ``on_first_request`` fires once, immediately before the first page is
     requested, for callers that date origin contacts.
@@ -1029,8 +735,8 @@ async def materialise_oapif_items(
     one over an existing dataset.
     """
     headers = credential_headers(credential_line)
-    # fix(#1746 B2b review r28): the prefix and suffix come from the module
-    # that sweeps them, so a file this writes is a file that sweep recognises.
+    # fix(#1746 B2b review r28): prefix and suffix come from the module that
+    # sweeps them, so a file this writes is one that sweep recognises.
     handle, path = tempfile.mkstemp(
         prefix=OAPIF_ITEMS_SCRATCH_PREFIX,
         suffix=OAPIF_ITEMS_SCRATCH_SUFFIX,
@@ -1040,10 +746,9 @@ async def materialise_oapif_items(
     os.chmod(path, 0o600)
 
     try:
-        # Refused before a client is opened when the deadline has already
-        # passed: `asyncio.timeout` on a past deadline only fires at the first
-        # suspension, which a fast enough first page never reaches. Shared with
-        # the endpoint check, which has the same clock and the same trap.
+        # Refused before a client is opened: `asyncio.timeout` on a past
+        # deadline only fires at the first suspension, which a fast enough
+        # first page never reaches. Shared with the endpoint check.
         budget = deadline_budget(deadline, error=ItemFetchFailedError)
     except ItemFetchFailedError:
         _discard(path)
@@ -1056,8 +761,8 @@ async def materialise_oapif_items(
             async with make_safe_client(
                 timeout=PROBE_TIMEOUT, credential_header=next(iter(headers))
             ) as client:
-                # Binary: the features are encoded once, and the count that
-                # bounds the file is then the count that is written.
+                # Binary: the features are encoded once, so the count that
+                # bounds the file is the count that is written.
                 with open(path, "wb") as out:
                     pages, written, number_matched, truncated = await _walk_pages(
                         client,
@@ -1083,23 +788,9 @@ async def materialise_oapif_items(
         features=written,
     )
     if number_matched is None and truncated is not False:
-        # fix(#1746 B2b review r24): the walk stopped short and the service did
-        # not say how many features there are, so the only honest answer is
-        # that the total is unknown. `written` would be the sample size, which
-        # a preview then showed as the collection's row count and re-upload
-        # turned into a delta against the real dataset.
-        #
-        # fix(#1746 B2b review r28): `truncated` rather than
-        # `written >= feature_limit`. The latter is also true of a collection
-        # that holds exactly the sample size and ended, which is a complete
-        # read: its total is known, and it is `written`.
-        #
-        # fix(#1770 round 42): `is not False` rather than truthy, now that
-        # `truncated` is tri-state. `True` (stopped short, unambiguous) and
-        # `None` (the page proved neither way) both mean the same thing
-        # here: nothing here can name the total, so it stays unknown. Only
-        # `False` -- the page itself proved there is nothing left -- lets
-        # `written` stand in for it below.
+        # fix(#1770 round 42): `is not False`. The walk stopped short (`True`)
+        # or the page proved neither (`None`), and neither can name the total,
+        # so it stays unknown rather than reporting the sample size.
         total: int | None = None
     else:
         total = number_matched if number_matched is not None else written

--- a/backend/app/platform/service_items.py
+++ b/backend/app/platform/service_items.py
@@ -89,9 +89,9 @@ PAGE_SIZE = 1000
 class MaterialisedCollection(NamedTuple):
     """A local extract, and what is known about the collection behind it.
 
-    ``features`` is the number of features written to the local extract. A full
-    walk writes the whole collection, so it equals ``total``; a sampled or
-    truncated read writes fewer.
+    ``features`` is the number of features written to the local extract. It may
+    be less than ``total`` when the walk stopped at a sample limit; equality is
+    not proof that no limit was applied.
 
     ``total`` is the collection's own size when it can be known: the service's
     ``numberMatched`` if it published one, otherwise the features written when

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -156,9 +156,9 @@ def _user_error_message(exc: Exception, *, registered: bool = False) -> str:
     if isinstance(exc, SQLAlchemyError):
         exc_text = str(exc).lower()
         if "querycancelederror" in exc_text or "statement timeout" in exc_text:
-            # fix(#813, #1013 review): name the budget that actually fired.
-            # The CTAS transaction carries the materialize one; the commit that
-            # ends it re-arms registration with its own, and both are settings.
+            # fix(#813, #1013): name the budget that actually fired. The CTAS
+            # transaction carries the materialize one; the commit that ends it re-arms
+            # registration with its own, and both are settings.
             budget = registration_timeout() if registered else materialize_timeout()
             return (
                 f"The analysis exceeded its {budget} processing "
@@ -199,9 +199,9 @@ async def _fail_cancelled_job(
     """
     from app.core.db import async_session
 
-    # fix(#700 review): release `working_session`'s job-row lock first, time-
-    # bounded so a wedged connection cannot eat the shield window, or the fenced
-    # update below waits on our own lock and the row strands in 'running'.
+    # fix(#700): release `working_session`'s job-row lock first, time-bounded so a
+    # wedged connection cannot eat the shield window, or the fenced update below
+    # waits on our own lock and the row strands in 'running'.
     try:
         await asyncio.wait_for(working_session.rollback(), timeout=5)
     except Exception:  # broad: cleanup must reach the fenced update regardless
@@ -462,9 +462,9 @@ async def _resolve_layer_table_ref(
         raise ValueError(f"{label.capitalize()} dataset not found")
     if not _SAFE_TABLE.match(layer.table_name):
         raise ValueError(f"Invalid {label} table name")
-    # fix(#1097 review): re-applied here, not just at enqueue, because a
-    # re-upload changes `Dataset.geometry_type` while the job waits. Polygonal
-    # for the mask; "any" for the join layer, where only absence is fatal.
+    # fix(#1097): re-applied here, not just at enqueue, because a re-upload changes
+    # `Dataset.geometry_type` while the job waits. Polygonal for the mask; "any" for the
+    # join layer, where only absence is fatal.
     geometry_type = (layer.geometry_type or "").upper()
     if require_geometry == "polygonal" and geometry_type not in _POLYGONAL:
         raise ValueError(
@@ -662,9 +662,9 @@ def append_analysis_output_record(user_metadata: "dict | None", out_table: str) 
     return {**(user_metadata or {}), ANALYSIS_OUTPUT_TABLE_FIELD: names}
 
 
-# fix(#1778 codex r10): the scope an analysis output table carries, 8 hex
-# characters of the job and 8 of the attempt. A retry keeps `IngestJob.id` and
-# changes only `attempt_id`, so the job half alone does not name one owner.
+# fix(#1778): the scope an analysis output table carries, 8 hex characters of the job
+# and 8 of the attempt. A retry keeps `IngestJob.id` and changes only `attempt_id`, so
+# the job half alone does not name one owner.
 _ANALYSIS_SCOPE_CHARS = 8
 _ANALYSIS_TABLE_MAX_CHARS = 63
 
@@ -786,9 +786,9 @@ async def resolve_analysis_output_table(
 _ANALYSIS_TABLE_NAME_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
 
 
-# fix(#1778 codex r6): which answers from `drop_unadopted_analysis_output` can
-# never change. A caller may forget the table's name only on one of these,
-# because that name is the last durable pointer to it; "failed" is retryable.
+# fix(#1778): which answers from `drop_unadopted_analysis_output` can never change. A
+# caller may forget the table's name only on one of these, because that name is the last
+# durable pointer to it; "failed" is retryable.
 ANALYSIS_OUTPUT_FINAL_OUTCOMES = frozenset({"adopted", "dropped", "invalid", "skipped"})
 
 AnalysisOutputOutcome = Literal["skipped", "invalid", "adopted", "dropped", "failed"]
@@ -824,9 +824,9 @@ async def drop_unadopted_analysis_output(
     if not _ANALYSIS_TABLE_NAME_RE.match(out_table):
         logger.warning("analysis.output_table_name_rejected", job_id=job_id)
         return "invalid"
-    # fix(#1778 codex r7): a sweep reaping a job's record may only drop the
-    # table THAT job named. "invalid" rather than "failed": a name that is not
-    # this job's can never become this job's, so retrying would pin the row.
+    # fix(#1778): a sweep reaping a job's record may only drop the table THAT job named.
+    # "invalid" rather than "failed": a name that is not this job's can never become
+    # this job's, so retrying would pin the row.
     if not analysis_output_table_belongs_to(out_table, owner_job_uuid):
         logger.warning("analysis.output_table_not_owned", job_id=job_id)
         return "invalid"
@@ -1094,8 +1094,8 @@ async def _materialize(
         # CREATE TABLE loses a race for the same generated name, an
         # unconditional cleanup would destroy the winner's table.
         out_table_created = False
-        # fix(#1013 review): flipped once registration re-arms its own
-        # statement_timeout, so a later failure quotes the budget that fired.
+        # fix(#1013): flipped once registration re-arms its own statement_timeout, so a
+        # later failure quotes the budget that fired.
         registration_started = False
         # Created inside the try so the finally below always reaps it: a
         # heartbeat left running renews a lease for a job nobody is executing,
@@ -1139,8 +1139,8 @@ async def _materialize(
                     require_geometry="polygonal",
                 )
             join_table_ref: str | None = None
-            # fix(#1097 review): the plain name is kept for the live-column
-            # recheck, which information_schema takes rather than a quoted ref.
+            # fix(#1097): the plain name is kept for the live-column recheck, which
+            # information_schema takes rather than a quoted ref.
             join_table_name: str | None = None
             if join_dataset_id is not None:
                 join_table_ref, join_table_name = await _resolve_layer_table_ref(
@@ -1160,9 +1160,9 @@ async def _materialize(
             )
 
             _base_table, collision_warning = await generate_table_name(title, session)
-            # fix(#1778 codex r7/r10): scoped by this job AND this attempt.
-            # `generate_table_name` chooses the readable half; the `_N` walk
-            # that matters for the RELATION is the scoped one below.
+            # fix(#1778): scoped by this job AND this attempt. `generate_table_name`
+            # chooses the readable half; the `_N` walk that matters for the RELATION is
+            # the scoped one below.
             out_table = await resolve_analysis_output_table(
                 session,
                 base=_base_table,
@@ -1170,9 +1170,9 @@ async def _materialize(
                 attempt_uuid=attempt_id,
                 schema=_schema,
             )
-            # fix(#1778 codex r10): the name, on the durable row, in the same
-            # transaction that creates the table (the commit after ANALYZE), as
-            # a LIST each attempt appends to — retry preserves `user_metadata`.
+            # fix(#1778): the name, on the durable row, in the same transaction that
+            # creates the table (the commit after ANALYZE), as a LIST each attempt
+            # appends to — retry preserves `user_metadata`.
             job.user_metadata = append_analysis_output_record(
                 job.user_metadata, out_table
             )
@@ -1248,9 +1248,9 @@ async def _materialize(
             )
             await session.execute(text(f"ALTER TABLE {out_ref} ADD PRIMARY KEY (gid)"))
             await add_4326_column(session, out_table, 4326, schema=_schema)
-            # fix(#701 review): the 4326 rewrite roughly doubles the geometry
-            # payload and adds the GIST index, so the post-CTAS probe
-            # undercounts the final footprint by a multiple.
+            # fix(#701): the 4326 rewrite roughly doubles the geometry payload and adds
+            # the GIST index, so the post-CTAS probe undercounts the final footprint by
+            # a multiple.
             await _enforce_output_size(session, _schema, out_table, operation=operation)
             # fix(#692): in-transaction ANALYZE. The table becomes visible to
             # autovacuum only at the commit below and the first tile queries
@@ -1290,9 +1290,9 @@ async def _materialize(
                 params={
                     "distance_meters": distance_meters,
                     "by_field": by_field,
-                    # fix(#1097 review): every operation that can take a DRAWN
-                    # mask, not clip alone. The drawn geometry is excluded from
-                    # provenance, so this is the only trace an area shaped it.
+                    # fix(#1097): every operation that can take a DRAWN mask, not clip
+                    # alone. The drawn geometry is excluded from provenance, so this is
+                    # the only trace an area shaped it.
                     "mask_source": (
                         ("layer" if mask_dataset_id else "drawn")
                         if operation in _DRAWN_MASK_OPERATIONS

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -1,4 +1,4 @@
-"""Materialize a PostGIS analysis result into a new dataset (M4).
+"""Materialize a PostGIS analysis result into a new dataset.
 
 The worker builds the output table with server-rendered SQL (shared
 expression templates in ``app.platform.analysis_sql``), normalizes it to the
@@ -63,22 +63,15 @@ _SAFE_IDENT = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _SAFE_TABLE = re.compile(r"^[a-z0-9_]+$")
 # Mirrors _POLYGONAL_TYPES in router_analysis: a mask layer must be polygonal.
 _POLYGONAL = {"POLYGON", "MULTIPOLYGON"}
-# Mirrors MASK_OPERATIONS in catalog/datasets/domain/schemas.py: the operations
-# whose second input can be a DRAWN polygon rather than a layer. Duplicated
-# rather than imported because processing/ must not import from
-# app.modules.catalog (PROCESS-02), the same reason _POLYGONAL is duplicated.
-# intersect is absent deliberately: it takes a layer only, so the discriminator
-# would be a constant there.
+# The operations whose second input can be a DRAWN polygon rather than a layer,
+# mirroring MASK_OPERATIONS in catalog/datasets/domain/schemas.py: processing/
+# must not import app.modules.catalog (PROCESS-02). intersect takes a layer only.
 _DRAWN_MASK_OPERATIONS = ("clip", "select_by_location")
 
 
-# The preview path is bounded (10s sandbox timeout, 500-row cap); the CTAS
-# here is the only unbounded statement a user can queue, so cap it.
-#
-# fix(#1013): the value is an operator setting now, not a hardcoded ceiling.
-# Read through a function rather than bound at import: these render into SQL
-# and into a user-facing message, and a module-level snapshot would freeze
-# whatever the settings object held the first time this module was imported.
+# fix(#1013): the CTAS is the only unbounded statement a user can queue, and
+# its budget is an operator setting. Read through a function rather than bound
+# at import, so no module-level snapshot can freeze the first value seen.
 def materialize_timeout() -> str:
     """The CTAS statement_timeout, as a PostgreSQL interval literal."""
     from app.core.config import settings
@@ -86,12 +79,9 @@ def materialize_timeout() -> str:
     return f"{settings.analysis_materialize_timeout_seconds}s"
 
 
-# The mid-task commit that makes the output table durable also ends the
-# transaction carrying the CTAS budget — registration then runs full-scan
-# metadata extraction (COUNT + ST_Extent + the sample-values CTE) in a fresh
-# transaction, which would otherwise have no statement budget at all
-# (fix(#692)). Larger than the CTAS budget by default: those scans are cheap
-# relative to the build, but must never be unbounded.
+# fix(#692): the mid-task commit ends the transaction carrying the CTAS budget,
+# so registration's full-scan metadata extraction would otherwise run with no
+# statement budget at all. Larger by default, but never unbounded.
 def registration_timeout() -> str:
     """The post-commit registration statement_timeout, as an interval literal."""
     from app.core.config import settings
@@ -99,98 +89,23 @@ def registration_timeout() -> str:
     return f"{settings.analysis_registration_timeout_seconds}s"
 
 
-# fix(#1012): per-statement work_mem for the materialize CTAS.
-#
-# The cluster-wide default is 8MB (db/postgresql.conf:93) — right for eighty
-# concurrent connections doing ordinary catalog queries, far too small for one
-# buffer or dissolve over hundreds of thousands of geometries, which spills to
-# pgsql_tmp long before it needs to. Dissolve wants it most: #694 turned off
-# hash aggregation there (it holds every group's union state in memory at once
-# and could OOM the shared db container), and the sorted aggregation that
-# replaces it is precisely what work_mem governs. Turning off hashagg without
-# raising work_mem trades an OOM risk for a guaranteed spill.
-#
-# WHICH BUDGET THIS COMES OUT OF. work_mem is allocated by the PostgreSQL
-# backend serving the session, so the memory lands in the `db` service, capped
-# by DB_MEM_LIMIT. That budget also holds shared_buffers (512MB),
-# maintenance_work_mem (128MB), and up to max_connections = 80 other backends
-# each entitled to their own work_mem. The worker's own WORKER_MEM_LIMIT is not
-# what constrains this; the Python side of materialize lives there, the sort
-# does not.
-#
-# work_mem is per OPERATION and per BACKEND, so one plan can allocate several
-# multiples of it: at most 2 memory-hungry nodes for these shapes (dissolve is
-# one Sort feeding a GroupAggregate; buffer and centroid have none; clip has a
-# join), times 2 backends. The second factor is guaranteed rather than assumed —
-# the override pins max_parallel_workers_per_gather to 1 for this transaction,
-# because db/postgresql.conf only governs the bundled database and says nothing
-# about an external one.
-#
-# THE CEILING IS AN OPERATOR SETTING, not a constant, because the two things
-# that decide what is safe are both invisible from here:
-#
-#   - DB_MEM_LIMIT is a compose `mem_limit` and is never passed into this
-#     container's environment, so this process cannot read the database's
-#     ceiling. It is also tunable (docker-compose.prod.yml documents 1.5g) and
-#     an external PostgreSQL may be smaller again.
-#   - The divisor below bounds concurrent materializes inside ONE worker
-#     process. It cannot bound a deployment running several worker services
-#     against the `ingest` queue; each replica would claim the budget
-#     independently. Bounding that needs a deployment-wide admission mechanism,
-#     which is #695's open question.
-#
-# So the setting defaults low enough to be safe under both unknowns rather than
-# optimal under neither: 64MB is 256MB worst case per worker replica, so even
-# two replicas sit inside the default 2 GB alongside shared_buffers and
-# maintenance_work_mem. An operator with a bigger database container and one
-# worker can raise it; one with a smaller container or more replicas must lower
-# it. config.py carries the arithmetic.
-#
-# Measured on a 60k-polygon grouped dissolve with enable_hashagg = off, the
-# leader's sort wanted 96MB: at the 8MB default it spilled 70MB to disk, and at
-# 128MB it stayed in memory. 64MB does not eliminate that spill, it shrinks it —
-# the conservative default trades some of the win for a ceiling that cannot OOM
-# the database on a deployment this process cannot measure.
-#
-# There is deliberately NO floor at the bundled 8MB default: that would be an
-# assumption about the connected cluster this process cannot check. An external
-# PostgreSQL tuned below 8MB would be RAISED by a clamp advertised as leaving it
-# alone, and an operator who wants less than 8MB per materialize could not have
-# it. ANALYSIS_MATERIALIZE_WORK_MEM_MB=0 is the honest way to say "do not touch
-# work_mem" — it skips the SET LOCAL entirely.
-#
-# The division is done in kB, not MB, so the budget is never exceeded by
-# rounding: a 64MB budget across 128 slots is 512kB each, not 1MB each. A
-# budget too small to divide into legal shares is rejected at boot rather than
-# resolved at run time — see validate_materialize_work_mem_budget.
+# fix(#1012): per-statement work_mem for the materialize CTAS, an operator
+# setting because the database's memory ceiling and the worker replica count are
+# both invisible here. 0 skips the SET LOCAL; config.py carries the arithmetic.
 
 
 async def _apply_materialize_work_mem(session: AsyncSession) -> None:
     """Raise work_mem for the CTAS transaction, unless the operator opted out.
 
-    SET LOCAL, so it applies to this statement and reverts with the
-    transaction — the other seventy-nine connections keep the cluster default.
-    A global bump would not be safe in the same way. Lives here rather than
-    inline in _materialize so the opt-out branch does not push that function
-    past its complexity cap.
+    SET LOCAL, so it reverts with the transaction and every other connection
+    keeps the cluster default.
     """
     work_mem = _materialize_work_mem()
     if work_mem is None:
         return
-    # Cap parallelism first, so the budget arithmetic is true by construction
-    # rather than by assuming the server's configuration. work_mem is granted to
-    # the leader AND to every parallel worker, so a server with
-    # max_parallel_workers_per_gather above 1 — a customised bundled conf, or
-    # any external PostgreSQL reached through DATABASE_URL_OVERRIDE, neither of
-    # which db/postgresql.conf:73 constrains — would multiply the ceiling by a
-    # number this process cannot see. One leader plus one worker is what the
-    # budget in config.py is sized for.
-    #
-    # LEAST, not a plain assignment: an operator who set 0 has DISABLED parallel
-    # query, and raising them to 1 would hand this statement a worker and the
-    # CPU and memory that comes with it. Only ever lower. set_config's third
-    # argument is is_local, so this is transaction-scoped exactly like SET LOCAL
-    # — which cannot take an expression.
+    # Cap parallelism first: work_mem is granted to the leader AND to every
+    # parallel worker, so config.py's budget holds only at one worker. LEAST,
+    # never a plain assignment: an operator who set 0 disabled parallel query.
     await session.execute(
         text(
             "SELECT set_config('max_parallel_workers_per_gather', "
@@ -209,24 +124,20 @@ def _materialize_work_mem() -> str | None:
     if budget_kb <= 0:
         return None
     # A share below PostgreSQL's 64kB minimum cannot happen: config.py's
-    # validate_materialize_work_mem_budget refuses to boot on it, because
-    # neither issuing the minimum (over budget) nor skipping the override
-    # (cluster's larger value, further over budget) honours the ceiling.
+    # validate_materialize_work_mem_budget refuses to boot on it.
     per_slot_kb = budget_kb // max(1, settings.worker_concurrency)
     if per_slot_kb % 1024 == 0:
         return f"{per_slot_kb // 1024}MB"
     return f"{per_slot_kb}kB"
 
 
-# fix(#694): post-CTAS backstop on the built output's on-disk size. The
-# enqueue gates read the cached feature_count snapshot, which can be stale;
-# this is the enforcement that can't be. Buffer is the motivating case: it
-# is the only amplifying operation and vector datasets carry no byte quota.
+# fix(#694): post-CTAS backstop on the built output's on-disk size. The enqueue
+# gates read a cached feature_count snapshot that can be stale; this cannot be.
+# Buffer motivates it: the one amplifying operation, and vectors have no quota.
 MAX_OUTPUT_BYTES = 2 * 1024**3
 
 # Served by the worker's :8001 /metrics endpoint (default registry).
-# Analysis-only counter; generalize to all ingest job types when
-# another type needs it.
+# Analysis-only; generalize when another ingest job type needs it.
 ANALYSIS_JOBS = Counter(
     "geolens_analysis_jobs_total",
     "Materialize-analysis job outcomes",
@@ -238,22 +149,16 @@ def _user_error_message(exc: Exception, *, registered: bool = False) -> str:
     """Map a failure onto text safe to return from ``GET /jobs/{job_id}``.
 
     SQLAlchemy stringifies DB errors with the full statement appended
-    (``[SQL: CREATE TABLE "data"."…" AS …]``), which would hand internal
-    schema and table names to the client (fix(#692)). Mirrors the sandbox's
+    (``[SQL: CREATE TABLE "data"."…" AS …]``), which would hand internal schema
+    and table names to the client. Mirrors the sandbox's
     ``_handle_execution_error`` categories; raw text stays in server logs.
     """
     if isinstance(exc, SQLAlchemyError):
         exc_text = str(exc).lower()
         if "querycancelederror" in exc_text or "statement timeout" in exc_text:
-            # fix(v1.6.0 audit D11): name the configured limit so the user
-            # knows what budget was exceeded. fix(#1013 review): WHICH limit
-            # depends on the phase — the CTAS transaction carries the
-            # materialize budget, and the commit that ends it re-arms
-            # registration with its own (#692). Naming the wrong one was
-            # harmless while both were hardcoded at 300s/600s and only the
-            # first was ever quoted; now that an operator can set them
-            # independently, a registration timeout quoting the materialize
-            # budget sends them to tune the setting that did not fire.
+            # fix(#813, #1013 review): name the budget that actually fired.
+            # The CTAS transaction carries the materialize one; the commit that
+            # ends it re-arms registration with its own, and both are settings.
             budget = registration_timeout() if registered else materialize_timeout()
             return (
                 f"The analysis exceeded its {budget} processing "
@@ -261,13 +166,9 @@ def _user_error_message(exc: Exception, *, registered: bool = False) -> str:
             )
         if isinstance(exc, (DataError, InternalError)):
             return "The analysis failed while processing this data"
-        # fix(#766): only the SQLSTATEs that mean "this column/type
-        # combination can't do this operation": 42883 undefined_function
-        # (e.g. no equality operator for `json` in a dissolve GROUP BY),
-        # 42803 grouping_error, 42804 datatype_mismatch. Deliberately NOT
-        # the whole class 42 — 42501 (privilege), 42P01 (missing table),
-        # and 42601 (syntax) are server or configuration faults and must
-        # keep reporting as the generic database error.
+        # fix(#766): only the SQLSTATEs meaning "this column/type combination
+        # can't do this operation" -- 42883, 42803, 42804. Not the whole class
+        # 42: 42501, 42P01 and 42601 are server or configuration faults.
         if isinstance(exc, ProgrammingError) and str(
             getattr(exc.orig, "sqlstate", "") or ""
         ) in ("42883", "42803", "42804"):
@@ -291,21 +192,16 @@ async def _fail_cancelled_job(
     """Bookkeeping for a materialize cancelled mid-run, on a fresh session.
 
     Fenced on the attempt token FIRST: a successful fence proves the row was
-    still 'running', so the final registration commit (which atomically
-    persists the dataset and flips the row to 'complete') has not happened,
-    and any committed output table is an unregistered orphan — safe to drop.
-    If the fence misses, the job already reached a terminal state; the table
-    is dropped only when the adoption probe proves no dataset registered it
-    (fix(v1.6.0 audit B13)).
+    still 'running', so the registration commit has not happened and any
+    committed output table is an unregistered orphan — safe to drop. If the
+    fence misses, the job already reached a terminal state, and the table is
+    dropped only when the adoption probe proves no dataset registered it.
     """
     from app.core.db import async_session
 
-    # fix(#700 review): the cancel can land while `working_session`'s open
-    # transaction still holds the job-row lock (any flush since its last
-    # commit, e.g. mid-commit). Release it first — time-bounded so a wedged
-    # connection can't eat the whole shield window — or the fenced update
-    # below waits on our own lock until the shield timeout and the row
-    # strands in 'running' anyway.
+    # fix(#700 review): release `working_session`'s job-row lock first, time-
+    # bounded so a wedged connection cannot eat the shield window, or the fenced
+    # update below waits on our own lock and the row strands in 'running'.
     try:
         await asyncio.wait_for(working_session.rollback(), timeout=5)
     except Exception:  # broad: cleanup must reach the fenced update regardless
@@ -321,19 +217,15 @@ async def _fail_cancelled_job(
                 "error_message": (
                     "The worker shut down before this analysis finished. Run it again."
                 ),
-                # fix(v1.6.0 audit B12): terminal writes must stamp
-                # completed_at (the ingest tasks all do) — without it the
-                # jobs UI renders '-' and retention ages on queue time.
+                # fix(#813): terminal writes stamp completed_at — without it
+                # the jobs UI renders '-' and retention ages on queue time.
                 "completed_at": datetime.now(timezone.utc),
             },
         ):
             await session.rollback()
-            # fix(v1.6.0 audit B13): mirror _mark_job_failed's fence-miss
-            # cleanup — a swept row leaves an unregistered orphan that used
-            # to leak permanently here. Probe for an adopting dataset row;
-            # no row means the DROP is safe. If the probe itself errors,
-            # prefer leaking the table to dropping a registered dataset's
-            # storage.
+            # fix(#814): a swept row leaves an unregistered orphan. Probe for
+            # an adopting dataset row; no row means the DROP is safe, and a
+            # probe that errors leaks the table rather than dropping storage.
             await drop_unadopted_analysis_output(
                 session,
                 out_table=out_table,
@@ -387,8 +279,7 @@ def _reject_output_column_collision(
     The router validates against ``column_info``, a catalog snapshot, and the
     queue wait sits between that and the live column list held here — so the
     check runs again against the real columns. Without it the CTAS fails on an
-    opaque "column specified more than once" after the whole wait
-    (fix(#953), extended to measure by fix(#954)).
+    opaque "column specified more than once" after the whole wait.
     """
     clashes = sorted(set(carry_cols) & set(generated))
     if clashes:
@@ -416,11 +307,6 @@ async def _resolve_and_validate_columns(
     a re-upload can replace either layer in that window, so each one runs again
     against the real columns. Returns the carried column lists the CTAS is
     built from, because resolving them is how most of these are checked.
-
-    Extracted in fix(#1097 review) rather than raising the C901 threshold on
-    ``_materialize``: the set had grown to five checks over two layers, and
-    they share a subject that the surrounding job bookkeeping does not.
-    fix(#1099) retired one of them, the overlay's ungroupable-type recheck.
     """
     carry_cols = (
         await _list_carry_columns(session, schema, src_table_name)
@@ -434,9 +320,8 @@ async def _resolve_and_validate_columns(
         _reject_reserved_alias_columns(carry_cols)
     if operation == "spatial_join" and join_table_name is not None:
         await _reject_missing_join_fields(session, schema, join_table_name, join_fields)
-    # fix(#956): an overlay carries columns from BOTH inputs, so it is the only
-    # operation that also needs the second layer's live column list — and the
-    # only one where two same-named columns are likely rather than exotic.
+    # fix(#956): an overlay carries columns from BOTH inputs, so it is the
+    # only operation that also needs the second layer's live column list.
     mask_carry_cols: list[str] = []
     if operation == "intersect" and mask_table_name is not None:
         mask_carry_cols = await _list_carry_columns(session, schema, mask_table_name)
@@ -451,10 +336,8 @@ async def _resolve_and_validate_columns(
 def _reject_reserved_alias_columns(carry_cols: list[str]) -> None:
     """Worker-side half of the reserved-alias guard.
 
-    fix(#1097 review): the router checked a catalog snapshot; a re-upload can
-    introduce a column in the alias namespace before the job runs. Same window
-    as the two rechecks below, and cheap, because the live column list is
-    already in hand here.
+    The router checked a catalog snapshot; a re-upload can introduce a column
+    in the alias namespace before the job runs.
     """
     reserved = sorted(c for c in carry_cols if c.startswith(INTERNAL_ALIAS_PREFIX))
     if reserved:
@@ -470,15 +353,11 @@ async def _reject_missing_join_fields(
 ) -> None:
     """The transferred fields must still exist on the join layer.
 
-    fix(#1097 review): the router validated them against column_info at
-    enqueue, and the worker re-resolved the join layer's TABLE without ever
-    re-checking its COLUMNS. A re-upload that drops or renames a requested
-    field left render_spatial_join referencing a column that is no longer
-    there, so the CTAS failed after the whole queue wait with a database error
-    naming a column the user had legitimately selected when they asked.
-
-    The sibling rechecks beside this one exist for exactly that window; this
-    one was the gap in the set.
+    The router validated them against ``column_info`` at enqueue. A re-upload
+    that drops or renames a requested field would otherwise leave
+    ``render_spatial_join`` referencing a column that is no longer there, so
+    the CTAS fails after the whole queue wait, naming a column the user
+    legitimately selected when they asked.
     """
     if not join_fields:
         return
@@ -506,13 +385,9 @@ async def _reject_missing_join_fields(
 def _ungroupable_type_name(data_type: str | None, udt_name: str | None) -> str | None:
     """The display name of a non-groupable column type, or None if groupable.
 
-    fix(#1097 review): information_schema reports EVERY array column's
-    data_type as 'ARRAY'; the element type only surfaces in udt_name, with a
-    leading underscore ('_json' for json[]). An exact data_type comparison
-    therefore admitted json[]/xml[] columns straight into GROUP BY, where
-    PostgreSQL cannot apply equality to them (SQLSTATE 42883, verified) — and
-    the catalog snapshot has the same blind spot, so the failure landed after
-    the queue wait. Elements, not arrays: int[]/text[] have equality and group
+    information_schema reports EVERY array column's data_type as 'ARRAY'; the
+    element type only surfaces in udt_name, with a leading underscore ('_json'
+    for json[]). Elements, not arrays: int[]/text[] have equality and group
     fine, so rejecting 'ARRAY' wholesale would refuse layers that work.
     """
     dt = str(data_type or "").lower()
@@ -529,15 +404,11 @@ async def _reject_ungroupable_by_field(
 ) -> None:
     """Dissolve's GROUP BY column must be groupable on the LIVE schema.
 
-    fix(#1097 review): dissolve names ``by_field`` in its GROUP BY, the router
-    checked it against the snapshot, and the snapshot cannot see a json[]
-    element type ('ARRAY'). One query answers both failure modes: a column the
-    re-upload dropped, and one whose live type has no equality operator.
-
-    fix(#1099): the last caller. Intersect had a twin of this beside it, for
-    the overlay columns it named in the same GROUP BY; those attributes are
-    joined back outside the aggregate now, so the operation that actually
-    groups by a user-chosen column is the only one left needing it.
+    The router checked ``by_field`` against the catalog snapshot, which cannot
+    see a json[] element type. One query answers both failure modes: a column
+    the re-upload dropped, and one whose live type has no equality operator.
+    Dissolve is the only caller — intersect joins its overlay attributes back
+    outside the aggregate.
     """
     row = (
         await session.execute(
@@ -572,14 +443,12 @@ async def _resolve_layer_table_ref(
 ) -> tuple[str, str]:
     """Re-resolve a secondary layer at run time: ``(table_ref, table_name)``.
 
-    fix(#953); fix(#956) added the bare name to the return, because an overlay
-    reads that layer's live columns out of ``information_schema``, which takes
-    a plain name rather than the quoted ref every other caller wants.
-
     Both two-layer operations need this — clip against a mask layer, and
     spatial_join against a join layer — with the same trust model: access was
     checked at enqueue by the router, and the table name is re-matched against
-    ``_SAFE_TABLE`` here because the queue wait sits between the two.
+    ``_SAFE_TABLE`` here because the queue wait sits between the two. The bare
+    name is returned beside the quoted ref for the ``information_schema``
+    lookups, which take a plain name.
 
     ``dataset_cls`` is passed in rather than imported: ``processing/`` must not
     import from ``app.modules.catalog.*`` (PROCESS-02), so the caller hands
@@ -593,25 +462,9 @@ async def _resolve_layer_table_ref(
         raise ValueError(f"{label.capitalize()} dataset not found")
     if not _SAFE_TABLE.match(layer.table_name):
         raise ValueError(f"Invalid {label} table name")
-    # fix(#1097 review): the geometry requirement is re-applied here, not just
-    # at enqueue. A re-upload can change what a layer IS while the job waits in
-    # the queue, and the swap updates Dataset.geometry_type, so the value the
-    # router checked is not the one the CTAS runs against.
-    #
-    # Two strengths, because the two layers want different things.
-    #
-    # "polygonal" is the mask's: _load_mask_dataset refuses points and lines,
-    # since unioning them produces a mask that clips nothing meaningful.
-    # Nothing downstream notices if that changes — the mask expression simply
-    # matches no rows, and the job dies on "Analysis produced no features",
-    # which sends the user to look at their own data rather than at the layer
-    # that changed underneath them.
-    #
-    # "any" is the join layer's. A spatial join counts in any direction, so
-    # points and lines stay valid and only the absence of geometry is fatal:
-    # a re-upload from a non-spatial source sets geometry_type to None and
-    # builds a table with no geom_4326 at all, and render_spatial_join
-    # references _j.geom_4326 (fix(#1097 review)).
+    # fix(#1097 review): re-applied here, not just at enqueue, because a
+    # re-upload changes `Dataset.geometry_type` while the job waits. Polygonal
+    # for the mask; "any" for the join layer, where only absence is fatal.
     geometry_type = (layer.geometry_type or "").upper()
     if require_geometry == "polygonal" and geometry_type not in _POLYGONAL:
         raise ValueError(
@@ -636,10 +489,9 @@ async def _recheck_size_caps(
     """Re-validate the enqueue-time size gates against the live tables.
 
     The queue wait can be long enough for a source or mask dataset to be
-    re-uploaded past its cap (fix(#701 review)), and the post-CTAS output
-    check is too late to protect the dissolve/mask union itself from OOM —
-    so the bounded counts run again here, immediately before the SQL is
-    built.
+    re-uploaded past its cap, and the post-CTAS output check is too late to
+    protect the dissolve/mask union itself from OOM — so the bounded counts run
+    again here, immediately before the SQL is built.
     """
     cap = MAX_SOURCE_FEATURES.get(operation)
     if cap is not None and await _count_features_bounded(session, src_ref, cap) > cap:
@@ -669,10 +521,10 @@ async def _enforce_output_size(
     ``pg_total_relation_size`` counts heap, TOAST, and indexes, so the
     post-rewrite call measures what the registered dataset will actually
     occupy. Resolved via pg_class with the ``:schema`` bind rather than a
-    ``regclass`` cast (fix(#701 review)): the tenant statement hook only
-    recognizes schema references in SQL text or schema-named binds, and it
-    masks string literals — a schema hidden inside a generic bind would
-    skip the tenant role setup and fail the lookup in multi-tenant.
+    ``regclass`` cast: the tenant statement hook only recognizes schema
+    references in SQL text or schema-named binds, and it masks string literals,
+    so a schema hidden inside a generic bind would skip the tenant role setup
+    and fail the lookup in multi-tenant.
     """
     result = await session.execute(
         text(
@@ -683,9 +535,8 @@ async def _enforce_output_size(
     )
     size_bytes = result.scalar_one_or_none()
     if size_bytes is not None and size_bytes > MAX_OUTPUT_BYTES:
-        # fix(v1.6.0 audit D11): only buffer has a distance to reduce —
-        # telling a clip/centroid/dissolve user to shrink a buffer they
-        # never set is a dead end.
+        # fix(#813): only buffer has a distance to reduce, so the others get
+        # advice they can act on.
         advice = (
             "Reduce the buffer distance or run it on a smaller dataset."
             if operation == "buffer"
@@ -709,12 +560,11 @@ async def _complete_job_for_attempt(
 ) -> None:
     """Commit registration together with the fenced terminal 'complete' write.
 
-    fix(#786): the terminal write is fenced on the attempt token, like the
-    claim and ``_fail_cancelled_job`` — a plain ``job.status = "complete"``
-    would overwrite a row the stale-job sweep already failed (a stalled
-    heartbeat expires the lease), resurrecting failed → complete and handing
-    the user a dataset for a job they were told failed. The fence shares the
-    registration transaction, so a miss rolls the Dataset row back with it.
+    The terminal write is fenced on the attempt token, like the claim and
+    ``_fail_cancelled_job``: a plain ``job.status = "complete"`` would overwrite
+    a row the stale-job sweep already failed and hand the user a dataset for a
+    job they were told failed. The fence shares the registration transaction,
+    so a miss rolls the Dataset row back with it.
     """
     if await update_ingest_job_for_attempt(
         session,
@@ -723,7 +573,7 @@ async def _complete_job_for_attempt(
         values={
             "status": "complete",
             "dataset_id": dataset_id,
-            # fix(v1.6.0 audit B12): stamp completion time like ingest does.
+            # fix(#813): stamp completion time like ingest does.
             "completed_at": datetime.now(timezone.utc),
         },
     ):
@@ -732,11 +582,9 @@ async def _complete_job_for_attempt(
         return
     await session.rollback()
     logger.warning("analysis.complete_write_superseded", job_id=job_id)
-    # The build commit made the output table durable, and the rollback above
-    # discarded this attempt's registration. fix(v1.6.0 audit B13): mirror
-    # _mark_job_failed's fence-miss cleanup — gate the drop on the adoption
-    # probe so a dataset row committed by any other actor keeps its storage,
-    # and prefer leaking the table over dropping one the probe can't clear.
+    # fix(#814): the output table is durable from the build commit and this
+    # attempt's registration is rolled back, so gate the drop on the adoption
+    # probe and prefer leaking over dropping live storage.
     adopted = True
     try:
         adopted = await _output_table_adopted(session, out_table)
@@ -754,14 +602,14 @@ async def _complete_job_for_attempt(
 
 
 async def _output_table_adopted(session: AsyncSession, out_table: str) -> bool:
-    """Whether a dataset row has adopted ``out_table`` (fix(v1.6.0 audit B13)).
+    """Whether a dataset row has adopted ``out_table``.
 
     Index-backed: ``catalog.datasets`` carries two partial unique indexes on
-    ``table_name`` (global and per-tenant). Tenant-scoped in multi_tenant —
-    an unscoped probe could match another tenant's dataset of the same name
-    and skip a legitimate drop (the IN-01 pattern from the ingest discover
-    query). With no tenant context in multi_tenant, report adopted: the
-    caller then prefers leaking a table over dropping one it can't attribute.
+    ``table_name`` (global and per-tenant). Tenant-scoped in multi_tenant, the
+    same way the ingest discover query is, because an unscoped probe could
+    match another tenant's dataset of the same name and skip a legitimate drop.
+    With no tenant context in multi_tenant it reports adopted, so the caller
+    leaks a table rather than dropping one it cannot attribute.
     """
     tid = current_tenant_var.get() if is_multi_tenant() else None
     if is_multi_tenant():
@@ -779,23 +627,17 @@ async def _output_table_adopted(session: AsyncSession, out_table: str) -> bool:
 
 
 # fix(#1778): the `user_metadata` field an analysis job names its output table
-# under. `out_table` is generated inside the worker and nothing durable carried
-# it, so a SIGKILL after the materialize commit left `data.<out_table>` (plus
-# its GIST index, up to MAX_OUTPUT_BYTES) with no catalog row, no DROP and no
-# reconciler that could ever name it. The name is written in the SAME
-# transaction that creates the table, so the two become durable together and a
-# row that has one has the other.
+# under, written in the SAME transaction that creates the table, so a row that
+# has one has the other and no orphan is left with nothing able to name it.
 ANALYSIS_OUTPUT_TABLE_FIELD = "analysis_out_table"
 
 
 def recorded_analysis_output_tables(user_metadata: object) -> tuple[str, ...]:
     """Every output table name a job row records, in the order recorded.
 
-    fix(#1778 codex r10): the field is a LIST that each attempt appends to. A
-    plain string is what it held before this commit and is read as a
-    one-element list, so an existing row keeps its pointer. Anything else
-    yields nothing rather than raising, because this reads a schemaless JSONB
-    blob.
+    The field is a LIST that each attempt appends to. A plain string is read as
+    a one-element list, and anything else yields nothing rather than raising,
+    because this reads a schemaless JSONB blob.
     """
     if not isinstance(user_metadata, dict):
         return ()
@@ -810,10 +652,9 @@ def recorded_analysis_output_tables(user_metadata: object) -> tuple[str, ...]:
 def append_analysis_output_record(user_metadata: "dict | None", out_table: str) -> dict:
     """Add ``out_table`` to the record without dropping what is already there.
 
-    fix(#1778 codex r10): `/jobs/{id}/retry` preserves ``user_metadata``, so
-    writing this attempt's name over the field dropped the previous attempt's
-    and stranded its table with nothing naming it. Appending is what lets every
-    reaper iterate all of them.
+    ``/jobs/{id}/retry`` preserves ``user_metadata``, so overwriting the field
+    would strand the previous attempt's table with nothing naming it. Every
+    reaper iterates the whole list.
     """
     names = list(recorded_analysis_output_tables(user_metadata))
     if out_table not in names:
@@ -822,10 +663,8 @@ def append_analysis_output_record(user_metadata: "dict | None", out_table: str) 
 
 
 # fix(#1778 codex r10): the scope an analysis output table carries, 8 hex
-# characters of the job and 8 of the attempt. Job alone was not enough: a retry
-# keeps `IngestJob.id` and changes only `attempt_id`, so every attempt of one
-# job derived the same name and a sweep holding attempt 1's could drop the
-# table attempt 2 had just created under it.
+# characters of the job and 8 of the attempt. A retry keeps `IngestJob.id` and
+# changes only `attempt_id`, so the job half alone does not name one owner.
 _ANALYSIS_SCOPE_CHARS = 8
 _ANALYSIS_TABLE_MAX_CHARS = 63
 
@@ -847,33 +686,18 @@ def analysis_output_table_name(
 ) -> str:
     """The physical name ONE attempt of one job may write its output to.
 
-    fix(#1778 codex r7) scoped this by job, which stopped two DIFFERENT jobs
-    sharing a name. fix(#1778 codex r10) adds the attempt, because a retry is
-    the same job: `/jobs/{id}/retry` keeps the id and mints a new attempt
-    token, so every attempt derived one name. A stale sweep could capture
-    attempt 1's name, settle the job `failed`, and then probe and drop while
-    attempt 2 was creating that same name -- and the ownership check passed,
-    because the name really was this job's.
+    Scoped by job AND attempt: ``/jobs/{id}/retry`` keeps the id and mints a
+    new attempt token, so without the attempt half a stale sweep holding
+    attempt 1's name probes and drops while attempt 2 is creating that same
+    name, and the ownership check passes because the name really is this job's.
+    The record accumulates every attempt's name, so no attempt's table is
+    stranded by that.
 
-    The objection to attempt scoping in r8 was that it strands the previous
-    attempt's orphan with nothing naming it, since the row has one field. That
-    is answered by making the record accumulate: it holds a LIST of names that
-    each attempt appends to, exactly as `unpublished_storage_keys` does since
-    r9, and every reaper iterates all of them. So the name identifies one
-    attempt's table and the record remembers every attempt's.
-
-    fix(#1778 audit r11): ``collision_suffix`` names the `_N` tag
-    ``resolve_analysis_output_table``'s walk tries, and it has to be applied
-    HERE, on the original ``base``, not by the caller pre-pending `_N` to
-    ``base`` and calling this again. The base is trimmed to leave room for
-    the scope AND the tag together, computed fresh from ``base`` every call
-    -- the same idiom `generate_table_name`'s own `_with_collision_suffix`
-    uses, and for the identical reason: trimming an ALREADY-TRIMMED string a
-    second time truncates the very characters that make one candidate differ
-    from the next. A ``base`` at or past the reserved limit (46 chars with no
-    tag) used to make every walked candidate identical once trimmed, so a
-    redelivery of the same attempt with an existing scoped table exhausted
-    the whole `_N` walk and raised instead of self-healing.
+    ``collision_suffix`` names the ``_N`` tag ``resolve_analysis_output_table``
+    walks, and it is applied HERE, on the original ``base``, which is trimmed
+    to leave room for the scope AND the tag together and recomputed from
+    ``base`` every call. Trimming an ALREADY-TRIMMED string a second time
+    truncates the very characters that make one candidate differ from the next.
     """
     scope = analysis_output_scope(job_uuid, attempt_uuid)
     tag = f"_{collision_suffix}" if collision_suffix is not None else ""
@@ -884,14 +708,11 @@ def analysis_output_table_name(
 def analysis_output_table_belongs_to(out_table: str, job_uuid: uuid.UUID) -> bool:
     """Whether ``out_table`` carries ``job_uuid``'s scope.
 
-    fix(#1778 codex r7): the ownership check every reaper makes before it drops
-    anything. The name embeds its owner, so this needs no catalog read, no
-    comment and no lock.
-
-    fix(#1778 codex r10): the attempt half is required to be PRESENT but is not
-    compared, because the reaper reads the name off the row that recorded it
-    and so already knows the attempt was one of this job's. What this refuses
-    is a name belonging to a different job, or one with no scope at all.
+    The ownership check every reaper makes before it drops anything. The name
+    embeds its owner, so this needs no catalog read and no lock. The attempt
+    half must be PRESENT but is not compared, because the reaper reads the name
+    off the row that recorded it; what this refuses is a name belonging to a
+    different job, or one with no scope at all.
     """
     return (
         re.search(
@@ -903,9 +724,8 @@ def analysis_output_table_belongs_to(out_table: str, job_uuid: uuid.UUID) -> boo
     )
 
 
-# fix(#1778 codex r10): how many `_N` walks the scoped-name probe makes before
-# giving up, and how much of the base it probes on. Same bound and same reason
-# as `generate_table_name`'s own.
+# How many `_N` walks the scoped-name probe makes before giving up, and how
+# much of the base it probes on. Same bound as `generate_table_name`'s own.
 _MAX_SCOPED_COLLISION_SUFFIX = 20
 _SCOPED_PROBE_CHARS = 20
 
@@ -920,29 +740,17 @@ async def resolve_analysis_output_table(
 ) -> str:
     """The scoped output name, collision-checked AS SCOPED.
 
-    fix(#1778 codex r10). ``generate_table_name`` walks its ``_N`` suffixes
-    against the UNSCOPED base while the relation on disk carries the scope, so
-    its candidate set and the names that actually exist never intersected: a
-    base of ``parcels`` probes ``parcels%``, finds ``parcels_ab12cd34ef56ab78``
-    in pg_class, asks whether ``parcels`` is taken, and hands back ``parcels``
-    unsuffixed, which scopes straight back onto the occupied name and fails at
-    CREATE TABLE. Attempt scoping makes that rare, because a retry gets a
-    different suffix, but not unreachable: the same attempt can be delivered
-    twice, and then the scoped name is identical.
+    ``generate_table_name`` walks its ``_N`` suffixes against the UNSCOPED base
+    while the relation on disk carries the scope, so its candidate set and the
+    names that exist never intersect. The walk therefore happens here, on the
+    name that will actually be created, and every candidate is derived from the
+    SAME original ``base`` via ``collision_suffix``.
 
-    So the walk happens here, on the name that will actually be created. One
-    prefix probe answers every candidate, and it reads pg_class rather than
+    One prefix probe answers every candidate, and it reads pg_class rather than
     information_schema for the reason ``generate_table_name`` gives: the
     standard filters information_schema to relations the current role has
     privileges on, and an orphan this role never granted itself is exactly the
     one this has to see.
-
-    fix(#1778 audit r11): every candidate below is derived from the SAME
-    original ``base`` via ``collision_suffix``, never by pre-pending `_N` to
-    ``base`` and trimming again. ``analysis_output_table_name`` reserves room
-    for the tag itself now, so a long ``base`` still yields a genuinely
-    distinct candidate per suffix instead of the same truncated string N
-    times over.
     """
     probe_prefix = base[:_SCOPED_PROBE_CHARS]
     taken = {
@@ -973,24 +781,13 @@ async def resolve_analysis_output_table(
 
 # A generated analysis table name, as `generate_table_name` produces them. The
 # name reaches the sweeps through a schemaless JSONB blob and is interpolated
-# into DDL, so it is re-checked at every use rather than trusted for having
-# been sanitized once.
+# into DDL, so it is re-checked at every use rather than trusted once.
 _ANALYSIS_TABLE_NAME_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
 
 
-# fix(#1778 codex r6): what `drop_unadopted_analysis_output` actually managed
-# to establish. The distinction that matters to the stale-job sweeps is FINAL
-# versus RETRYABLE: a caller may forget the table's name only once the answer
-# can never change, because that name is the last durable pointer to it.
-#
-#   "adopted"  a dataset row owns the table. Final: it is not an orphan.
-#   "dropped"  the DROP committed. Final: there is nothing left to name.
-#   "invalid"  the recorded name is not an identifier `generate_table_name`
-#              could have produced, so no table of that name was made by this
-#              system and no retry can change the string. Final.
-#   "skipped"  nothing was named. Final, vacuously.
-#   "failed"   the probe or the DROP raised. NOT final. The table may exist and
-#              be unadopted, so the record has to survive for the next sweep.
+# fix(#1778 codex r6): which answers from `drop_unadopted_analysis_output` can
+# never change. A caller may forget the table's name only on one of these,
+# because that name is the last durable pointer to it; "failed" is retryable.
 ANALYSIS_OUTPUT_FINAL_OUTCOMES = frozenset({"adopted", "dropped", "invalid", "skipped"})
 
 AnalysisOutputOutcome = Literal["skipped", "invalid", "adopted", "dropped", "failed"]
@@ -1006,48 +803,29 @@ async def drop_unadopted_analysis_output(
 ) -> AnalysisOutputOutcome:
     """Drop an analysis output table no dataset row has adopted.
 
-    fix(#1778): the probe-then-drop the two fence-miss handlers already ran,
-    lifted into one function so the stale-job sweeps can apply the same policy
-    to a job whose worker was killed outright. Failure direction is the one
-    those handlers chose: an adoption probe that itself errors leaks a table
-    rather than dropping a registered dataset's storage.
-
-    The name is re-validated here because the sweeps read it out of
-    ``user_metadata``, a JSONB blob with no schema, and it is interpolated into
-    a DDL statement that takes no bind parameters.
-
-    fix(#1778 codex r7): ``owner_job_uuid`` is the job whose record is being
-    reaped, and a name that is not that job's is refused. It is required, with
-    no default. The in-worker handlers would pass their own id either way, so
-    an optional gate would have bought nothing but a way to forget it: the
+    ``owner_job_uuid`` is the job whose record is being reaped, and a name that
+    is not that job's is refused. It is required, with no default, because the
     caller that most needs the check is a sweep acting on a name read off a row
-    that may be older than the table now standing at it.
+    that may be older than the table now standing at it. The name is
+    re-validated here too, because the sweeps read it out of ``user_metadata``,
+    a JSONB blob with no schema, and it is interpolated into a DDL statement
+    that takes no bind parameters.
 
-    fix(#1778 codex r6): it REPORTS, rather than returning the same ``None``
-    whether it dropped the table or failed to. The two fence-miss handlers can
-    ignore that -- they are inside the worker, and the job row still names the
-    table afterwards -- but the sweeps cannot. They clear the recorded name on
-    the strength of this call, and the name is the last durable pointer to the
-    table, so a swallowed failure read as success stripped the record and left
-    the table orphaned for good: exactly the leak this function exists to stop,
-    reintroduced by the function itself.
-
-    Note that a probe that RAISES is "failed" and not "adopted". Treating an
-    unreadable catalog as adoption is the right call for whether to DROP -- it
-    prefers a leak to destroying a live dataset's storage -- and the wrong one
-    for whether the question is settled, because nothing was established.
+    Returns which of ``skipped``/``invalid``/``adopted``/``dropped``/``failed``
+    it established. The sweeps clear the recorded name on the strength of that,
+    and the name is the last durable pointer to the table, so a probe that
+    RAISES is "failed" and not "adopted": preferring a leak to destroying a
+    live dataset's storage is the right call for whether to DROP, and the wrong
+    one for whether the question is settled.
     """
     if out_table is None:
         return "skipped"
     if not _ANALYSIS_TABLE_NAME_RE.match(out_table):
         logger.warning("analysis.output_table_name_rejected", job_id=job_id)
         return "invalid"
-    # fix(#1778 codex r7): the ownership gate. A sweep reaping a job's record
-    # may only drop the table THAT job named, and the name says which job that
-    # is. Without this the sweep was free to drop a table a different job had
-    # since created under a reused name, between the adoption probe and the
-    # DROP. "invalid" rather than "failed": a name that is not this job's can
-    # never become this job's, so retrying it forever would pin the row.
+    # fix(#1778 codex r7): a sweep reaping a job's record may only drop the
+    # table THAT job named. "invalid" rather than "failed": a name that is not
+    # this job's can never become this job's, so retrying would pin the row.
     if not analysis_output_table_belongs_to(out_table, owner_job_uuid):
         logger.warning("analysis.output_table_not_owned", job_id=job_id)
         return "invalid"
@@ -1081,16 +859,13 @@ async def _mark_job_failed(
 ) -> None:
     """Roll back, record the failure, and drop this job's own partial table.
 
-    fix(#786): fenced on the attempt token FIRST, mirroring
-    ``_fail_cancelled_job`` — the previous plain ORM write could overwrite a
-    terminal state some other actor already set (the stale-job sweep failing
-    the row after a stalled lease, or a final commit that reached the server
-    before the connection dropped, leaving the row 'complete'). A successful
-    fence proves the row was still 'running', so the registration commit has
-    not happened and any committed output table is an unregistered orphan —
-    safe to drop. If the fence misses, the row is left alone; the table is
-    dropped only when the adoption probe proves no dataset registered it
-    (fix(v1.6.0 audit B13)).
+    Fenced on the attempt token FIRST, mirroring ``_fail_cancelled_job``: a
+    plain ORM write could overwrite a terminal state some other actor already
+    set. A successful fence proves the row was still 'running', so the
+    registration commit has not happened and any committed output table is an
+    unregistered orphan — safe to drop. If the fence misses, the row is left
+    alone and the table is dropped only when the adoption probe proves no
+    dataset registered it.
     """
     await session.rollback()
     if not await update_ingest_job_for_attempt(
@@ -1101,19 +876,15 @@ async def _mark_job_failed(
             "status": "failed",
             # Sanitized (fix(#692)): raw DB errors embed the generated SQL.
             "error_message": _user_error_message(exc, registered=registered),
-            # fix(v1.6.0 audit B12): stamp completion time like ingest does.
+            # fix(#813): stamp completion time like ingest does.
             "completed_at": datetime.now(timezone.utc),
         },
     ):
         await session.rollback()
         logger.warning("analysis.failed_write_superseded", job_id=job_id)
-        # fix(v1.6.0 audit B13): a fence miss means some other actor set a
-        # terminal state, but only a completed job has adopted the table —
-        # a swept row leaves an unregistered orphan that used to leak
-        # permanently. Probe for an adopting dataset row; no row means the
-        # DROP is safe. Failure direction stays safe: if the probe itself
-        # errors, prefer leaking the table to dropping a registered
-        # dataset's storage.
+        # fix(#813): a fence miss means another actor set a terminal state,
+        # but only a completed job has adopted the table. Probe first; a probe
+        # that errors leaks the table rather than dropping live storage.
         await drop_unadopted_analysis_output(
             session,
             out_table=out_table,
@@ -1139,12 +910,11 @@ async def _list_carry_columns(
 ) -> list[str]:
     """Attribute columns to carry into 1:1 op output (skip system/geom cols).
 
-    fix(#763): every name is carried — GDAL launders only case/`-`/`#`, so
-    ingested tables legitimately hold columns like ``Área`` or ``2020_pop``;
-    filtering to identifier-shaped names silently dropped them from every
-    analysis output. Rendering quotes via ``_sql_quote_ident``, whose
-    colon escape also keeps Socrata-style ``:id`` columns from being parsed
-    as bind parameters by ``text()``.
+    Every name is carried — GDAL launders only case/`-`/`#`, so ingested
+    tables legitimately hold columns like ``Área`` or ``2020_pop``. Rendering
+    quotes via ``_sql_quote_ident``, whose colon escape also keeps
+    Socrata-style ``:id`` columns from being parsed as bind parameters by
+    ``text()``.
     """
     rows = await session.execute(
         text(
@@ -1160,16 +930,12 @@ async def _list_carry_columns(
 def _wrap_not_empty(select_sql: str) -> str:
     """Exclude NULL/EMPTY-geometry rows inside the CTAS itself.
 
-    fix(#786): ``_enforce_output_size`` probes ``pg_total_relation_size``
-    right after the CTAS, and the post-CTAS DELETE cannot shrink what it
-    measures — dead tuples keep their pages until a rewrite. Rows the
-    cleanup removes therefore counted toward the output ceiling for
-    buffer/centroid/dissolve and the drawn-mask clip, failing analyses
-    whose real output is small. The clip-by-layer branch has filtered
-    in-CTAS since fix(#719 review); this extends the same rule to the
-    other shapes. ``OFFSET 0`` fences subquery pull-up so the geometry
-    expression (``ST_Buffer`` at worst) is evaluated once per row rather
-    than re-evaluated inside the outer WHERE.
+    ``_enforce_output_size`` probes ``pg_total_relation_size`` right after the
+    CTAS, and the post-CTAS DELETE cannot shrink what it measures — dead tuples
+    keep their pages until a rewrite — so rows the cleanup removes would count
+    toward the output ceiling. ``OFFSET 0`` fences subquery pull-up so the
+    geometry expression (``ST_Buffer`` at worst) is evaluated once per row
+    rather than re-evaluated inside the outer WHERE.
     """
     return (
         f"SELECT * FROM ({select_sql} OFFSET 0) AS _rows"
@@ -1192,13 +958,9 @@ def _build_materialize_select(
 ) -> str:
     """Render the SELECT that produces the output table's rows."""
     if operation == "intersect" and mask_table_ref is not None:
-        # fix(#956): the only branch whose output rows are not 1:1 with source
-        # rows, so it is also the only one besides dissolve that generates its
-        # own gid — the unconditional ADD PRIMARY KEY (gid) below would die on
-        # duplicates otherwise. The empty-geometry filter is inside the
-        # renderer for the same reason clip's is (fix(#719 review)):
-        # _enforce_output_size measures the CTAS before the post-CTAS DELETE
-        # can shrink it.
+        # fix(#956): the only branch whose output rows are not 1:1 with
+        # source rows, so it generates its own gid — ADD PRIMARY KEY (gid)
+        # below would die on duplicates. Empty geometries filtered in-renderer.
         return render_intersect_pairs(
             src_ref,
             mask_table_ref,
@@ -1206,9 +968,8 @@ def _build_materialize_select(
             mask_columns=[_sql_quote_ident(c) for c in (mask_carry_cols or [])],
         )
     if operation == "measure":
-        # fix(#954): the same renderer the preview uses, so a saved measurement
-        # equals the one the user approved rather than being recomputed by a
-        # second expression that could drift.
+        # fix(#954): the same renderer the preview uses, so a saved
+        # measurement equals the one the user approved.
         measure_cols, measure_join = render_measure_columns(src="_src")
         cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
         return _wrap_not_empty(
@@ -1219,8 +980,7 @@ def _build_materialize_select(
     if operation == "spatial_join" and join_table_ref is not None:
         # fix(#953): the same two laterals the preview uses, so the saved
         # dataset and the approved preview agree row for row — including the
-        # tie-break, which is the difference between one output row per source
-        # feature and a duplicate-gid CTAS that dies on ADD PRIMARY KEY below.
+        # tie-break, without which the CTAS dies on ADD PRIMARY KEY below.
         join_cols, joins = render_spatial_join(
             join_table_ref, src="_src", join_fields=join_fields
         )
@@ -1233,13 +993,11 @@ def _build_materialize_select(
     if operation == "dissolve":
         # ST_MakeValid: one invalid ring would abort the whole union.
         # ST_CollectionExtract: a union over mixed geometry types returns a
-        # GEOMETRYCOLLECTION, which the MVT tile path can't render — keep only
-        # the highest-dimension components so the output stays typed.
+        # GEOMETRYCOLLECTION, which the MVT tile path can't render.
         union_expr = "ST_Multi(ST_CollectionExtract(ST_Union(ST_MakeValid(geom_4326))))"
         if by_field:
-            # fix(#836): quote via _sql_quote_ident like every other identifier
-            # site here — _SAFE_IDENT already guards by_field, but a lone
-            # inline-quoting divergence is where the next escaping bug hides.
+            # fix(#836): quote via _sql_quote_ident like every other
+            # identifier site here, leaving no inline-quoting divergence.
             col = _sql_quote_ident(by_field)
             return _wrap_not_empty(
                 f"SELECT (row_number() OVER ())::integer AS gid, {col}, "
@@ -1253,13 +1011,8 @@ def _build_materialize_select(
         )
     if operation == "select_by_location" and mask_table_ref is not None:
         # fix(#955): whole source rows, filtered. No lateral and no CTE, so
-        # unlike the clip branch below there is nothing for the not-empty
-        # filter to catch downstream — _wrap_not_empty applies it to the source
-        # geometry directly, which is what the output geometry IS.
-        #
-        # The DRAWN-mask half needs no branch at all: render_geometry_expr
-        # returns the pass-through and its <where>, and the generic tail
-        # below is already the right shape.
+        # _wrap_not_empty applies to the source geometry directly, which is
+        # what the output geometry IS. A DRAWN mask needs no branch here.
         where = render_select_by_location_where(mask_table_ref, src="_src")
         cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
         return _wrap_not_empty(
@@ -1267,20 +1020,9 @@ def _build_materialize_select(
             f" FROM {src_ref} AS _src{where}"
         )
     if operation == "clip" and mask_table_ref is not None:
-        # fix(#719): the same subdivided-mask join the preview uses. This used
-        # to render a single whole-layer ST_Union instead, so a clip whose
-        # preview came back in under a second could exhaust the 300s CTAS
-        # budget on "Create dataset" (see render_clip_layer_join for the
-        # measurements).
-        #
-        # The empty-result filter is applied HERE, not left to the post-CTAS
-        # DELETE (fix(#719 review)). The row filter admits a source row on a
-        # bounding-box overlap, so a wide or concave mask lets through rows
-        # whose geometries never actually intersect; their lateral yields
-        # geom_out = NULL. _enforce_output_size runs against the CTAS BEFORE
-        # that DELETE, so those rows could fail an analysis as oversized when
-        # the dataset it would have saved is small. Clip has no source-feature
-        # cap, so nothing else bounds how many of them there are.
+        # fix(#719): the same subdivided-mask join the preview uses. The
+        # empty-result filter is applied HERE, before _enforce_output_size
+        # measures a CTAS holding bounding-box overlaps that yield NULL.
         cte, lateral, where = render_clip_layer_join(mask_table_ref, src="_src")
         cols = "".join(f"_src.{_sql_quote_ident(c)}, " for c in carry_cols)
         return (
@@ -1328,22 +1070,9 @@ async def _materialize(
         if job is None:
             logger.warning("analysis.job_not_found", job_id=job_id)
             return
-        # Fenced claim (fix(#692), the ingest_file pattern): pending → running
-        # succeeds at most once per attempt token, and stamps
-        # started_at/heartbeat_at — the liveness signals the stale-job sweep
-        # and the lease below depend on (fix(#682 review): statement_timeout
-        # bounds each STATEMENT, not the task, so a large materialize can
-        # legitimately run long and only the lease keeps it out of the sweep).
-        # Without the claim this worker would act on rows some other actor
-        # already moved to a terminal state — the pending-sweeper failing a
-        # backlogged job after an hour, or the defer orphan-guard failing the
-        # row after the queue INSERT committed — and resurrect them: the
-        # per-user cap admits a second CTAS, and a dataset appears for a job
-        # the user was told failed.
-        #
-        # The row's own attempt_id is the token (column-defaulted at
-        # creation; retry=0, so there is no second delivery to fence against).
-        # Rows predating that default are adopted atomically.
+        # fix(#692): fenced claim, pending → running at most once per attempt
+        # token, stamping the liveness signals the sweep and the lease need.
+        # Without it a row another actor already made terminal is resurrected.
         attempt_id = job.attempt_id or await resolve_ingest_job_attempt(job.id, None)
         if attempt_id is None or not await claim_ingest_job_attempt(
             session, job.id, attempt_id
@@ -1351,9 +1080,8 @@ async def _materialize(
             await session.rollback()
             logger.warning("analysis.attempt_not_claimed", job_id=job_id)
             return
-        # current_step only, no numeric progress: the operation is a single
-        # CTAS, so there is no intra-statement telemetry to report and a bar
-        # parked at 10% for five minutes reads as "stuck" rather than "busy".
+        # current_step only, no numeric progress: one CTAS has no
+        # intra-statement telemetry, and a parked bar reads as "stuck".
         job.current_step = "analyzing"
         await session.commit()
 
@@ -1362,18 +1090,15 @@ async def _materialize(
         )
         out_table: str | None = None
         # Only drop the output table on failure if THIS job created it: when
-        # CREATE TABLE itself fails because a concurrent job won the same
-        # generated name, an unconditional cleanup would destroy the winner's
-        # table while its dataset registration stays live.
+        # CREATE TABLE loses a race for the same generated name, an
+        # unconditional cleanup would destroy the winner's table.
         out_table_created = False
-        # fix(#1013 review): flipped when the CTAS transaction commits and
-        # registration re-arms its own statement_timeout, so a failure after
-        # that point quotes the budget that actually fired.
+        # fix(#1013 review): flipped once registration re-arms its own
+        # statement_timeout, so a later failure quotes the budget that fired.
         registration_started = False
         # Created inside the try so the finally below always reaps it: a
-        # heartbeat left running after an exception here would renew a lease
-        # for a job nobody is executing, and the sweep can never fail a row
-        # with a fresh lease (fix(#692)).
+        # heartbeat left running renews a lease for a job nobody is executing,
+        # and the sweep can never fail a row with a fresh lease.
         heartbeat: asyncio.Task[None] | None = None
         try:
             # Renews on its own session, so it never contends with the work
@@ -1399,9 +1124,8 @@ async def _materialize(
                 )
             src_ref = f'"{_schema}"."{src.table_name}"'
 
-            # Layer-sourced clip mask: re-resolve the table name at run time
-            # (access was checked at enqueue by the router, same trust model
-            # as the source dataset).
+            # Layer-sourced clip mask: re-resolved at run time, same trust
+            # model as the source dataset (access checked at enqueue).
             mask_table_ref: str | None = None
             mask_table_name: str | None = None
             if mask_dataset_id is not None:
@@ -1414,10 +1138,8 @@ async def _materialize(
                     require_geometry="polygonal",
                 )
             join_table_ref: str | None = None
-            # fix(#1097 review): the plain name is kept now, not discarded. The
-            # transferred fields have to be re-checked against this layer's
-            # LIVE columns, and information_schema takes a name rather than the
-            # quoted ref.
+            # fix(#1097 review): the plain name is kept for the live-column
+            # recheck, which information_schema takes rather than a quoted ref.
             join_table_name: str | None = None
             if join_dataset_id is not None:
                 join_table_ref, join_table_name = await _resolve_layer_table_ref(
@@ -1437,13 +1159,9 @@ async def _materialize(
             )
 
             _base_table, collision_warning = await generate_table_name(title, session)
-            # fix(#1778 codex r7/r10): scoped by this job AND this attempt, so
-            # neither another job nor another attempt of this one can be handed
-            # the same physical name. `generate_table_name` still chooses the
-            # readable half and still collides against the catalog and the
-            # retired names, which is what the eventual dataset table_name
-            # needs; the `_N` walk that matters for the RELATION is the scoped
-            # one below, because the unscoped walk can never see a scoped name.
+            # fix(#1778 codex r7/r10): scoped by this job AND this attempt.
+            # `generate_table_name` chooses the readable half; the `_N` walk
+            # that matters for the RELATION is the scoped one below.
             out_table = await resolve_analysis_output_table(
                 session,
                 base=_base_table,
@@ -1451,41 +1169,23 @@ async def _materialize(
                 attempt_uuid=attempt_id,
                 schema=_schema,
             )
-            # fix(#1778): the name, on the durable row, in the same transaction
-            # that creates the table (the commit after ANALYZE below). Without
-            # it a hard kill after that commit left the table unreachable: the
-            # stale sweep is a plain status UPDATE, every DROP of this table
-            # lives in a handler this process would never run, and no
-            # reconciler can name a table nothing recorded.
-            #
-            # fix(#1778 codex r10): a LIST that each attempt APPENDS to, the
-            # shape `unpublished_storage_keys` took in r9 and for the same
-            # reason. `/jobs/{id}/retry` preserves `user_metadata`, so writing
-            # this attempt's name over the field dropped the previous attempt's
-            # and stranded its table with nothing naming it. A string from
-            # before this commit is read as a one-element list, so an existing
-            # row keeps its pointer.
+            # fix(#1778 codex r10): the name, on the durable row, in the same
+            # transaction that creates the table (the commit after ANALYZE), as
+            # a LIST each attempt appends to — retry preserves `user_metadata`.
             job.user_metadata = append_analysis_output_record(
                 job.user_metadata, out_table
             )
             if collision_warning:
-                # fix(#786): persisted like the upload path (tasks_vector) —
-                # the job-status endpoint surfaces
-                # user_metadata['collision_warning'] as warning_message, so
-                # discarding it here silently landed an analysis output in
-                # e.g. parcels_buffered_3 with no indication to the user.
+                # fix(#786): persisted like the upload path — the job-status
+                # endpoint surfaces user_metadata['collision_warning'] as
+                # warning_message, so discarding it hides the renamed output.
                 job.user_metadata = {
                     **(job.user_metadata or {}),
                     "collision_warning": collision_warning,
                 }
-            # INVARIANT: from the user_metadata/current_step assignments above
-            # to the commit after ANALYZE, every statement must stay text() —
-            # SQLAlchemy autoflushes only for ORM queries, so the dirty job
-            # row is flushed (and its row lock taken) only microseconds inside
-            # that commit. A single ORM select() added in this stretch would
-            # autoflush the dirty row and hold the job-row lock across the
-            # CTAS, blocking renew_ingest_job_heartbeat (separate session,
-            # same row) for the entire build.
+            # INVARIANT: every statement from the assignments above to the
+            # commit after ANALYZE stays text(). One ORM select() would autoflush
+            # the dirty job row, taking its lock across the whole CTAS.
             out_ref = f'"{_schema}"."{out_table}"'
 
             carry_cols, mask_carry_cols = await _resolve_and_validate_columns(
@@ -1515,28 +1215,18 @@ async def _materialize(
             await _apply_materialize_work_mem(session)
             if operation == "dissolve":
                 # fix(#694): hash aggregation holds every group's union state
-                # in memory at once, so a grouped dissolve over enough
-                # polygons can OOM-kill the shared db container. Sorted
-                # aggregation bounds memory to one group at a time. The
-                # enqueue-time feature cap is the first line of defense;
-                # this is the second.
+                # in memory at once and can OOM-kill the shared db container;
+                # sorted aggregation bounds it to one group at a time.
                 await session.execute(text("SET LOCAL enable_hashagg = off"))
             await session.execute(text(f"CREATE TABLE {out_ref} AS {select_sql}"))
             out_table_created = True
-            # Early exit only — a table already over the ceiling must not
-            # hold the single worker slot through the rewrite phases. The
+            # Early exit only — a table already over the ceiling must not hold
+            # the single worker slot through the rewrite phases. The
             # authoritative check runs after add_4326_column below.
             await _enforce_output_size(session, _schema, out_table, operation=operation)
-            # Rows with nothing to show are excluded inside the CTAS for
-            # EVERY shape (fix(#786), extending fix(#719 review)'s clip
-            # rule via _wrap_not_empty): buffer/centroid map NULL source
-            # geometries to NULL, dissolve unions an all-NULL group to NULL,
-            # and boundary-grazing clips survive ST_Intersects but extract to
-            # EMPTY (see analysis_sql.render_geometry_expr). The preview
-            # filters the same rows in SQL (fix(#680 review)) — the saved
-            # dataset must agree with the preview the user approved. This
-            # DELETE stays as the backstop enforcing that invariant should a
-            # future query shape miss the in-CTAS filter.
+            # fix(#786): rows with nothing to show are excluded inside the
+            # CTAS for every shape via _wrap_not_empty, matching the preview.
+            # This DELETE is the backstop should a query shape miss that filter.
             await session.execute(
                 text(f"DELETE FROM {out_ref} WHERE geom IS NULL OR ST_IsEmpty(geom)")
             )
@@ -1544,9 +1234,8 @@ async def _materialize(
                 text(f"SELECT EXISTS (SELECT 1 FROM {out_ref})")
             )
             if not has_features:
-                # e.g. a clip matching nothing, or dissolving an empty
-                # dataset (whose no-GROUP-BY aggregate still yields one
-                # NULL-geometry row) — fail loud instead of registering junk.
+                # e.g. a clip matching nothing, or dissolving an empty dataset
+                # (whose no-GROUP-BY aggregate yields one NULL-geometry row).
                 raise ValueError("Analysis produced no features to save")
             # CTAS yields an untyped geometry column (typmod srid=0), which
             # metadata extraction reports as SRID 0 — stamp the 4326 typmod.
@@ -1559,24 +1248,20 @@ async def _materialize(
             await session.execute(text(f"ALTER TABLE {out_ref} ADD PRIMARY KEY (gid)"))
             await add_4326_column(session, out_table, 4326, schema=_schema)
             # fix(#701 review): the 4326 rewrite roughly doubles the geometry
-            # payload, rewrites every row, and adds the GIST index — the
-            # post-CTAS probe undercounts the final footprint by a multiple,
-            # so the ceiling is enforced here, on the finished relation.
+            # payload and adds the GIST index, so the post-CTAS probe
+            # undercounts the final footprint by a multiple.
             await _enforce_output_size(session, _schema, out_table, operation=operation)
-            # In-transaction ANALYZE (fix(#692)): the table only becomes
-            # visible to autovacuum at the commit below, and the first tile
-            # queries land before its pass — without statistics the planner
-            # has no geometry selectivity for `&&` against the fresh GIST
-            # index and can seq-scan a large output.
+            # fix(#692): in-transaction ANALYZE. The table becomes visible to
+            # autovacuum only at the commit below and the first tile queries
+            # land before its pass, with no `&&` selectivity for the GIST index.
             await session.execute(text(f"ANALYZE {out_ref}"))
             job.current_step = "registering"
             await session.commit()
             registration_started = True
 
-            # The commit above ended the transaction and the SET LOCAL with
-            # it — give registration its own budget (fix(#692)). Set here
-            # rather than inside register_existing_table, which is shared
-            # with the upload path.
+            # fix(#692): the commit above ends the SET LOCAL with its
+            # transaction. Set here rather than inside register_existing_table,
+            # which is shared with the upload path.
             await session.execute(
                 text(f"SET LOCAL statement_timeout = '{registration_timeout()}'")
             )
@@ -1588,12 +1273,9 @@ async def _materialize(
                     table_name=out_table, title=title, visibility="private"
                 ),
                 requester,
-                # fix(#1452): this output table was CTAS'd a few lines up, so
-                # it is GeoLens's to drop when the dataset is deleted. Without
-                # this it would be indistinguishable from a table an operator
-                # registered — same postgis origin, same null source_format —
-                # and the detach that protects the operator's table would leak
-                # one of these on every delete.
+                # fix(#1452): CTAS'd a few lines up, so it is GeoLens's to
+                # drop when the dataset is deleted. Without it the detach that
+                # protects an operator-registered table leaks one per delete.
                 managed=True,
             )
             # feat(#765): provenance before the completing commit, so a
@@ -1607,19 +1289,9 @@ async def _materialize(
                 params={
                     "distance_meters": distance_meters,
                     "by_field": by_field,
-                    # fix(#1097 review): every operation that can take a
-                    # DRAWN mask, not clip alone. The drawn geometry itself is
-                    # deliberately excluded from provenance (it can be
-                    # kilobytes), so for a drawn select_by_location this
-                    # discriminator was the only trace that an area shaped the
-                    # selection at all — without it those params serialise
-                    # empty and the lineage says a selection happened by no
-                    # visible means.
-                    #
-                    # The sibling of the job-metadata fix in the previous
-                    # round. That one was the writer the review named; this is
-                    # the other writer of the same fact, and fixing only the
-                    # named one is what left this behind.
+                    # fix(#1097 review): every operation that can take a DRAWN
+                    # mask, not clip alone. The drawn geometry is excluded from
+                    # provenance, so this is the only trace an area shaped it.
                     "mask_source": (
                         ("layer" if mask_dataset_id else "drawn")
                         if operation in _DRAWN_MASK_OPERATIONS
@@ -1640,14 +1312,9 @@ async def _materialize(
                 operation=operation,
             )
         except asyncio.CancelledError:
-            # Graceful worker shutdown cancels this task after the drain
-            # window; `except Exception` cannot catch it, and retry=0 means no
-            # redelivery — without this branch the row would strand in
-            # 'running', holding the user's one analysis slot, until the
-            # 60-minute sweep (fix(#692)). Bookkeeping runs on a fresh session
-            # (this one may be mid-statement) and is shielded so the
-            # cancellation doesn't also cancel it; then re-raise so the queue
-            # records the abort.
+            # fix(#692): a graceful shutdown cancels this task and `except
+            # Exception` cannot catch it, so without this branch the row strands
+            # in 'running'. Shielded, so the cleanup is not cancelled too.
             try:
                 await asyncio.shield(
                     asyncio.wait_for(
@@ -1685,10 +1352,9 @@ async def _materialize(
                 registered=registration_started,
             )
         finally:
-            # The row has left 'running' by now, so the loop would exit on its
-            # own at the next renewal — stop (cancel + await, the ingest
-            # convention) so the task neither outlives the work by a heartbeat
-            # interval nor leaks a pending task through worker shutdown.
+            # Stop (cancel + await, the ingest convention) so the task neither
+            # outlives the work by a heartbeat interval nor leaks a pending
+            # task through worker shutdown.
             await stop_ingest_job_heartbeat(heartbeat)
 
 

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -725,7 +725,8 @@ def analysis_output_table_belongs_to(out_table: str, job_uuid: uuid.UUID) -> boo
 
 
 # How many `_N` walks the scoped-name probe makes before giving up, and how
-# much of the base it probes on. Same bound as `generate_table_name`'s own.
+# much of the base it probes on. Same reason as `generate_table_name`'s own
+# pair: the probe prefix must stay a prefix of every candidate the walk emits.
 _MAX_SCOPED_COLLISION_SUFFIX = 20
 _SCOPED_PROBE_CHARS = 20
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2618,7 +2618,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `include` off the origin; `require_wfs_layer` at the spawn points. 1881.
     # chore(#1873): review-history comments trimmed. Cap 1881 -> 1385, exact.
     "backend/app/platform/service_endpoints.py": 1385,
-    # fix(#1770 round 42): first entry, crossed _RATCHET_INCLUSION_LOC on the
+    # fix(#1770): first entry, crossed _RATCHET_INCLUSION_LOC on the
     # completeness-predicate unification. `_page_proves_complete` is the one
     # function round 41's full-walk-only proof and round 42's sampled-preview
     # mirror of it both call now, and `_end_of_chain`/`_sample_truncated` are
@@ -2627,10 +2627,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `_resolve_conformance` was pulled out of `probe_ogcapi` in #1746).
     # Most of the added lines are the docstrings recording the round 38-42
     # history so a future reader does not re-derive it from the diff.
-    # fix(#1770 round 44 P2): +8. The items-page JSON parse also catches
+    # fix(#1770): +8. The items-page JSON parse also catches
     # `RecursionError` now, same reasoning as `service_endpoints.py::
     # _parsed_json`. Cap 1033 -> 1041, exact.
-    # fix(#1770 round 47): +49. Two closed classes: every advertised-href
+    # fix(#1770): +49. Two closed classes: every advertised-href
     # site (`_advertised_items_href`/`_with_page_size`/`_next_href`) now
     # runs through `bounded_service_url`/`bounded_parse_qsl`, and
     # `_walk_pages`'s per-feature re-serialisation catches `UnicodeEncode
@@ -2638,7 +2638,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # escape as an internal exception. Cap 1041 -> 1090, exact (`ruff
     # format` wrapped one `urljoin(base, bounded_service_url(...))` call
     # onto three lines after the round-47 diff landed).
-    # fix(#1770 round 47b): +16. `HrefTooLongError` handling at the three
+    # fix(#1770): +16. `HrefTooLongError` handling at the three
     # `bounded_service_url` catch sites, each getting its own wording
     # distinct from the generic "unparseable" refusal. Cap 1090 -> 1106,
     # exact.
@@ -2838,7 +2838,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # tenant_adoption_sql.py); the remainder is one read per object the adoption
     # boundary covers, and each is a single SQL statement that has to see the
     # whole object at once.
-    # fix(#998 codex r45-r49): +130 — read side mirrors every apply-side ownership surface — run the provisioner grant-option guard
+    # fix(#998): +130 — read side mirrors every apply-side ownership surface — run the provisioner grant-option guard
     # before the plain revokes it protects; mirror the multirange and
     # schema-less default-privilege refusals on the read side so the dry run
     # cannot call adopted what --apply stops on.
@@ -5397,7 +5397,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # correct for the tree that produced it and neither is correct for the
     # merge, which is the conflict doing its job.
     #
-    # fix(#1097 review): +40 on top of that, for
+    # fix(#1097): +40 on top of that, for
     # _reject_ungroupable_overlay_columns — the worker half of the overlay type
     # guard. The router validates a catalog SNAPSHOT and a re-upload can
     # replace the overlay before the job runs, the same window
@@ -5405,33 +5405,33 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # names, because the live name list was already read there and would not
     # have caught it: the column that breaks the CTAS has an ordinary name.
     #
-    # fix(#1097 review): +91 for the live-schema rechecks. Two more guards (the
+    # fix(#1097): +91 for the live-schema rechecks. Two more guards (the
     # reserved-alias prefix, and re-checking transferred join fields against the
     # join layer's live columns) plus _resolve_and_validate_columns, which the
     # set moved into rather than raising _materialize's C901 threshold: five
     # checks over two layers share a subject the surrounding job bookkeeping
     # does not.
     #
-    # fix(#1097 review): +21 for re-applying the polygon requirement on the
+    # fix(#1097): +21 for re-applying the polygon requirement on the
     # mask layer at resolve time. The router refuses a non-polygonal mask at
     # enqueue and a re-upload can change that layer's geometry_type while the
     # job waits, and nothing downstream notices: the mask matches no rows and
     # the job dies on "produced no features", pointing the user at their data
     # instead of at the layer that changed.
     #
-    # fix(#1097 review): +22 for the second geometry strength. The mask must
+    # fix(#1097): +22 for the second geometry strength. The mask must
     # still be polygonal; the JOIN layer must only still be spatial, because a
     # join counts in any direction — but a re-upload from a non-spatial source
     # leaves no geom_4326 for render_spatial_join to reference.
     #
-    # fix(#1097 review): +20 for _DRAWN_MASK_OPERATIONS and the note on why
+    # fix(#1097): +20 for _DRAWN_MASK_OPERATIONS and the note on why
     # mask_source belongs to every operation that can take a drawn mask. The
     # drawn geometry is deliberately excluded from provenance, so that
     # discriminator is the only trace a drawn selection leaves — the constant
     # is duplicated from schemas because PROCESS-02 forbids the import, and a
     # test pins the two copies together.
     #
-    # fix(#1097 review): +3 for linearizing the three pass-through CTAS
+    # fix(#1097): +3 for linearizing the three pass-through CTAS
     # geometry columns (measure, spatial_join, select_by_location) so a curved
     # source row is stored linear — a curved geometry written into the derived
     # table would fail that layer's tiles and feature reads later.
@@ -5439,7 +5439,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # ingest, so the pass-through columns read the bare column. Cap
     # 1450 -> 1449, exact.
     #
-    # fix(#1097 review): +62 for the array-element half of the ungroupable
+    # fix(#1097): +62 for the array-element half of the ungroupable
     # guards. information_schema stores an array column's data_type as
     # 'ARRAY', so json[]/xml[] passed the exact scalar comparison and failed
     # the CTAS with 42883 after the queue wait; _ungroupable_type_name reads
@@ -5465,14 +5465,14 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `drop_unadopted_analysis_output` the stale-job sweeps call too. The
     # helper's docstring and its identifier re-validation are most of the net
     # growth; the two inlined copies came out. Cap 1420 -> 1462.
-    # fix(#1778 codex r6): +33. `drop_unadopted_analysis_output` returns what
+    # fix(#1778): +33. `drop_unadopted_analysis_output` returns what
     # it established rather than the same None whether it dropped the table or
     # failed to. The sweep clears the recorded name on the strength of that
     # call, and the name is the table's last durable pointer, so a swallowed
     # failure read as success orphaned the table permanently. The five outcomes
     # and the note on why a raised probe is "failed" and not "adopted" are the
     # growth. Cap 1462 -> 1495.
-    # fix(#1778 codex r7): +79. Output table names are scoped by the job that
+    # fix(#1778): +79. Output table names are scoped by the job that
     # creates them, so two jobs can never hold one physical name and the sweep
     # can verify ownership from the name alone, with no marker, registry or
     # lock. `analysis_output_table_name` and `analysis_output_table_belongs_to`
@@ -5482,7 +5482,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # keyword with no default: the in-worker handlers pass their own id either
     # way, so an optional one would have bought nothing but a way to forget it.
     # Cap 1495 -> 1580, exact.
-    # fix(#1778 codex r10): +122. The scope grows an attempt half — job scoping
+    # fix(#1778): +122. The scope grows an attempt half — job scoping
     # alone left a retry able to derive the same name as its predecessor, since
     # `/jobs/{id}/retry` keeps `IngestJob.id` and only mints a new attempt
     # token. `analysis_output_table_name` takes both now, and the record
@@ -5495,7 +5495,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `generate_table_name`'s own `_N` walk only ever probed the unscoped base,
     # so it could hand back a name that scoped straight onto an orphan a
     # previous attempt of the same job left behind. Cap 1580 -> 1702, exact.
-    # fix(#1778 audit r11): +23. `analysis_output_table_name` takes an
+    # fix(#1778): +23. `analysis_output_table_name` takes an
     # optional `collision_suffix` now instead of the caller pre-pending `_N`
     # to `base` and calling it again -- the second trim of an already-trimmed
     # string threw away the very characters that made one candidate differ

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2642,8 +2642,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `bounded_service_url` catch sites, each getting its own wording
     # distinct from the generic "unparseable" refusal. Cap 1090 -> 1106,
     # exact.
-    # chore(#1873): review-history comments trimmed. Cap 1106 -> 800, exact.
-    "backend/app/platform/service_items.py": 800,
+    # chore(#1873): review-history comments trimmed. Cap 1106 -> 797, exact.
+    "backend/app/platform/service_items.py": 797,
     # fix(#1758): the ArcGIS sign-in protocol, which crossed 1000 lines over
     # nine review rounds. What the growth bought, in order: the two-phase
     # split that resolves WHERE a password would go before any lock or budget
@@ -2842,8 +2842,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # before the plain revokes it protects; mirror the multirange and
     # schema-less default-privilege refusals on the read side so the dry run
     # cannot call adopted what --apply stops on.
-    # chore(#1873): review-history comments trimmed. Cap 1303 -> 1277, exact.
-    "backend/app/core/db/tenant_adoption.py": 1277,
+    # chore(#1873): review-history comments trimmed. Cap 1303 -> 1276, exact.
+    "backend/app/core/db/tenant_adoption.py": 1276,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5504,8 +5504,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # self-healing. The tag is reserved for up front, in the same limit
     # computation as the scope, the idiom `generate_table_name`'s own
     # `_with_collision_suffix` already uses. Cap 1702 -> 1725, exact.
-    # chore(#1873): review-history comments trimmed. Cap 1725 -> 1391, exact.
-    "backend/app/processing/analysis/tasks.py": 1391,
+    # chore(#1873): review-history comments trimmed. Cap 1725 -> 1392, exact.
+    "backend/app/processing/analysis/tasks.py": 1392,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2642,8 +2642,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `bounded_service_url` catch sites, each getting its own wording
     # distinct from the generic "unparseable" refusal. Cap 1090 -> 1106,
     # exact.
-    # chore(#1873): review-history comments trimmed. Cap 1106 -> 797, exact.
-    "backend/app/platform/service_items.py": 797,
+    # chore(#1873): review-history comments trimmed. Cap 1106 -> 800, exact.
+    "backend/app/platform/service_items.py": 800,
     # fix(#1758): the ArcGIS sign-in protocol, which crossed 1000 lines over
     # nine review rounds. What the growth bought, in order: the two-phase
     # split that resolves WHERE a password would go before any lock or budget

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2642,7 +2642,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `bounded_service_url` catch sites, each getting its own wording
     # distinct from the generic "unparseable" refusal. Cap 1090 -> 1106,
     # exact.
-    "backend/app/platform/service_items.py": 1106,
+    # chore(#1873): review-history comments trimmed. Cap 1106 -> 797, exact.
+    "backend/app/platform/service_items.py": 797,
     # fix(#1758): the ArcGIS sign-in protocol, which crossed 1000 lines over
     # nine review rounds. What the growth bought, in order: the two-phase
     # split that resolves WHERE a password would go before any lock or budget
@@ -2841,7 +2842,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # before the plain revokes it protects; mirror the multirange and
     # schema-less default-privilege refusals on the read side so the dry run
     # cannot call adopted what --apply stops on.
-    "backend/app/core/db/tenant_adoption.py": 1303,
+    # chore(#1873): review-history comments trimmed. Cap 1303 -> 1277, exact.
+    "backend/app/core/db/tenant_adoption.py": 1277,
     # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
     # matching the #435 convention: growth needs a reviewed carve-out here,
     # shrinking must lower the cap in the same commit.
@@ -5502,7 +5504,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # self-healing. The tag is reserved for up front, in the same limit
     # computation as the scope, the idiom `generate_table_name`'s own
     # `_with_collision_suffix` already uses. Cap 1702 -> 1725, exact.
-    "backend/app/processing/analysis/tasks.py": 1725,
+    # chore(#1873): review-history comments trimmed. Cap 1725 -> 1391, exact.
+    "backend/app/processing/analysis/tasks.py": 1391,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.


### PR DESCRIPTION
Refs #1873

Third slice of the measured cleanup: the forward-only tenant-adoption tool, the OGC API items reader, and the analysis materialize worker.

Comments and docstrings only. **No code line changed, not even a reformat**: a tokenizer that drops COMMENT tokens and replaces every docstring with a placeholder reports the token stream identical before and after for each file. SQL comments inside string literals are untouched for the same reason, since editing one would move a token.

Rules applied, per the convention in AGENTS.md: an inline comment that references a finding keeps its anchor and the invariant, three lines at most; docstrings state the contract and carry no anchors at all, so every `fix(#N)` in one is removed and the finding it pointed at is recorded below instead; every trap comment that names a concrete failure stays, phrased as the invariant it protects rather than as an account of the bug; comments that restated the next line were deleted. No comment block over three lines remains in any of the three files, and no docstring is written in the past tense about the code.

## None of the three files registers a route

This is the trap that cost #1922 eleven rounds, so it was checked first rather than assumed. All three files have zero route decorators and no `fastapi` import at all, so no published OpenAPI description moves and `backend/openapi.json`, both SDKs and `frontend/src/types/api.generated.ts` are untouched:

```
$ grep -nE '@[A-Za-z_.]*(router|app)\.(get|post|put|patch|delete|head|options|api_route|websocket)' \
    backend/app/core/db/tenant_adoption.py \
    backend/app/platform/service_items.py \
    backend/app/processing/analysis/tasks.py
$ echo $?
1
$ grep -n "fastapi\|APIRouter\|include_in_schema" <the same three files>
$ echo $?
1
```

Positive control for that pattern, so the empty result is evidence rather than a broken grep: the same expression finds 6 handlers in `backend/app/processing/tiles/router.py`.

## Bare finding markers

Three distinct bare markers were in these files and all are gone. `v1.6.0 audit D11`, `B12` and `B13` resolve only in a private audit document; `git log -S` on each places them in #813 (`fix: v1.6.0 pre-tag audit remediation`) and, for three of the six `B13` sites, #814 (`fix: pre-tag follow-up batch for 1.6.0`), so each site now carries the anchor its own line was introduced by. The bare `IN-01` in `_output_table_adopted` is replaced by the sibling it points at, the ingest discover query's tenant scoping, which a reader can actually find.

`PROCESS-02` stays. It is not a private-tracker id: it names a layering rule this repo defines and enforces in `backend/tests/test_layering.py`, and seven other files under `backend/app/` reference it by that name (`analysis/provenance.py`, `ingest/url_fetch.py`, `ingest/manifest_service.py`, `ingest/router.py`, `ai/chat_validation.py`, `export/router.py`, `catalog/sources/schemas.py`). Ten only if the `PROCESS-04` sibling is counted, which is not a reference by that name.

## Anchors carry the issue number and nothing else

`fix(#1746 B2b review r16)` is now `fix(#1746)`, `fix(#1770 round 47 P1)` is `fix(#1770)`, and so on for forty anchor occurrences across the three files. AGENTS.md gives the form as `fix(#1234)` and sends what the review said to the PR body or the issue, so the round, reviewer and severity labels are history by that definition. Issue numbers and the invariant after the colon are untouched.

This covers the anchors on lines the branch already rewrote and the ones it had otherwise left alone, so the three modules are closed out rather than leaving ten lines for a fourth pass.

Four markers are deliberately still there: `-- fix(#998 codex r46)` and its three siblings at `tenant_adoption.py:681,705,725,918` are SQL comments inside string literals, not Python comments. The substitution ran over COMMENT tokens only, so editing them would move a token and break the comment-only guarantee this branch rests on. They belong to whoever next edits that SQL.

Worth flagging for the issue rather than this PR: the merged slice #1922 left the same labels in its own files (`fix(#1778 r8)` and `fix(#430 V-03)` are both live in `processing/tiles/router.py` on main), so the same finding is waiting there.

## Before and after

Counted with the tokenizer: "prose" is comment plus docstring lines, "blocks" is runs of eight or more consecutive comment lines.

| file | lines before | lines after | prose before | prose after | blocks >= 8 before | blocks >= 8 after |
| --- | --- | --- | --- | --- | --- | --- |
| `core/db/tenant_adoption.py` | 1303 | 1276 | 150 | 124 | 0 | 0 |
| `platform/service_items.py` | 1106 | 797 | 608 | 309 | 13 | 0 |
| `processing/analysis/tasks.py` | 1725 | 1392 | 685 | 362 | 13 | 0 |

`tenant_adoption.py` reads much leaner than the table in #1873, which measured it at 673 prose lines on `b7478cc7a`. The file has since been split three ways: the ported DDL is in `tenant_adoption_sql.py` and the report types in `tenant_adoption_report.py`, and most of what remains here is SQL text inside string literals rather than comments. Its module docstring is deliberately over three lines: it is an operator entry point, and the invocation, the `--apply` contract and the ACL a restore leaves behind are the contract, not narrative. It is 24 lines rather than 49.

`_MODULE_LOC_CAPS` in `tests/test_layering.py` is lowered to each file's new exact size, since `test_module_loc_caps_have_no_headroom` requires exact.

## Verification

```
$ cd backend && uv run ruff check . && uv run ruff format --check .
All checks passed!
1184 files already formatted

$ python3 <scratch>/tokeq.py
OK: code tokens identical  backend/app/core/db/tenant_adoption.py
OK: code tokens identical  backend/app/platform/service_items.py
OK: code tokens identical  backend/app/processing/analysis/tasks.py

$ python3 <scratch>/blockcheck.py      # no comment run longer than three lines
backend/app/core/db/tenant_adoption.py: comment blocks >3 lines: none
backend/app/platform/service_items.py: comment blocks >3 lines: none
backend/app/processing/analysis/tasks.py: comment blocks >3 lines: none

$ pytest -q -p no:randomly tests/test_layering.py tests/test_rule1_structural.py \
    tests/test_rule2_structural.py tests/test_codeql_qtable_suppressions.py \
    tests/test_analysis_output_reap_1778.py tests/test_analysis_provenance.py \
    tests/test_analysis_materialize.py tests/test_analysis_intersect.py \
    tests/test_analysis_measure.py tests/test_analysis_preview.py \
    tests/test_analysis_select_by_location.py tests/test_analysis_spatial_join.py \
    tests/test_analysis_curved_sources.py
514 passed in 155.02s

$ pytest -q -p no:randomly tests/test_service_auth_transport_1746.py \
    tests/test_services_endpoints.py tests/test_service_column_info_1359.py \
    tests/test_tenant_ownership_adoption.py tests/test_tenant_attribution_materialize.py \
    tests/test_stale_pending_reaper.py tests/test_job_cancel_endpoint.py \
    tests/test_feature_lock_order_1847.py
673 passed, 1 skipped in 163.75s
```

The suites that read these modules as text pin AST shapes and code needles, not comment text: `test_analysis_output_reap_1778` on the resolve/persist/commit ordering and the scoped-name regex, and `TestBothModulesReadThroughOneRequestFunction` in `test_service_auth_transport_1746` on the single request site and the `# codeql[py/full-ssrf]` marker count in `service_items` (still zero).

No CHANGELOG entry, matching #1918 and #1922: the diff has no user-facing effect.

## History moved out of the source

### `backend/app/core/db/tenant_adoption.py`

**Module docstring (#998).** The reason the tool exists rather than a downgrade: migration `0019_tenant_provisioning_boundary` is the only place that has ever moved restored tenant schemas, roles and relations under the provisioning boundary, and reaching it again meant `alembic downgrade 0016`, which walks back through migrations that either refuse on data the current schema legitimately holds or discard state the re-upgrade cannot rebuild. On a populated cluster that is a data-loss event, not a recovery procedure. Two ways adoption deliberately differs from a replay of 0019: 0019 installs its SECURITY DEFINER functions with plain `CREATE FUNCTION`, which collides with the functions a restored dump already carries, and 0019 parked tenant relations on the provisioner so its provisioning function could rewrite their ACLs, which migration 0024 removed, so at head the relations move straight to the per-tenant writer and the reader's per-relation `SELECT` is granted by the writer itself, the same contract ingest follows.

**`live_tenant_boundary`.** Migration 0018 froze a six-table tuple by design and later migrations widened the live set. That is why the enumeration is read from the database; the docstring now says the invariant without the history.

**`_MEMBER_OPTIONS_PRESENT`.** `pg_auth_members.inherit_option`/`set_option` arrived in PostgreSQL 16 and GeoLens supports 13 and up per the README, so naming those columns directly is a parse error on an older server. Reading them back out of the row as jsonb parses everywhere.

**`cluster_topology_error`.** The rejected alternative was a read-only paraphrase of `ensure_cluster_roles`'s guard, which could drift from it.

**`missing_provisioner_grants`.** Replaying globals brings the provisioner role back and brings none of these object privileges with it.

**`ensure_cluster_roles`.** An operator may have granted the migrator the provisioner role by hand, especially before PostgreSQL 16 where CREATEROLE leaves no automatic membership to compare against.

**`release_bootstrap_membership`.** The automatic ADMIN membership PostgreSQL gives a role's creator cannot be revoked by a member: its grantor is the bootstrap superuser, and on a managed provider no customer role can assume that.

### Three docstring anchors with no entry below

The claim that every removed docstring anchor is recorded here was too broad, and it is worth being exact about which three are not, and how they differ.

For `_require_object` (r21) and `_has_next` (r28) only the anchor went; the sentence each one introduced survives verbatim in the docstring, so nothing about the behaviour is lost and there is no history to move. `_list_carry_columns` (#763) is the real one: the docstring keeps "every name is carried" and the GDAL laundering fact, but the failure clause was cut and is now recorded nowhere else in the repo, so it goes here. Filtering the carried columns to identifier-shaped names silently dropped legitimately named columns, `Área` or `2020_pop`, from every analysis output.

### `backend/app/platform/service_items.py`

**Module docstring (#1746 B2b review r16).** The measurement behind "GDAL offers no scope that would confine it": GDAL 3.10.3, the version in the worker image, was tested with two local servers, the credential configured for the first only, and `ogr2ogr` run against an OAPIF endpoint whose `next` pointed at the second. A `[configoptions]` section of a `GDAL_CONFIG_FILE` applied the option and proved the file is read; every `[credentials]` `path=` prefix applied it to nothing at all, including the origin it named. `CPLHTTPFetch`, which both the WFS and OAPIF drivers use, does not consult path-specific options for http(s) URLs; that section serves the `/vsi*` handlers. WFS was measured too rather than assumed: served a `wfs:FeatureCollection` carrying `next="http://other-origin/"`, GDAL never fetched it.

**`MAX_BYTES` (r17, r19, r20).** r17 added the download counter because a page is decoded before any feature of it is written, so counting the output missed where the memory goes. r19 removed a written-bytes counter on the reasoning that compact UTF-8 output is a subset of the pages it came from. r20 caught that: `1e15` is four bytes on the wire and parses to a float whose repr is eighteen characters, Python only switches to exponent notation at 1e16, so a chain comfortably inside the download cap could leave many gigabytes on a staging volume shared with every other import.

**`MAX_PAGE_BYTES` (r22).** 64 MiB down to 16 MiB. 16 MiB against `PAGE_SIZE` features is about 16 KiB of JSON per feature, still far past any honest geometry.

**`MAX_STRUCTURAL_TOKENS` (r22).** Measured on this interpreter against 1 MiB pages: `[1.5,1.5,...]` 8.2x (32.8 bytes per structural token), `[1,1,...]` 4.5x (8.9), `[{"a":1},...]` 24.1x (96.4), `[[[1]],...]` 30.7x (61.4). One 16 MiB page of the worst shape is about 490 MiB decoded and 64 MiB was about 2 GiB, the whole API container from a single page. A full page of `PAGE_SIZE` polygon features costs about 22,000 tokens, measured and pinned in the suite, so the bound is roughly ninety times what an honest service would produce.

**`MaterialisedCollection` (r24).** A preview asks for a handful of features and gets a file holding exactly that many, so everything downstream read the sample size as the collection's row count: the import preview showed it, and re-upload's schema diff turned it into a row-count delta against the real dataset.

**`_require_feature_page` (r21, r29, r31).** r21: `features or []` read an HTTP 200 JSON error envelope as an empty page, and read `"features": null` and `"features": {}` the same way, so a preview succeeded with zero rows and a refresh or re-upload handed an empty FeatureCollection to ogr2ogr. r29 enumerated the rest of the class; the `links`-present-but-not-a-list shape is the one it reported. OGC API Features requires links on every items response, which is why the second-page rule is spec-aligned. r31 added the `numberReturned` self-check.

**`_advertised_items_href` (r20).** Fabricating `/collections/{id}/items` was a regression against the path this replaced: GDAL followed the advertised link, and `service_endpoints` treats advertised links as authoritative, so a valid service with a non-conventional layout passed the probe and then 404ed at preview and import.

**`_with_page_size` and the three `bounded_service_url` sites (#1770 round 47 P1, 47b).** `_with_page_size` gating its own length again is defence in depth against a future second caller; `_advertised_items_href` already gates the same href once, so only an adversarial query packed with many short pairs reaches that `except` in practice. 47b gave each `HrefTooLongError` site its own wording rather than the generic "unparseable" refusal.

**`_fetch_page` (r23, r25, #1770 round 44 P2).** r23 moved the request itself into `fetch_document` so the two paths' protections cannot diverge again. The depth bomb in round 44 is 900,000 nested `[` at 1.8 bytes each, under both the byte cap and `MAX_STRUCTURAL_TOKENS`, which counts brackets rather than nesting depth; uncaught, a worker's OAPIF item-page walk died unclassified instead of surfacing this module's coded refusal.

**`_page_proves_complete` and the first-page proof (#1770 rounds 38, 40, 41, 42).** Round 38 read the two `links` shapes as one and additionally accepted a page shorter than `limit=PAGE_SIZE` as proof by itself, reasoning a server with more to give would have filled it. That assumes the server's own page size is at least `PAGE_SIZE`, which is the server's choice. Round 40 removed the length-based proof but then required `numberMatched` on the `links`-present shape too, refusing every conforming server that states no `next` and has nothing else to say. Round 42 made the two-shape rule one function, because a sampled preview landing on the same boundary had been asking a weaker, page-local question (`index + 1 < len(features) or _has_next(document)`) that could not see a service omitting both `links` and `numberMatched` on a page no bigger than the sample.

**`_sample_truncated` and `_end_of_chain` (#1770 round 42).** Both were extracted out of `_walk_pages` to keep it under ruff's C901 ceiling, the same way `_resolve_conformance` was extracted out of `probe_ogcapi` in #1746. Extraction is what this repo does about that rather than another exemption. `_end_of_chain` needs no `pages == 1` restriction on its sampled branch: `_require_links` already refuses an absent `links` member on every page past the first.

**`_walk_pages` counts (r30, r31, round 34).** r30 gated the whole `numberMatched` comparison on a full walk, which let a sampled read of five features past a `numberMatched` of two. Round 34 introduced `observed`, because a hundred-feature page under a `numberMatched` of ten and a five-row preview left `written == 5`, which is `<= 10` and passed: the sample masked the page's real size from the one check that exists to catch it.

**`_walk_pages` writes (r18, r19, r21, #1770 round 47 P2).** r18: closing the array at the page cap returns a prefix that reads as a complete collection. r19: the default `ensure_ascii=True` escapes every non-ASCII character to `\uXXXX`, so a collection of non-Latin text wrote roughly three bytes on disk for each one counted against the download cap. r21: the on-disk comparison used to happen after the write, so the bound was one expanded feature short of being one. Round 47 P2: `errors="surrogatepass"` and `"surrogateescape"` were both rejected, since either writes bytes GDAL and PostGIS cannot read back as UTF-8, trading a coded refusal for silent corruption on disk.

**`materialise_oapif_items` (r17, r28).** The client's own timeout is per inactivity, so ten thousand pages of a service trickling inside the read timeout is hours of an API request or an ingest worker, and this loop ran before the caller's own clock started in both callers. r28: `truncated` rather than `written >= feature_limit`, since the latter is also true of a collection holding exactly the sample size, which is a complete read whose total is known.

### `backend/app/processing/analysis/tasks.py`

**`materialize_timeout` (#1013).** The preview path is bounded by a 10s sandbox timeout and a 500-row cap; the CTAS is the only unbounded statement a user can queue.

**`registration_timeout` (#692).** Registration's fresh transaction runs full-scan metadata extraction, a COUNT plus ST_Extent plus the sample-values CTE. Larger than the CTAS budget by default because those scans are cheap relative to the build.

**`_materialize_work_mem` and `_apply_materialize_work_mem` (#1012, #694, #695).** The cluster-wide default is 8MB, right for eighty concurrent connections doing ordinary catalog queries and far too small for one buffer or dissolve over hundreds of thousands of geometries. Dissolve wants it most: #694 turned off hash aggregation there, and the sorted aggregation that replaces it is precisely what work_mem governs, so turning off hashagg without raising work_mem trades an OOM risk for a guaranteed spill. work_mem is allocated by the PostgreSQL backend, so the memory lands in the `db` service under DB_MEM_LIMIT, alongside shared_buffers (512MB), maintenance_work_mem (128MB) and up to `max_connections = 80` other backends. It is per operation and per backend, so one plan can allocate several multiples: at most 2 memory-hungry nodes for these shapes, times 2 backends, and the second factor is guaranteed rather than assumed because the override pins `max_parallel_workers_per_gather` to 1 for this transaction. The ceiling is a setting because DB_MEM_LIMIT is a compose `mem_limit` never passed into this container's environment, and because the divisor bounds concurrent materializes inside one worker process and cannot bound a deployment running several worker replicas against the `ingest` queue, which is #695's open question. Measured on a 60k-polygon grouped dissolve with `enable_hashagg = off`, the leader's sort wanted 96MB: at the 8MB default it spilled 70MB to disk and at 128MB it stayed in memory, so the 64MB default shrinks that spill rather than eliminating it. There is deliberately no floor at the bundled 8MB, because an external PostgreSQL tuned below it would be raised by a clamp advertised as leaving it alone.

**`_user_error_message` (#692, #1013 review, #813, #766).** Naming the wrong budget was harmless while both were hardcoded at 300s/600s and only the first was ever quoted; now that an operator can set them independently, a registration timeout quoting the materialize budget sends them to tune the setting that did not fire. The SQLSTATE list is 42883 undefined_function (no equality operator for `json` in a dissolve GROUP BY), 42803 grouping_error and 42804 datatype_mismatch, deliberately not the whole class 42.

**`_fail_cancelled_job` (#700 review).** The cancel can land while the working session's open transaction still holds the job-row lock, from any flush since its last commit.

**The fence-miss handlers (#786, #813, #814).** #786 fenced the terminal writes on the attempt token: the previous plain ORM write could overwrite a terminal state some other actor already set, either the stale-job sweep failing the row after a stalled lease or a final commit that reached the server before the connection dropped. #813 stamped `completed_at` on terminal writes, matching the ingest tasks. #814 added the adoption probe to the fence-miss paths, where a swept row used to leave an unregistered orphan that leaked permanently.

**The live-schema rechecks (#953, #954, #956, #1097 review, #1099).** Each has an enqueue-time twin reading `column_info`, and the queue wait is the window. `_resolve_and_validate_columns` was extracted in the #1097 review rather than raising the C901 threshold on `_materialize`, once the set had grown to five checks over two layers. #1099 retired the overlay's ungroupable-type recheck, since intersect joins its overlay attributes back outside the aggregate now. `_ungroupable_type_name` exists because an exact `data_type` comparison admitted `json[]`/`xml[]` columns straight into GROUP BY, where PostgreSQL cannot apply equality to them (SQLSTATE 42883, verified), and the catalog snapshot has the same blind spot. `_reject_missing_join_fields` was the gap in that set: the worker re-resolved the join layer's table without ever re-checking its columns.

**`_resolve_layer_table_ref` geometry strengths (#1097 review).** "polygonal" is the mask's, because `_load_mask_dataset` refuses points and lines, and nothing downstream notices if that changes: the mask expression simply matches no rows and the job dies on "Analysis produced no features", which sends the user to look at their own data rather than at the layer that changed underneath them. "any" is the join layer's, because a spatial join counts in any direction and only the absence of geometry is fatal: a re-upload from a non-spatial source sets `geometry_type` to None and builds a table with no `geom_4326`, which `render_spatial_join` references.

**`_enforce_output_size` (#701 review).** The `regclass` cast was rejected because the tenant statement hook only recognizes schema references in SQL text or schema-named binds and masks string literals.

**The #1778 output-table record (codex r6, r7, r9, r10, audit r11).** `out_table` is generated inside the worker and nothing durable carried it, so a SIGKILL after the materialize commit left `data.<out_table>` plus its GIST index, up to MAX_OUTPUT_BYTES, with no catalog row, no DROP and no reconciler that could name it. r7 scoped the name by job, which stopped two different jobs sharing one. r10 added the attempt, because a retry is the same job: `/jobs/{id}/retry` keeps the id and mints a new attempt token, so a stale sweep could capture attempt 1's name, settle the job failed, then probe and drop while attempt 2 was creating that same name, and the ownership check passed because the name really was this job's. The r8 objection to attempt scoping was that it strands the previous attempt's orphan; that is answered by making the record a list each attempt appends to, the shape `unpublished_storage_keys` took in r9. r6 made the drop report its outcome rather than returning the same `None` whether it dropped the table or failed to, because the sweeps clear the recorded name on the strength of that call and a swallowed failure read as success stripped the last pointer to the table. Audit r11: `analysis_output_table_name` takes `collision_suffix` rather than the caller pre-pending `_N` to `base` and calling again, because trimming an already-trimmed string a second time truncates the characters that make one candidate differ from the next, so a `base` at or past the reserved limit (46 chars with no tag) made every walked candidate identical and exhausted the whole `_N` walk instead of self-healing.

**`resolve_analysis_output_table` (#1778 codex r10).** The concrete failure: a base of `parcels` probes `parcels%`, finds `parcels_ab12cd34ef56ab78` in pg_class, asks whether `parcels` is taken, and hands back `parcels` unsuffixed, which scopes straight back onto the occupied name and fails at CREATE TABLE. Attempt scoping makes that rare but not unreachable, since the same attempt can be delivered twice.

**`_wrap_not_empty` (#786, #719 review, #680 review).** The post-CTAS DELETE cannot shrink what `pg_total_relation_size` measures, because dead tuples keep their pages until a rewrite, so rows the cleanup removed counted toward the output ceiling for buffer/centroid/dissolve and the drawn-mask clip. The clip-by-layer branch had filtered in-CTAS since the #719 review; #786 extended the rule. The preview filters the same rows in SQL since the #680 review, so the saved dataset agrees with the preview the user approved.

**`_build_materialize_select` branches (#719, #953, #954, #955, #956, #836).** #719: a single whole-layer `ST_Union` meant a clip whose preview came back in under a second could exhaust the 300s CTAS budget on "Create dataset"; see `render_clip_layer_join` for the measurements. The clip filter is in-CTAS because the row filter admits a source row on a bounding-box overlap, so a wide or concave mask lets through rows whose geometries never intersect and whose lateral yields `geom_out = NULL`, and clip has no source-feature cap bounding how many of them there are. #836: `_SAFE_IDENT` already guards `by_field`, but a lone inline-quoting divergence is where the next escaping bug hides.

**`_materialize` (#682 review, #692, #786, #1013 review, #1452).** #682: `statement_timeout` bounds each statement, not the task, so a large materialize can legitimately run long and only the lease keeps it out of the sweep. Without the fenced claim this worker acts on rows some other actor already moved to a terminal state, the pending-sweeper failing a backlogged job after an hour or the defer orphan-guard failing the row after the queue INSERT committed. The row's own `attempt_id` is the token, column-defaulted at creation, and `retry=0` means there is no second delivery to fence against. #786: discarding `collision_warning` silently landed an analysis output in e.g. `parcels_buffered_3` with no indication to the user. #1452: without `managed=True` the output would be indistinguishable from a table an operator registered, same postgis origin and same null `source_format`, and the detach that protects the operator's table would leak one of these on every delete. The provenance `mask_source` discriminator covers every operation that can take a drawn mask rather than clip alone, because the drawn geometry itself is excluded from provenance for size, so for a drawn `select_by_location` it is the only trace that an area shaped the selection at all.
