### PR TITLE
fix(ingest): publish the commit token as the credential the route reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and releases use semantic versioning.
 - A VRT regeneration could hang indefinitely while publishing if a metadata edit held the
   dataset's catalog record. That wait is now capped at 15 seconds, and a regeneration that gives
   up logs how long it waited and whether the budget expired or it lost a deadlock. (#1938)
+- The import-commit endpoint published its `token` field as a confirmation token from the preview
+  step, with no length limit, while on a service import the server reads that field as the service
+  credential and caps it at 1000 characters. The API document, both SDKs and the generated
+  TypeScript types now describe and declare what the server reads. (#1931)
 
 ## [1.18.1] - 2026-09-05
 

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -1126,7 +1126,7 @@ async def run_ogr2ogr_service(
         layer_name: Layer name (empty for ESRIJSON)
         table_name: Target table name (without schema prefix)
         db_conn_str: PG connection string for ogr2ogr
-        service_type: "wfs" or "arcgis_featureserver"
+        service_type: "wfs", "ogcapi_features" or "arcgis_featureserver"
         timeout: Seconds before killing subprocess (default 30 min)
         is_non_spatial: When True, omit geometry-specific flags (-nlt, -t_srs,
             GEOMETRY_NAME) to avoid dropping attribute columns for tables with

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -1427,9 +1427,9 @@ async def commit_import(
     try:
         commit = Subclass.model_validate(request.model_dump())
     except ValidationError as e:
-        # fix(#1755, #1923): the only enforcement of the import-commit door's
-        # stricter token rules — the flat CommitRequest declares neither the
-        # shared safe-token rule nor the 1000-character cap.
+        # fix(#1755, #1931): the only enforcement of the import-commit door's
+        # shared safe-token rule. The flat CommitRequest declares the cap the
+        # contract publishes; a charset rule has no JSON Schema spelling.
         raise RequestValidationError(errors=e.errors())
 
     # fix(#823): dash-guard + all_layers membership check for the commit's

--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.platform.service_auth import (
+    DEPRECATED_TOKEN_SUFFIX,
     SERVICE_AUTH_FIELD_DESCRIPTION,
     ServiceAuthRequest,
     _validate_safe_token,
@@ -293,9 +294,18 @@ class CommitRequest(BaseModel):
         le=998999,
         description="EPSG code to use when the source CRS is missing or incorrect. Assigns (relabels) the CRS the source is read under rather than reprojecting from it: raster pixel values are unchanged, and vector geometries are reprojected to EPSG:4326 from the assigned CRS as usual.",
     )
+    # fix(#1931): the cap is declared here as well as on ServiceCommitRequest
+    # because only this model's schema is published, and a constraint a caller
+    # cannot read is not part of the contract.
     token: str | None = Field(
         default=None,
-        description="Optional confirmation token returned by the preview step. Required for some workflows.",
+        max_length=1000,
+        description=(
+            "Optional auth token for a protected remote service, read only "
+            "when the job imports a service layer (WFS, ArcGIS FeatureServer). "
+            "Never persisted to the database. Ignored on file-upload jobs."
+            + DEPRECATED_TOKEN_SUFFIX
+        ),
     )
     temporal_start: datetime | None = Field(
         default=None, description="ISO 8601 start of the dataset's temporal extent."

--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -234,7 +234,7 @@ class RasterCommitRequest(BaseCommitRequest):
 
 
 class ServiceCommitRequest(BaseCommitRequest):
-    """Commit request for remote service layers (WFS, ArcGIS FeatureServer)."""
+    """Commit request for remote service layers (WFS, OGC API Features, or ArcGIS)."""
 
     token: str | None = Field(
         default=None,
@@ -302,7 +302,7 @@ class CommitRequest(BaseModel):
         max_length=1000,
         description=(
             "Optional auth token for a protected remote service, read only "
-            "when the job imports a service layer (WFS, ArcGIS FeatureServer). "
+            "when the job imports a service layer (WFS, OGC API Features, or ArcGIS). "
             "At most 1000 characters. Never persisted to the database. "
             "Ignored on file-upload jobs." + DEPRECATED_TOKEN_SUFFIX
         ),

--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -303,8 +303,8 @@ class CommitRequest(BaseModel):
         description=(
             "Optional auth token for a protected remote service, read only "
             "when the job imports a service layer (WFS, ArcGIS FeatureServer). "
-            "Never persisted to the database. Ignored on file-upload jobs."
-            + DEPRECATED_TOKEN_SUFFIX
+            "At most 1000 characters. Never persisted to the database. "
+            "Ignored on file-upload jobs." + DEPRECATED_TOKEN_SUFFIX
         ),
     )
     temporal_start: datetime | None = Field(

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3797,13 +3797,14 @@
           "token": {
             "anyOf": [
               {
+                "maxLength": 1000,
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Optional confirmation token returned by the preview step. Required for some workflows.",
+            "description": "Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.",
             "title": "Token"
           },
           "temporal_start": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3804,7 +3804,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). At most 1000 characters. Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.",
+            "description": "Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, OGC API Features, or ArcGIS). At most 1000 characters. Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.",
             "title": "Token"
           },
           "temporal_start": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3804,7 +3804,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.",
+            "description": "Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). At most 1000 characters. Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.",
             "title": "Token"
           },
           "temporal_start": {

--- a/backend/tests/test_1755_token_validator_consolidation.py
+++ b/backend/tests/test_1755_token_validator_consolidation.py
@@ -309,7 +309,7 @@ class TestTheCommitDoorsRefuseOverHttp:
         assert resp.status_code == 422, resp.text
         detail = resp.json()["detail"]
         assert isinstance(detail, str)
-        assert detail.startswith("token:")
+        assert detail.startswith("body.token:")
         assert over_cap not in resp.text
         task.defer_async.assert_not_awaited()
 

--- a/backend/tests/test_commit_request_schemas.py
+++ b/backend/tests/test_commit_request_schemas.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 
 from app.processing.ingest.schemas import (
     BaseCommitRequest,
+    CommitRequest,
     RasterCommitRequest,
     ServiceCommitRequest,
     VectorCommitRequest,
@@ -205,3 +206,45 @@ class TestFieldDistribution:
             # feat(#1746 B2b): the structured spelling of the same credential.
             "auth",
         }
+
+
+def _constraints(field_schema: dict) -> dict:
+    """A field's published constraints — everything but its prose and default."""
+    return {
+        key: value
+        for key, value in field_schema.items()
+        if key not in ("title", "default", "description")
+    }
+
+
+class TestTheFlatUnionPublishesWhatTheSubclassesEnforce:
+    """``CommitRequest`` is the only schema a caller of the commit route reads."""
+
+    @pytest.mark.parametrize(
+        "subclass",
+        [VectorCommitRequest, RasterCommitRequest, ServiceCommitRequest],
+        ids=lambda model: model.__name__,
+    )
+    def test_a_shared_field_publishes_the_constraint_it_is_judged_by(
+        self, subclass: type
+    ) -> None:
+        flat = CommitRequest.model_json_schema()["properties"]
+        for name, published in subclass.model_json_schema()["properties"].items():
+            if name not in flat:
+                continue
+            assert _constraints(flat[name]) == _constraints(published), name
+
+    def test_the_union_omits_only_strict_cog(self) -> None:
+        """A subclass field absent from the union cannot be set by a caller:
+        the handler re-validates the subclass from this model's dump."""
+        omitted = {
+            name
+            for model in (
+                VectorCommitRequest,
+                RasterCommitRequest,
+                ServiceCommitRequest,
+            )
+            for name in model.model_fields
+            if name not in CommitRequest.model_fields
+        }
+        assert omitted == {"strict_cog"}

--- a/backend/tests/test_commit_request_schemas.py
+++ b/backend/tests/test_commit_request_schemas.py
@@ -7,6 +7,9 @@ FastAPI, no fixtures. Fast (< 1 second total). They prove:
   - Field distribution matches D-04 in CONTEXT.md
 """
 
+import inspect
+import re
+
 import pytest
 from pydantic import ValidationError
 
@@ -17,6 +20,7 @@ from app.processing.ingest.schemas import (
     ServiceCommitRequest,
     VectorCommitRequest,
 )
+from app.processing.ingest.tasks_common import resolve_service_type
 
 
 class TestVectorCommitRequest:
@@ -240,6 +244,21 @@ class TestTheFlatUnionPublishesWhatTheSubclassesEnforce:
         token = CommitRequest.model_json_schema()["properties"]["token"]
         bound = next(b["maxLength"] for b in token["anyOf"] if "maxLength" in b)
         assert f"{bound} characters" in token["description"]
+
+    def test_the_token_description_names_every_service_family_it_reaches(
+        self,
+    ) -> None:
+        """`resolve_service_type` is the accepted set; a family missing from the
+        description is one an SDK caller would import anonymously."""
+        accepted = re.findall(
+            r'startswith\("([^"]+)"\)', inspect.getsource(resolve_service_type)
+        )
+        assert accepted, "the accepted prefixes are no longer readable there"
+        description = CommitRequest.model_json_schema()["properties"]["token"][
+            "description"
+        ]
+        for prefix in accepted:
+            assert prefix in description, prefix
 
     def test_the_union_omits_only_strict_cog(self) -> None:
         """A subclass field absent from the union cannot be set by a caller:

--- a/backend/tests/test_commit_request_schemas.py
+++ b/backend/tests/test_commit_request_schemas.py
@@ -234,6 +234,13 @@ class TestTheFlatUnionPublishesWhatTheSubclassesEnforce:
                 continue
             assert _constraints(flat[name]) == _constraints(published), name
 
+    def test_the_token_description_states_the_bound_it_declares(self) -> None:
+        """Both SDK generators drop `maxLength`, so the bound reaches a caller
+        of either one only through the prose."""
+        token = CommitRequest.model_json_schema()["properties"]["token"]
+        bound = next(b["maxLength"] for b in token["anyOf"] if "maxLength" in b)
+        assert f"{bound} characters" in token["description"]
+
     def test_the_union_omits_only_strict_cog(self) -> None:
         """A subclass field absent from the union cannot be set by a caller:
         the handler re-validates the subclass from this model's dump."""

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7041,7 +7041,7 @@ export interface components {
             srid_override?: number | null;
             /**
              * Token
-             * @description Optional confirmation token returned by the preview step. Required for some workflows.
+             * @description Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
              */
             token?: string | null;
             /**

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7041,7 +7041,7 @@ export interface components {
             srid_override?: number | null;
             /**
              * Token
-             * @description Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). At most 1000 characters. Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
+             * @description Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, OGC API Features, or ArcGIS). At most 1000 characters. Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
              */
             token?: string | null;
             /**

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7041,7 +7041,7 @@ export interface components {
             srid_override?: number | null;
             /**
              * Token
-             * @description Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
+             * @description Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). At most 1000 characters. Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
              */
             token?: string | null;
             /**

--- a/sdks/python/geolens/models/commit_request.py
+++ b/sdks/python/geolens/models/commit_request.py
@@ -48,8 +48,9 @@ class CommitRequest:
             srid_override (int | None | Unset): EPSG code to use when the source CRS is missing or incorrect. Assigns
                 (relabels) the CRS the source is read under rather than reprojecting from it: raster pixel values are unchanged,
                 and vector geometries are reprojected to EPSG:4326 from the assigned CRS as usual.
-            token (None | str | Unset): Optional confirmation token returned by the preview step. Required for some
-                workflows.
+            token (None | str | Unset): Optional auth token for a protected remote service, read only when the job imports a
+                service layer (WFS, ArcGIS FeatureServer). Never persisted to the database. Ignored on file-upload jobs.
+                Deprecated: use the auth object with method bearer.
             temporal_start (datetime.datetime | None | Unset): ISO 8601 start of the dataset's temporal extent.
             temporal_end (datetime.datetime | None | Unset): ISO 8601 end of the dataset's temporal extent.
             compression (None | str | Unset): Raster only: target compression for COG output (e.g. 'LZW', 'DEFLATE').

--- a/sdks/python/geolens/models/commit_request.py
+++ b/sdks/python/geolens/models/commit_request.py
@@ -49,8 +49,8 @@ class CommitRequest:
                 (relabels) the CRS the source is read under rather than reprojecting from it: raster pixel values are unchanged,
                 and vector geometries are reprojected to EPSG:4326 from the assigned CRS as usual.
             token (None | str | Unset): Optional auth token for a protected remote service, read only when the job imports a
-                service layer (WFS, ArcGIS FeatureServer). Never persisted to the database. Ignored on file-upload jobs.
-                Deprecated: use the auth object with method bearer.
+                service layer (WFS, ArcGIS FeatureServer). At most 1000 characters. Never persisted to the database. Ignored on
+                file-upload jobs. Deprecated: use the auth object with method bearer.
             temporal_start (datetime.datetime | None | Unset): ISO 8601 start of the dataset's temporal extent.
             temporal_end (datetime.datetime | None | Unset): ISO 8601 end of the dataset's temporal extent.
             compression (None | str | Unset): Raster only: target compression for COG output (e.g. 'LZW', 'DEFLATE').

--- a/sdks/python/geolens/models/commit_request.py
+++ b/sdks/python/geolens/models/commit_request.py
@@ -49,8 +49,8 @@ class CommitRequest:
                 (relabels) the CRS the source is read under rather than reprojecting from it: raster pixel values are unchanged,
                 and vector geometries are reprojected to EPSG:4326 from the assigned CRS as usual.
             token (None | str | Unset): Optional auth token for a protected remote service, read only when the job imports a
-                service layer (WFS, ArcGIS FeatureServer). At most 1000 characters. Never persisted to the database. Ignored on
-                file-upload jobs. Deprecated: use the auth object with method bearer.
+                service layer (WFS, OGC API Features, or ArcGIS). At most 1000 characters. Never persisted to the database.
+                Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
             temporal_start (datetime.datetime | None | Unset): ISO 8601 start of the dataset's temporal extent.
             temporal_end (datetime.datetime | None | Unset): ISO 8601 end of the dataset's temporal extent.
             compression (None | str | Unset): Raster only: target compression for COG output (e.g. 'LZW', 'DEFLATE').

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -2270,7 +2270,7 @@ export type CommitRequest = {
     /**
      * Token
      *
-     * Optional confirmation token returned by the preview step. Required for some workflows.
+     * Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
      */
     token?: string | null;
     /**

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -2270,7 +2270,7 @@ export type CommitRequest = {
     /**
      * Token
      *
-     * Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
+     * Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). At most 1000 characters. Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
      */
     token?: string | null;
     /**

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -2270,7 +2270,7 @@ export type CommitRequest = {
     /**
      * Token
      *
-     * Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, ArcGIS FeatureServer). At most 1000 characters. Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
+     * Optional auth token for a protected remote service, read only when the job imports a service layer (WFS, OGC API Features, or ArcGIS). At most 1000 characters. Never persisted to the database. Ignored on file-upload jobs. Deprecated: use the auth object with method bearer.
      */
     token?: string | null;
     /**


### PR DESCRIPTION
## What the published contract said

`POST /ingest/commit/{job_id}` publishes the flat `CommitRequest` union as its
request body. Its `token` field was published like this:

```json
"token": {
  "anyOf": [{"type": "string"}, {"type": "null"}],
  "description": "Optional confirmation token returned by the preview step. Required for some workflows.",
  "title": "Token"
}
```

No length limit, and a description naming a concept this door does not have —
the ingest preview response carries no token. `preview_token`, on the
config-import surface, is the concept that sentence describes.

## What the code actually does

The route re-validates the body against the subclass `_pick_commit_subclass(job)`
returns, and `token` exists on exactly one of the three: `ServiceCommitRequest`,
chosen when the job has a `source_url` and no `file_path`. There it is the
credential the remote service is called with, capped at 1000 characters and held
to the shared safe-token rule. `VectorCommitRequest` and `RasterCommitRequest`
declare no `token` at all, so on a file-upload job the value is dropped by the
re-validation and never read.

The API tells callers to use it that way: the ArcGIS sign-in handler's docstring —
itself a published description — says to put the returned token in the `token`
field on probe, preview, commit and refresh.

## This is a contract-accuracy fix, not a security fix

Nothing was unvalidated at runtime. The subclass re-validation applied the cap and
the shared safe-token rule before the value was read, and `#1930` had already
brought the cap itself in line with the six sibling service doors. What was wrong
was only what the server *said*: a caller reading the OpenAPI document, either
generated SDK, or the TypeScript types learned neither what the field is nor what
bounds it, and was told it was something else.

## The change

`CommitRequest.token` now declares `max_length=1000` and a description covering
the field on both paths: the credential on a service import, ignored on a file
upload. The deprecation sentence comes from the same `DEPRECATED_TOKEN_SUFFIX`
constant the sibling doors use.

**Annotate rather than restructure.** Publishing the three subclasses instead
would be the structural alternative, and it cannot be written: the union is
discriminated by *job state* (`source_url`, `user_metadata.file_type`), not by any
field in the body, so OpenAPI has no discriminator to key on and a caller could
not tell which branch applies without knowing the job. The flat union is the wire
contract by design — its own docstring says so — and `srid_override` already sets
the precedent on this exact model, where one published description covers the
vector and raster readings. Annotating is the honest fix here, not just the
smaller one.

The cap is declared and enforced rather than published cosmetically, so the
over-cap refusal moves one layer out, from the subclass re-validation to body
validation. That is where the six sibling service doors already refuse one: same
422, same scrubbed problem detail, and the `body.` loc prefix
`test_a_second_field_error_keeps_the_flattened_list` already asserts for the
re-upload door. The shared safe-token rule stays on the subclass alone: `isprintable()`
plus a whitespace check has no faithful JSON Schema spelling, so duplicating it
would add enforcement without adding contract accuracy.

## The bound has to be in the prose, not only in `maxLength`

Neither SDK generator carries `maxLength` through. `openapi-python-client` emits
`token: None | str | Unset = UNSET` with no constraint, and `@hey-api/openapi-ts`
emits `token?: string | null`; both reproduce the description verbatim and drop
everything else. A caller working from either SDK rather than the raw OpenAPI
document would still have met the 1000-character bound as a 422 — the audience
most likely to hit it, and the one this PR exists for.

So the description names the bound as well as declaring it. `test_the_token_
description_states_the_bound_it_declares` asserts the number in the prose against
the `maxLength` the schema declares, so the sentence cannot drift from the
constraint it describes — which is the failure mode this whole PR is about.

## The service families are named as the validator accepts them

The description named WFS and ArcGIS FeatureServer, which reads as the whole set
and is not it. `resolve_service_type` accepts three prefixes — `ArcGIS`, `WFS`
and `OGC API` — and says so in its own refusal: "Expected a type starting with
'ArcGIS', 'WFS', or 'OGC API'." OGC API Features is not a theoretical omission:
`run_ogr2ogr_service` has a branch that materialises a protected collection's
pages in-process with the credential, precisely because the GDAL header file
cannot be scoped to one origin. A caller reading either SDK would have submitted
that import anonymously. `ArcGIS` is a bare prefix match, so MapServer resolves
through it too — which is why the sentence names families rather than products.

`test_the_token_description_names_every_service_family_it_reaches` reads the
accepted prefixes out of `resolve_service_type` and requires each in the
published description, so the list is checked against the set rather than
restated beside it. Positive control: the prefixes are `['ArcGIS', 'WFS', 'OGC
API']` and the previous description contained the first two only.

`run_ogr2ogr_service`'s own parameter docs carried the same omission, on the
function that holds the OAPIF branch. Corrected in place — internal, so no
generated artifact moves for it. `ServiceCommitRequest`'s class docstring had it
too and is corrected with the same edit; it is not a published component.

## Regenerated artifacts

All four, in that order — `make openapi` (which `make sdks` re-runs itself) before
the SDK generation, and the frontend generator last, since its gate lives in a
different CI job from the SDK drift gate:

| artifact | why | gate |
| --- | --- | --- |
| `backend/openapi.json` | `maxLength` + description | `dump_openapi.py --check`, exit 0 |
| `sdks/python/geolens/models/commit_request.py` | description, bound included, in the model docstring | `make sdks-check`, exit 0 |
| `sdks/typescript/src/client/types.gen.ts` | description, bound included, on the `CommitRequest` type | `make sdks-check`, exit 0 |
| `frontend/src/types/api.generated.ts` | `@description` on the same field | `npm run types:check`, exit 0 |

The hand-typed mirror `frontend/src/types/api.ts` needs no change: TypeScript
carries neither the description nor the length bound.

Both drift gates compare against `HEAD`, so each one fails on correct but
uncommitted output. Both were run after the commit.

## Tests

`test_commit_request_schemas.py` gains the general form of the defect: for every
subclass, each field the flat union also publishes must publish the same
constraints, prose and default aside. A second test pins the one subclass field
the union omits, `strict_cog`, since a field absent there cannot be set by a
caller at all.

Positive control, measured before the change: that comparison reported exactly one
mismatch across all three subclasses — `ServiceCommitRequest.token`, flat
`{"anyOf": [{"type": "string"}, …]}` against subclass
`{"anyOf": [{"maxLength": 1000, "type": "string"}, …]}`. It reports none after.

`test_the_import_commit_door_refuses_a_token_past_the_cap` now asserts
`body.token:`, the loc the earlier refusal produces. The rest of that assertion —
422, the credential absent from the response body, nothing deferred to the queue —
is unchanged and still passes.

## Also found, not fixed here

`RasterCommitRequest.strict_cog` is absent from the flat union, so the handler's
re-validation drops it before the subclass sees it and the worker always reads
`False`. The published option cannot be set by any caller. That is a functional
gap rather than a documentation one and wants its own decision; the new test pins
the current set so it cannot quietly grow.

## Verification

Re-run in full after the description change; the drift gates all ran post-commit.

```
cd backend && uv run ruff check .                          # All checks passed!
cd backend && uv run ruff format --check .                 # 1187 files already formatted
pytest tests/test_commit_request_schemas.py \
       tests/test_layering.py \
       tests/test_1755_token_validator_consolidation.py    # 144 passed, exit 0
pytest tests/test_sdks_round_trip.py \
       tests/test_api_contract_openapi.py \
       tests/test_openapi_property_order.py \
       tests/test_fe_sdk_type_drift.py \
       tests/test_service_auth_contract_1746.py \
       tests/test_commit_revalidates_source_url.py \
       tests/test_ingest.py                                # 159 passed, exit 0
pytest tests/test_service_auth_transport_1746.py \
       tests/test_door_token_policy_1746.py \
       tests/test_import_token_lease_1676.py \
       tests/test_ingest_layer_name_guard.py \
       tests/test_1184_body_limit_per_route.py             # 451 passed, exit 0
JWT_SECRET_KEY=… PYTHONPATH=. \
  uv run python scripts/dump_openapi.py --check            # exit 0
make sdks-check                                            # exit 0
cd frontend && npm run types:check                         # exit 0
make cli-test                                              # 8 passed, 2 skipped, exit 0
```

Closes #1931
Refs #1923, #1930
