### PR TITLE
fix(ingest): bound the raster-replace and VRT-publish catalog waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and releases use semantic versioning.
   could wait indefinitely, leaving the dataset's table unreadable for as long as the hold lasted.
   That wait is now capped at 60 seconds, and a reupload that gives up reports lock contention and
   logs how long it waited, having rolled the swap back whole. (#1921)
+- A raster replace could hang indefinitely in its final step when another operation held the
+  dataset's catalog row. That step now runs under a 30-second budget, so the job fails and can be
+  retried instead of heartbeating until the stale-job sweep reaps it. (#1937)
 
 ## [1.18.1] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,10 @@ and releases use semantic versioning.
   That wait is now capped at 60 seconds, and a reupload that gives up reports lock contention and
   logs how long it waited, having rolled the swap back whole. (#1921)
 - A raster replace could hang indefinitely in its final step when another operation held the
-  dataset's catalog row. That step now runs under a 30-second budget, so the job fails and can be
-  retried instead of heartbeating until the stale-job sweep reaps it. (#1937)
+  dataset's catalog row. That wait is now capped at 30 seconds, and a replace that gives up
+  reports lock contention and logs how long it waited, rather than heartbeating until the
+  stale-job sweep reaps it. Waiting for storage-quota accounting stays uncapped, so a replace
+  still queues behind another upload by the same owner instead of failing. (#1937)
 - A VRT regeneration could hang indefinitely while publishing if a metadata edit held the
   dataset's catalog record. That wait is now capped at 15 seconds, and a regeneration that gives
   up logs how long it waited and whether the budget expired or it lost a deadlock. (#1938)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and releases use semantic versioning.
 - A raster replace could hang indefinitely in its final step when another operation held the
   dataset's catalog row. That step now runs under a 30-second budget, so the job fails and can be
   retried instead of heartbeating until the stale-job sweep reaps it. (#1937)
+- A VRT regeneration could hang indefinitely while publishing if a metadata edit held the
+  dataset's catalog record. That wait is now capped at 15 seconds, and a regeneration that gives
+  up logs how long it waited and whether the budget expired or it lost a deadlock. (#1938)
 
 ## [1.18.1] - 2026-09-05
 

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -15,7 +15,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import set_committed_value
 
-from app.core.db.sqlstate import is_lock_conflict
+from app.core.db.sqlstate import is_lock_conflict, sqlstate
 
 # The budget a REQUEST spends waiting for the pair. A worker passes
 # ``lock_timeout=None``: ``SET LOCAL`` applies for the rest of the transaction,
@@ -30,6 +30,42 @@ _USE_REQUEST_DEFAULT: Any = object()
 # The machine-readable code for a contended row, wherever it is reported: the
 # 409 body, and a bulk-delete item that carries its conflict instead of raising.
 CATALOG_LOCK_CONFLICT_CODE = "catalog_lock_conflict"
+
+
+# fix(#1937, #1938): an expired budget and a lost deadlock end an acquisition
+# alike, and the two send an operator looking for different things.
+_CONFLICT_REPORTS = {
+    "55P03": (
+        "lock_timeout",
+        "The wait expired. Find the holder of this dataset's catalog rows in "
+        "pg_stat_activity.",
+    ),
+    "40P01": (
+        "deadlock",
+        "PostgreSQL chose this transaction as the deadlock victim. Look for "
+        "the other side of the cycle: a holder of this dataset's catalog rows "
+        "that is itself waiting on something this transaction holds.",
+    ),
+}
+_CONFLICT_REPORT_UNKNOWN = (
+    "lock_failed",
+    "The wait failed and reported no SQLSTATE.",
+)
+
+
+def lock_conflict_report(
+    conflict: BaseException, *, event_prefix: str
+) -> tuple[str, str, str | None]:
+    """The log event, operator hint and SQLSTATE for a failed acquisition.
+
+    The event is ``<event_prefix>_lock_timeout``, ``<event_prefix>_deadlock``
+    or ``<event_prefix>_lock_failed``. One definition, because a per-site copy
+    is a per-site drift.
+    """
+    cause = conflict.__cause__
+    code = sqlstate(cause) if isinstance(cause, DBAPIError) else None
+    suffix, hint = _CONFLICT_REPORTS.get(code, _CONFLICT_REPORT_UNKNOWN)
+    return f"{event_prefix}_{suffix}", hint, code
 
 
 # fix(#1847, #1890): true from the SET LOCAL until the transaction that ran it

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -94,6 +94,11 @@ from app.processing.ingest.tasks_raster_swap import (
 
 logger = structlog.get_logger(__name__)
 
+# fix(#1937): the budget every phase-2 statement runs on, the catalog wait
+# included. Its holders are request writers capped at REQUEST_LOCK_TIMEOUT and
+# a sibling upload's quota lock, so a wait past this is stuck, not queued.
+_PHASE2_TIMEOUT_MS = 30_000
+
 
 class RasterReplaceError(Exception):
     """A raster replace that failed for a reason the user can act on."""
@@ -553,6 +558,7 @@ async def reupload_raster(
             phase="phase2",
             attempt_id=attempt_uuid,
             require_status="running",
+            lock_and_statement_timeout_ms=_PHASE2_TIMEOUT_MS,
         ) as (session, job):
             if job is None:
                 return

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -31,14 +31,21 @@ import io
 import os
 import shutil
 import tempfile
+import time
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from app.core.db.tenant_session import tenant_task
+from app.platform.catalog_locks import (
+    CATALOG_LOCK_CONFLICT_CODE,
+    CatalogLockConflict,
+    lock_conflict_report,
+)
 from app.platform.jobs.heartbeat import (
     claim_job_attempt_and_start_heartbeat,
     require_ingest_job_update,
@@ -94,10 +101,47 @@ from app.processing.ingest.tasks_raster_swap import (
 
 logger = structlog.get_logger(__name__)
 
-# fix(#1937): the budget every phase-2 statement runs on, the catalog wait
-# included. Its holders are request writers capped at REQUEST_LOCK_TIMEOUT and
-# a sibling upload's quota lock, so a wait past this is stuck, not queued.
+# fix(#1937): bounds the job-row SELECT `_job_phase_session` runs before the
+# caller gets control, then the catalog wait alone. Sized against holders of
+# the catalog rows, which are short writers, not against object-storage work.
 _PHASE2_TIMEOUT_MS = 30_000
+
+
+@contextmanager
+def _reporting_catalog_wait(*, job_id: str, dataset_id: str):
+    """Classify and log a failed catalog acquisition, then re-raise it.
+
+    ``dataset_id`` must be a value read BEFORE the wait: the acquisition rolls
+    back before it raises, and that expires every loaded instance.
+    """
+    wait_started = time.perf_counter()
+    try:
+        yield
+    except CatalogLockConflict as conflict:
+        log_event, hint, code = lock_conflict_report(
+            conflict, event_prefix="raster_replace_catalog"
+        )
+        logger.warning(
+            log_event,
+            job_id=job_id,
+            dataset_id=dataset_id,
+            waited_ms=round((time.perf_counter() - wait_started) * 1000),
+            budget=_PHASE2_TIMEOUT_MS,
+            sqlstate=code,
+            hint=hint,
+        )
+        raise
+
+
+def _raster_refresh_error_code(exc: BaseException) -> str:
+    """Map a raster-replace failure onto its run ``error_code``.
+
+    A contended catalog row reports as contention: nothing was written, and
+    the reader's next step is to find the holder, not to inspect the raster.
+    """
+    if isinstance(exc, CatalogLockConflict):
+        return CATALOG_LOCK_CONFLICT_CODE
+    return "raster_refresh_failed"
 
 
 class RasterReplaceError(Exception):
@@ -562,6 +606,10 @@ async def reupload_raster(
         ) as (session, job):
             if job is None:
                 return
+            # fix(#1937): the kwarg has bounded the SELECT above, which is the
+            # whole of its job. Clearing it leaves the catalog wait below to
+            # lock_timeout, so expiry is 55P03 and maps to CatalogLockConflict.
+            await session.execute(text("SET LOCAL statement_timeout = 0"))
             job.current_step = "finalize"
             job.progress = 0.8
 
@@ -700,14 +748,21 @@ async def reupload_raster(
                 lock_catalog_rows,
             )
 
-            await lock_catalog_rows(
-                session,
-                dataset_cls=Dataset,
-                record_cls=type(dataset.record),
-                dataset_id=dataset.id,
-                record_id=dataset.record_id,
-                lock_timeout=None,
-            )
+            # fix(#1937): the id is read before the wait — the rollback inside
+            # a failed acquisition expires every loaded instance.
+            with _reporting_catalog_wait(job_id=job_id, dataset_id=str(dataset.id)):
+                await lock_catalog_rows(
+                    session,
+                    dataset_cls=Dataset,
+                    record_cls=type(dataset.record),
+                    dataset_id=dataset.id,
+                    record_id=dataset.record_id,
+                    lock_timeout=None,
+                )
+            # fix(#1937): the reservation below waits on a per-user advisory
+            # lock a sibling first ingest holds across a whole COG upload, and
+            # both GUCs clamp an advisory wait. It must be unbounded.
+            await session.execute(text("SET LOCAL lock_timeout = 0"))
             # fix(#1911): evaluated at write time, under the lock, so the counter
             # read into `dataset` before the wait is never written back over a
             # peer's commit.
@@ -906,7 +961,7 @@ async def reupload_raster(
             await record_refresh_failure(
                 err_session,
                 ingest_job_id=job_uuid,
-                error_code="raster_refresh_failed",
+                error_code=_raster_refresh_error_code(exc),
                 error_message=str(exc),
                 contacted_origin=False,
             )

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -106,6 +106,11 @@ logger = structlog.get_logger(__name__)
 # the catalog rows, which are short writers, not against object-storage work.
 _PHASE2_TIMEOUT_MS = 30_000
 
+# fix(#1937): the failure write goes through the same ingest_jobs row phase 2
+# contends for. Its holders self-cap far below this (`cancel_job` at 2s; the
+# sweep and startup recovery use SKIP LOCKED), so a wait past it is stuck.
+_ERROR_WRITE_TIMEOUT_MS = 10_000
+
 
 @contextmanager
 def _reporting_catalog_wait(*, job_id: str, dataset_id: str):
@@ -940,8 +945,14 @@ async def reupload_raster(
         # excludes terminal runs). A flag check would be a third fence with
         # nothing left to catch.
         logger.exception("Raster replace failed", job_id=job_id, task="reupload_raster")
+        # fix(#1937): bounding phase 2 made this write reachable under
+        # contention. If it expires the job stays `running` with its heartbeat
+        # stopped below, so the stale sweep settles it instead of a hung worker.
         async with _job_phase_session(
-            job_uuid, phase="error_write", attempt_id=attempt_uuid
+            job_uuid,
+            phase="error_write",
+            attempt_id=attempt_uuid,
+            lock_and_statement_timeout_ms=_ERROR_WRITE_TIMEOUT_MS,
         ) as (err_session, _err_job):
             await update_ingest_job_for_attempt(
                 err_session,

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -54,45 +54,24 @@ from app.processing.ingest.tasks_raster_common import (
 )
 
 # fix(#1938): the budget for the publish transaction's catalog.records wait.
-# Its only holders are record-only writers, whose own acquisition is capped at
-# REQUEST_LOCK_TIMEOUT and which commit a statement or two after taking it.
+# Its only holders are request handlers that dirty the record and hold it from
+# flush to commit; nothing caps that, so this is a stuck-not-queued threshold.
 _PUBLISH_CATALOG_TIMEOUT = "15s"
-
-# fix(#1938): an expired budget and a lost deadlock send an operator looking
-# for different things.
-_PUBLISH_WAIT_FAILURES = {
-    "55P03": (
-        "vrt_publish_catalog_lock_timeout",
-        "The publish's catalog.records wait expired. Find the holder of this "
-        "dataset's catalog.records row in pg_stat_activity.",
-    ),
-    "40P01": (
-        "vrt_publish_catalog_deadlock",
-        "PostgreSQL chose this publish as the deadlock victim. Look for the "
-        "other side of the cycle: a transaction holding this dataset's records "
-        "row and waiting on something this one holds.",
-    ),
-}
-_PUBLISH_WAIT_UNKNOWN = (
-    "vrt_publish_catalog_lock_failed",
-    "The publish's catalog wait failed and reported no SQLSTATE.",
-)
 
 
 def _log_publish_wait_failure(
     conflict: BaseException, *, job_id: str, dataset_id: str, waited_ms: int
 ) -> None:
-    """Report a failed publish catalog wait as expiry, deadlock or no SQLSTATE.
+    """Report a failed publish catalog wait, classified by its SQLSTATE.
 
     ``dataset_id`` must be read BEFORE the acquisition: ``lock_catalog_rows``
     rolls back before it raises, and that expires every loaded instance.
     """
-    from app.core.db.sqlstate import sqlstate
-    from sqlalchemy.exc import DBAPIError
+    from app.platform.catalog_locks import lock_conflict_report
 
-    cause = conflict.__cause__
-    code = sqlstate(cause) if isinstance(cause, DBAPIError) else None
-    log_event, hint = _PUBLISH_WAIT_FAILURES.get(code, _PUBLISH_WAIT_UNKNOWN)
+    log_event, hint, code = lock_conflict_report(
+        conflict, event_prefix="vrt_publish_catalog"
+    )
     structlog.get_logger().warning(
         log_event,
         job_id=job_id,
@@ -1440,6 +1419,9 @@ async def regenerate_vrt(
                     # fix(#1938): read before the wait — the rollback inside a
                     # failed acquisition expires every loaded instance.
                     log_dataset_id = str(vrt_dataset.id)
+                    pre_wait_lock_timeout = await session.scalar(
+                        text("SELECT current_setting('lock_timeout')")
+                    )
                     wait_started = time.perf_counter()
                     try:
                         await lock_catalog_rows(
@@ -1460,6 +1442,13 @@ async def regenerate_vrt(
                             ),
                         )
                         raise
+                    # fix(#1938): the budget ends with the wait it was sized
+                    # for. The UPDATEs below sit outside lock_catalog_rows, so
+                    # an expiry there would raise a bare DBAPIError.
+                    await session.execute(
+                        text("SELECT set_config('lock_timeout', :value, true)"),
+                        {"value": pre_wait_lock_timeout},
+                    )
                     # feat(#1267) / ADR-002 Decision 5a: project the
                     # generation's completion instant into last_refreshed_at,
                     # in the SAME transaction as the generation swap, so

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -12,6 +12,7 @@ Storage portability (STOR-03/04, Phase 1210):
   a provider swap (s3 -> azure -> local) requires no changes to stored VRT XML.
 """
 
+import time
 import uuid
 from datetime import datetime, timezone
 
@@ -51,6 +52,56 @@ from app.processing.ingest.tasks_raster_common import (
     publish_commit_landed,
     record_unpublished_storage_keys,
 )
+
+# fix(#1938): the budget for the publish transaction's catalog.records wait.
+# Its only holders are record-only writers, whose own acquisition is capped at
+# REQUEST_LOCK_TIMEOUT and which commit a statement or two after taking it.
+_PUBLISH_CATALOG_TIMEOUT = "15s"
+
+# fix(#1938): an expired budget and a lost deadlock send an operator looking
+# for different things.
+_PUBLISH_WAIT_FAILURES = {
+    "55P03": (
+        "vrt_publish_catalog_lock_timeout",
+        "The publish's catalog.records wait expired. Find the holder of this "
+        "dataset's catalog.records row in pg_stat_activity.",
+    ),
+    "40P01": (
+        "vrt_publish_catalog_deadlock",
+        "PostgreSQL chose this publish as the deadlock victim. Look for the "
+        "other side of the cycle: a transaction holding this dataset's records "
+        "row and waiting on something this one holds.",
+    ),
+}
+_PUBLISH_WAIT_UNKNOWN = (
+    "vrt_publish_catalog_lock_failed",
+    "The publish's catalog wait failed and reported no SQLSTATE.",
+)
+
+
+def _log_publish_wait_failure(
+    conflict: BaseException, *, job_id: str, dataset_id: str, waited_ms: int
+) -> None:
+    """Report a failed publish catalog wait as expiry, deadlock or no SQLSTATE.
+
+    ``dataset_id`` must be read BEFORE the acquisition: ``lock_catalog_rows``
+    rolls back before it raises, and that expires every loaded instance.
+    """
+    from app.core.db.sqlstate import sqlstate
+    from sqlalchemy.exc import DBAPIError
+
+    cause = conflict.__cause__
+    code = sqlstate(cause) if isinstance(cause, DBAPIError) else None
+    log_event, hint = _PUBLISH_WAIT_FAILURES.get(code, _PUBLISH_WAIT_UNKNOWN)
+    structlog.get_logger().warning(
+        log_event,
+        job_id=job_id,
+        dataset_id=dataset_id,
+        waited_ms=waited_ms,
+        budget=_PUBLISH_CATALOG_TIMEOUT,
+        sqlstate=code,
+        hint=hint,
+    )
 
 
 def read_vrt_metadata(vrt_path: str) -> dict:
@@ -1378,19 +1429,37 @@ async def regenerate_vrt(
                 )
                 vrt_dataset = dataset_result.scalar_one_or_none()
                 if vrt_dataset is not None:
-                    # fix(#1847): the writes below dirty both rows. The asset
-                    # SELECT above already locks this datasets row through its
-                    # join, incidentally; state it. A no-op re-lock.
-                    from app.platform.catalog_locks import lock_catalog_rows
-
-                    await lock_catalog_rows(
-                        session,
-                        dataset_cls=Dataset,
-                        record_cls=type(vrt_dataset.record),
-                        dataset_id=vrt_dataset.id,
-                        record_id=vrt_dataset.record_id,
-                        lock_timeout=None,
+                    # fix(#1847, #1938): the writes below dirty both rows. The
+                    # asset SELECT above took the datasets row through its join;
+                    # catalog.records is not in that query, so it is a real wait.
+                    from app.platform.catalog_locks import (
+                        CatalogLockConflict,
+                        lock_catalog_rows,
                     )
+
+                    # fix(#1938): read before the wait — the rollback inside a
+                    # failed acquisition expires every loaded instance.
+                    log_dataset_id = str(vrt_dataset.id)
+                    wait_started = time.perf_counter()
+                    try:
+                        await lock_catalog_rows(
+                            session,
+                            dataset_cls=Dataset,
+                            record_cls=type(vrt_dataset.record),
+                            dataset_id=vrt_dataset.id,
+                            record_id=vrt_dataset.record_id,
+                            lock_timeout=_PUBLISH_CATALOG_TIMEOUT,
+                        )
+                    except CatalogLockConflict as conflict:
+                        _log_publish_wait_failure(
+                            conflict,
+                            job_id=job_id,
+                            dataset_id=log_dataset_id,
+                            waited_ms=round(
+                                (time.perf_counter() - wait_started) * 1000
+                            ),
+                        )
+                        raise
                     # feat(#1267) / ADR-002 Decision 5a: project the
                     # generation's completion instant into last_refreshed_at,
                     # in the SAME transaction as the generation swap, so

--- a/backend/tests/test_feature_lock_order_1847.py
+++ b/backend/tests/test_feature_lock_order_1847.py
@@ -2449,8 +2449,8 @@ class TestWorkerDoorsAcquireBeforeTheirWrites:
                 "now false."
             )
 
-    def test_worker_doors_do_not_clamp_their_transaction(self):
-        """`lock_timeout=None` appears at worker doors only, never on a request path.
+    def test_the_raster_replace_door_is_the_only_unclamped_acquisition(self):
+        """`lock_timeout=None` appears there alone, and nowhere on a request path.
 
         `SET LOCAL` applies for the rest of the transaction, so a worker
         carrying the request budget would fail a multi-minute ingest on
@@ -2477,11 +2477,10 @@ class TestWorkerDoorsAcquireBeforeTheirWrites:
                             none_sites.append(str(path.relative_to(app_dir.parent)))
         assert sorted(set(none_sites)) == [
             "app/processing/ingest/tasks_raster_replace.py",
-            "app/processing/ingest/tasks_vrt.py",
         ], (
-            "lock_timeout=None belongs to worker tasks only, and never to the "
-            "reupload swap, which holds AccessExclusiveLock across its wait and "
-            f"names its own budget (#1921). Found: {none_sites}"
+            "the raster-replace door is the one acquisition with no lock_timeout "
+            "of its own, because its phase budget (#1937) covers it. Every other "
+            f"site names a budget. Found: {none_sites}"
         )
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4621,10 +4621,19 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1653, exact.
     # fix(#1847): the phase-2 job load locks the row and the lock-order
     # rationale left the source. Cap 1653 -> 1640, exact.
-    # fix(#1938): +69 — the publish's catalog.records wait gets a budget and
-    # events telling an expired budget from a lost deadlock. Cap 1640 -> 1709,
-    # exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1709,
+    # fix(#1938): +58 — the publish's catalog.records wait gets a budget, a
+    # restore after it, and a classified failure report whose SQLSTATE table
+    # lives in catalog_locks instead. Cap 1640 -> 1698, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1698,
+    # --- entered by the inclusion rule, fix(#1937) ------------------------
+    # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
+    # The budget alone is six lines; the rest is what a newly failable wait
+    # owes its reader — a classified warning naming the SQLSTATE, the waited
+    # ms and the budget, an error_code mapper so contention does not report as
+    # a bad raster, and the reset that keeps the quota reservation below it
+    # unbounded. The reporter is a context manager so the acquisition stays a
+    # direct call the #1847 gates can see. Cap 1045, exact.
+    "backend/app/processing/ingest/tasks_raster_replace.py": 1045,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4621,7 +4621,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1653, exact.
     # fix(#1847): the phase-2 job load locks the row and the lock-order
     # rationale left the source. Cap 1653 -> 1640, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1640,
+    # fix(#1938): +69 — the publish's catalog.records wait gets a budget and
+    # events telling an expired budget from a lost deadlock. Cap 1640 -> 1709,
+    # exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1709,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4632,8 +4632,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # ms and the budget, an error_code mapper so contention does not report as
     # a bad raster, and the reset that keeps the quota reservation below it
     # unbounded. The reporter is a context manager so the acquisition stays a
-    # direct call the #1847 gates can see. Cap 1045, exact.
-    "backend/app/processing/ingest/tasks_raster_replace.py": 1045,
+    # direct call the #1847 gates can see, and the failure write carries a bound
+    # of its own so phase 2's contention cannot move onto it. Cap 1056, exact.
+    "backend/app/processing/ingest/tasks_raster_replace.py": 1056,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.

--- a/backend/tests/test_raster_replace_phase_budget_1937.py
+++ b/backend/tests/test_raster_replace_phase_budget_1937.py
@@ -1,0 +1,222 @@
+"""Raster replace's phase 2 runs every statement on a named budget (#1937).
+
+The catalog wait it ends with is covered by that budget, so a held row fails
+the job rather than hanging it. The DB tests need the Docker test database.
+"""
+
+import ast
+import asyncio
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import delete, select, text
+from sqlalchemy.exc import DBAPIError
+
+from app.core.db.sqlstate import is_lock_conflict, sqlstate
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.catalog_locks import lock_catalog_rows
+from app.platform.jobs.models import IngestJob
+from app.processing.ingest import tasks_raster_replace
+from app.processing.ingest.tasks_common import _job_phase_session
+
+from tests.factories import get_user_id
+from tests.test_swap_lock_timeout_scope_1917 import make_swap_target
+
+pytestmark = pytest.mark.anyio
+
+# Short enough that a held row outlasts it in under a second.
+_TEST_BUDGET_MS = 500
+
+
+def _phase_two_call() -> ast.Call:
+    """The ``_job_phase_session`` call ``reupload_raster`` opens phase 2 with."""
+    source = Path(tasks_raster_replace.__file__).read_text()
+    calls = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", None) == "_job_phase_session"
+        and any(
+            kw.arg == "phase"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value == "phase2"
+            for kw in node.keywords
+        )
+    ]
+    assert len(calls) == 1, f"expected one phase-2 session bracket; found {len(calls)}"
+    return calls[0]
+
+
+def _phase_two_keywords() -> dict[str, ast.expr]:
+    return {kw.arg: kw.value for kw in _phase_two_call().keywords if kw.arg}
+
+
+async def _as_postgres_renders(value_ms: int) -> str:
+    """What ``current_setting('lock_timeout')`` reports back for *value_ms*."""
+    import app.core.db as db_module
+
+    async with db_module.async_session() as probe:
+        rendered = await probe.scalar(
+            text("SELECT set_config('lock_timeout', :value, true)"),
+            {"value": str(value_ms)},
+        )
+        await probe.rollback()
+    return rendered
+
+
+@pytest.fixture
+async def swap_target(client, test_db_session):
+    async for target in make_swap_target(client, test_db_session):
+        yield target
+
+
+@pytest.fixture
+async def running_job(test_db_session):
+    """A claimed ``ingest_jobs`` row the phase bracket can load and fence on."""
+    job = IngestJob(
+        source_filename=f"phase_budget_{uuid.uuid4().hex[:8]}.tif",
+        created_by=await get_user_id(test_db_session, "admin"),
+        status="running",
+        current_step="finalize",
+        progress=0.8,
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+    ids = (job.id, job.attempt_id)
+    yield ids
+    await test_db_session.execute(delete(IngestJob).where(IngestJob.id == ids[0]))
+    await test_db_session.commit()
+
+
+class TestPhaseTwoCallSite:
+    """Pure AST — no DB."""
+
+    def test_the_phase_bracket_names_the_module_budget(self) -> None:
+        budget = _phase_two_keywords().get("lock_and_statement_timeout_ms")
+        assert isinstance(budget, ast.Name) and budget.id == "_PHASE2_TIMEOUT_MS", (
+            "reupload_raster's phase 2 enters _job_phase_session without "
+            f"lock_and_statement_timeout_ms ({ast.dump(budget) if budget else None}), "
+            "so the helper issues neither SET LOCAL and every statement in the "
+            "phase — the catalog wait included — runs unbounded."
+        )
+
+    def test_the_acquisition_leaves_the_phase_budget_in_force(self) -> None:
+        source = Path(tasks_raster_replace.__file__).read_text()
+        passed = [
+            kw.value
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", None) == "lock_catalog_rows"
+            for kw in node.keywords
+            if kw.arg == "lock_timeout"
+        ]
+        assert len(passed) == 1, f"expected one acquisition; found {len(passed)}"
+        assert isinstance(passed[0], ast.Constant) and passed[0].value is None, (
+            "the acquisition installs its own lock_timeout, which replaces the "
+            "phase budget for the rest of the transaction."
+        )
+
+
+class TestPhaseTwoBudgetAgainstPostgres:
+    async def test_the_catalog_wait_starts_on_the_phase_budget(
+        self, swap_target, running_job
+    ) -> None:
+        """Both timeouts are in force when the acquisition is entered."""
+        stub, _staging = swap_target
+        job_id, attempt_id = running_job
+        expected = await _as_postgres_renders(tasks_raster_replace._PHASE2_TIMEOUT_MS)
+        observed: dict[str, object] = {}
+
+        async def _recording_lock(session, **kwargs):
+            observed["lock_timeout"] = await session.scalar(
+                text("SELECT current_setting('lock_timeout')")
+            )
+            observed["statement_timeout"] = await session.scalar(
+                text("SELECT current_setting('statement_timeout')")
+            )
+            await lock_catalog_rows(session, **kwargs)
+
+        async with _job_phase_session(
+            job_id,
+            phase="phase2",
+            attempt_id=attempt_id,
+            require_status="running",
+            lock_and_statement_timeout_ms=tasks_raster_replace._PHASE2_TIMEOUT_MS,
+        ) as (session, job):
+            assert job is not None
+            await _recording_lock(
+                session,
+                dataset_cls=Dataset,
+                record_cls=Record,
+                dataset_id=stub.id,
+                record_id=stub.record_id,
+                lock_timeout=None,
+            )
+            await session.rollback()
+
+        assert observed["lock_timeout"] == expected, (
+            f"the acquisition was entered on lock_timeout "
+            f"{observed['lock_timeout']!r}, not the {expected!r} PostgreSQL "
+            f"renders {tasks_raster_replace._PHASE2_TIMEOUT_MS} to. A '0' here "
+            "is an unbounded wait on a contended catalog row."
+        )
+        assert observed["statement_timeout"] == expected, (
+            f"statement_timeout read {observed['statement_timeout']!r} at the "
+            "acquisition, so the phase's other statements are unbounded even "
+            "where the lock wait is not."
+        )
+
+    async def test_a_holder_past_the_budget_aborts_the_phase(
+        self, swap_target, running_job, monkeypatch
+    ) -> None:
+        """Expiry raises 57014 — statement_timeout wins the tie at equal values."""
+        stub, _staging = swap_target
+        job_id, attempt_id = running_job
+        monkeypatch.setattr(tasks_raster_replace, "_PHASE2_TIMEOUT_MS", _TEST_BUDGET_MS)
+        import app.core.db as db_module
+
+        async def _run_phase() -> None:
+            async with _job_phase_session(
+                job_id,
+                phase="phase2",
+                attempt_id=attempt_id,
+                require_status="running",
+                lock_and_statement_timeout_ms=tasks_raster_replace._PHASE2_TIMEOUT_MS,
+            ) as (session, job):
+                assert job is not None
+                await lock_catalog_rows(
+                    session,
+                    dataset_cls=Dataset,
+                    record_cls=Record,
+                    dataset_id=stub.id,
+                    record_id=stub.record_id,
+                    lock_timeout=None,
+                )
+
+        async with db_module.async_session() as holder:
+            await holder.execute(
+                select(Dataset.id).where(Dataset.id == stub.id).with_for_update()
+            )
+            loop = asyncio.get_running_loop()
+            started = loop.time()
+            with pytest.raises(DBAPIError) as excinfo:
+                await asyncio.wait_for(_run_phase(), timeout=30)
+            waited_ms = (loop.time() - started) * 1000
+            await holder.rollback()
+
+        assert waited_ms >= _TEST_BUDGET_MS * 0.8, (
+            f"the phase gave up after {round(waited_ms)}ms against a "
+            f"{_TEST_BUDGET_MS}ms budget, so this run proves nothing about the wait"
+        )
+        assert sqlstate(excinfo.value) == "57014", (
+            f"the held row aborted the phase with {sqlstate(excinfo.value)!r}. "
+            "lock_and_statement_timeout_ms arms statement_timeout at statement "
+            "start and lock_timeout only once the wait begins, so at equal "
+            "values statement_timeout is always the earlier deadline."
+        )
+        assert not is_lock_conflict(excinfo.value), (
+            "57014 is outside LOCK_CONFLICT, so lock_catalog_rows re-raises the "
+            "DBAPIError instead of the rolled-back CatalogLockConflict; the "
+            "phase bracket's own handler does the rollback."
+        )

--- a/backend/tests/test_raster_replace_phase_budget_1937.py
+++ b/backend/tests/test_raster_replace_phase_budget_1937.py
@@ -1,7 +1,8 @@
-"""Raster replace's phase 2 runs every statement on a named budget (#1937).
+"""Raster replace's phase 2 bounds two waits and leaves the rest alone (#1937).
 
-The catalog wait it ends with is covered by that budget, so a held row fails
-the job rather than hanging it. The DB tests need the Docker test database.
+The kwarg covers the job SELECT, `lock_timeout` covers the catalog wait, and
+both are cleared before the quota reservation, which waits on an advisory lock
+a sibling upload holds across a whole COG upload. DB tests need the test database.
 """
 
 import ast
@@ -10,12 +11,18 @@ import uuid
 from pathlib import Path
 
 import pytest
+import structlog
 from sqlalchemy import delete, select, text
 from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm import joinedload
 
-from app.core.db.sqlstate import is_lock_conflict, sqlstate
-from app.modules.catalog.datasets.domain.models import Dataset, Record
-from app.platform.catalog_locks import lock_catalog_rows
+from app.core.db.sqlstate import sqlstate
+from app.modules.catalog.datasets.domain.models import Dataset
+from app.platform.catalog_locks import (
+    CATALOG_LOCK_CONFLICT_CODE,
+    CatalogLockConflict,
+    lock_catalog_rows,
+)
 from app.platform.jobs.models import IngestJob
 from app.processing.ingest import tasks_raster_replace
 from app.processing.ingest.tasks_common import _job_phase_session
@@ -26,15 +33,30 @@ from tests.test_swap_lock_timeout_scope_1917 import make_swap_target
 pytestmark = pytest.mark.anyio
 
 # Short enough that a held row outlasts it in under a second.
-_TEST_BUDGET_MS = 500
+_TEST_BUDGET_MS = 400
+
+# The lock `reserve_storage_bytes` takes; a sibling first ingest holds it from
+# `create_raster_dataset` until its own commit, across three storage puts.
+_QUOTA_LOCK = (
+    "SELECT pg_advisory_xact_lock("
+    "hashtextextended('geolens:dataset_quota:' || :uid, 0))"
+)
+
+
+def _reupload_raster_body() -> ast.FunctionDef:
+    source = Path(tasks_raster_replace.__file__).read_text()
+    return next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "reupload_raster"
+    )
 
 
 def _phase_two_call() -> ast.Call:
     """The ``_job_phase_session`` call ``reupload_raster`` opens phase 2 with."""
-    source = Path(tasks_raster_replace.__file__).read_text()
     calls = [
         node
-        for node in ast.walk(ast.parse(source))
+        for node in ast.walk(_reupload_raster_body())
         if isinstance(node, ast.Call)
         and getattr(node.func, "id", None) == "_job_phase_session"
         and any(
@@ -48,8 +70,27 @@ def _phase_two_call() -> ast.Call:
     return calls[0]
 
 
-def _phase_two_keywords() -> dict[str, ast.expr]:
-    return {kw.arg: kw.value for kw in _phase_two_call().keywords if kw.arg}
+def _set_local_line(guc: str) -> int:
+    """Line of the ``SET LOCAL <guc> = 0`` reset inside ``reupload_raster``."""
+    lines = [
+        node.lineno
+        for node in ast.walk(_reupload_raster_body())
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value == f"SET LOCAL {guc} = 0"
+    ]
+    assert len(lines) == 1, f"expected one 'SET LOCAL {guc} = 0'; found {lines}"
+    return lines[0]
+
+
+def _call_line(name: str) -> int:
+    lines = [
+        node.lineno
+        for node in ast.walk(_reupload_raster_body())
+        if isinstance(node, ast.Call) and getattr(node.func, "id", None) == name
+    ]
+    assert len(lines) == 1, f"expected one {name} call; found {lines}"
+    return lines[0]
 
 
 async def _as_postgres_renders(value_ms: int) -> str:
@@ -89,16 +130,44 @@ async def running_job(test_db_session):
     await test_db_session.commit()
 
 
+async def _take_the_pair(session, dataset, acquire=lock_catalog_rows) -> None:
+    """The acquisition as ``reupload_raster`` makes it, reporter included."""
+    with tasks_raster_replace._reporting_catalog_wait(
+        job_id="job-1", dataset_id=str(dataset.id)
+    ):
+        await acquire(
+            session,
+            dataset_cls=Dataset,
+            record_cls=type(dataset.record),
+            dataset_id=dataset.id,
+            record_id=dataset.record_id,
+            lock_timeout=None,
+        )
+
+
+def _enter_phase(job_id, attempt_id):
+    """The phase-2 bracket with the module's budget, as ``reupload_raster`` opens it."""
+    return _job_phase_session(
+        job_id,
+        phase="phase2",
+        attempt_id=attempt_id,
+        require_status="running",
+        lock_and_statement_timeout_ms=tasks_raster_replace._PHASE2_TIMEOUT_MS,
+    )
+
+
 class TestPhaseTwoCallSite:
     """Pure AST — no DB."""
 
     def test_the_phase_bracket_names_the_module_budget(self) -> None:
-        budget = _phase_two_keywords().get("lock_and_statement_timeout_ms")
+        budget = {kw.arg: kw.value for kw in _phase_two_call().keywords if kw.arg}.get(
+            "lock_and_statement_timeout_ms"
+        )
         assert isinstance(budget, ast.Name) and budget.id == "_PHASE2_TIMEOUT_MS", (
             "reupload_raster's phase 2 enters _job_phase_session without "
             f"lock_and_statement_timeout_ms ({ast.dump(budget) if budget else None}), "
-            "so the helper issues neither SET LOCAL and every statement in the "
-            "phase — the catalog wait included — runs unbounded."
+            "so the helper issues neither SET LOCAL and the job SELECT it runs "
+            "before the caller gets control is unbounded."
         )
 
     def test_the_acquisition_leaves_the_phase_budget_in_force(self) -> None:
@@ -113,16 +182,56 @@ class TestPhaseTwoCallSite:
         ]
         assert len(passed) == 1, f"expected one acquisition; found {len(passed)}"
         assert isinstance(passed[0], ast.Constant) and passed[0].value is None, (
-            "the acquisition installs its own lock_timeout, which replaces the "
-            "phase budget for the rest of the transaction."
+            "the acquisition installs its own lock_timeout, which would persist "
+            "onto the quota reservation below it."
+        )
+
+    def test_statement_timeout_is_cleared_before_the_phase_does_its_work(self) -> None:
+        assert _set_local_line("statement_timeout") < _call_line("lock_catalog_rows"), (
+            "statement_timeout is still armed at the catalog wait, so expiry is "
+            "57014, which is outside LOCK_CONFLICT: lock_catalog_rows re-raises "
+            "a bare DBAPIError whose str() is a SQL statement, and two "
+            "user-visible error_message columns store it verbatim."
+        )
+
+    def test_lock_timeout_is_cleared_before_the_quota_reservation(self) -> None:
+        reset = _set_local_line("lock_timeout")
+        assert _call_line("lock_catalog_rows") < reset, (
+            "lock_timeout is cleared before the catalog wait it exists for, "
+            "leaving that wait unbounded"
+        )
+        assert reset < _call_line("reserve_replacement_bytes"), (
+            "the quota reservation runs under a lock_timeout. It waits on a "
+            "per-user advisory lock a sibling first ingest holds across a whole "
+            "COG upload, and both GUCs clamp an advisory wait, so a replace that "
+            "waited and succeeded before now fails after its own upload is done."
+        )
+
+
+class TestRasterRefreshErrorCode:
+    """Pure mapping — no DB."""
+
+    def test_a_contended_catalog_row_maps_to_its_own_code(self) -> None:
+        code = tasks_raster_replace._raster_refresh_error_code(
+            CatalogLockConflict("held")
+        )
+        assert code == CATALOG_LOCK_CONFLICT_CODE, (
+            "a lock-contention failure reports as a bad raster, sending the "
+            "reader to inspect a file that was never the problem"
+        )
+
+    def test_everything_else_keeps_its_path_code(self) -> None:
+        assert (
+            tasks_raster_replace._raster_refresh_error_code(RuntimeError("gdal"))
+            == "raster_refresh_failed"
         )
 
 
 class TestPhaseTwoBudgetAgainstPostgres:
-    async def test_the_catalog_wait_starts_on_the_phase_budget(
+    async def test_the_catalog_wait_runs_on_lock_timeout_alone(
         self, swap_target, running_job
     ) -> None:
-        """Both timeouts are in force when the acquisition is entered."""
+        """On entry to the acquisition: budget on lock_timeout, statement_timeout off."""
         stub, _staging = swap_target
         job_id, attempt_id = running_job
         expected = await _as_postgres_renders(tasks_raster_replace._PHASE2_TIMEOUT_MS)
@@ -137,22 +246,17 @@ class TestPhaseTwoBudgetAgainstPostgres:
             )
             await lock_catalog_rows(session, **kwargs)
 
-        async with _job_phase_session(
-            job_id,
-            phase="phase2",
-            attempt_id=attempt_id,
-            require_status="running",
-            lock_and_statement_timeout_ms=tasks_raster_replace._PHASE2_TIMEOUT_MS,
-        ) as (session, job):
+        async with _enter_phase(job_id, attempt_id) as (session, job):
             assert job is not None
-            await _recording_lock(
-                session,
-                dataset_cls=Dataset,
-                record_cls=Record,
-                dataset_id=stub.id,
-                record_id=stub.record_id,
-                lock_timeout=None,
-            )
+            await session.execute(text("SET LOCAL statement_timeout = 0"))
+            loaded = (
+                await session.execute(
+                    select(Dataset)
+                    .options(joinedload(Dataset.record))
+                    .where(Dataset.id == stub.id)
+                )
+            ).scalar_one()
+            await _take_the_pair(session, loaded, _recording_lock)
             await session.rollback()
 
         assert observed["lock_timeout"] == expected, (
@@ -161,38 +265,34 @@ class TestPhaseTwoBudgetAgainstPostgres:
             f"renders {tasks_raster_replace._PHASE2_TIMEOUT_MS} to. A '0' here "
             "is an unbounded wait on a contended catalog row."
         )
-        assert observed["statement_timeout"] == expected, (
+        assert observed["statement_timeout"] == "0", (
             f"statement_timeout read {observed['statement_timeout']!r} at the "
-            "acquisition, so the phase's other statements are unbounded even "
-            "where the lock wait is not."
+            "acquisition, so expiry is 57014 rather than the 55P03 that becomes "
+            "a rolled-back CatalogLockConflict."
         )
 
-    async def test_a_holder_past_the_budget_aborts_the_phase(
+    async def test_a_holder_past_the_budget_reports_contention(
         self, swap_target, running_job, monkeypatch
     ) -> None:
-        """Expiry raises 57014 — statement_timeout wins the tie at equal values."""
+        """Expiry is a CatalogLockConflict, logged with the wait and the budget."""
         stub, _staging = swap_target
         job_id, attempt_id = running_job
         monkeypatch.setattr(tasks_raster_replace, "_PHASE2_TIMEOUT_MS", _TEST_BUDGET_MS)
         import app.core.db as db_module
 
-        async def _run_phase() -> None:
-            async with _job_phase_session(
-                job_id,
-                phase="phase2",
-                attempt_id=attempt_id,
-                require_status="running",
-                lock_and_statement_timeout_ms=tasks_raster_replace._PHASE2_TIMEOUT_MS,
-            ) as (session, job):
+        async def _run_phase(clear_statement_timeout: bool = True) -> None:
+            async with _enter_phase(job_id, attempt_id) as (session, job):
                 assert job is not None
-                await lock_catalog_rows(
-                    session,
-                    dataset_cls=Dataset,
-                    record_cls=Record,
-                    dataset_id=stub.id,
-                    record_id=stub.record_id,
-                    lock_timeout=None,
-                )
+                if clear_statement_timeout:
+                    await session.execute(text("SET LOCAL statement_timeout = 0"))
+                loaded = (
+                    await session.execute(
+                        select(Dataset)
+                        .options(joinedload(Dataset.record))
+                        .where(Dataset.id == stub.id)
+                    )
+                ).scalar_one()
+                await _take_the_pair(session, loaded)
 
         async with db_module.async_session() as holder:
             await holder.execute(
@@ -200,8 +300,9 @@ class TestPhaseTwoBudgetAgainstPostgres:
             )
             loop = asyncio.get_running_loop()
             started = loop.time()
-            with pytest.raises(DBAPIError) as excinfo:
-                await asyncio.wait_for(_run_phase(), timeout=30)
+            with structlog.testing.capture_logs() as captured:
+                with pytest.raises(CatalogLockConflict) as excinfo:
+                    await asyncio.wait_for(_run_phase(), timeout=30)
             waited_ms = (loop.time() - started) * 1000
             await holder.rollback()
 
@@ -209,14 +310,103 @@ class TestPhaseTwoBudgetAgainstPostgres:
             f"the phase gave up after {round(waited_ms)}ms against a "
             f"{_TEST_BUDGET_MS}ms budget, so this run proves nothing about the wait"
         )
-        assert sqlstate(excinfo.value) == "57014", (
-            f"the held row aborted the phase with {sqlstate(excinfo.value)!r}. "
-            "lock_and_statement_timeout_ms arms statement_timeout at statement "
-            "start and lock_timeout only once the wait begins, so at equal "
-            "values statement_timeout is always the earlier deadline."
+        assert sqlstate(excinfo.value.__cause__) == "55P03"
+        expired = [
+            r
+            for r in captured
+            if r.get("event") == "raster_replace_catalog_lock_timeout"
+        ]
+        assert len(expired) == 1, (
+            f"expected one raster_replace_catalog_lock_timeout event; got {captured}"
         )
-        assert not is_lock_conflict(excinfo.value), (
-            "57014 is outside LOCK_CONFLICT, so lock_catalog_rows re-raises the "
-            "DBAPIError instead of the rolled-back CatalogLockConflict; the "
-            "phase bracket's own handler does the rollback."
+        assert expired[0]["log_level"] == "warning"
+        assert expired[0]["dataset_id"] == str(stub.id)
+        assert expired[0]["budget"] == _TEST_BUDGET_MS
+        assert expired[0]["sqlstate"] == "55P03"
+        assert expired[0]["waited_ms"] >= _TEST_BUDGET_MS * 0.8
+
+        # Leaving statement_timeout armed is what makes the same wait raise a
+        # bare DBAPIError, whose str() two error_message columns store verbatim.
+        async with db_module.async_session() as holder:
+            await holder.execute(
+                select(Dataset.id).where(Dataset.id == stub.id).with_for_update()
+            )
+            with pytest.raises(DBAPIError) as raw:
+                await asyncio.wait_for(_run_phase(False), timeout=30)
+            await holder.rollback()
+
+        assert not isinstance(raw.value, CatalogLockConflict)
+        assert sqlstate(raw.value) == "57014"
+        assert "SELECT" in str(raw.value), (
+            "the 57014 path no longer carries SQL in str(exc); if that holds, "
+            "the statement_timeout reset is no longer load-bearing for the "
+            "error surface and this assertion should be revisited"
         )
+
+    @pytest.mark.parametrize(
+        "clear_the_budget", [True, False], ids=["reset", "no_reset"]
+    )
+    async def test_the_quota_reservation_outlasts_the_budget(
+        self, swap_target, running_job, monkeypatch, test_db_session, clear_the_budget
+    ) -> None:
+        """The reservation waits out a sibling upload only because the reset runs."""
+        stub, _staging = swap_target
+        job_id, attempt_id = running_job
+        monkeypatch.setattr(tasks_raster_replace, "_PHASE2_TIMEOUT_MS", _TEST_BUDGET_MS)
+        owner = await get_user_id(test_db_session, "admin")
+        import app.core.db as db_module
+
+        held = asyncio.Event()
+        hold_for = (_TEST_BUDGET_MS / 1000) * 3
+
+        async def _sibling_upload() -> None:
+            async with db_module.async_session() as sibling:
+                await sibling.execute(text(_QUOTA_LOCK), {"uid": str(owner)})
+                held.set()
+                await asyncio.sleep(hold_for)
+                await sibling.rollback()
+
+        sibling_task = asyncio.create_task(_sibling_upload())
+        await held.wait()
+
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        async with _enter_phase(job_id, attempt_id) as (session, job):
+            assert job is not None
+            await session.execute(text("SET LOCAL statement_timeout = 0"))
+            loaded = (
+                await session.execute(
+                    select(Dataset)
+                    .options(joinedload(Dataset.record))
+                    .where(Dataset.id == stub.id)
+                )
+            ).scalar_one()
+            await _take_the_pair(session, loaded)
+            if clear_the_budget:
+                await session.execute(text("SET LOCAL lock_timeout = 0"))
+            aborted = None
+            try:
+                await session.execute(text(_QUOTA_LOCK), {"uid": str(owner)})
+            except DBAPIError as exc:
+                aborted = sqlstate(exc)
+            waited_ms = (loop.time() - started) * 1000
+            await session.rollback()
+        await sibling_task
+
+        if clear_the_budget:
+            assert aborted is None, (
+                f"the reservation aborted with {aborted!r} despite the reset. "
+                "A replace that waited and succeeded now fails after its own "
+                "COG and quicklooks are already uploaded."
+            )
+            assert waited_ms >= _TEST_BUDGET_MS, (
+                f"the reservation acquired in {round(waited_ms)}ms, under the "
+                f"{_TEST_BUDGET_MS}ms budget, so the sibling was not holding "
+                "and this run proves nothing"
+            )
+        else:
+            assert aborted == "55P03", (
+                "the budget did not clamp the advisory wait, so the reset above "
+                f"it guards nothing (got {aborted!r}). Both GUCs clamp an "
+                "advisory-lock wait; that is why the reset has to exist."
+            )

--- a/backend/tests/test_raster_replace_phase_budget_1937.py
+++ b/backend/tests/test_raster_replace_phase_budget_1937.py
@@ -23,6 +23,7 @@ from app.platform.catalog_locks import (
     CatalogLockConflict,
     lock_catalog_rows,
 )
+from app.platform.jobs.heartbeat import update_ingest_job_for_attempt
 from app.platform.jobs.models import IngestJob
 from app.processing.ingest import tasks_raster_replace
 from app.processing.ingest.tasks_common import _job_phase_session
@@ -52,8 +53,8 @@ def _reupload_raster_body() -> ast.FunctionDef:
     )
 
 
-def _phase_two_call() -> ast.Call:
-    """The ``_job_phase_session`` call ``reupload_raster`` opens phase 2 with."""
+def _phase_call(phase: str) -> ast.Call:
+    """The ``_job_phase_session`` call ``reupload_raster`` opens *phase* with."""
     calls = [
         node
         for node in ast.walk(_reupload_raster_body())
@@ -62,12 +63,20 @@ def _phase_two_call() -> ast.Call:
         and any(
             kw.arg == "phase"
             and isinstance(kw.value, ast.Constant)
-            and kw.value.value == "phase2"
+            and kw.value.value == phase
             for kw in node.keywords
         )
     ]
-    assert len(calls) == 1, f"expected one phase-2 session bracket; found {len(calls)}"
+    assert len(calls) == 1, f"expected one {phase} bracket; found {len(calls)}"
     return calls[0]
+
+
+def _budget_name(phase: str) -> str | None:
+    """The constant the *phase* bracket names as its budget, if any."""
+    budget = {kw.arg: kw.value for kw in _phase_call(phase).keywords if kw.arg}.get(
+        "lock_and_statement_timeout_ms"
+    )
+    return budget.id if isinstance(budget, ast.Name) else None
 
 
 def _set_local_line(guc: str) -> int:
@@ -160,14 +169,19 @@ class TestPhaseTwoCallSite:
     """Pure AST — no DB."""
 
     def test_the_phase_bracket_names_the_module_budget(self) -> None:
-        budget = {kw.arg: kw.value for kw in _phase_two_call().keywords if kw.arg}.get(
-            "lock_and_statement_timeout_ms"
-        )
-        assert isinstance(budget, ast.Name) and budget.id == "_PHASE2_TIMEOUT_MS", (
+        assert _budget_name("phase2") == "_PHASE2_TIMEOUT_MS", (
             "reupload_raster's phase 2 enters _job_phase_session without "
-            f"lock_and_statement_timeout_ms ({ast.dump(budget) if budget else None}), "
-            "so the helper issues neither SET LOCAL and the job SELECT it runs "
-            "before the caller gets control is unbounded."
+            f"lock_and_statement_timeout_ms ({_budget_name('phase2')}), so the "
+            "helper issues neither SET LOCAL and the job SELECT it runs before "
+            "the caller gets control is unbounded."
+        )
+
+    def test_the_error_write_names_its_own_budget(self) -> None:
+        assert _budget_name("error_write") == "_ERROR_WRITE_TIMEOUT_MS", (
+            "the failure write is unbounded. It UPDATEs the same ingest_jobs "
+            "row phase 2 contends for, so bounding phase 2 alone moves the "
+            "contention onto a wait nothing ends, with the heartbeat still "
+            "reporting the job alive."
         )
 
     def test_the_acquisition_leaves_the_phase_budget_in_force(self) -> None:
@@ -341,6 +355,55 @@ class TestPhaseTwoBudgetAgainstPostgres:
             "the 57014 path no longer carries SQL in str(exc); if that holds, "
             "the statement_timeout reset is no longer load-bearing for the "
             "error surface and this assertion should be revisited"
+        )
+
+    async def test_the_error_write_gives_up_on_a_held_job_row(
+        self, running_job, monkeypatch
+    ) -> None:
+        """The failure write bounds its own UPDATE against the same job row."""
+        job_id, attempt_id = running_job
+        monkeypatch.setattr(
+            tasks_raster_replace, "_ERROR_WRITE_TIMEOUT_MS", _TEST_BUDGET_MS
+        )
+        import app.core.db as db_module
+
+        async def _write_the_failure() -> None:
+            async with _job_phase_session(
+                job_id,
+                phase="error_write",
+                attempt_id=attempt_id,
+                lock_and_statement_timeout_ms=(
+                    tasks_raster_replace._ERROR_WRITE_TIMEOUT_MS
+                ),
+            ) as (err_session, _job):
+                await update_ingest_job_for_attempt(
+                    err_session,
+                    job_id,
+                    attempt_id,
+                    values={"status": "failed", "error_message": "replace failed"},
+                )
+                await err_session.commit()
+
+        async with db_module.async_session() as holder:
+            await holder.execute(
+                select(IngestJob.id).where(IngestJob.id == job_id).with_for_update()
+            )
+            loop = asyncio.get_running_loop()
+            started = loop.time()
+            with pytest.raises(DBAPIError) as excinfo:
+                await asyncio.wait_for(_write_the_failure(), timeout=30)
+            waited_ms = (loop.time() - started) * 1000
+            await holder.rollback()
+
+        assert waited_ms >= _TEST_BUDGET_MS * 0.8, (
+            f"the error write gave up after {round(waited_ms)}ms against a "
+            f"{_TEST_BUDGET_MS}ms budget, so this run proves nothing"
+        )
+        assert sqlstate(excinfo.value) == "57014", (
+            f"the held job row ended the error write with "
+            f"{sqlstate(excinfo.value)!r}. Both GUCs are armed here and the "
+            "blocking statement is the UPDATE, so statement_timeout holds the "
+            "earlier deadline; nothing on this path stores str(exc)."
         )
 
     @pytest.mark.parametrize(

--- a/backend/tests/test_vrt_publish_catalog_wait_1938.py
+++ b/backend/tests/test_vrt_publish_catalog_wait_1938.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 import structlog
-from asyncpg.exceptions import DeadlockDetectedError
+from asyncpg.exceptions import DeadlockDetectedError, LockNotAvailableError
 from sqlalchemy import select, text
 from sqlalchemy.exc import DBAPIError
 
@@ -41,6 +41,16 @@ def _publish_lock_call() -> ast.Call:
     ]
     assert len(calls) == 1, f"expected one acquisition; found {len(calls)}"
     return calls[0]
+
+
+# Modules an argument may read through; anything else is a live instance.
+_SAFE_ROOTS = frozenset({"time"})
+
+
+def _root_name(node: ast.expr) -> str | None:
+    while isinstance(node, (ast.Attribute, ast.Call, ast.Subscript)):
+        node = node.func if isinstance(node, ast.Call) else node.value
+    return node.id if isinstance(node, ast.Name) else None
 
 
 def _failure_log_call() -> ast.Call:
@@ -98,11 +108,12 @@ class TestPublishCallSite:
         )
 
     def test_the_failure_report_reads_no_orm_attribute(self) -> None:
-        args = _failure_log_call()
         offenders = [
-            kw.arg
-            for kw in args.keywords
-            if kw.arg and isinstance(kw.value, ast.Attribute)
+            f"{kw.arg}={_root_name(sub)}.{sub.attr}"
+            for kw in _failure_log_call().keywords
+            if kw.arg
+            for sub in ast.walk(kw.value)
+            if isinstance(sub, ast.Attribute) and _root_name(sub) not in _SAFE_ROOTS
         ]
         assert not offenders, (
             f"{offenders} are read off a loaded instance after the acquisition "
@@ -115,6 +126,12 @@ class TestPublishCallSite:
         ("cause", "log_event", "code", "needle"),
         [
             (
+                DBAPIError("stmt", {}, LockNotAvailableError("expired")),
+                "vrt_publish_catalog_lock_timeout",
+                "55P03",
+                "pg_stat_activity",
+            ),
+            (
                 DBAPIError("stmt", {}, DeadlockDetectedError("cycle")),
                 "vrt_publish_catalog_deadlock",
                 "40P01",
@@ -122,7 +139,7 @@ class TestPublishCallSite:
             ),
             (None, "vrt_publish_catalog_lock_failed", None, "no SQLSTATE"),
         ],
-        ids=["deadlock", "no_sqlstate"],
+        ids=["expiry", "deadlock", "no_sqlstate"],
     )
     def test_the_cause_picks_the_event(self, cause, log_event, code, needle) -> None:
         conflict = CatalogLockConflict("held")
@@ -202,6 +219,23 @@ class TestPublishWaitAgainstPostgres:
             f"the acquisition ran on lock_timeout {in_force!r}, not the "
             f"{expected!r} PostgreSQL renders "
             f"{tasks_vrt._PUBLISH_CATALOG_TIMEOUT!r} to."
+        )
+
+    def test_the_budget_is_restored_after_the_acquisition(self) -> None:
+        """The UPDATEs after the wait run on the value the transaction arrived with."""
+        source = Path(tasks_vrt.__file__).read_text()
+        restores = [
+            node.lineno
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and "set_config('lock_timeout'" in node.value
+        ]
+        assert len(restores) == 1, f"expected one restore; found {restores}"
+        assert _publish_lock_call().lineno < restores[0], (
+            "the restore runs before the wait it exists for. Those UPDATEs sit "
+            "outside lock_catalog_rows, so a 55P03 there is a bare DBAPIError "
+            "whose str() carries the statement and its bound parameters."
         )
 
     async def test_a_held_records_row_expires_the_budget(

--- a/backend/tests/test_vrt_publish_catalog_wait_1938.py
+++ b/backend/tests/test_vrt_publish_catalog_wait_1938.py
@@ -1,0 +1,248 @@
+"""The VRT publish's catalog acquisition carries its own budget (#1938).
+
+Its ``catalog.records`` half is a real wait: the asset SELECT's join covers
+``catalog.datasets`` alone. The DB tests need the Docker test database.
+"""
+
+import ast
+import asyncio
+import uuid
+from pathlib import Path
+
+import pytest
+import structlog
+from asyncpg.exceptions import DeadlockDetectedError
+from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError
+
+from app.core.db.sqlstate import sqlstate
+from app.modules.catalog.datasets.domain.models import Dataset, Record
+from app.platform.catalog_locks import CatalogLockConflict, lock_catalog_rows
+from app.processing.ingest import tasks_vrt
+from app.processing.raster.models import RasterAsset
+
+from tests.test_swap_lock_timeout_scope_1917 import make_swap_target
+
+pytestmark = pytest.mark.anyio
+
+# Short enough that a held row outlasts it in under a second.
+_TEST_BUDGET = "400ms"
+_TEST_BUDGET_MS = 400
+
+
+def _publish_lock_call() -> ast.Call:
+    """The ``lock_catalog_rows`` call the VRT publish transaction makes."""
+    source = Path(tasks_vrt.__file__).read_text()
+    calls = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", None) == "lock_catalog_rows"
+    ]
+    assert len(calls) == 1, f"expected one acquisition; found {len(calls)}"
+    return calls[0]
+
+
+def _failure_log_call() -> ast.Call:
+    source = Path(tasks_vrt.__file__).read_text()
+    calls = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", None) == "_log_publish_wait_failure"
+    ]
+    assert len(calls) == 1, f"expected one failure report; found {len(calls)}"
+    return calls[0]
+
+
+async def _as_postgres_renders(value: str) -> str:
+    """What ``current_setting('lock_timeout')`` reports back for *value*."""
+    import app.core.db as db_module
+
+    async with db_module.async_session() as probe:
+        rendered = await probe.scalar(
+            text("SELECT set_config('lock_timeout', :value, true)"), {"value": value}
+        )
+        await probe.rollback()
+    return rendered
+
+
+@pytest.fixture
+async def vrt_target(client, test_db_session):
+    """A committed dataset/record pair with the raster asset the publish joins."""
+    async for stub, _staging in make_swap_target(client, test_db_session):
+        test_db_session.add(
+            RasterAsset(
+                dataset_id=stub.id,
+                asset_uri=f"rasters/{uuid.uuid4().hex}/source.vrt",
+                storage_backend="local",
+            )
+        )
+        await test_db_session.commit()
+        yield stub
+
+
+class TestPublishCallSite:
+    """Pure AST and pure mapping — no DB."""
+
+    def test_the_acquisition_names_the_publish_budget(self) -> None:
+        passed = {
+            kw.arg: kw.value for kw in _publish_lock_call().keywords if kw.arg
+        }.get("lock_timeout")
+        assert (
+            isinstance(passed, ast.Name) and passed.id == "_PUBLISH_CATALOG_TIMEOUT"
+        ), (
+            "the publish acquires catalog.records with "
+            f"{ast.dump(passed) if passed else None}. That row is not in the "
+            "asset SELECT's join, so nothing else bounds the wait for it."
+        )
+
+    def test_the_failure_report_reads_no_orm_attribute(self) -> None:
+        args = _failure_log_call()
+        offenders = [
+            kw.arg
+            for kw in args.keywords
+            if kw.arg and isinstance(kw.value, ast.Attribute)
+        ]
+        assert not offenders, (
+            f"{offenders} are read off a loaded instance after the acquisition "
+            "failed. lock_catalog_rows rolls back before it raises, which "
+            "expires every instance, so the read raises MissingGreenlet and "
+            "replaces the conflict with a greenlet error."
+        )
+
+    @pytest.mark.parametrize(
+        ("cause", "log_event", "code", "needle"),
+        [
+            (
+                DBAPIError("stmt", {}, DeadlockDetectedError("cycle")),
+                "vrt_publish_catalog_deadlock",
+                "40P01",
+                "deadlock victim",
+            ),
+            (None, "vrt_publish_catalog_lock_failed", None, "no SQLSTATE"),
+        ],
+        ids=["deadlock", "no_sqlstate"],
+    )
+    def test_the_cause_picks_the_event(self, cause, log_event, code, needle) -> None:
+        conflict = CatalogLockConflict("held")
+        conflict.__cause__ = cause
+        with structlog.testing.capture_logs() as captured:
+            tasks_vrt._log_publish_wait_failure(
+                conflict, job_id="job-1", dataset_id="ds-1", waited_ms=7
+            )
+        assert [r["event"] for r in captured] == [log_event]
+        assert captured[0]["log_level"] == "warning"
+        assert captured[0]["sqlstate"] == code
+        assert needle in captured[0]["hint"]
+        assert captured[0]["budget"] == tasks_vrt._PUBLISH_CATALOG_TIMEOUT
+        assert captured[0]["waited_ms"] == 7
+
+
+class TestPublishWaitAgainstPostgres:
+    async def test_the_asset_select_covers_the_datasets_row_alone(
+        self, vrt_target
+    ) -> None:
+        """The join takes catalog.datasets incidentally and never catalog.records."""
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as publisher,
+            db_module.async_session() as probe,
+        ):
+            await publisher.execute(
+                select(RasterAsset)
+                .join(Dataset, RasterAsset.dataset_id == Dataset.id)
+                .where(Dataset.id == vrt_target.id)
+                .with_for_update()
+            )
+            await probe.execute(text("SET LOCAL lock_timeout = '250ms'"))
+            with pytest.raises(DBAPIError):
+                await probe.execute(
+                    select(Dataset.id)
+                    .where(Dataset.id == vrt_target.id)
+                    .with_for_update()
+                )
+            await probe.rollback()
+
+            await probe.execute(text("SET LOCAL lock_timeout = '250ms'"))
+            free = await probe.scalar(
+                select(Record.id)
+                .where(Record.id == vrt_target.record_id)
+                .with_for_update()
+            )
+            assert free == vrt_target.record_id, (
+                "the asset SELECT takes catalog.records too, so the publish's "
+                "second acquisition needs no budget of its own"
+            )
+            await probe.rollback()
+            await publisher.rollback()
+
+    async def test_the_publish_budget_is_in_force_at_the_acquisition(
+        self, vrt_target
+    ) -> None:
+        expected = await _as_postgres_renders(tasks_vrt._PUBLISH_CATALOG_TIMEOUT)
+        import app.core.db as db_module
+
+        async with db_module.async_session() as session:
+            await lock_catalog_rows(
+                session,
+                dataset_cls=Dataset,
+                record_cls=Record,
+                dataset_id=vrt_target.id,
+                record_id=vrt_target.record_id,
+                lock_timeout=tasks_vrt._PUBLISH_CATALOG_TIMEOUT,
+            )
+            in_force = await session.scalar(
+                text("SELECT current_setting('lock_timeout')")
+            )
+            await session.rollback()
+
+        assert in_force == expected, (
+            f"the acquisition ran on lock_timeout {in_force!r}, not the "
+            f"{expected!r} PostgreSQL renders "
+            f"{tasks_vrt._PUBLISH_CATALOG_TIMEOUT!r} to."
+        )
+
+    async def test_a_held_records_row_expires_the_budget(
+        self, vrt_target, monkeypatch
+    ) -> None:
+        """The wait gives up as lock contention instead of hanging the job."""
+        monkeypatch.setattr(tasks_vrt, "_PUBLISH_CATALOG_TIMEOUT", _TEST_BUDGET)
+        import app.core.db as db_module
+
+        async with (
+            db_module.async_session() as holder,
+            db_module.async_session() as publisher,
+        ):
+            await holder.execute(
+                select(Record.id)
+                .where(Record.id == vrt_target.record_id)
+                .with_for_update()
+            )
+            loop = asyncio.get_running_loop()
+            started = loop.time()
+            with pytest.raises(CatalogLockConflict) as excinfo:
+                await asyncio.wait_for(
+                    lock_catalog_rows(
+                        publisher,
+                        dataset_cls=Dataset,
+                        record_cls=Record,
+                        dataset_id=vrt_target.id,
+                        record_id=vrt_target.record_id,
+                        lock_timeout=tasks_vrt._PUBLISH_CATALOG_TIMEOUT,
+                    ),
+                    timeout=30,
+                )
+            waited_ms = (loop.time() - started) * 1000
+            await holder.rollback()
+
+        assert waited_ms >= _TEST_BUDGET_MS * 0.8, (
+            f"the wait gave up after {round(waited_ms)}ms against a "
+            f"{_TEST_BUDGET} budget, so this run proves nothing about it"
+        )
+        cause = excinfo.value.__cause__
+        assert sqlstate(cause) == "55P03", (
+            f"the expiry reported {sqlstate(cause)!r}, so the three-way dispatch "
+            "cannot tell it from a deadlock"
+        )


### PR DESCRIPTION
Two sibling worker waits found while auditing #1933, each unbounded for its own reason. Neither runs DDL across its wait, so the exposure is a hung job that heartbeats until the stale sweep reaps it, not an unreadable dataset.

Four commits: one per issue, then two addressing review.

## #1937 — raster replace

`reupload_raster` phase 2 entered `_job_phase_session` without `lock_and_statement_timeout_ms`, and that helper issues its two `SET LOCAL`s only when the kwarg is given. The worker never installs the API budget (`install_api_statement_timeout` has one caller, `app/api/main.py`), so `lock_timeout` and `statement_timeout` were both `0` and the catalog acquisition that ends the phase could wait forever behind a held row.

**The budget is armed for the helper's own SELECT, then narrowed twice.** `lock_and_statement_timeout_ms=30_000` covers the `SELECT … FOR NO KEY UPDATE` the helper runs before the caller gets control — the hole #1778 opened it for. On entry, `statement_timeout` is cleared. Immediately after the acquisition, `lock_timeout` is cleared. Net: job SELECT bounded, catalog wait bounded, everything else exactly as before this PR.

**Why the whole-phase budget was wrong** (caught in review). `reserve_replacement_bytes` → `reserve_storage_bytes` takes a per-user advisory lock. A sibling *first ingest* holds that same lock from `create_raster_dataset` (`tasks_raster_common.py:207-208`) to its commit at `tasks_raster.py:706` — across three `storage.put` calls and `archive_lossy_original`, with no commit in between. So the legitimate wait there is as long as another upload by the same owner takes. Measured, against a held advisory lock:

| GUC set to 800 ms | elapsed | SQLSTATE | `is_lock_conflict` |
| --- | --- | --- | --- |
| `lock_timeout` | 815 ms | `55P03` | `True` |
| `statement_timeout` | 802 ms | `57014` | `False` |

**Both** GUCs clamp an advisory wait, so "bound `lock_timeout` only" is not a middle path, and a per-call clamp would not have helped either — `reserve_replacement_bytes` runs *downstream* of the acquisition, so a per-call `SET LOCAL` persists onto it. Hence an explicit reset. It bites only where an operator has set `max_storage_bytes_per_user` (`cap <= 0` returns early), but the failure lands after this attempt's COG and quicklooks are already uploaded, and `_retry_capability` refuses to replay a reupload job, so the user redoes it by hand.

**Capture-and-restore does not work here**, unlike #1917/#1921. `_job_phase_session` issues both `SET LOCAL`s at session start, before the job SELECT and before the caller gets control, so `current_setting` read from inside the block returns *the budget* — restoring it puts the budget back. #1917's shape works at its own site because the captured value predates the clamp. Two explicit resets are the only correct form.

**Why 30 seconds.** Sized against holders of the *catalog rows*: request-path writers of that pair cap their own acquisition at `REQUEST_LOCK_TIMEOUT` (2 s) and hold from flush to commit. It is deliberately not sized against object-storage work, which is what the resets take back out of its scope.

### The failure write, bounded too

Bounding phase 2 put a budget on the `SELECT … FOR NO KEY UPDATE` it takes on its `ingest_jobs` row, so a contended job row now raises there rather than waiting. The outer failure handler then entered `_job_phase_session(phase="error_write")` with no budget and wrote through that same row — moving contention from a bounded statement onto an unbounded one, with the heartbeat still reporting the job alive. Found in review; it is a pre-existing path that this PR's change makes reachable.

The blocking statement is not the obvious one, and it matters for where the bound goes. The error-write bracket passes no `require_status`, so `_job_phase_session` does not apply `with_for_update(key_share=True)` and its SELECT is plain. Measured against a held row: the plain SELECT does not block at all; the `UPDATE` inside `update_ingest_job_for_attempt` blocks and ends at `57014` after 409 ms on a 400 ms budget.

**Bounded rather than routed around the row**, because marking the job failed *is* a write to that row — there is nothing to route around. `_ERROR_WRITE_TIMEOUT_MS = 10_000`, sized against holders of the *job* row rather than the catalog rows: `cancel_job` runs its transition under a 2 s `lock_timeout`, and the stale sweep and startup recovery both take candidates `FOR UPDATE SKIP LOCKED`, so they never hold against this.

**If the bound itself expires**, the job never records its failure, stays `running`, and settles only when the stale sweep reaps it. The `finally` stops the heartbeat, so nothing keeps it looking alive. That is worse than a recorded failure and better than a worker that hangs forever, and it is a real behaviour change rather than a pure fix.

Scope is deliberately narrow: every other error write in the tree is unbounded the same way (`tasks_vector.py`, `tasks_raster.py`, `tasks_reupload.py`), on already-merged code including #1933's own path. That is the same class, filed separately, and not widened into here.

**Non-goal: `idle_in_transaction_session_timeout`.** The issue lists three zeros; this closes two, deliberately. Phase 2 legitimately sits idle inside its transaction across three `storage.put` calls and `archive_lossy_original`, which PUTs the whole original raster. Any value that bounds an abandoned transaction here kills a working replace.

### What the expiry reports

Clearing `statement_timeout` also fixes the *failure surface*, and this is why the two resets are not interchangeable. On `lock_timeout` alone the abort is `55P03`, which `is_lock_conflict` matches, so `lock_catalog_rows` raises a rolled-back `CatalogLockConflict`. Left on `statement_timeout` it is `57014`, which it does not match, so a bare `DBAPIError` propagates — and `str(exc)` is a SQL statement with its bound parameters, which `tasks_raster_replace.py` stores twice:

- `ingest_jobs.error_message` — no redaction, no truncation, rendered verbatim by the reupload dialog the user is watching.
- `dataset_refresh_runs.error_message` via `redact_run_error`, which strips URL credentials and truncates at 2000 but does not strip SQL.

With a typed exception the acquisition now also maps to `catalog_lock_conflict` instead of the hardcoded `raster_refresh_failed`, so contention no longer sends the reader to inspect a raster file, and the failed wait logs its SQLSTATE, the ms it waited, the budget and a hint — matching what the #1938 half already did.

## #1938 — VRT publish

Two defects, and the comment mattered more than the bound.

The comment called the acquisition a no-op re-lock because "the asset SELECT above already locks this datasets row through its join". True of one row of two. The asset SELECT is `with_for_update()` with no `of=`, which compiles to a bare `FOR UPDATE`, and PostgreSQL locks a row from every table in the FROM list — so the datasets row really is taken incidentally. `catalog.records` is not in that query, so the second acquisition is a genuine wait, and it ran with `lock_timeout=None` on a bare `async_session()`. `test_the_asset_select_covers_the_datasets_row_alone` measures both halves against PostgreSQL.

The bound is a per-call `lock_timeout` of 15 s — deliberately the opposite shape from #1937's. `regenerate_vrt` phase 2 opens a plain `async_session()`, not `_job_phase_session`, so the phase-budget kwarg is not reachable without adopting the helper, and the wait is the only statement here that needs one.

**The 15 s is re-derived** (review). The first justification cited `_PAIR_WRITER_EXEMPTIONS`' "record only" entries as short request transactions capped at `REQUEST_LOCK_TIMEOUT`; those entries are `apply_manifest_record_metadata` and `_write_swapped_fields`, a pure in-memory helper and a sync no-session helper — neither a request transaction, neither taking a lock. What actually holds `catalog.records` here: an ordered pair-writer blocks on the datasets row this transaction already holds, so the only holders are request handlers that dirty the record and hold it from flush to commit. Nothing caps that hold, so 15 s is a stuck-not-queued threshold, not a derived bound, and the comment now says so.

The publish also **restores the `lock_timeout` it installs**, for the same reason #1937 clears its own: the two raw `UPDATE`s after the acquisition sit outside `lock_catalog_rows`, so a `55P03` there is a bare `DBAPIError` on the same `str(exc)` path into both `error_message` columns.

## Shared classification

The SQLSTATE dispatch (`55P03` / `40P01` / unreadable cause) lives in `catalog_locks.lock_conflict_report`, next to the exception it classifies, so the two sites cannot drift. Each site keeps its own event prefix (`raster_replace_catalog_*`, `vrt_publish_catalog_*`) and passes a dataset id read *before* the acquisition — `lock_catalog_rows` rolls back before it raises, and a rolled-back session expires every loaded instance, so building the kwargs afterwards raises `MissingGreenlet` instead of reporting the conflict. That was #1933's P1. #1933's own inline copy in `tasks_common.py` is deliberately left alone: it is separately reviewed and merged, and folding it in would re-ratchet a cap that PR just set. Worth a follow-up.

The reporter is a **context manager rather than a wrapper function**. Extracting the acquisition into a helper hid it from four `#1847` AST gates that match `lock_catalog_rows` by name inside `reupload_raster` — two failed loudly, and the rest (`_acquires_raster_first`, `TestEveryJobWriterLeadsWithTheJobRow`) would have started passing vacuously. `with` is not a mccabe decision point, so this satisfies the C901 gate without moving the call out of view.

## Structural gate

`test_feature_lock_order_1847.py::test_worker_doors_do_not_clamp_their_transaction` asserted an exact list of `lock_timeout=None` sites, which post-#1933 read `["tasks_raster_replace.py", "tasks_vrt.py"]`. The VRT clamp removes one, so the literal, message, docstring and test name narrow to the one site left — renamed `test_the_raster_replace_door_is_the_only_unclamped_acquisition`. That site keeps `lock_timeout=None` on purpose: it runs under the phase's `lock_timeout`, and a per-call value would persist onto the quota reservation.

## Caps

- `tasks_vrt.py`: **1640 → 1698**, exact.
- `tasks_raster_replace.py`: **new entry at 1056**, exact — it crossed the 1000-line inclusion rule. The budget itself is six lines; the rest is what a newly failable wait owes its reader.

## Tests

Two files, each with a structural half needing no database and a DB-backed half. Both bounds carry a **negative half** that measures why the reset is needed rather than only that it works:

- `test_the_quota_reservation_outlasts_the_budget[no_reset]` shows the budget really does abort the advisory wait with `55P03`; `[reset]` shows it survives.
- `test_a_holder_past_the_budget_reports_contention` asserts `CatalogLockConflict`/`55P03` with the reset, then re-runs without it and asserts a bare `DBAPIError`/`57014` carrying SQL in `str(exc)`.

Review fixes to the #1938 tests: `test_the_failure_report_reads_no_orm_attribute` matched `isinstance(kw.value, ast.Attribute)` and was therefore blind to `str(dataset.id)` — an `ast.Call`, and the exact shape of #1933's P1. It now walks each argument and names the offending root, verified by reintroducing that literal. The `55P03` branch of the dispatch, previously asserted nowhere, is now parametrized alongside the other two.

Expected GUC strings are derived with a positive control (`SELECT set_config('lock_timeout', :v, true)` returns the value as PostgreSQL renders it), because `current_setting` canonicalises units — 30000 reads back as `'30s'`.

## Verification

```
cd backend && uv run pytest tests/test_raster_replace_phase_budget_1937.py \
  tests/test_vrt_publish_catalog_wait_1938.py tests/test_feature_lock_order_1847.py \
  tests/test_layering.py -q
# 153 passed, 1 skipped — exit 0

cd backend && uv run pytest tests/test_regenerate_vrt_integration.py tests/test_raster_replace_1221.py \
  tests/test_worker_swap_bump_after_lock_1911.py tests/test_vrt_staged_mutation_1327.py \
  tests/test_tasks_common_phase_brackets.py tests/test_job_cancel_vrt.py \
  tests/test_swap_catalog_wait_bound_1921.py tests/test_swap_lock_timeout_scope_1917.py \
  tests/test_reupload_swap_lock_retry.py -q
# 179 passed — exit 0

cd backend && uv run ruff check . && uv run ruff format --check .
# All checks passed! — exit 0
```

Counterfactuals: removing any of the three bounds fails its gate; reverting either bound fails its structural test; reverting the VRT clamp also fails the #1847 gate; reintroducing `str(vrt_dataset.id)` fails the no-ORM-attribute gate.

No schema, API or config impact. `CHANGELOG.md` gains one Fixed entry per issue; #1937's names the uncapped quota wait so operators do not read the 30 s as covering it.

Closes #1937
Closes #1938
