### PR TITLE
docs(adr): reconstruct ADR-002 from its in-source citations

### DIFF
--- a/.github/ADR-002.md
+++ b/.github/ADR-002.md
@@ -1,0 +1,425 @@
+# ADR-002: Dataset source origin and refresh
+
+**Status:** accepted, shipped across milestone 5 (#1218 through #1269, with later
+amendments). **Scope:** how a dataset records where its data came from, and what
+happens when GeoLens goes back to that source.
+
+> **This document was reconstructed from its own citations (#1939).** The original
+> was never committed, and thirty-seven sites in `backend/app/`, `backend/alembic/`
+> and `backend/tests/` had been citing it for months. What follows is derived from
+> those sites and from the code they annotate, so it describes what the code does
+> rather than what the original ADR may have said. Numbers nobody cited could not be
+> recovered, and they are marked as gaps instead of being filled in with a guess.
+> Where a citation and the code disagree, the disagreement is written down.
+
+---
+
+## Context
+
+Before this work a dataset recorded almost nothing about where it came from.
+`datasets.source_url` existed, but it is descriptive prose in the metadata PATCH map,
+so a user could edit it, and nothing else pointed anywhere. Re-pulling a service
+dataset meant walking the re-upload dialog and restating the URL, the service type
+and the layer by hand, through a door whose name says "re-upload the same thing".
+Failed attempts left no trace at all: `ingest_jobs` rows are purged after
+`ingest_jobs_retention_days`, and `dataset_versions` is a success ledger that says
+nothing about the attempts that never produced a version.
+
+The decisions below give a dataset a machine-written pointer to its source and a durable
+history of every attempt to go back to it. The refresh door then reads that pointer
+rather than asking the client to restate it.
+
+---
+
+## Decisions
+
+### Decision 1
+
+Not recovered. No site in the tree cites it.
+
+### Decision 2: Derived state gets no column and no write path
+
+Origin classification and source freshness are pure functions of columns that already
+exist, so neither is stored. `classify_origin` derives origin from `source_format` and
+`record_type`; `source_freshness` derives from `update_frequency`,
+`last_refreshed_at` and origin. A stored copy of either could only ever disagree with
+the values it came from, and two independent implementations of the same derivation is
+the same bug one level out, which is why `classify_origin` moved server-side and the
+frontend's `datasetOrigin()` became a consumer of the computed response field.
+
+The same argument retires `origin_kind` as a column and, in Decision 8,
+`quality_score_numeric`.
+
+`schema_drift_status` is the deliberate contrast: it IS stored, because drift compares
+a pre-refresh schema that no longer exists by the time anyone reads the row. It derives
+from nothing at read time.
+
+Implementation: `backend/app/platform/dataset_origin.py`,
+`backend/app/modules/catalog/datasets/domain/source_freshness.py`.
+
+### Decision 3: The source-state columns, and what may be written into them
+
+Seven nullable columns on `catalog.datasets`, two CHECK constraints and one partial
+index (migration `0036_dataset_source_state`), plus a best-effort per-origin backfill.
+
+The columns are `origin_uri`, `origin_ref`, `last_refreshed_at`, `last_checked_at`,
+`source_health`, `source_health_detail` and `schema_drift_status`.
+
+**All seven are system-managed.** None is in `_DATASET_FIELD_MAP`, so the metadata
+PATCH cannot reach them. `source_url` stays beside `origin_uri` as user-editable prose;
+`origin_uri` is the machine pointer, written by ingest and by nothing else.
+
+**NULL is the only stored spelling of "never determined".** The CHECK sets deliberately
+exclude an `unknown` literal, and the API projects NULL to `"unknown"` at the response
+boundary. `source_health` is `healthy`, `missing` or `inaccessible`;
+`schema_drift_status` is `none` or `drifted`. With both spellings legal every query
+would have to handle two of them forever.
+
+**No column may be named for a capability that does not exist.** There is deliberately
+no `last_verified_at`: v1 has no verification layer, and a column named for one would
+be a lie in the schema. See invariant 9.
+
+**A stored reason string carries no raw exception, no URL with query-string
+credentials, and no GDAL command line.** This clause covers `source_health_detail` and
+`dataset_refresh_runs.error_message`. It is why the PostGIS strategy composes its
+messages from a SQLSTATE lookup rather than from driver text, and why the STAC strategy
+composes them rather than passing through anything the origin sent.
+
+**A service credential is request-scoped.** It is supplied per request, is never stored,
+and a run that outlives its credential must ask a person for a new one rather than
+retrying unauthenticated and reporting the origin's 401 as the fault. The transport for
+that is Amendment A7; the durability rule is invariant 4.
+
+### Decision 4: one durable row per refresh attempt, in `catalog.dataset_refresh_runs`
+
+Migration `0037_dataset_refresh_runs`. The row survives the `ingest_jobs` retention
+purge, which is the whole reason the jobs table cannot be the record of refreshes and
+why `ingest_job_id` is `ON DELETE SET NULL`. No backfill: nothing before the migration
+recorded a refresh outcome, so every historical row would be invented.
+
+#### 4a: A sibling table, not more columns on `dataset_versions`
+
+`dataset_versions` is a success ledger whose identity is
+`UNIQUE (dataset_id, version_number)`, and `version_number` means "the Nth good state of
+this data". A failed refresh has no Nth good state, so making the counter nullable would
+not add a column, it would destroy the meaning of the constraint. Two tables joined by
+one nullable FK is cheaper than one table with a nullable identity.
+
+#### 4b: The row is created at DISPATCH, in the request transaction
+
+Not at swap commit. An at-commit design cannot represent a run that never committed: a
+worker that dies mid-fetch leaves no history row, and the `ingest_jobs` row that might
+have hinted at it is purged after the retention window. The caller must not commit
+inside `create_pending_run`; the run row and whatever else the request writes land
+together, and the task is deferred only after that commit succeeds.
+
+This accepts one gap. Create-then-defer is not atomic, so a process that dies between
+the commit and the `defer` leaves a run `pending` with no task behind it. Closing it
+properly needs a dispatch outbox, which is scheduler infrastructure that gate 4
+excludes, so the stale-run sweep compensates instead.
+
+#### 4c
+
+Not recovered. No site in the tree cites it.
+
+#### 4d: The history is append-only, and its terminal statuses mean what they say
+
+A retry is a NEW row, never an edit of the old one.
+
+`blocked` is reserved and deliberately absent from the CHECK: v1 has no schema policy,
+so the state is unreachable and shipping it would invite dead handling code. Widening a
+VARCHAR CHECK is a two-line migration for whoever adds an enforced policy.
+
+`cancelled` is a bookkeeping correction, not a stop signal. The sweep may write it only
+once the work is provably not happening: no Procrastinate job in a live state references
+the bound ingest job, and that job is absent, `failed`, or `pending` with no live task.
+(#1677 later added a second writer of this status for an explicit user cancel. See
+"Where the code and this record disagree".)
+
+#### 4e: Field redaction on the read path
+
+A caller who is neither the dataset owner nor an admin sees the timeline and the
+outcomes, and five fields come back null: `triggered_by`, `triggered_by_username`,
+`error_code`, `error_message` and `schema_diff`. Without that, a PUBLIC dataset's
+refresh history enumerates the people who edit it, and failure text leaks origin detail.
+
+The redaction is asserted against a NAMED signed-in third party as well as an anonymous
+reader. A requester-scoped check that only exercises `user is None` reads as complete
+and is not.
+
+### Decision 5: Refresh execution
+
+#### 5a: Per-origin refresh strategies
+
+Four origins can be re-pulled: `upload`, `postgis`, `service`, `stac`. A dataset drawn
+in the app (`created`) came from nowhere and answers 409 `refresh_not_applicable`. The
+allowlist is deliberate: an origin kind nobody has classified reads "unknown", which
+withholds advice, rather than "overdue", which names an action that may not exist.
+
+Two of the strategies move no data at all.
+
+- **Registered PostGIS.** The origin IS the relation the catalog serves from, so the
+  refresh re-measures it: recount features, recompute the extent, rebuild the column
+  schema snapshot, the sample values, the attribute metadata and the quality score.
+  There is no fetch, no staging table and no swap. This strategy owns the health verdict
+  for its origin kind, because the probe refuses postgis origins outright, and the
+  mapping is a SQLSTATE lookup rather than a guess.
+- **STAC.** The dataset is nothing but a pointer at somebody else's COG. The refresh
+  re-reads the item document and follows the asset if the publisher moved it. Only the
+  pointer changes.
+
+`last_refreshed_at` means "last committed successful swap", so whichever operation is a
+given origin's refresh is the operation that dates it. A VRT has no origin of its own
+and classifies as NULL, and its generation swap projects the generation's completion
+instant into `last_refreshed_at` in the same transaction, so source freshness reads a
+live signal across record types instead of a creation-time floor forever.
+
+The door's two 409 refusals are distinct on purpose: `refresh_not_applicable` means this
+kind of dataset has no origin to re-measure, `origin_unavailable` means it does and
+GeoLens never recorded a usable pointer to it.
+
+#### 5b: One mutation per dataset at a time, and v1 rejects rather than queues
+
+A concurrent trigger gets 409 `dataset_busy`. The refusal comes from the partial unique
+index `uq_refresh_runs_one_active` on `dataset_id WHERE status IN ('pending','running')`,
+so it is atomic at request time. A check-then-insert leaves a window between the SELECT
+and the INSERT, and that window is exactly where a double-click lands: the loser of the
+race would otherwise reach the worker and discover the winner at the advisory lock, with
+both jobs already queued.
+
+#### 5c
+
+Not recovered. Cited once, in the module docstring of
+`backend/app/modules/catalog/datasets/api/router_refresh.py`, alongside 5a, 5b and 6.
+Nothing else in the tree cites it and its content cannot be reconstructed from that one
+mention.
+
+### Decision 6: The duplicate-source guard keys on `origin_uri`
+
+Re-keyed from `source_url`, which a user can PATCH, to the system-managed `origin_uri`.
+Behaviour on existing rows is unchanged, because migration 0036 backfills `origin_uri`
+for a STAC dataset from the same `source_url` value the guard already keyed on. The
+index is partial (`WHERE origin_uri IS NOT NULL`): upload and created datasets have no
+remote origin to point at, so most rows are NULL.
+
+### Decision 7: A raster dataset IS its COG
+
+The pre-conversion upload is a transient input, not a second copy of the data. Two
+consequences.
+
+**The origin restamps to the uploaded file with no remote URI.** Both the first-ingest
+tail and the replace swap write an `upload` origin carrying the filename and the content
+hash.
+
+**The upload itself is deleted once the COG carries everything it did.** Keeping a
+second copy of every raster ever uploaded bought nothing and cost object storage forever;
+every re-processing case an operator actually has starts from the COG just as well.
+
+Two exceptions, both of which retain:
+
+- **A failed conversion** leaves those bytes as the operator's only diagnostic copy,
+  bounded by the retention purge.
+- **A lossy conversion** makes the upload the only faithful copy in existence. "Lossless"
+  is a claim about the profile that ran, not about conversion in general. The import form
+  offers four lossless compressions (DEFLATE by default, LZW, ZSTD, LERC) and two that
+  discard detail (JPEG, WEBP); `cog_preserves_source` in
+  `backend/app/processing/raster/cog.py` is the audit of everything `convert_to_cog` can
+  apply. A lossy original is copied to
+  `originals/<dataset_id>/` and gets its own counted `dataset_assets` row under the key
+  `archived_original:<hash>` (migration `0038_dataset_assets_archived_original`), so
+  per-user storage sums see the bytes it consumes. One row per kept original: a single
+  row would have counted only the newest and left every superseded original accumulating
+  uncounted.
+
+`RUNBOOK.md` section 9 states both retention windows for operators.
+
+### Decision 8: Drop `datasets.quality_score_numeric`
+
+It was written nowhere, read nowhere, and absent from `openapi.json`. The only thing it
+could ever have become is a derived roll-up of `quality_detail`, and persisting a derived
+value separately is a second source of truth that goes stale, which is Decision 2 again.
+This decision is not gated on the rest of ADR-002. Migration
+`0035_drop_quality_score_numeric`.
+
+---
+
+## Invariants
+
+Invariants 1, 2, 3, 5, 6 and 7 are not cited anywhere and could not be recovered.
+Several sites call the ones below "handoff invariants", which suggests they were
+recorded in a milestone handoff section of the original document; the numbering is
+shared with the invariants cited as "ADR-002 invariant N", so they are listed together.
+
+**Invariant 4: The source binding holds no plaintext secret.**
+`build_origin_ref` is the only door into `datasets.origin_ref`, and it raises on any key
+the kind does not declare rather than dropping it, so `token`, `password` and
+`authorization` cannot land even by accident. The same rule refuses a signed URL: a
+credentialed href is dropped at STAC capture and refused again by the import request
+validator, and a publisher who starts signing hrefs makes the binding unstorable
+(reported as `inaccessible` / `unauthorized`, never `missing`, because nothing was
+deleted).
+
+**Invariant 8: A scheduled occurrence needs a durable identity.**
+`scheduled` is excluded from the trigger CHECK today. The migration that adds it must,
+in the SAME migration, add `scheduled_for` and its `UNIQUE (dataset_id, scheduled_for)`
+partial index, or the occurrence has no identity anything can be idempotent against.
+
+**Invariant 9: The schema does not name capabilities that do not exist.**
+The concrete case is the absent `last_verified_at`. See Decision 3.
+
+**Invariant 10: Last-known-good is sacred.**
+A failed refresh changes no data and no freshness. Nothing outside a success block
+writes `last_refreshed_at`, `origin_ref`, `origin_uri` or an asset row, so a refresh that
+could not resolve leaves the dataset serving exactly what it served before. For raster
+replace the same rule is stronger: the previous COG is not deleted or overwritten until
+the replacement has been written to storage AND read back successfully, the new objects
+land under keys derived from the attempt id and their own content hash so they can
+collide with nothing, the pointer moves in a single transaction alongside the tile-cache
+bump, and only after that transaction commits are the superseded objects reaped.
+
+**Invariant 11: Same executor.**
+Admission control, the run row and the history a user reads are one implementation shared
+by every door. The refresh endpoint calls `create_pending_run` exactly as `reupload_commit`
+does; the PostGIS and STAC strategies go through `create_pending_run`,
+`defer_with_orphan_guard` and `make_refresh_run_failed_rollback` unchanged. What varies
+per origin kind is the binding it unpacks and the task it defers. A second admission path
+is how one door ends up with a rule the other lacks, and a copy-pasted state machine is
+how this invariant dies quietly.
+
+---
+
+## Gates: what v1 deliberately does not do
+
+Gates 1, 3 and 5 are not cited anywhere and could not be recovered.
+
+**Gate 2: No external PostGIS federation.**
+The `postgis` origin kind accepts `table_name` and nothing else: no host, port, DSN or
+credential key. The stored value is schema-qualified and names a relation in this
+instance's own database, and the worker proves it names the dataset's own live table
+before reading anything. Adding federation therefore needs a new origin kind here, not a
+wider JSON blob at a later PR's convenience. (#1452 added `managed` to that kind. It is
+an ownership fact about the same relation the pointer already names, not a second
+address.)
+
+**Gate 4: No scheduler in this milestone.**
+`scheduled` is not a trigger. This is also why 4b's create-then-defer gap is compensated
+by a sweep rather than closed by a dispatch outbox.
+
+---
+
+## Amendments
+
+Amendments A1 to A4, A6, A8 and A9 are not cited anywhere and could not be recovered.
+
+**A5: Schema drift is recorded, never refused.** (#1223)
+The diff is measured before the writes that overwrite the values it compares, and it
+never blocks a refresh. This is also why `blocked` is unreachable in 4d.
+
+**A7: The credential handoff channel.** (#1220)
+A refresh of a protected service needs a token in the worker, and the worker is a
+different process. Every existing route is durable: Procrastinate task arguments are rows
+in `catalog.procrastinate_jobs`, `ingest_jobs.user_metadata` is a column, and a failed job
+keeps both until the retention purge. Invariant 4 rules all of them out, so the handoff
+uses a channel that is neither PostgreSQL nor the request. The API writes the secret once
+into the shared cache under an unguessable reference with a short TTL, passes only the
+REFERENCE through the task arguments, and the worker consumes it with an atomic
+read-and-delete. Single use comes from `GETDEL`, bounded lifetime from `SET ... EX`, and
+the reference means nothing once claimed or expired. This needs a real shared cache: the
+in-memory fallback would be invisible to the claimant, so the module reports honestly
+when there is no store and the door refuses a token-bearing request rather than failing
+every refresh as `credential_expired` with nothing in the logs saying why.
+
+**A10: The refresh lifecycle becomes observable, and the strategy set widens.**
+(#1265, #1266, #1268, with #1269 as its milestone-close acceptance)
+Four audit actions (`refresh.dispatch`, `refresh.succeeded`, `refresh.failed`,
+`refresh.abandoned`) plus Prometheus series. The run row is mutable and cascades with its
+dataset, so it is a status board rather than a ledger; the audit log is append-only and
+survives, which is why the lifecycle emits into both. The audit payload is ids, origin
+kind, trigger, status and error code, and specifically not `error_message`: redacted free
+text is the wrong thing to lean on when a closed vocabulary is available. The metrics are
+gauges polled from the table rather than counters at the event, because terminal
+transitions happen in a worker that serves no `/metrics`, and because
+`MultiProcessCollector` SUMS counters across API workers, so a poll-and-increment design
+would report N times the truth.
+
+**2026-08-09, unnumbered: one provenance projection for every surface.** (#1316)
+Decision 4e's redaction model became the single provenance projection for dataset reads
+(single, list and collection), `/versions/`, and refresh-runs itself. The owner and any
+admin see raw provenance in full (`origin_uri`, `origin_ref`, `uploaded_by`, `file_hash`);
+every other reader of an accessible dataset, named or anonymous, gets those fields nulled
+and keeps the capability summary (origin kind, `source_freshness`, `source_health`,
+`last_refreshed_at`, `last_checked_at`). The predicate is
+`can_view_dataset_provenance` in `backend/app/modules/catalog/authorization.py`. This
+amendment is dated rather than lettered at its citation sites, so it is recorded here the
+same way.
+
+---
+
+## Where the code and this record disagree
+
+Each item below is a live divergence between what a citation claims and what the code it
+annotates does. They are written down rather than smoothed over, because a reader who
+takes this document as a description of the running system needs to know which clauses
+the code only partly honours.
+
+**Decision 3's reason-string clause is two-thirds enforced.** `redact_run_error` in
+`backend/app/platform/refresh/service.py` carries the three-part prohibition in its own
+docstring, and does two of them: it calls `redact_url_credentials`, which handles URLs and
+URL-shaped substrings inside free text, and it truncates at 2000 characters. It does not
+strip a raw exception, and it removes a GDAL command line only to the extent that the
+command line contains a URL. A driver or database exception reaching that helper is stored
+in full, up to the truncation limit.
+
+**One site inside the refresh machinery composes exactly what Decision 3 forbids.**
+`make_refresh_run_failed_rollback` builds `f"Failed to queue refresh task: {defer_exc}"`
+and hands it to `record_refresh_failure`, which redacts credentials and stores the rest.
+
+**`ingest_jobs.error_message` carries the same class of text and no ADR-002 citation.**
+It is written by `_fail_job` in `backend/app/processing/ingest/tasks_common.py` as
+`redact_url_credentials(str(exc))`, which is the same two-of-three shape, and it is the
+field `frontend/src/components/dataset/ReuploadDialog.tsx` renders to the user. The
+Decision 3 citations only ever name `source_health_detail` and
+`dataset_refresh_runs.error_message`, so this surface was never inside the policy as
+cited, even though it is the same failure text from the same handlers.
+
+**`cancelled` now has two writers, and one of them is a stop signal.** Decision 4d, as
+cited at `service.py`, is explicit that the status is a bookkeeping correction and never a
+stop signal. #1677 added `cancel_run_for_job`, which writes `cancelled` with
+`error_code="user_cancelled"` when a person asks in-flight work to stop, and a
+`refresh.cancelled` audit action described as exactly that. The two writers are
+distinguishable by `error_code`, and the sweep's proof obligations are unchanged, but the
+decision as cited no longer describes the whole of the status.
+
+**Migration 0036's backfill predicate is deliberately wider than ADR-002's.** The
+migration says so in a comment: "ADR-002's predicate names the common case rather than an
+exclusion (widened deliberately, #1218 review)". Restricting it to `vector_dataset` would
+have left registered non-spatial tables as the only rows whose pointer depended on whether
+they were registered before or after the migration.
+
+**`origin_ref`'s declared key sets have grown.** `asset_href` is described at its own site
+as "additive to ADR-002's declared stac shape" (#1222 later added `item_href` and
+`item_id`), and `managed` joined `table_name` on the postgis kind (#1452). Both additions
+are argued at their sites as not touching invariant 4 or gate 2, which holds: neither is a
+credential and neither is a second address. The declared shapes in the original document
+were narrower than what ships.
+
+**Decision 5b's admission control covers the four doors that create a run.** Those are the
+re-upload commit and the refresh endpoint's three strategy dispatchers. VRT regeneration
+mutates a dataset, projects into `last_refreshed_at` under Decision 5a, and does not go
+through `create_pending_run`; `catalog.vrt_generations` has no single-active partial unique
+index of its own, and `vrt` is not one of the run table's five `origin_kind` values.
+
+**One `origin_kind` value has never been written.** `raster` is in the CHECK constraint and
+reserved for the raster-replace door, but `reupload_commit` stamps every raster-replace run
+`upload`. #1325 decided to document the split rather than close it by renaming a value or
+migrating a column.
+
+---
+
+## Related
+
+- `RUNBOOK.md` section 9 states Decision 7's retention windows for operators.
+- `.github/ARCHITECTURE.md` maps where the modules named above live.
+- `AGENTS.md`, under "Inline review-comment convention", holds the rule this document
+  exists to satisfy: a comment that cites a finding must cite something a reader can
+  look up.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -2503,8 +2503,8 @@ asset carries everything the upload did, and every re-processing case an
 operator actually has — different overview levels, different compression,
 different internal tiling — starts from the COG just as well as from the
 original. Keeping a second copy of every raster ever uploaded bought nothing and
-cost object storage forever, so in that case it is no longer kept (ADR-002
-Decision 7).
+cost object storage forever, so in that case it is no longer kept
+([ADR-002](.github/ADR-002.md) Decision 7).
 
 ### When the conversion is lossy, the upload is kept
 


### PR DESCRIPTION
## What

Adds `.github/ADR-002.md`, reconstructed from the 37 in-source citations that had nothing to resolve to, and turns `RUNBOOK.md`'s one passing citation into a link.

No in-source citation was changed. No artifact was regenerated. The diff is two files.

## Why reconstruct rather than repoint

Three reasons, in order of weight:

1. **Repointing 37 sites is the larger and riskier edit.** They span seven modules under `backend/app/`, four Alembic migrations, and a dozen test suites. Writing one file touches one file.
2. **The citations already work as cross-references.** `Decision 7` is cited from `tasks_raster.py`, `tasks_raster_replace.py`, `tasks_raster_common.py`, `tasks_raster_swap.py`, `tasks_common.py`, `raster/cog.py`, `raster/models.py`, migration 0038 and `RUNBOOK.md`. A reader who lands on any one of them can already find the other eight. Replacing the shared token with per-site issue anchors would destroy that and gain nothing.
3. **Repointing anything that reaches a `Field(description=...)` or a route-handler docstring forces a full regeneration.** Several of the 37 sites are published API documentation: the token is in `backend/openapi.json`, five generated Python SDK modules, `sdks/typescript/src/client/{sdk,types}.gen.ts` and `frontend/src/types/api.generated.ts`. A docs-only change should not move four generated artifacts.

## Where it lives, and why

`.github/ADR-002.md`, beside `CONTRIBUTING.md` and `ARCHITECTURE.md`. The Repository Docs Policy in `AGENTS.md` is explicit that root docs are single-purpose and enumerated, that no root `docs/` directory may be reintroduced, and that contributor-facing architecture docs live under `.github/`. The filename is exactly the token the 37 sites carry, so `grep -rn ADR-002` from any citation lands on it.

## How each decision was derived

Every clause comes from a citation site plus the code it annotates. The document says so at the top, and says plainly that it describes what the code does rather than what the original ADR may have said.

| Number | Derived from |
|---|---|
| Decision 2 | `platform/dataset_origin.py:6`, `source_freshness.py:18`, `router_refresh.py:979`, `test_dataset_source_freshness.py:296` |
| Decision 3 | migration `0036` header, `datasets/domain/models.py:538-556`, `refresh/service.py:87`, `tasks_postgis_refresh.py:172`, `tasks_stac_refresh.py:91`, `refresh/credentials.py:328` |
| Decision 4 / 4a / 4b / 4d / 4e | migration `0037` header, `refresh/models.py:3,41`, `refresh/service.py:10,850`, `router_reupload.py:968`, `router.py:765`, `schemas.py:1466`, `test_dataset_refresh_runs.py:1378` |
| Decision 5a / 5b | `source_freshness.py:47,58,146`, `tasks_postgis_refresh.py:3`, `tasks_stac_refresh.py:3`, `tasks_vrt.py:1394`, migration `0037:123`, `refresh/models.py:92` |
| Decision 6 | `datasets/domain/models.py:419`, migration `0036:327` |
| Decision 7 | `tasks_raster.py:118,636,892`, `tasks_raster_replace.py:22,966`, `tasks_raster_common.py:253`, `tasks_raster_swap.py:104`, `raster/cog.py:67`, `raster/models.py:271`, migration `0038`, `RUNBOOK.md` § 9 |
| Decision 8 | migration `0035` header |
| Invariants 4, 8, 9, 10, 11 | `dataset_origin.py:15,339`, `adapters/stac.py:151,192`, `refresh/models.py:51`, `datasets/domain/models.py:556`, `tasks_raster_replace.py:11`, `tasks_stac_refresh.py:29`, `router_refresh.py:21` |
| Gates 2, 4 | `dataset_origin.py:18,164`, `router_refresh.py:424`, `ingest/service.py:919`, `refresh/models.py:50`, `refresh/service.py:951` |
| Amendments A5, A7, A10 | `tasks_postgis_refresh.py:969`, `refresh/credentials.py:3`, `audit/actions.py:112`, `observability/metrics/refresh.py:3`, `test_refresh_gate_1269.py:3` |
| 2026-08-09 amendment | `catalog/authorization.py:468`, `test_provenance_projection_1316.py:4` |

Numbers no site cites could not be recovered and are marked as gaps rather than invented: **Decision 1**, **Decision 4c**, **Decision 5c**, **invariants 1-3 and 5-7**, **gates 1, 3, 5**, and **amendments A1-A4, A6, A8, A9**. Decision 5c is the notable one: it is cited exactly once, in `router_refresh.py`'s module docstring alongside 5a, 5b and 6, and one mention is not enough to reconstruct a decision from.

## Where the citations and the code disagree

The document has a closing section for these rather than smoothing them over. This is the part that makes the change more than citation hygiene: the policy has teeth and is only partly enforced.

- **Decision 3's reason-string clause is two-thirds enforced.** `redact_run_error` carries the three-part prohibition in its own docstring (no raw exception, no URL with query-string credentials, no GDAL command line) and implements two of them: it calls `redact_url_credentials` and truncates at 2000 characters. It does not strip a raw exception.
- **One site inside the refresh machinery composes exactly what the clause forbids.** `make_refresh_run_failed_rollback` interpolates the raw defer exception into the stored reason before handing it to `record_refresh_failure`.
- **`ingest_jobs.error_message` carries the same class of text and no ADR-002 citation.** It is written as `redact_url_credentials(str(exc))`, the same two-of-three shape, and is the field `ReuploadDialog.tsx` renders to the user. The Decision 3 citations only ever name `source_health_detail` and `dataset_refresh_runs.error_message`.
- **`cancelled` now has two writers and one of them is a stop signal.** Decision 4d, as cited at `refresh/service.py`, says the status is a bookkeeping correction and never a stop signal. #1677 added `cancel_run_for_job`, which writes it with `error_code="user_cancelled"` for an explicit user cancel, plus a `refresh.cancelled` audit action described as exactly that.
- **Migration 0036's backfill predicate is deliberately wider than ADR-002's**, and says so in a comment ("widened deliberately, #1218 review").
- **`origin_ref`'s declared key sets have grown** past what the original document declared: `asset_href` is called "additive to ADR-002's declared stac shape" at its own site, and #1452 added `managed` to the postgis kind. Both hold invariant 4 and gate 2.
- **Decision 5b's admission control covers the four doors that create a run.** VRT regeneration mutates a dataset and projects into `last_refreshed_at` under Decision 5a, does not go through `create_pending_run`, and `catalog.vrt_generations` has no single-active partial unique index.
- **One `origin_kind` value has never been written.** `raster` is in the CHECK constraint and reserved for the raster-replace door, but `reupload_commit` stamps every raster-replace run `upload` (#1325 decided to document the split).

## Verification

- `pre-commit run --all-files`: all hooks pass, including the AGENTS.md unanchored-marker hook and the secret detector.
- `git diff --name-only origin/main...HEAD`: `.github/ADR-002.md` and `RUNBOOK.md` only. Nothing under `backend/app/`, no migration, no generated artifact.
- No CHANGELOG entry: this adds a contributor doc with no user-facing behaviour change, and the scope for this branch was the two files above.

Closes #1939
