### PR TITLE
chore(backend): resolve the comment-anchor findings in #1940, #1941 and #1927

### DIFF
--- a/backend/app/modules/catalog/sources/cog_info.py
+++ b/backend/app/modules/catalog/sources/cog_info.py
@@ -191,7 +191,7 @@ async def fetch_cog_info(url: str) -> dict | None:
     settle: under-stamping a real contact is recoverable, fabricating one
     for a never-contacted origin is not.
 
-    SEC-OBSV-02 (sec-audit 2026-05-21): SSRF protection here is a DUAL GATE.
+    fix(#1927) SEC-OBSV-02: SSRF protection here is a DUAL GATE.
     Both gates MUST be preserved when adding new callers -- bypassing either
     is an SSRF regression:
 

--- a/backend/app/modules/catalog/sources/cog_info.py
+++ b/backend/app/modules/catalog/sources/cog_info.py
@@ -191,25 +191,14 @@ async def fetch_cog_info(url: str) -> dict | None:
     settle: under-stamping a real contact is recoverable, fabricating one
     for a never-contacted origin is not.
 
-    fix(#1927) SEC-OBSV-02: SSRF protection here is a DUAL GATE.
-    Both gates MUST be preserved when adding new callers -- bypassing either
-    is an SSRF regression:
-
-    Gate 1 (caller-side): EVERY caller of _fetch_cog_info MUST first call
-    app.platform.security.validate_url_for_ssrf(url) before
-    passing the URL here. The import-flow call at line 454 satisfies this;
-    any new caller MUST add the same pre-validation.
-
-    Gate 2 (Titiler-side): docker-compose's Titiler service sets
-    CPL_VSIL_CURL_ALLOWED_EXTENSIONS=.tif,.tiff,.cog,.vrt -- even if a
-    malicious URL slips past Gate 1, Titiler's own GDAL VSI clamp rejects
-    non-raster file extensions.
-
-    Removing Gate 1 OR loosening Gate 2 must be a deliberate audit-tracked
-    decision, not a refactor side-effect. fix(#1375) added a third request to
-    the same internal Titiler service for the same already-validated ``url``,
-    inside both gates and adding no origin this function did not already
-    reach; a caller that reached a new origin would need its own Gate 1.
+    SEC-OBSV-02: SSRF protection is a dual gate and both halves must hold for
+    every caller. Gate 1 is caller-side: validate the URL with
+    ``app.platform.security.validate_url_for_ssrf`` before calling this
+    function. Gate 2 is Titiler-side: the service sets
+    ``CPL_VSIL_CURL_ALLOWED_EXTENSIONS``, so its own GDAL VSI clamp rejects a
+    non-raster extension even for a URL that slipped past Gate 1. Removing
+    Gate 1 or loosening Gate 2 is an SSRF regression, not a refactor
+    side-effect. Recorded in #1927.
     """
     try:
         async with httpx.AsyncClient(

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -42,7 +42,7 @@ logger = structlog.stdlib.get_logger(__name__)
 
 # PostgreSQL OID / OID-alias types. The ``reg*`` family resolves an integer OID
 # to a catalog NAME (role, relation, namespace, function, type), and the family
-# is the building block of ``::oid::regrole`` chains (fix(#565 r11/r12)).
+# is the building block of ``::oid::regrole`` chains (fix(#565)).
 _OID_ALIAS_TYPES: frozenset[str] = frozenset(
     {
         "oid",
@@ -429,7 +429,7 @@ _MAX_LINEAGE_HOPS = 4
 
 # The managed 4326 geometry column. Ingest keeps the ORIGINAL `geom` in
 # whatever CRS it arrived in and adds this one alongside, so "reached a base
-# table" is not "reached a bounded geometry" (fix(#1001 r3)).
+# table" is not "reached a bounded geometry" (fix(#1001)).
 _MANAGED_GEOMETRY_COLUMN = "geom_4326"
 
 
@@ -563,7 +563,7 @@ def _derived_select(source: exp.Expression, owner: exp.Select) -> exp.Select | N
     if isinstance(source, exp.Table):
         # Schema-less: a reference to a CTE, resolved by the CTE's OWN name
         # rather than by the binding name — `FROM bad AS x` binds x to bad
-        # (fix(#1001 codex r3)).
+        # (fix(#1001)).
         definition = _cte_definition(owner, source.name)
         return definition if isinstance(definition, exp.Select) else None
     if isinstance(source, exp.Subquery) and isinstance(source.this, exp.Select):
@@ -924,7 +924,7 @@ def _check_function_allowlist(
         if fn_name in _BLOCKED_FUNCTIONS or (
             extra_blocked is not None and fn_name in extra_blocked
         ):
-            # fix(#565 r17): `extra_blocked` lets the raw-SQL endpoint drop
+            # fix(#565): `extra_blocked` lets the raw-SQL endpoint drop
             # output-amplifying functions that neither the SQL-length cap nor
             # row_limit bounds, while AI chat keeps them.
             logger.info("sandbox.blocked_function", sql=sql, function=fn_name)
@@ -1004,7 +1004,7 @@ def validate_sql(
 
     _reject_oversized_values(stmt, sql, max_values_rows)
 
-    # fix(#565 r19): `||` is string concatenation, an output amplifier
+    # fix(#565): `||` is string concatenation, an output amplifier
     # equivalent to concat, and an exp.DPipe operator rather than a Func, so
     # the function blocklist misses it. Blocked when the caller blocks concat.
     if (
@@ -1029,7 +1029,7 @@ def validate_sql(
     # access-checked. Everything left must pass the data.* check.
     tables: set[tuple[str, str]] = set()
     for table in stmt.find_all(exp.Table):
-        # fix(#565 r23): fold unquoted identifiers as PostgreSQL resolves them
+        # fix(#565): fold unquoted identifiers as PostgreSQL resolves them
         # BEFORE the access check -- `FROM DATA.ROADS` resolves to `data.roads`,
         # so comparing the preserved case would 404 a readable table.
         schema = _folded_identifier(table.args.get("db")) or ""
@@ -1085,7 +1085,7 @@ def _resolve_cte(table: exp.Table) -> exp.CTE | None:
                         return c
         elif isinstance(node, _SCOPE_TYPES):
             # The WITH's arg key has drifted across sqlglot releases
-            # ("with" -> "with_"), so find it by type. fix(#565 P2 r5): a WITH
+            # ("with" -> "with_"), so find it by type. fix(#565): a WITH
             # over a UNION attaches to the exp.Union, not to its branches.
             with_clause = next(
                 (c for c in node.iter_expressions() if isinstance(c, exp.With)),
@@ -1144,7 +1144,7 @@ _SCOPE_TYPES: tuple[type[exp.Expression], ...] = (
     exp.Except,
 )
 
-# fix(#565 r20): a synthetic key for the TOTAL cross-product degree.
+# fix(#565): a synthetic key for the TOTAL cross-product degree.
 # Per-base-table exponents catch SELF-join amplification, but three DISTINCT
 # tables cross-joined is N*M*K with each at exponent 1, so the max misses it.
 _XPROD_KEY: tuple[str, str] = ("", "__xprod__")
@@ -1275,7 +1275,7 @@ def _source_fanout(source: exp.Expression, memo: _FanoutMemo) -> _FanoutMap:
         # reject) is scanned once.
         return {(source.db or "", source.name): 1}
     if isinstance(source, exp.Lateral):
-        # fix(#565 r6): a LATERAL re-evaluates per outer row and its OUTPUT
+        # fix(#565): a LATERAL re-evaluates per outer row and its OUTPUT
         # rows join into the FROM product, so it is a row source like a derived
         # table. Its INTERNAL per-row work is added in _work_fanout.
         inner = _lateral_inner_scope(source)
@@ -1284,12 +1284,12 @@ def _source_fanout(source: exp.Expression, memo: _FanoutMemo) -> _FanoutMap:
         inner = source.this
         if isinstance(inner, _SCOPE_TYPES):
             return _rows_fanout(inner, memo)
-        # fix(#565 r8): a parenthesized FROM join group is a Subquery wrapping
+        # fix(#565): a parenthesized FROM join group is a Subquery wrapping
         # a Table that carries its joins in `.args["joins"]`, not a SELECT, so
         # cost the head and every joined source rather than reporting 0.
         return _group_fanout(inner, memo)
     if isinstance(source, exp.Values):
-        # fix(#565 r17/r18): a constant VALUES relation contributes rows, and
+        # fix(#565): a constant VALUES relation contributes rows, and
         # ALL VALUES share ONE key -- per-node ids let k distinct VALUES each
         # report 1 and slip 256^k combinations.
         return {("", "__values__"): 1}
@@ -1487,7 +1487,7 @@ def _correlated_scopes(
                 # own per-row predicate.
                 break
             elif isinstance(ancestor, exp.AggFunc):
-                # fix(#565 r15): an aggregate ARGUMENT (or FILTER) is evaluated
+                # fix(#565): an aggregate ARGUMENT (or FILTER) is evaluated
                 # for every INPUT row, so the ungrouped-aggregate reduction
                 # must NOT zero its multiplier.
                 under_aggregate = True
@@ -1495,7 +1495,7 @@ def _correlated_scopes(
             ancestor = ancestor.parent
         if clause is None:
             continue
-        # fix(#565 P2 r14/r16): classified by the clause that runs the scope.
+        # fix(#565): classified by the clause that runs the scope.
         # Only per-output work shrinks when the SELECT aggregates, EXCEPT an
         # aggregate argument; LIMIT / OFFSET are evaluated ONCE.
         if isinstance(clause, (exp.Limit, exp.Offset)):
@@ -1533,7 +1533,7 @@ def _work_fanout(
     out = dict(input_rows)
     if isinstance(node, exp.Select):
         # SIBLING per-row scopes run additively, so combine each group by the
-        # per-table MAX rather than the sum (fix(#565 P2 r13): summing rejects
+        # per-table MAX rather than the sum (fix(#565): summing rejects
         # a legitimate query with two scalar subqueries over one table).
         per_input, per_output, per_statement = _correlated_scopes(node)
         pin: _FanoutMap = {}

--- a/backend/app/platform/service_endpoints.py
+++ b/backend/app/platform/service_endpoints.py
@@ -62,7 +62,7 @@ ENDPOINT_CHECK_FAILED_POLICY = (
     "again."
 )
 
-# fix(#1770 r37/r46): only the rels this codebase dereferences, scoped to the
+# fix(#1770): only the rels this codebase dereferences, scoped to the
 # document type each is read FROM -- `conformance` off the LANDING page,
 # `items` off the COLLECTION document. Listing pages and entries read neither.
 _LANDING_RELS = frozenset({"conformance"})
@@ -101,22 +101,22 @@ MAX_DOCUMENT_TOKENS = 1_000_000
 # ~162 MiB at the worst measured 339 bytes each, ten times any real document.
 MAX_DOCUMENT_ELEMENTS = 500_000
 
-# fix(#1770 r43): a single start tag carrying hundreds of thousands of
+# fix(#1770): a single start tag carrying hundreds of thousands of
 # attributes counts as ONE `<`, so the per-element budget never sees it while
 # expat still allocates one dict entry per attribute. Bounded directly.
 MAX_DOCUMENT_ATTRIBUTES = 500_000
 
-# fix(#1770 r47): 256, well under `sys.getrecursionlimit()`'s default of
+# fix(#1770): 256, well under `sys.getrecursionlimit()`'s default of
 # 1,000. A budget at that default admits a document deep enough to blow the
 # interpreter's own stack in whatever walks the parsed tree next.
 MAX_DOCUMENT_DEPTH = 256
 
-# fix(#1770 r47): a service-advertised href's query string is free real estate
+# fix(#1770): a service-advertised href's query string is free real estate
 # no document budget prices -- its separators live inside one JSON string, so
 # `structural_tokens` answers ~0. 8192 is the conventional request-line limit.
 MAX_SERVICE_HREF_BYTES = 8192
 
-# fix(#1770 r47): the second, independent bound -- 8192 bytes still packs over
+# fix(#1770): the second, independent bound -- 8192 bytes still packs over
 # a thousand `a=1&` pairs, and no real operation link carries a few dozen.
 MAX_QUERY_FIELDS = 256
 
@@ -153,7 +153,7 @@ def bounded_parse_qsl(query: str) -> list[tuple[str, str]]:
 # means no caller deadline, which is the direct-call and offline case.
 DEFAULT_CHECK_TIMEOUT = 30.0
 
-# What to ask a service for. fix(#1746 r25): content negotiation belongs to the
+# What to ask a service for. fix(#1746): content negotiation belongs to the
 # read, not to a header a caller may forget -- a service that serves HTML for
 # `*/*` answers the probe with a document and the check with a web page.
 OGC_JSON_ACCEPT = "application/geo+json, application/json"
@@ -266,17 +266,17 @@ def _capabilities_url(url: str) -> str:
 
 # The two ways a WFS capabilities document names an operation endpoint: 1.1/2.0
 # `ows:DCP/ows:HTTP/ows:Get` with `xlink:href`, 1.0 `DCPType/HTTP/Get` with an
-# `onlineResource` attribute and no xlink (fix(#1746 r15)). Matched by LOCAL name.
+# `onlineResource` attribute and no xlink (fix(#1746)). Matched by LOCAL name.
 _WFS_ENDPOINT_ATTRIBUTES = frozenset({"href", "onlineresource"})
 
-# fix(#1770 r36): the operations the read-only ogr2ogr/OGR_WFS path can ever
+# fix(#1770): the operations the read-only ogr2ogr/OGR_WFS path can ever
 # ask for. Transaction, LockFeature and the stored-query operations are never
 # requested, so their advertised endpoint is never contacted. Matched lower-cased.
 _WFS_READ_OPERATIONS = frozenset(
     {"getcapabilities", "describefeaturetype", "getfeature", "getpropertyvalue"}
 )
 
-# fix(#1770 r36): WFS 1.0 has no element naming an operation the way
+# fix(#1770): WFS 1.0 has no element naming an operation the way
 # `ows:Operation name="..."` does -- the operation IS the element under
 # `<Request>`, so this closed vocabulary keeps `Request`/`DCPType`/`HTTP` out.
 _WFS_1_0_OPERATION_TAGS = frozenset(
@@ -299,7 +299,7 @@ def _local_name(tag: str) -> str:
 def _wfs_root(xml_bytes: bytes) -> Element:
     """Parse an untrusted WFS document: bytes so an encoding declaration is
     honoured, DTD refused."""
-    # fix(#1746 r26): `forbid_dtd=True`. defusedxml refuses entity declarations
+    # fix(#1746): `forbid_dtd=True`. defusedxml refuses entity declarations
     # by default but allows a DOCTYPE naming an external subset, which a WFS
     # document has no use for and the element bound cannot see.
     return ET.fromstring(xml_bytes, forbid_dtd=True)
@@ -321,7 +321,7 @@ def _operation_hrefs(root: Element) -> list[str]:
     spell the namespaces differently, and parsed with defusedxml.
     """
     hrefs: list[str] = []
-    # fix(#1770 r47): iterative, not recursive. A recursive walk is bounded by
+    # fix(#1770): iterative, not recursive. A recursive walk is bounded by
     # `sys.getrecursionlimit()` (default 1,000), not by `MAX_DOCUMENT_DEPTH`,
     # so it can blow the stack on a document the preflight admits.
     stack: list[tuple[object, str | None]] = [(root, None)]
@@ -371,12 +371,12 @@ def _next_page(document: object, base: str) -> str | None:
     for link in document.get("links", []) or []:
         if isinstance(link, dict) and link.get("rel") == "next" and link.get("href"):
             try:
-                # fix(#1770 r47): refused before `urljoin` even runs.
+                # fix(#1770): refused before `urljoin` even runs.
                 resolved = urljoin(
                     base, bounded_service_url(str(link["href"]), what="next")
                 )
             except ValueError as exc:
-                # fix(#1746 r16, #1770 r47b): an address the parser cannot read
+                # fix(#1746, #1770): an address the parser cannot read
                 # is not one to walk to, and the stop is warned rather than
                 # silent. The href never reaches the message; it is untrusted.
                 logger.warning(
@@ -399,19 +399,19 @@ def _assert_same_origin(url: str, hrefs: list[str], base: str | None = None) -> 
     """
     for href in hrefs:
         try:
-            # fix(#1770 r47): the shared length gate both the OGC API and the
+            # fix(#1770): the shared length gate both the OGC API and the
             # WFS href sinks feed into, applied before `urljoin`.
             href = bounded_service_url(href, what="operation")
-            # fix(#1746 r19): resolved against the document, which after a
+            # fix(#1746): resolved against the document, which after a
             # canonical redirect is not the URL asked for; the origin compared
             # against is still the submitted one.
             resolved = urljoin(base or url, href)
         except HrefTooLongError:
-            # fix(#1770 r47b): its own wording -- "unparseable" is true of a
+            # fix(#1770): its own wording -- "unparseable" is true of a
             # malformed address but not of one merely too long to be parsed.
             raise CrossOriginEndpointError("href exceeds the length limit") from None
         except ValueError:
-            # fix(#1746 r16): `urljoin` raises on some malformed absolute
+            # fix(#1746): `urljoin` raises on some malformed absolute
             # references. An address that cannot be resolved is not one to send
             # a credential to; the raw href is never echoed.
             raise CrossOriginEndpointError("unparseable") from None
@@ -698,7 +698,7 @@ async def fetch_document(
     try:
         await validate_url_for_ssrf(url)
         if on_first_request is not None:
-            # fix(#1746 r34): only once validation has succeeded.
+            # fix(#1746): only once validation has succeeded.
             on_first_request()
         # The client's transport pins the validated IP and revalidates every
         # redirect hop. The marker below must stay the LAST line before the call.
@@ -709,7 +709,7 @@ async def fetch_document(
                 # exist to distrust is not worth the bytes.
                 raise error(f"HTTP {response.status_code}")
             body = await read_bounded_body(response, budget, error=error)
-            # fix(#1746 r19): the URL the representation actually came from. A
+            # fix(#1746): the URL the representation actually came from. A
             # same-origin canonical redirect changes what a relative href in
             # the body is relative to.
             final_url = str(response.url)
@@ -1261,12 +1261,12 @@ async def _check_wfs(
         root = _wfs_root(xml_bytes)
         hrefs = _operation_hrefs(root)
     except (ET.ParseError, DefusedXmlException) as exc:
-        # fix(#1746 r26): `DefusedXmlException` is a `ValueError`, NOT a
+        # fix(#1746): `DefusedXmlException` is a `ValueError`, NOT a
         # `ParseError`, so catching only the latter lets a document carrying an
         # entity declaration escape as a 500.
         raise EndpointCheckFailedError(str(exc)) from None
     except RecursionError as exc:
-        # fix(#1770 r47): last line of defense -- the walk above is iterative
+        # fix(#1770): last line of defense -- the walk above is iterative
         # now, but `ET.fromstring` is not this module's code. Translated to the
         # coded refusal every other unreadable description gets.
         raise EndpointCheckFailedError(str(exc)) from None
@@ -1282,14 +1282,14 @@ async def _check_ogcapi(
     on_first_request: "Callable[[], None] | None" = None,
 ) -> None:
     body, from_url = await _fetch(client, url, headers, on_first_request)
-    # fix(#1770 r46): the landing page, the only document type `conformance` is
+    # fix(#1770): the landing page, the only document type `conformance` is
     # ever read from.
     _assert_same_origin(
         url, _ogcapi_link_hrefs(_parsed_json(body), _LANDING_RELS), from_url
     )
 
     if collection is not None:
-        # fix(#1746 r14): the collection this import will actually read,
+        # fix(#1746): the collection this import will actually read,
         # fetched directly -- a listing is paginated, so a check that reads
         # only the first page misses a collection chosen from a later one.
         body, from_url = await _fetch(
@@ -1298,7 +1298,7 @@ async def _check_ogcapi(
             headers,
         )
         document = _parsed_json(body)
-        # fix(#1770 r46): the collection document, the only document type
+        # fix(#1770): the collection document, the only document type
         # `items` is ever read from.
         _assert_same_origin(
             url, _ogcapi_link_hrefs(document, _COLLECTION_RELS), from_url
@@ -1307,20 +1307,20 @@ async def _check_ogcapi(
 
     # The probe has no collection yet, so it walks the listing. Bounded, and
     # reaching the bound is recorded rather than treated as a clean pass. The
-    # `collection is not None` branch above has no live caller (fix(#1770 r46b)).
+    # `collection is not None` branch above has no live caller (fix(#1770)).
     page_url: str | None = f"{url.rstrip('/')}/collections"
     for _page in range(_MAX_COLLECTION_PAGES):
         if page_url is None:
             return
         body, from_url = await _fetch(client, page_url, headers)
         listing = _parsed_json(body)
-        # fix(#1770 r46/r46b): the listing page dereferences neither rel, and
+        # fix(#1770): the listing page dereferences neither rel, and
         # `frozenset()` names that at a call site a structural test pins. A
         # deliberate no-op: `_ogcapi_link_hrefs` returns `[]` for any document.
         _assert_same_origin(url, _ogcapi_link_hrefs(listing, frozenset()), from_url)
         collections = listing.get("collections") if isinstance(listing, dict) else None
         for entry in collections or []:
-            # fix(#1770 r46/r46b): an entry's inlined `items` href is never
+            # fix(#1770): an entry's inlined `items` href is never
             # read either -- `_resolve_items_url` re-fetches the collection
             # document. Kept as a call site for the same structural test.
             _assert_same_origin(url, _ogcapi_link_hrefs(entry, frozenset()), from_url)

--- a/backend/app/platform/storage/titiler_url.py
+++ b/backend/app/platform/storage/titiler_url.py
@@ -20,8 +20,8 @@ under `cog_url.py` would mislead future readers.
 
 NOTE: Titiler is currently internal-only (no `ports:` block in docker-compose).
 If that ever changes, the security stance at tiles/router.py::_titiler_client
-(SEC-OBSV-01) and stac_router.py::_fetch_cog_info (SEC-OBSV-02) must be
-re-audited — see the docstring contracts at those sites.
+(fix(#1927) SEC-OBSV-01) and sources/cog_info.py::fetch_cog_info
+(fix(#1927) SEC-OBSV-02) must be re-audited — see the contracts at those sites.
 """
 
 from urllib.parse import urlencode

--- a/backend/app/platform/storage/titiler_url.py
+++ b/backend/app/platform/storage/titiler_url.py
@@ -20,8 +20,8 @@ under `cog_url.py` would mislead future readers.
 
 NOTE: Titiler is currently internal-only (no `ports:` block in docker-compose).
 If that ever changes, the security stance at tiles/router.py::_titiler_client
-(fix(#1927) SEC-OBSV-01) and sources/cog_info.py::fetch_cog_info
-(fix(#1927) SEC-OBSV-02) must be re-audited — see the contracts at those sites.
+(SEC-OBSV-01) and sources/cog_info.py::fetch_cog_info (SEC-OBSV-02) must be
+re-audited. Both are recorded in #1927; the contracts live at those sites.
 """
 
 from urllib.parse import urlencode

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -1193,20 +1193,12 @@ async def create_fan_out_jobs(
     except (
         Exception
     ) as exc:  # broad: any clone/defer failure returns per-layer error, not a 500
-        logger = None
-        try:
-            import structlog as _structlog
-
-            logger = _structlog.get_logger(__name__)
-        except Exception:  # broad: structlog optional — defer to print if unavailable
-            pass
-        if logger:
-            logger.warning(
-                "Fan-out layer dispatch failed",
-                layer_name=layer.layer_name,
-                original_job_id=str(original_job.id),
-                error=str(exc),
-            )
+        logger.warning(
+            "Fan-out layer dispatch failed",
+            layer_name=layer.layer_name,
+            original_job_id=str(original_job.id),
+            error=str(exc),
+        )
         # fix(#1774 review, codex P2): reset the session before returning. The
         # commit above carries this child's row AND its dispatch marker, and a
         # transactional failure there leaves the session refusing every later
@@ -1232,12 +1224,11 @@ async def create_fan_out_jobs(
             await session.rollback()
             await session.refresh(original_job)
         except Exception:  # broad: a dead connection cannot be reset here
-            if logger:
-                logger.warning(
-                    "Fan-out layer session reset failed",
-                    layer_name=layer.layer_name,
-                    original_job_id=parent_job_id,
-                )
+            logger.warning(
+                "Fan-out layer session reset failed",
+                layer_name=layer.layer_name,
+                original_job_id=parent_job_id,
+            )
         from app.processing.ingest.schemas import FanOutLayerResult
 
         return FanOutLayerResult(

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -728,7 +728,7 @@ async def _resolve_raster_meta(
         nodata=row["nodata"],
         tile_cache_version=row["tile_cache_version"] or 1,
     )
-    # fix(#1329 P1): the write key comes from the SNAPSHOT's own version. Under
+    # fix(#1329): the write key comes from the SNAPSHOT's own version. Under
     # the requested one, `v=N+1` against a row at N parks the CURRENT snapshot
     # on that key, and it survives the swap for a full TTL.
     store_key = (
@@ -794,7 +794,7 @@ async def _resolve_raster_access(
     Raises HTTPException on any auth or lookup failure.
     """
     # Metadata comes from cache; auth checks always run per-request.
-    # fix(#1518 P2 r3): a 404 here precedes any capability evaluation, so the
+    # fix(#1518): a 404 here precedes any capability evaluation, so the
     # credential rule applies to the answer.
     try:
         meta = await _resolve_raster_meta(db, dataset_id, requested_version)
@@ -899,7 +899,7 @@ async def raster_auth_check(
         403 if embed token is invalid
         404 if dataset not found, not a raster, or has no raster asset
     """
-    # fix(#1372 r4): nginx keys on the FIRST occurrence of `v` and matches the
+    # fix(#1372): nginx keys on the FIRST occurrence of `v` and matches the
     # name case-insensitively; `QueryParams.get()` returns the LAST occurrence
     # of an exact-case name. Read once, because two decisions below use it.
     v_values = [
@@ -926,7 +926,7 @@ async def raster_auth_check(
         if _is_publicly_cacheable(meta.visibility, meta.record_status)
         else "private"
     )
-    # fix(#1372 r3/r4): a shared-cache entry may only be written under the
+    # fix(#1372): a shared-cache entry may only be written under the
     # CURRENT version, or a caller pre-warms the NEXT key with pre-replace
     # bytes. So: exactly one case-insensitive `v`, or served no-store.
     if (
@@ -1060,7 +1060,7 @@ async def raster_tile_proxy(
     # as "png?stretch=..." and the built URL carries two `?` (Titiler 422s).
     if "?" in fmt:
         # Recover render params that arrived ONLY in the path, so styling is not
-        # silently dropped. fix(#1770 r47b): bounded, because `{fmt}` is
+        # silently dropped. fix(#1770): bounded, because `{fmt}` is
         # attacker-reachable unauthenticated; a ValueError recovers nothing.
         try:
             _buried = parse_qs(fmt.split("?", 1)[1], max_num_fields=MAX_QUERY_FIELDS)
@@ -1098,7 +1098,7 @@ async def raster_tile_proxy(
         )
 
     # Effective bounds resolved ONCE, where activity is decided: an INACTIVE
-    # parameter's value is ALWAYS the absent default. fix(#1778 r8): otherwise
+    # parameter's value is ALWAYS the absent default. fix(#1778): otherwise
     # `?stretch=stddev&pmin=1e309` set eff_pmin=inf and 500'd on `int(pmin)`.
     _pmin_pmax_active = stretch == "percentile"
     _sigma_active = stretch == "stddev"
@@ -1108,7 +1108,7 @@ async def raster_tile_proxy(
 
     # Validated before any Titiler call, and only when the ACTIVE
     # stretch mode reads the value, so a value nginx blanks from the cache key
-    # cannot turn a cached 200 into a 422. fix(#1778 r8): isfinite explicitly.
+    # cannot turn a cached 200 into a 422. fix(#1778): isfinite explicitly.
     if stretch == "percentile" and (pmin is not None or pmax is not None):
         if (
             not math.isfinite(eff_pmin)
@@ -1536,7 +1536,7 @@ async def get_tile_tokens_batch(
             raster_assets_by_dataset_id.get(dataset.id),
         )
 
-    # fix(#1518 P2): the flag above is only set on the FALLBACK arm, which a
+    # fix(#1518): the flag above is only set on the FALLBACK arm, which a
     # batch of public datasets never reaches, so the question is asked again
     # here. Still the real validator against a real id, never header presence.
     if not capability_authorized and embed_token:
@@ -1728,7 +1728,7 @@ async def _assert_dataset_still_registered(
 
     registered = (await db.execute(stmt)).scalar_one_or_none()
 
-    # fix(#1451 P1): hand the API-pool connection back before returning, or
+    # fix(#1451): hand the API-pool connection back before returning, or
     # every tile the pool builds occupies one for its PostGIS query and gzip.
     # Read-only, so the rollback discards nothing.
     await db.rollback()
@@ -2000,7 +2000,7 @@ async def _acquire_and_serve_tile(
             await tile_cache.set(
                 cache_key, z, x, y, b"", ttl=cache_ttl, cols_key=cols_cache_key
             )
-        # fix(#430 V-03): empty tiles were uncacheable — reuse the tile's Cache-Control
+        # fix(#430) V-03: empty tiles were uncacheable — reuse the tile's Cache-Control
         # from base_headers (drop Content-Encoding; a 204 has no body).
         return Response(
             status_code=status.HTTP_204_NO_CONTENT,
@@ -2089,7 +2089,7 @@ async def cluster_tile_endpoint(
         scope=scope,
         user=user,
     )
-    # fix(#1518 P2 r4): after authorization, not before. "Not a point dataset"
+    # fix(#1518): after authorization, not before. "Not a point dataset"
     # is a property of the RESOURCE, and it told an unauthorized caller that a
     # private dataset exists and what geometry it holds.
     _ensure_clusterable_dataset(meta)
@@ -2136,7 +2136,7 @@ async def cluster_tile_endpoint(
                         cache_ttl,
                         _cluster_cache_control,
                         empty=True,
-                    ),  # fix(#430 V-03)
+                    ),  # fix(#430) V-03
                 )
             # MVT-04: cache hits also carry an ETag / honor If-None-Match.
             return _tile_response(
@@ -2302,7 +2302,7 @@ async def tile_endpoint(
                         cache_ttl,
                         _tile_cache_control,
                         empty=True,
-                    ),  # fix(#430 V-03)
+                    ),  # fix(#430) V-03
                 )
             # MVT-04: cache hits also carry an ETag / honor If-None-Match.
             return _tile_response(

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -2000,8 +2000,8 @@ async def _acquire_and_serve_tile(
             await tile_cache.set(
                 cache_key, z, x, y, b"", ttl=cache_ttl, cols_key=cols_cache_key
             )
-        # fix(#430) V-03: empty tiles were uncacheable — reuse the tile's Cache-Control
-        # from base_headers (drop Content-Encoding; a 204 has no body).
+        # fix(#430) V-03: an empty tile reuses the tile's Cache-Control from
+        # base_headers, minus Content-Encoding, because a 204 has no body.
         return Response(
             status_code=status.HTTP_204_NO_CONTENT,
             headers={k: v for k, v in base_headers.items() if k != "Content-Encoding"},

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5156,7 +5156,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # refactor(#1711): +32. `_cleanup_saved_upload`, beside the drain it awaits
     # and the save it undoes, plus the module logger its body reads and the
     # provider import its S3 branch makes. Cap 1590 -> 1622, exact.
-    "backend/app/processing/ingest/service.py": 1622,
+    # chore(#1940): -9, the fan-out error path no longer re-imports structlog or
+    # guards on the result; the module binds `logger` unconditionally.
+    # Cap 1622 -> 1613, exact.
+    "backend/app/processing/ingest/service.py": 1613,
     # fix(#1738): first entry, crossed _RATCHET_INCLUSION_LOC (842 -> 1019) on
     # the change that gave this task a repair phase. What the growth bought:
     # `geom_4326` on a registered table was written once, at registration, and

--- a/backend/tests/test_titiler_url_helper.py
+++ b/backend/tests/test_titiler_url_helper.py
@@ -88,9 +88,9 @@ def test_tiles_router_uses_helper():
 
     source = Path(__file__).parent.parent / "app" / "processing" / "tiles" / "router.py"
     text = source.read_text()
-    # Strip comments before checking for literal Titiler hosts. SEC-OBSV-01
-    # docstring/comment references "Titiler" in prose but never the literal
-    # "http://titiler:8000" host string -- verified by static read.
+    # Strip comments before checking for literal Titiler hosts. The
+    # fix(#1927) SEC-OBSV-01 comment names "Titiler" in prose but never the
+    # literal "http://titiler:8000" host string.
     non_comment_lines = [
         line for line in text.splitlines() if not line.strip().startswith("#")
     ]


### PR DESCRIPTION
Three comment-hygiene issues in one pass. No behaviour change: 76 of the 82
changed lines are comments or docstring prose, and the remaining code change is
the removal of an unreachable guard.

## #1940 — the unreachable structlog guard in `create_fan_out_jobs`

`backend/app/processing/ingest/service.py` imports structlog at module level
(line 17) and binds `logger = structlog.get_logger(__name__)` (line 57). The
function-local `import structlog as _structlog` inside the `except` arm of
`create_fan_out_jobs` is therefore a `sys.modules` hit that cannot raise, its
`except Exception: pass` is dead, and both `if logger:` guards are always true.

Unreachability evidence: `logger` appears six times inside the function (the two
local bindings plus four uses, all in the same `except` block). Removing the
bindings makes the four uses resolve to the module global, which is the object
the local rebind produced anyway, so the emitted records are identical. Both
`logger.warning(...)` calls carry magic trailing commas and exceed 88 characters
joined, so `ruff format` leaves them expanded.

## #1941 — review-round labels inside `fix(#N ...)` anchors

Fifty-five anchors still carried the round, reviewer or severity the finding was
raised under (`fix(#565 P2 r14/r16)`, `fix(#1770 r47b)`, `fix(#998 codex r45)`).
Substitution is in place: every byte outside the parentheses is unchanged and no
file gains or loses a line, so no cap moves. This is only the leftover-label
pass; #1873 already reflowed these blocks and none of them is re-wrapped here.

| File | Anchors |
| --- | --- |
| `backend/app/processing/tiles/router.py` | 13 |
| `backend/app/platform/sandbox/validator.py` | 14 |
| `backend/app/platform/service_endpoints.py` | 27 |
| `backend/app/core/db/tenant_adoption.py` | 1 |

Three deliberate exceptions:

- `fix(#1001/#1589)` in the validator is a two-issue anchor, not metadata, and is
  untouched.
- `fix(#1746 r16, #1770 r47b)` in `service_endpoints.py` names two issues, so it
  becomes `fix(#1746, #1770)` rather than collapsing to one.
- The three `V-03` sites in the tiles router keep the token, moved outside the
  parens as `fix(#430) V-03`, matching `fix(#394) SH-04` and `fix(#688) auth
  priority 2` in the same file. `V-03` cross-references three sites plus a ledger
  note in `test_layering.py`, and it is the only invariant the two trailing sites
  carry.

The four `-- fix(#998 codex r4x)` markers at `tenant_adoption.py` lines 706, 730,
750 and 943 are inside SQL string literals; rewriting them would change emitted
SQL, so they are left alone. Line 1078 in the same file is a genuine Python
comment and is trimmed.

## #1927 — make the SEC-OBSV tokens resolvable

`SEC-OBSV-01` / `SEC-OBSV-02` name findings from an audit whose report is not in
this repository. Each now carries `#1927` in the form
`backend/app/processing/tiles/router.py:201` already used on main:

- `backend/app/platform/storage/titiler_url.py:23` (module docstring)
- `backend/app/modules/catalog/sources/cog_info.py:194` (`fetch_cog_info`
  docstring) — the real SEC-OBSV-02 site
- `backend/tests/test_titiler_url_helper.py:91`

`titiler_url.py` pointed SEC-OBSV-02 at `stac_router.py::_fetch_cog_info`; the
function is `fetch_cog_info` and it moved to `sources/cog_info.py` in #1266, so
the pointer now names where it lives.

## Schema / API / config impact

None. Every edited docstring belongs to a module or a private helper, not to a
route handler, so `backend/openapi.json` and the generated SDKs are unchanged.

## Cap ratchet

One, in `_MODULE_LOC_CAPS`:
`backend/app/processing/ingest/service.py` **1622 -> 1613** (exact), for the nine
lines #1940 removes.

## Corrections to the issue bodies

- #1941 gives the validator's path as `modules/catalog/sandbox/`. That directory
  does not exist; the file is `backend/app/platform/sandbox/validator.py`.
- #1941 says 11 sites in the tiles router. There are 13.
- #1941 lists four `tenant_adoption.py` markers. There are five: the fifth
  (line 1078) is the only one that is a Python comment, and the four it does list
  are the SQL-literal ones that must not be touched.
- #1927 lists three SEC-OBSV sites and names `platform/security.py`, which
  contains no such token. There are four sites; the missing one is
  `modules/catalog/sources/cog_info.py`, and `tiles/router.py:201` was already
  done on main.

## Verification

All run in the branch worktree; every exit status captured directly, not from
piped output.

| Command | Result |
| --- | --- |
| `uv run pytest tests/test_layering.py tests/test_titiler_url_helper.py tests/test_codeql_qtable_suppressions.py -q` | exit 0, 68 passed |
| `uv run pytest tests/test_ingest_fan_out.py tests/test_job_cancel_fan_out.py tests/test_commit_attempted_marker_doors.py -q` | exit 0, 35 passed |
| `uv run pytest tests/test_rule2_structural.py tests/test_rule1_structural.py -q` | exit 0, 118 passed |
| `uv run ruff check .` | exit 0, all checks passed |
| `uv run ruff format --check .` | exit 0, 1186 files already formatted |
| `pre-commit run --all-files` | exit 0, 15 hooks passed |

Closes #1940
Closes #1941
Closes #1927


## Rebase note: the `tenant_adoption.py` edit is gone

This branch originally carried a one-line width trim of the `fix(#998 codex r45)`
Python comment in `backend/app/core/db/tenant_adoption.py`. #1936 landed the same
logical edit first and did it better, reflowing the block to two lines instead of
keeping the three-line wrap. The rebase conflicted on exactly that comment and the
resolution takes main's version, so the file no longer appears in this diff. The
marker count table above and the note about the five markers describe the state
this branch was written against; the fifth marker is now #1936's to account for.

The four `-- fix(#998 codex r4x)` markers inside SQL string literals remain
untouched by both PRs, which is the point. #1936's reflow moved them to lines 681,
705, 725 and 918.
