### PR TITLE
fix(ingest): bound the worker error-write path onto the job row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,9 @@ and releases use semantic versioning.
 - A file import, service import, reupload, raster import or VRT regeneration that failed while
   another operation held its job row hung there instead of recording the failure, with the
   heartbeat still reporting the job alive. That write is now capped at 10 seconds. A job whose
-  write gives up records nothing, is settled by the stale-job sweep once its heartbeat stops,
-  and for a refresh leaves its history row to be closed by the refresh sweep instead. (#1950)
+  write gives up still reports the error that actually failed the job, and the timeout is logged
+  separately; the job row itself records nothing and is settled by the stale-job sweep once its
+  heartbeat stops, with a refresh's history row closed by the refresh sweep instead. (#1950)
 
 ## [1.18.1] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,11 @@ and releases use semantic versioning.
 - A malformed vector-tile path now answers 400 however it is malformed. A path missing the `data.`
   prefix, or carrying an empty table name, previously answered 404, which read as a missing
   dataset rather than a bad request. (#1929)
-- A file import, service import, reupload or raster import that failed while another operation
-  held its job row hung there instead of recording the failure, with the heartbeat still
-  reporting the job alive. That write is now capped at 10 seconds; a job whose write gives up
-  records nothing and is settled by the stale-job sweep once its heartbeat stops. (#1950)
+- A file import, service import, reupload, raster import or VRT regeneration that failed while
+  another operation held its job row hung there instead of recording the failure, with the
+  heartbeat still reporting the job alive. That write is now capped at 10 seconds. A job whose
+  write gives up records nothing, is settled by the stale-job sweep once its heartbeat stops,
+  and for a refresh leaves its history row to be closed by the refresh sweep instead. (#1950)
 
 ## [1.18.1] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ and releases use semantic versioning.
 - A malformed vector-tile path now answers 400 however it is malformed. A path missing the `data.`
   prefix, or carrying an empty table name, previously answered 404, which read as a missing
   dataset rather than a bad request. (#1929)
+- A file import, service import, reupload or raster import that failed while another operation
+  held its job row hung there instead of recording the failure, with the heartbeat still
+  reporting the job alive. That write is now capped at 10 seconds; a job whose write gives up
+  records nothing and is settled by the stale-job sweep once its heartbeat stops. (#1950)
 
 ## [1.18.1] - 2026-09-05
 

--- a/backend/app/platform/jobs/heartbeat.py
+++ b/backend/app/platform/jobs/heartbeat.py
@@ -9,6 +9,7 @@ import structlog
 from sqlalchemy import text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.db.sqlstate import sqlstate
 from app.platform.jobs.models import IngestJob
 
 HEARTBEAT_INTERVAL_SECONDS = 30.0
@@ -126,6 +127,31 @@ async def claim_ingest_job_attempt(
 # ingest_jobs row. A long holder is a LATER attempt's phase bracket, whose id
 # the fence no longer matches, so no wait starts and a wait past this is stuck.
 JOB_ERROR_WRITE_TIMEOUT_MS = 10_000
+
+
+# fix(#1950): the two SQLSTATEs the budget itself produces — statement_timeout
+# and lock_timeout. Any other DBAPIError out of the failure write is a database
+# problem, reported under the sibling event rather than as an expiry.
+ERROR_WRITE_EXPIRY_CODES = ("57014", "55P03")
+
+
+def log_job_error_write_failure(exc: BaseException, *, job_id: str, task: str) -> None:
+    """Record a failed terminal job write as its own event.
+
+    The caller must swallow *exc* and re-raise whatever it was already handling:
+    this write is secondary, and letting it out replaces the cause the operator
+    needs with a lock timeout.
+    """
+    code = sqlstate(exc)
+    structlog.get_logger().warning(
+        "job_error_write_timeout"
+        if code in ERROR_WRITE_EXPIRY_CODES
+        else "job_error_write_failed",
+        job_id=job_id,
+        task=task,
+        sqlstate=code,
+        budget_ms=JOB_ERROR_WRITE_TIMEOUT_MS,
+    )
 
 
 async def arm_job_error_write_budget(session: AsyncSession) -> None:

--- a/backend/app/platform/jobs/heartbeat.py
+++ b/backend/app/platform/jobs/heartbeat.py
@@ -122,6 +122,12 @@ async def claim_ingest_job_attempt(
     return bool(result.rowcount)  # type: ignore[attr-defined]
 
 
+# fix(#1950): the budget a worker's terminal failure write spends on its own
+# ingest_jobs row. Holders self-cap far below it (`cancel_job` at 2s; the sweep
+# and startup recovery take candidates SKIP LOCKED), so a longer wait is stuck.
+JOB_ERROR_WRITE_TIMEOUT_MS = 10_000
+
+
 async def update_ingest_job_for_attempt(
     session: AsyncSession,
     job_id: uuid.UUID,

--- a/backend/app/platform/jobs/heartbeat.py
+++ b/backend/app/platform/jobs/heartbeat.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 
 import structlog
-from sqlalchemy import update
+from sqlalchemy import text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.platform.jobs.models import IngestJob
@@ -122,10 +122,25 @@ async def claim_ingest_job_attempt(
     return bool(result.rowcount)  # type: ignore[attr-defined]
 
 
-# fix(#1950): the budget a worker's terminal failure write spends on its own
-# ingest_jobs row. Holders self-cap far below it (`cancel_job` at 2s; the sweep
-# and startup recovery take candidates SKIP LOCKED), so a longer wait is stuck.
+# fix(#1950): the budget an attempt-fenced failure write spends on its own
+# ingest_jobs row. A long holder is a LATER attempt's phase bracket, whose id
+# the fence no longer matches, so no wait starts and a wait past this is stuck.
 JOB_ERROR_WRITE_TIMEOUT_MS = 10_000
+
+
+async def arm_job_error_write_budget(session: AsyncSession) -> None:
+    """Bound this transaction's wait on the job row at the error-write budget.
+
+    Issue it on the transaction that carries the failure UPDATE and after any
+    rollback on that session: ``SET LOCAL`` dies with the transaction, so an
+    arm placed before a rollback or a commit is gone by the next statement.
+    """
+    await session.execute(
+        text(f"SET LOCAL lock_timeout = {JOB_ERROR_WRITE_TIMEOUT_MS}")
+    )
+    await session.execute(
+        text(f"SET LOCAL statement_timeout = {JOB_ERROR_WRITE_TIMEOUT_MS}")
+    )
 
 
 async def update_ingest_job_for_attempt(

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1264,14 +1264,17 @@ async def load_job_for_error_write(
 ):
     """Load the job row a failure tail is about to settle, under the shared budget.
 
-    Returns ``None`` when the row is gone, when a newer attempt owns it, or when
-    the budget expired: an expiry is logged as its own event and the session is
-    rolled back, so the caller's remaining writes still run and the ingest
-    failure it was handling stays the task's outcome.
+    Never raises. Every caller reaches it from inside an ``except``, where a
+    raise would replace the ingest failure with a lock timeout.
 
-    fix(#1950 codex r2): the budget bounds this SELECT, which is what makes the
-    load itself able to fail. Every caller reaches it from inside an ``except``,
-    where a raise here would replace the cause with a lock timeout.
+    Returns ``None`` when the row is gone, when a newer attempt owns it, or when
+    the budget expired; the expiry is logged as its own event. On every ``None``
+    the transaction is ended, so the caller's remaining writes run unbudgeted on
+    a clean session rather than inheriting a budget meant for the job row.
+
+    On a hit the transaction stays open and budgeted, and the returned row is
+    live: ending it here would expire the instance the caller is about to pass
+    to ``_cleanup_staging_on_failure``.
     """
     from sqlalchemy import select
     from sqlalchemy.exc import DBAPIError
@@ -1288,7 +1291,10 @@ async def load_job_for_error_write(
     try:
         await arm_job_error_write_budget(session)
         result = await session.execute(select(IngestJob).where(*filters))
-        return result.scalar_one_or_none()
+        job = result.scalar_one_or_none()
+        if job is None:
+            await session.rollback()
+        return job
     except DBAPIError as write_failure:
         await session.rollback()
         log_job_error_write_failure(write_failure, job_id=str(job_uuid), task=task_name)
@@ -1359,10 +1365,6 @@ async def _cleanup_staging_on_failure(
     # that dispatch on its type or re-raise it are unaffected.
     error_message = redact_url_credentials(str(exc))
     await session.rollback()
-    # fix(#1950): armed AFTER the rollback that would discard it and before the
-    # UPDATE, which is the statement that blocks on a contended job row. It
-    # expires with the commit below, so the DROP stays unbounded as before.
-    await arm_job_error_write_budget(session)
 
     failure_update = sa_update(type(job)).where(type(job).id == job_id)
     if attempt_id is not None:
@@ -1382,6 +1384,10 @@ async def _cleanup_staging_on_failure(
     written = False
     result = None
     try:
+        # fix(#1950): armed AFTER the rollback that would discard it and before
+        # the UPDATE, which is the statement that blocks on a contended job row;
+        # inside the guard because arming can fail on a lost connection too.
+        await arm_job_error_write_budget(session)
         result = await session.execute(
             failure_update.values(
                 status="failed",

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1292,14 +1292,19 @@ async def _cleanup_staging_on_failure(
     can fail belongs after the commit, in its own guarded block, with a
     rollback of its own wreckage.
 
-    fix(#1950): the failure UPDATE runs under ``JOB_ERROR_WRITE_TIMEOUT_MS``.
-    A contended job row raises out of here rather than waiting, so the job stays
-    ``running`` and whatever a caller writes after this call is skipped too.
+    fix(#1950): the failure UPDATE runs under ``JOB_ERROR_WRITE_TIMEOUT_MS``. On
+    a contended job row it gives up rather than waiting, logs
+    ``job_error_write_timeout``, and returns — the job stays ``running`` and the
+    caller re-raises the failure it was already handling.
     """
     from sqlalchemy import text
     from sqlalchemy import update as sa_update
+    from sqlalchemy.exc import DBAPIError
 
-    from app.platform.jobs.heartbeat import arm_job_error_write_budget
+    from app.platform.jobs.heartbeat import (
+        arm_job_error_write_budget,
+        log_job_error_write_failure,
+    )
     from app.processing.ingest.metadata import _qtable
 
     job_id = job.id
@@ -1331,14 +1336,24 @@ async def _cleanup_staging_on_failure(
             type(job).attempt_id == attempt_id,
             type(job).status.in_(("pending", "running")),
         )
-    result = await session.execute(
-        failure_update.values(
-            status="failed",
-            error_message=error_message,
-            completed_at=completed_at,
+    # fix(#1950): an expired budget must not become the task's outcome. Swallowed
+    # and logged as its own event, so the caller re-raises the ingest failure and
+    # the report below still runs; `written` gates what the write earned.
+    written = False
+    result = None
+    try:
+        result = await session.execute(
+            failure_update.values(
+                status="failed",
+                error_message=error_message,
+                completed_at=completed_at,
+            )
         )
-    )
-    await session.commit()
+        await session.commit()
+        written = True
+    except DBAPIError as write_failure:
+        await session.rollback()
+        log_job_error_write_failure(write_failure, job_id=str(job_id), task=task_name)
 
     # fix(#1778 codex r2): the DROP runs AFTER the failure row is committed,
     # not before it. PostgreSQL aborts the whole transaction on any statement
@@ -1376,11 +1391,12 @@ async def _cleanup_staging_on_failure(
                     task=task_name,
                 )
 
-    if attempt_id is not None and not result.rowcount:
+    if written and attempt_id is not None and not result.rowcount:
         return
-    job.status = "failed"
-    job.error_message = error_message
-    job.completed_at = completed_at
+    if written:
+        job.status = "failed"
+        job.error_message = error_message
+        job.completed_at = completed_at
     structlog.get_logger().exception(
         "Ingest task failed",
         job_id=str(job_id),

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1255,6 +1255,46 @@ async def stamp_failed_origin_health(
         await invalidate_catalog_cache()
 
 
+async def load_job_for_error_write(
+    session,
+    job_uuid: uuid.UUID,
+    attempt_uuid: uuid.UUID | None,
+    *,
+    task_name: str,
+):
+    """Load the job row a failure tail is about to settle, under the shared budget.
+
+    Returns ``None`` when the row is gone, when a newer attempt owns it, or when
+    the budget expired: an expiry is logged as its own event and the session is
+    rolled back, so the caller's remaining writes still run and the ingest
+    failure it was handling stays the task's outcome.
+
+    fix(#1950 codex r2): the budget bounds this SELECT, which is what makes the
+    load itself able to fail. Every caller reaches it from inside an ``except``,
+    where a raise here would replace the cause with a lock timeout.
+    """
+    from sqlalchemy import select
+    from sqlalchemy.exc import DBAPIError
+
+    from app.platform.jobs.heartbeat import (
+        arm_job_error_write_budget,
+        log_job_error_write_failure,
+    )
+    from app.platform.jobs.models import IngestJob
+
+    filters = [IngestJob.id == job_uuid]
+    if attempt_uuid is not None:
+        filters.append(IngestJob.attempt_id == attempt_uuid)
+    try:
+        await arm_job_error_write_budget(session)
+        result = await session.execute(select(IngestJob).where(*filters))
+        return result.scalar_one_or_none()
+    except DBAPIError as write_failure:
+        await session.rollback()
+        log_job_error_write_failure(write_failure, job_id=str(job_uuid), task=task_name)
+        return None
+
+
 async def _cleanup_staging_on_failure(
     session,
     *,

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1293,13 +1293,13 @@ async def _cleanup_staging_on_failure(
     rollback of its own wreckage.
 
     fix(#1950): the failure UPDATE runs under ``JOB_ERROR_WRITE_TIMEOUT_MS``.
-    A contended job row raises out of here rather than waiting, and the job
-    then records nothing: it stays ``running`` until the stale sweep reaps it.
+    A contended job row raises out of here rather than waiting, so the job stays
+    ``running`` and whatever a caller writes after this call is skipped too.
     """
     from sqlalchemy import text
     from sqlalchemy import update as sa_update
 
-    from app.platform.jobs.heartbeat import JOB_ERROR_WRITE_TIMEOUT_MS
+    from app.platform.jobs.heartbeat import arm_job_error_write_budget
     from app.processing.ingest.metadata import _qtable
 
     job_id = job.id
@@ -1317,12 +1317,7 @@ async def _cleanup_staging_on_failure(
     # fix(#1950): armed AFTER the rollback that would discard it and before the
     # UPDATE, which is the statement that blocks on a contended job row. It
     # expires with the commit below, so the DROP stays unbounded as before.
-    await session.execute(
-        text(f"SET LOCAL lock_timeout = {JOB_ERROR_WRITE_TIMEOUT_MS}")
-    )
-    await session.execute(
-        text(f"SET LOCAL statement_timeout = {JOB_ERROR_WRITE_TIMEOUT_MS}")
-    )
+    await arm_job_error_write_budget(session)
 
     failure_update = sa_update(type(job)).where(type(job).id == job_id)
     if attempt_id is not None:

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -1291,10 +1291,15 @@ async def _cleanup_staging_on_failure(
     the job sat `running` with no reason recorded. Anything added here that
     can fail belongs after the commit, in its own guarded block, with a
     rollback of its own wreckage.
+
+    fix(#1950): the failure UPDATE runs under ``JOB_ERROR_WRITE_TIMEOUT_MS``.
+    A contended job row raises out of here rather than waiting, and the job
+    then records nothing: it stays ``running`` until the stale sweep reaps it.
     """
     from sqlalchemy import text
     from sqlalchemy import update as sa_update
 
+    from app.platform.jobs.heartbeat import JOB_ERROR_WRITE_TIMEOUT_MS
     from app.processing.ingest.metadata import _qtable
 
     job_id = job.id
@@ -1309,6 +1314,15 @@ async def _cleanup_staging_on_failure(
     # that dispatch on its type or re-raise it are unaffected.
     error_message = redact_url_credentials(str(exc))
     await session.rollback()
+    # fix(#1950): armed AFTER the rollback that would discard it and before the
+    # UPDATE, which is the statement that blocks on a contended job row. It
+    # expires with the commit below, so the DROP stays unbounded as before.
+    await session.execute(
+        text(f"SET LOCAL lock_timeout = {JOB_ERROR_WRITE_TIMEOUT_MS}")
+    )
+    await session.execute(
+        text(f"SET LOCAL statement_timeout = {JOB_ERROR_WRITE_TIMEOUT_MS}")
+    )
 
     failure_update = sa_update(type(job)).where(type(job).id == job_id)
     if attempt_id is not None:

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -11,7 +11,7 @@ import functools
 import time
 import uuid
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1285,6 +1285,12 @@ async def load_job_for_error_write(
     )
     from app.platform.jobs.models import IngestJob
 
+    async def _end_transaction() -> None:
+        # A rollback on a connection that is already gone raises, and this
+        # helper's whole job is to not raise.
+        with suppress(Exception):  # broad: best-effort, the caller re-raises
+            await session.rollback()
+
     filters = [IngestJob.id == job_uuid]
     if attempt_uuid is not None:
         filters.append(IngestJob.attempt_id == attempt_uuid)
@@ -1293,10 +1299,10 @@ async def load_job_for_error_write(
         result = await session.execute(select(IngestJob).where(*filters))
         job = result.scalar_one_or_none()
         if job is None:
-            await session.rollback()
+            await _end_transaction()
         return job
     except DBAPIError as write_failure:
-        await session.rollback()
+        await _end_transaction()
         log_job_error_write_failure(write_failure, job_id=str(job_uuid), task=task_name)
         return None
 
@@ -1398,7 +1404,10 @@ async def _cleanup_staging_on_failure(
         await session.commit()
         written = True
     except DBAPIError as write_failure:
-        await session.rollback()
+        # Same reason as the loader's: the callers below re-raise the ingest
+        # failure, and a rollback that raises would take its place.
+        with suppress(Exception):  # broad: best-effort, the caller re-raises
+            await session.rollback()
         log_job_error_write_failure(write_failure, job_id=str(job_id), task=task_name)
 
     # fix(#1778 codex r2): the DROP runs AFTER the failure row is committed,

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import datetime, timezone
 
 import structlog
+from sqlalchemy.exc import DBAPIError
 
 from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.core.tenancy import is_multi_tenant
@@ -11,6 +12,7 @@ from app.platform.cache.tiles import invalidate_catalog_cache
 from app.platform.jobs.heartbeat import (
     JOB_ERROR_WRITE_TIMEOUT_MS,
     claim_job_attempt_and_start_heartbeat,
+    log_job_error_write_failure,
     require_ingest_job_update,
     resolve_ingest_attempt_or_skip,
     stop_ingest_job_heartbeat,
@@ -797,8 +799,8 @@ async def ingest_raster(
         # REMED-03 / P2-05: route through _job_phase_session.
         #
         # fix(#1950): the budget covers the UPDATE below, the statement that
-        # blocks on a contended job row. If it expires the job records nothing
-        # and stays `running` until the stale sweep reaps it.
+        # blocks on a contended job row. An expiry leaves the job `running` for
+        # the stale sweep; the handler below keeps the cause as the outcome.
         try:
             async with _job_phase_session(
                 job_uuid,
@@ -825,6 +827,13 @@ async def ingest_raster(
                     )
                 )
                 await err_session.commit()
+        except DBAPIError as write_failure:
+            # fix(#1950): swallowed so the `raise` below re-raises the ingest
+            # failure. Letting an expiry out would hand the operator a lock
+            # timeout in place of the cause, and skip the notification.
+            log_job_error_write_failure(
+                write_failure, job_id=job_id, task="ingest_raster"
+            )
         finally:
             # fix(#1213 review r1, #1950): the `finally` reapers gate on THIS
             # variable, so every exit from this handler sets it — the bounded

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -799,32 +799,37 @@ async def ingest_raster(
         # fix(#1950): the budget covers the UPDATE below, the statement that
         # blocks on a contended job row. If it expires the job records nothing
         # and stays `running` until the stale sweep reaps it.
-        async with _job_phase_session(
-            job_uuid,
-            phase="error_write",
-            attempt_id=attempt_uuid,
-            lock_and_statement_timeout_ms=JOB_ERROR_WRITE_TIMEOUT_MS,
-        ) as (
-            err_session,
-            _err_job,
-        ):
-            from sqlalchemy import update as sa_update
+        try:
+            async with _job_phase_session(
+                job_uuid,
+                phase="error_write",
+                attempt_id=attempt_uuid,
+                lock_and_statement_timeout_ms=JOB_ERROR_WRITE_TIMEOUT_MS,
+            ) as (
+                err_session,
+                _err_job,
+            ):
+                from sqlalchemy import update as sa_update
 
-            await err_session.execute(
-                sa_update(IngestJob)
-                .where(
-                    IngestJob.id == job_uuid,
-                    IngestJob.attempt_id == attempt_uuid,
-                    IngestJob.status == "running",
+                await err_session.execute(
+                    sa_update(IngestJob)
+                    .where(
+                        IngestJob.id == job_uuid,
+                        IngestJob.attempt_id == attempt_uuid,
+                        IngestJob.status == "running",
+                    )
+                    .values(
+                        status="failed",
+                        error_message=str(exc),
+                        completed_at=datetime.now(timezone.utc),
+                    )
                 )
-                .values(
-                    status="failed",
-                    error_message=str(exc),
-                    completed_at=datetime.now(timezone.utc),
-                )
-            )
-            await err_session.commit()
-        final_status = "failed"
+                await err_session.commit()
+        finally:
+            # fix(#1213 review r1, #1950): the `finally` reapers gate on THIS
+            # variable, so every exit from this handler sets it — the bounded
+            # error write above can raise past a positional assignment.
+            final_status = "failed"
         # EVENT-03: notify on ingest failed (non-fatal, after commit — deferred import).
         # status="failed" is already committed above (err_session.commit) so a
         # notification error cannot roll back or alter the terminal job write

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -9,6 +9,7 @@ from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.core.tenancy import is_multi_tenant
 from app.platform.cache.tiles import invalidate_catalog_cache
 from app.platform.jobs.heartbeat import (
+    JOB_ERROR_WRITE_TIMEOUT_MS,
     claim_job_attempt_and_start_heartbeat,
     require_ingest_job_update,
     resolve_ingest_attempt_or_skip,
@@ -794,8 +795,15 @@ async def ingest_raster(
         # Write failure status via a fresh session — phase 1/2 sessions are
         # already closed (or rolled back) by the time we get here.
         # REMED-03 / P2-05: route through _job_phase_session.
+        #
+        # fix(#1950): the budget covers the UPDATE below, the statement that
+        # blocks on a contended job row. If it expires the job records nothing
+        # and stays `running` until the stale sweep reaps it.
         async with _job_phase_session(
-            job_uuid, phase="error_write", attempt_id=attempt_uuid
+            job_uuid,
+            phase="error_write",
+            attempt_id=attempt_uuid,
+            lock_and_statement_timeout_ms=JOB_ERROR_WRITE_TIMEOUT_MS,
         ) as (
             err_session,
             _err_job,

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -17,6 +17,7 @@ from app.platform.catalog_locks import (
 )
 from app.platform.dataset_origin import classify_origin, service_layer_identity
 from app.platform.jobs.heartbeat import (
+    arm_job_error_write_budget,
     attempt_scoped_staging_table,
     claim_job_attempt_and_start_heartbeat,
     require_ingest_job_update,
@@ -541,45 +542,44 @@ async def reupload_file(
         # Phase 1/2 sessions are already closed (or rolled back) by the time
         # we get here. Open a fresh session, re-load the job, and run the
         # shared cleanup helper.
-        async with async_session() as err_session:
-            err_job_result = await err_session.execute(
-                select(IngestJob).where(
-                    IngestJob.id == job_uuid,
-                    IngestJob.attempt_id == attempt_uuid,
+        try:
+            async with async_session() as err_session:
+                # fix(#1778 r6, #1950): the SELECT can stall behind a table lock
+                # the row's own UPDATE never sees. The helper below rolls back
+                # and re-arms, so this covers the load alone.
+                await arm_job_error_write_budget(err_session)
+                err_job_result = await err_session.execute(
+                    select(IngestJob).where(
+                        IngestJob.id == job_uuid,
+                        IngestJob.attempt_id == attempt_uuid,
+                    )
                 )
-            )
-            err_job = err_job_result.scalar_one_or_none()
-            if err_job is not None:
-                await _cleanup_staging_on_failure(
+                err_job = err_job_result.scalar_one_or_none()
+                if err_job is not None:
+                    await _cleanup_staging_on_failure(
+                        err_session,
+                        staging_table=staging_tn,
+                        job=err_job,
+                        exc=exc,
+                        task_name="reupload_file",
+                        attempt_id=attempt_uuid,
+                    )
+                # feat(#1219): outside the err_job guard on purpose — the run
+                # is keyed on the job id, which is known even when the job row
+                # itself has gone, and a failure is history too.
+                await record_refresh_failure(
                     err_session,
-                    staging_table=staging_tn,
-                    job=err_job,
-                    exc=exc,
-                    task_name="reupload_file",
-                    attempt_id=attempt_uuid,
+                    ingest_job_id=job_uuid,
+                    error_code=_file_refresh_error_code(exc),
+                    error_message=str(exc),
+                    contacted_origin=False,
                 )
-            # feat(#1219): failures are history too — "a refresh that silently
-            # vanishes from history is worse than one that visibly failed".
-            # Outside the err_job guard on purpose: the run is keyed on the job
-            # id, which is known even when the row itself has gone.
-            await record_refresh_failure(
-                err_session,
-                ingest_job_id=job_uuid,
-                error_code=_file_refresh_error_code(exc),
-                error_message=str(exc),
-                contacted_origin=False,
-            )
-            await err_session.commit()
-        # fix(#1213 review r1): mark the local status terminal before
-        # re-raising. `_cleanup_staging_on_failure` above writes status=failed
-        # to the DB row, but the `finally` reap reads THIS variable, and it was
-        # still "pending" — so the terminal-status guard returned early and the
-        # client-writable staging object survived every failure past the early
-        # validation block (CRS detection, ogr2ogr, staging-table work). The
-        # task is retry=0, so every exception here is terminal, and the stale
-        # purge is no backstop for reupload jobs (see the reap comment below).
-        # Mirrors tasks_vector.py's broad-except handler.
-        final_status = "failed"
+                await err_session.commit()
+        finally:
+            # fix(#1213 review r1, #1950): the `finally` reapers gate on THIS
+            # variable, so every exit from this handler sets it — the bounded
+            # error write above can raise past a positional assignment.
+            final_status = "failed"
         raise
     finally:
         async with cleanup_step("reupload_file heartbeat", job_id=job_id):
@@ -1263,6 +1263,10 @@ async def reupload_service(
         scrub_secret_from_exception(exc, token)
         # Phase 1/2 sessions are already closed by the time we get here.
         async with async_session() as err_session:
+            # fix(#1778 r6, #1950): the SELECT can stall behind a table lock the
+            # row's own UPDATE never sees. The helper below rolls back and
+            # re-arms, so this covers the load alone.
+            await arm_job_error_write_budget(err_session)
             err_job_result = await err_session.execute(
                 select(IngestJob).where(
                     IngestJob.id == job_uuid,

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -17,7 +17,6 @@ from app.platform.catalog_locks import (
 )
 from app.platform.dataset_origin import classify_origin, service_layer_identity
 from app.platform.jobs.heartbeat import (
-    arm_job_error_write_budget,
     attempt_scoped_staging_table,
     claim_job_attempt_and_start_heartbeat,
     require_ingest_job_update,
@@ -47,6 +46,7 @@ from app.processing.ingest.tasks_common import (
     _archive_original_file,
     _bind_task_log_context,
     _cleanup_staging_on_failure,
+    load_job_for_error_write,
     reap_downloaded_staging_source,
     reap_presigned_staging_object,
     _current_tenant_role,
@@ -544,17 +544,11 @@ async def reupload_file(
         # shared cleanup helper.
         try:
             async with async_session() as err_session:
-                # fix(#1778 r6, #1950): the SELECT can stall behind a table lock
-                # the row's own UPDATE never sees. The helper below rolls back
-                # and re-arms, so this covers the load alone.
-                await arm_job_error_write_budget(err_session)
-                err_job_result = await err_session.execute(
-                    select(IngestJob).where(
-                        IngestJob.id == job_uuid,
-                        IngestJob.attempt_id == attempt_uuid,
-                    )
+                # fix(#1950 codex r2): arms the budget, loads the row, and
+                # swallows an expiry — the failure below is the task's outcome.
+                err_job = await load_job_for_error_write(
+                    err_session, job_uuid, attempt_uuid, task_name="reupload_file"
                 )
-                err_job = err_job_result.scalar_one_or_none()
                 if err_job is not None:
                     await _cleanup_staging_on_failure(
                         err_session,
@@ -1263,17 +1257,11 @@ async def reupload_service(
         scrub_secret_from_exception(exc, token)
         # Phase 1/2 sessions are already closed by the time we get here.
         async with async_session() as err_session:
-            # fix(#1778 r6, #1950): the SELECT can stall behind a table lock the
-            # row's own UPDATE never sees. The helper below rolls back and
-            # re-arms, so this covers the load alone.
-            await arm_job_error_write_budget(err_session)
-            err_job_result = await err_session.execute(
-                select(IngestJob).where(
-                    IngestJob.id == job_uuid,
-                    IngestJob.attempt_id == attempt_uuid,
-                )
+            # fix(#1950 codex r2): arms the budget, loads the row, and
+            # swallows an expiry — the failure below is the task's outcome.
+            err_job = await load_job_for_error_write(
+                err_session, job_uuid, attempt_uuid, task_name="reupload_service"
             )
-            err_job = err_job_result.scalar_one_or_none()
             if err_job is not None:
                 await _cleanup_staging_on_failure(
                     err_session,

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -13,6 +13,7 @@ from app.core.db.tenant_session import tenant_task
 from app.core.url_redaction import scrub_secret_from_exception
 from app.platform.dataset_origin import service_layer_identity
 from app.platform.jobs.heartbeat import (
+    JOB_ERROR_WRITE_TIMEOUT_MS,
     attempt_scoped_staging_table,
     claim_job_attempt_and_start_heartbeat,
     require_ingest_job_update,
@@ -843,28 +844,36 @@ async def ingest_file(
         # It mutates the ORM row it is given, so a NULL job (race with a row
         # delete) skips it: there is no row left to fail, and the re-raise
         # below still records the failure on the queue row.
-        async with _job_phase_session(
-            job_uuid, phase="error_write", attempt_id=attempt_uuid
-        ) as (
-            err_session,
-            err_job,
-        ):
-            if err_job is not None:
-                await _cleanup_staging_on_failure(
-                    err_session,
-                    staging_table=staging_table_name,
-                    job=err_job,
-                    exc=exc,
-                    task_name="ingest_file",
-                    attempt_id=attempt_uuid,
-                )
-            else:
-                structlog.get_logger().exception(
-                    "Ingest task failed",
-                    job_id=job_id,
-                    task="ingest_file",
-                )
-        final_status = "failed"
+        try:
+            async with _job_phase_session(
+                job_uuid,
+                phase="error_write",
+                attempt_id=attempt_uuid,
+                lock_and_statement_timeout_ms=JOB_ERROR_WRITE_TIMEOUT_MS,
+            ) as (
+                err_session,
+                err_job,
+            ):
+                if err_job is not None:
+                    await _cleanup_staging_on_failure(
+                        err_session,
+                        staging_table=staging_table_name,
+                        job=err_job,
+                        exc=exc,
+                        task_name="ingest_file",
+                        attempt_id=attempt_uuid,
+                    )
+                else:
+                    structlog.get_logger().exception(
+                        "Ingest task failed",
+                        job_id=job_id,
+                        task="ingest_file",
+                    )
+        finally:
+            # fix(#1213 review r1, #1950): the `finally` reapers gate on THIS
+            # variable, so every exit from this handler sets it — the bounded
+            # error write above can raise past a positional assignment.
+            final_status = "failed"
         raise
     finally:
         async with cleanup_step("ingest_file heartbeat", job_id=job_id):
@@ -1337,7 +1346,10 @@ async def ingest_service(
         # so the helper's pattern-based redaction is layered on an exception
         # that no longer carries this attempt's token in any shape.
         async with _job_phase_session(
-            job_uuid, phase="error_write", attempt_id=attempt_uuid
+            job_uuid,
+            phase="error_write",
+            attempt_id=attempt_uuid,
+            lock_and_statement_timeout_ms=JOB_ERROR_WRITE_TIMEOUT_MS,
         ) as (
             err_session,
             err_job,

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import structlog
 from sqlalchemy import or_, text, update
+from sqlalchemy.exc import DBAPIError
 
 from app.core.db.tenant_session import tenant_task
 from app.core.url_redaction import scrub_secret_from_exception
@@ -16,6 +17,7 @@ from app.platform.jobs.heartbeat import (
     JOB_ERROR_WRITE_TIMEOUT_MS,
     attempt_scoped_staging_table,
     claim_job_attempt_and_start_heartbeat,
+    log_job_error_write_failure,
     require_ingest_job_update,
     resolve_ingest_attempt_or_skip,
     update_ingest_job_for_attempt,
@@ -869,6 +871,13 @@ async def ingest_file(
                         job_id=job_id,
                         task="ingest_file",
                     )
+        except DBAPIError as write_failure:
+            # fix(#1950 codex r2): the budget covers the helper's own load, so
+            # an expiry there arrives here. Swallowed for the reason the helper
+            # swallows its UPDATE's: the cause below is the task's outcome.
+            log_job_error_write_failure(
+                write_failure, job_id=job_id, task="ingest_file"
+            )
         finally:
             # fix(#1213 review r1, #1950): the `finally` reapers gate on THIS
             # variable, so every exit from this handler sets it — the bounded
@@ -1345,30 +1354,38 @@ async def ingest_service(
         # `ingest_file` records. The exact-value scrub above still runs FIRST,
         # so the helper's pattern-based redaction is layered on an exception
         # that no longer carries this attempt's token in any shape.
-        async with _job_phase_session(
-            job_uuid,
-            phase="error_write",
-            attempt_id=attempt_uuid,
-            lock_and_statement_timeout_ms=JOB_ERROR_WRITE_TIMEOUT_MS,
-        ) as (
-            err_session,
-            err_job,
-        ):
-            if err_job is not None:
-                await _cleanup_staging_on_failure(
-                    err_session,
-                    staging_table=staging_table_name,
-                    job=err_job,
-                    exc=exc,
-                    task_name="ingest_service",
-                    attempt_id=attempt_uuid,
-                )
-            else:
-                structlog.get_logger().exception(
-                    "Ingest task failed",
-                    job_id=job_id,
-                    task="ingest_service",
-                )
+        try:
+            async with _job_phase_session(
+                job_uuid,
+                phase="error_write",
+                attempt_id=attempt_uuid,
+                lock_and_statement_timeout_ms=JOB_ERROR_WRITE_TIMEOUT_MS,
+            ) as (
+                err_session,
+                err_job,
+            ):
+                if err_job is not None:
+                    await _cleanup_staging_on_failure(
+                        err_session,
+                        staging_table=staging_table_name,
+                        job=err_job,
+                        exc=exc,
+                        task_name="ingest_service",
+                        attempt_id=attempt_uuid,
+                    )
+                else:
+                    structlog.get_logger().exception(
+                        "Ingest task failed",
+                        job_id=job_id,
+                        task="ingest_service",
+                    )
+        except DBAPIError as write_failure:
+            # fix(#1950 codex r2): the budget covers the helper's own load, so
+            # an expiry there arrives here. Swallowed for the reason the helper
+            # swallows its UPDATE's: the cause below is the task's outcome.
+            log_job_error_write_failure(
+                write_failure, job_id=job_id, task="ingest_service"
+            )
         raise
     finally:
         # fix(#1755 item 11): `purge_token_on_failure` (`tasks_common.py`), the

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -17,6 +17,7 @@ import uuid
 from datetime import datetime, timezone
 
 import structlog
+from sqlalchemy.exc import DBAPIError
 
 from sqlalchemy import select
 
@@ -24,6 +25,7 @@ from app.platform.cache.tiles import invalidate_catalog_cache
 from app.platform.jobs.heartbeat import (
     arm_job_error_write_budget,
     claim_job_attempt_and_start_heartbeat,
+    log_job_error_write_failure,
     maintain_vrt_generation_heartbeat,
     require_ingest_job_update,
     resolve_ingest_attempt_or_skip,
@@ -1588,57 +1590,61 @@ async def regenerate_vrt(
         )
         # Failure handler runs via a fresh session: mark vrt asset failed,
         # mark generation failed, mark job failed.
-        async with async_session() as err_session:
-            from sqlalchemy import update as sa_update
+        try:
+            async with async_session() as err_session:
+                from sqlalchemy import update as sa_update
 
-            # fix(#1950): the publish wait above raises CatalogLockConflict on a
-            # held catalog row, so this handler runs while the job row may be
-            # contended too. All three writes below share the budget.
-            await arm_job_error_write_budget(err_session)
-            await update_ingest_job_for_attempt(
-                err_session,
-                job_uuid,
-                attempt_uuid,
-                values={
-                    "status": "failed",
-                    "error_message": str(exc),
-                    "completed_at": datetime.now(timezone.utc),
-                },
-            )
-            # Mark only the asset that still points at this exact generation.
-            # If a newer retry owns the pointer, leave its status untouched.
-            await err_session.execute(
-                sa_update(RasterAsset)
-                .where(
-                    RasterAsset.dataset_id == vrt_id,
-                    RasterAsset.current_generation_id == generation_uuid,
+                # fix(#1950): the publish wait above gives up on a held
+                # catalog row, so this handler runs while the job row may be
+                # contended too. All three writes below share the budget.
+                await arm_job_error_write_budget(err_session)
+                await update_ingest_job_for_attempt(
+                    err_session,
+                    job_uuid,
+                    attempt_uuid,
+                    values={
+                        "status": "failed",
+                        "error_message": str(exc),
+                        "completed_at": datetime.now(timezone.utc),
+                    },
                 )
-                .values(status="failed", current_generation_id=None)
-            )
-
-            # Update generation record on failure.
-            if generation_uuid is not None:
-                gen_result = await err_session.execute(
-                    select(VrtGeneration).where(VrtGeneration.id == generation_uuid)
+                # Mark only the asset that still points at this exact generation.
+                # If a newer retry owns the pointer, leave its status untouched.
+                await err_session.execute(
+                    sa_update(RasterAsset)
+                    .where(
+                        RasterAsset.dataset_id == vrt_id,
+                        RasterAsset.current_generation_id == generation_uuid,
+                    )
+                    .values(status="failed", current_generation_id=None)
                 )
-                gen = gen_result.scalar_one_or_none()
-                # fix(#1778 codex r1): and the same rule stated at the write
-                # rather than only at the caller. The two guards above are
-                # local flags; this one is a property of the statement, so a
-                # future path into this handler cannot relabel a generation
-                # whose artifact is published, whatever it believes about the
-                # commit. It is the peer of the `current_generation_id` fence
-                # on the asset update and the `running` fence on the job.
-                if gen and gen.status != "completed":
-                    gen.status = "failed"
-                    gen.completed_at = datetime.now(timezone.utc)
-                    if gen.started_at:
-                        gen.duration_seconds = (
-                            gen.completed_at - gen.started_at
-                        ).total_seconds()
-                    gen.error_message = str(exc)
 
-            await err_session.commit()
+                # Update generation record on failure.
+                if generation_uuid is not None:
+                    gen_result = await err_session.execute(
+                        select(VrtGeneration).where(VrtGeneration.id == generation_uuid)
+                    )
+                    gen = gen_result.scalar_one_or_none()
+                    # fix(#1778 codex r1): fenced at the statement, not only
+                    # at the caller — a future path into this handler cannot
+                    # relabel a generation whose artifact is published.
+                    if gen and gen.status != "completed":
+                        gen.status = "failed"
+                        gen.completed_at = datetime.now(timezone.utc)
+                        if gen.started_at:
+                            gen.duration_seconds = (
+                                gen.completed_at - gen.started_at
+                            ).total_seconds()
+                        gen.error_message = str(exc)
+
+                await err_session.commit()
+        except DBAPIError as write_failure:
+            # fix(#1950): swallowed so the `raise` below re-raises the cause
+            # this handler was called for. Letting an expiry out would hand
+            # the operator a lock timeout in place of the build failure.
+            log_job_error_write_failure(
+                write_failure, job_id=job_id, task="regenerate_vrt"
+            )
         raise
     finally:
         async with cleanup_step("regenerate_vrt generation heartbeat", job_id=job_id):

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -48,6 +48,7 @@ from app.processing.ingest.tasks_common import (
     _bind_task_log_context,
     cleanup_step,
     _cleanup_staging_on_failure,
+    load_job_for_error_write,
     task_app,
 )
 from app.processing.ingest.tasks_raster_common import (
@@ -855,14 +856,9 @@ async def ingest_vrt(
         # staging table — its artifacts are the object keys the `finally`
         # below reaps.
         async with async_session() as err_session:
-            err_job = (
-                await err_session.execute(
-                    select(IngestJob).where(
-                        IngestJob.id == job_uuid,
-                        IngestJob.attempt_id == attempt_uuid,
-                    )
-                )
-            ).scalar_one_or_none()
+            err_job = await load_job_for_error_write(
+                err_session, job_uuid, attempt_uuid, task_name="ingest_vrt"
+            )
             if err_job is not None:
                 await _cleanup_staging_on_failure(
                     err_session,

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 
 from app.platform.cache.tiles import invalidate_catalog_cache
 from app.platform.jobs.heartbeat import (
+    arm_job_error_write_budget,
     claim_job_attempt_and_start_heartbeat,
     maintain_vrt_generation_heartbeat,
     require_ingest_job_update,
@@ -1590,6 +1591,10 @@ async def regenerate_vrt(
         async with async_session() as err_session:
             from sqlalchemy import update as sa_update
 
+            # fix(#1950): the publish wait above raises CatalogLockConflict on a
+            # held catalog row, so this handler runs while the job row may be
+            # contended too. All three writes below share the budget.
+            await arm_job_error_write_budget(err_session)
             await update_ingest_job_for_attempt(
                 err_session,
                 job_uuid,

--- a/backend/tests/finding_markers.py
+++ b/backend/tests/finding_markers.py
@@ -400,7 +400,7 @@ UNANCHORED_MARKER_DEBT: dict[str, int] = {
     "processing/ingest/service.py": 20,
     "processing/ingest/tasks_common.py": 47,
     "processing/ingest/tasks_postgis_refresh.py": 2,
-    "processing/ingest/tasks_raster.py": 37,
+    "processing/ingest/tasks_raster.py": 35,
     "processing/ingest/tasks_raster_common.py": 6,
     "processing/ingest/tasks_raster_replace.py": 4,
     "processing/ingest/tasks_reupload.py": 7,

--- a/backend/tests/test_job_error_write_bound_1950.py
+++ b/backend/tests/test_job_error_write_bound_1950.py
@@ -15,9 +15,9 @@ from pathlib import Path
 
 import pytest
 import structlog.testing
-from asyncpg.exceptions import QueryCanceledError
+from asyncpg.exceptions import ConnectionDoesNotExistError, QueryCanceledError
 from sqlalchemy import delete, select, text
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, InterfaceError
 
 import app.processing.ingest.tasks_raster as tasks_raster
 from app.core.db.sqlstate import sqlstate
@@ -562,10 +562,11 @@ class _IngestFailed(RuntimeError):
 class _LoaderSession:
     """Records what `load_job_for_error_write` does to the session it is given."""
 
-    def __init__(self, *, raises: bool) -> None:
+    def __init__(self, *, raises: bool, rollback_raises: bool = False) -> None:
         self.armed = 0
         self.rolled_back = 0
         self._raises = raises
+        self._rollback_raises = rollback_raises
 
     async def execute(self, statement):
         if "SET LOCAL" in str(statement):
@@ -577,6 +578,8 @@ class _LoaderSession:
 
     async def rollback(self) -> None:
         self.rolled_back += 1
+        if self._rollback_raises:
+            raise InterfaceError("ROLLBACK", {}, ConnectionDoesNotExistError("gone"))
 
 
 class _NoRows:
@@ -612,6 +615,20 @@ class TestTheTimeoutDoesNotReplaceTheCause:
         )
         assert timeouts[0]["task"] == "reupload_file"
         assert timeouts[0]["sqlstate"] == "57014"
+
+    async def test_a_lost_connection_cannot_raise_out_of_the_loader(self) -> None:
+        """Its `Never raises` contract has to hold when the recovery fails too."""
+        session = _LoaderSession(raises=True, rollback_raises=True)
+        with structlog.testing.capture_logs() as captured:
+            loaded = await load_job_for_error_write(
+                session, uuid.uuid4(), uuid.uuid4(), task_name="ingest_vrt"
+            )
+
+        assert loaded is None
+        assert session.rolled_back == 1
+        assert [r for r in captured if r.get("event") == "job_error_write_timeout"], (
+            f"the rollback's own failure skipped the log; got {captured}"
+        )
 
     async def test_a_missed_lookup_does_not_leave_the_budget_armed(self) -> None:
         """The callers write the run row next, on this session, out of scope."""

--- a/backend/tests/test_job_error_write_bound_1950.py
+++ b/backend/tests/test_job_error_write_bound_1950.py
@@ -36,6 +36,17 @@ pytestmark = pytest.mark.anyio
 # uncontended write never reaches it.
 _TEST_BUDGET_MS = 400
 
+# Every tail that settles a failed job through `_cleanup_staging_on_failure`,
+# mapped to the budgeted loader that reads its job row first. The membership is
+# checked against the tree, not trusted.
+_HELPER_ROUTED_TAILS = {
+    ("tasks_vector", "ingest_file"): "_job_phase_session",
+    ("tasks_vector", "ingest_service"): "_job_phase_session",
+    ("tasks_reupload", "reupload_file"): "load_job_for_error_write",
+    ("tasks_reupload", "reupload_service"): "load_job_for_error_write",
+    ("tasks_vrt", "ingest_vrt"): "load_job_for_error_write",
+}
+
 
 def _arm_call_lines(tree: ast.AST) -> list[int]:
     """Line numbers of every ``arm_job_error_write_budget`` call in *tree*."""
@@ -288,16 +299,24 @@ class TestTheBoundIsWhereTheBlockingStatementIs:
             "status 'pending' so the finally-block reapers return early"
         )
 
-    @pytest.mark.parametrize(
-        ("module_name", "task_name"),
-        [
-            ("tasks_vector", "ingest_file"),
-            ("tasks_vector", "ingest_service"),
-            ("tasks_reupload", "reupload_file"),
-            ("tasks_reupload", "reupload_service"),
-        ],
-    )
-    def test_the_four_helper_routed_tails_still_route_there(
+    def test_every_helper_routed_tail_is_named_here(self) -> None:
+        """The list below was hand-written and missed `ingest_vrt` twice."""
+        found = set()
+        for path in Path(tasks_raster.__file__).parent.glob("tasks*.py"):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.AsyncFunctionDef):
+                    continue
+                if "_cleanup_staging_on_failure" in _call_names([node]):
+                    found.add((path.stem, node.name))
+        assert found == set(_HELPER_ROUTED_TAILS), (
+            f"the helper-routed tails are {sorted(found)}, and this file "
+            f"bounds {sorted(_HELPER_ROUTED_TAILS)}. A tail nobody listed "
+            "loads its job row unbounded and hangs with its heartbeat running"
+        )
+
+    @pytest.mark.parametrize(("module_name", "task_name"), sorted(_HELPER_ROUTED_TAILS))
+    def test_every_helper_routed_tail_still_routes_there(
         self, module_name: str, task_name: str
     ) -> None:
         """Each tail's bound is the shared helper's, so it must still call it."""
@@ -310,11 +329,7 @@ class TestTheBoundIsWhereTheBlockingStatementIs:
             f"{module_name}.{task_name} writes its own terminal failure row "
             "again, so the budget in the shared helper no longer covers it"
         )
-        loader = (
-            "load_job_for_error_write"
-            if module_name == "tasks_reupload"
-            else "_job_phase_session"
-        )
+        loader = _HELPER_ROUTED_TAILS[(module_name, task_name)]
         assert loader in source, (
             f"{module_name}.{task_name} loads the job row for its error write "
             f"without {loader}, so the guarded load that swallows an expired "

--- a/backend/tests/test_job_error_write_bound_1950.py
+++ b/backend/tests/test_job_error_write_bound_1950.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 import structlog.testing
+from asyncpg.exceptions import QueryCanceledError
 from sqlalchemy import delete, select, text
 from sqlalchemy.exc import DBAPIError
 
@@ -26,6 +27,7 @@ from app.platform.jobs.models import IngestJob
 from app.processing.ingest.tasks_common import (
     _cleanup_staging_on_failure,
     _job_phase_session,
+    load_job_for_error_write,
 )
 
 pytestmark = pytest.mark.anyio
@@ -213,6 +215,14 @@ class TestTheBoundIsWhereTheBlockingStatementIs:
                 "regenerate_vrt",
                 lambda: _task_source("tasks_vrt", "regenerate_vrt"),
             ),
+            # The four helper-routed tails load the job row BEFORE the helper,
+            # under the same budget, so an expiry there lands in a frame the
+            # helper's own handler cannot reach (#1950 codex r2). The two
+            # vector tails guard that load in place; the two re-upload tails
+            # share `load_job_for_error_write`, whose guard is its own entry.
+            ("ingest_file", lambda: _task_source("tasks_vector", "ingest_file")),
+            ("ingest_service", lambda: _task_source("tasks_vector", "ingest_service")),
+            ("load_job_for_error_write", lambda: load_job_for_error_write),
         ],
     )
     def test_every_error_write_swallows_its_own_failure(self, owner, getter) -> None:
@@ -299,6 +309,16 @@ class TestTheBoundIsWhereTheBlockingStatementIs:
         assert "_cleanup_staging_on_failure" in source, (
             f"{module_name}.{task_name} writes its own terminal failure row "
             "again, so the budget in the shared helper no longer covers it"
+        )
+        loader = (
+            "load_job_for_error_write"
+            if module_name == "tasks_reupload"
+            else "_job_phase_session"
+        )
+        assert loader in source, (
+            f"{module_name}.{task_name} loads the job row for its error write "
+            f"without {loader}, so the guarded load that swallows an expired "
+            "budget is no longer the one it runs"
         )
 
 
@@ -526,6 +546,47 @@ class _IngestFailed(RuntimeError):
 
 class TestTheTimeoutDoesNotReplaceTheCause:
     """The bound must not trade a hang for the wrong diagnosis."""
+
+    async def test_the_shared_loader_swallows_its_own_expiry(self) -> None:
+        """The re-upload tails call it from inside `except`, so it must return."""
+
+        class _Session:
+            def __init__(self) -> None:
+                self.armed = 0
+                self.rolled_back = 0
+
+            async def execute(self, statement):
+                if "SET LOCAL" in str(statement):
+                    self.armed += 1
+                    return None
+                raise DBAPIError(
+                    "SELECT", {}, QueryCanceledError("canceling statement")
+                )
+
+            async def rollback(self) -> None:
+                self.rolled_back += 1
+
+        session = _Session()
+        with structlog.testing.capture_logs() as captured:
+            loaded = await load_job_for_error_write(
+                session, uuid.uuid4(), uuid.uuid4(), task_name="reupload_file"
+            )
+
+        assert session.armed == 2, (
+            f"the loader issued {session.armed} SET LOCALs before its SELECT, so "
+            "the statement this test expires was never under the budget"
+        )
+        assert loaded is None
+        assert session.rolled_back == 1, (
+            "the loader left the session in an aborted transaction, so the run "
+            "row the caller still has to write fails with 25P02"
+        )
+        timeouts = [r for r in captured if r.get("event") == "job_error_write_timeout"]
+        assert len(timeouts) == 1, (
+            f"expected one job_error_write_timeout event; got {captured}"
+        )
+        assert timeouts[0]["task"] == "reupload_file"
+        assert timeouts[0]["sqlstate"] == "57014"
 
     @staticmethod
     async def _tail_shape(session, job, cause: BaseException, seen: list) -> None:

--- a/backend/tests/test_job_error_write_bound_1950.py
+++ b/backend/tests/test_job_error_write_bound_1950.py
@@ -544,29 +544,39 @@ class _IngestFailed(RuntimeError):
     """A recognisable stand-in for whatever the pipeline actually raised."""
 
 
+class _LoaderSession:
+    """Records what `load_job_for_error_write` does to the session it is given."""
+
+    def __init__(self, *, raises: bool) -> None:
+        self.armed = 0
+        self.rolled_back = 0
+        self._raises = raises
+
+    async def execute(self, statement):
+        if "SET LOCAL" in str(statement):
+            self.armed += 1
+            return None
+        if self._raises:
+            raise DBAPIError("SELECT", {}, QueryCanceledError("canceling statement"))
+        return _NoRows()
+
+    async def rollback(self) -> None:
+        self.rolled_back += 1
+
+
+class _NoRows:
+    @staticmethod
+    def scalar_one_or_none():
+        return None
+
+
 class TestTheTimeoutDoesNotReplaceTheCause:
     """The bound must not trade a hang for the wrong diagnosis."""
 
     async def test_the_shared_loader_swallows_its_own_expiry(self) -> None:
         """The re-upload tails call it from inside `except`, so it must return."""
 
-        class _Session:
-            def __init__(self) -> None:
-                self.armed = 0
-                self.rolled_back = 0
-
-            async def execute(self, statement):
-                if "SET LOCAL" in str(statement):
-                    self.armed += 1
-                    return None
-                raise DBAPIError(
-                    "SELECT", {}, QueryCanceledError("canceling statement")
-                )
-
-            async def rollback(self) -> None:
-                self.rolled_back += 1
-
-        session = _Session()
+        session = _LoaderSession(raises=True)
         with structlog.testing.capture_logs() as captured:
             loaded = await load_job_for_error_write(
                 session, uuid.uuid4(), uuid.uuid4(), task_name="reupload_file"
@@ -587,6 +597,20 @@ class TestTheTimeoutDoesNotReplaceTheCause:
         )
         assert timeouts[0]["task"] == "reupload_file"
         assert timeouts[0]["sqlstate"] == "57014"
+
+    async def test_a_missed_lookup_does_not_leave_the_budget_armed(self) -> None:
+        """The callers write the run row next, on this session, out of scope."""
+        session = _LoaderSession(raises=False)
+        loaded = await load_job_for_error_write(
+            session, uuid.uuid4(), uuid.uuid4(), task_name="reupload_service"
+        )
+
+        assert loaded is None
+        assert session.rolled_back == 1, (
+            "a superseded attempt leaves the SET LOCALs in force, so the run "
+            "row the caller still writes inherits the job row's budget and an "
+            "expiry there replaces the ingest failure"
+        )
 
     @staticmethod
     async def _tail_shape(session, job, cause: BaseException, seen: list) -> None:

--- a/backend/tests/test_job_error_write_bound_1950.py
+++ b/backend/tests/test_job_error_write_bound_1950.py
@@ -1,6 +1,6 @@
 """fix(#1950): the bound on a worker's terminal failure write.
 
-Five ingest tails settle a failed job by UPDATEing its ``ingest_jobs`` row on a
+Six ingest tails settle a failed job by UPDATEing its ``ingest_jobs`` row on a
 fresh session. That UPDATE runs under a 10-second budget, so a held row ends it
 instead of parking the worker while the heartbeat reports the job alive.
 """
@@ -34,26 +34,72 @@ pytestmark = pytest.mark.anyio
 _TEST_BUDGET_MS = 400
 
 
-def _error_write_bracket_budget() -> str | None:
-    """The name ``ingest_raster``'s error-write bracket passes as its budget."""
-    tree = ast.parse(Path(tasks_raster.__file__).read_text())
+def _arm_call_lines(tree: ast.AST) -> list[int]:
+    """Line numbers of every ``arm_job_error_write_budget`` call in *tree*."""
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", None) == "arm_job_error_write_budget"
+    ]
+
+
+def _method_call_lines(tree: ast.AST, attr: str) -> list[int]:
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and getattr(node.func, "attr", None) == attr
+    ]
+
+
+def _failed_status_lines(tree: ast.AST) -> list[int]:
+    """Line numbers of every ``status="failed"`` keyword or dict entry."""
+    lines = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.keyword)
+        and node.arg == "status"
+        and isinstance(node.value, ast.Constant)
+        and node.value.value == "failed"
+    ]
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
+        if not isinstance(node, ast.Dict):
             continue
-        if getattr(node.func, "id", None) != "_job_phase_session":
-            continue
-        phases = [
-            kw.value.value
+        for key, value in zip(node.keys, node.values):
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == "status"
+                and isinstance(value, ast.Constant)
+                and value.value == "failed"
+            ):
+                lines.append(key.lineno)
+    return lines
+
+
+def _is_error_write_bracket(node: ast.AST) -> bool:
+    """Whether *node* is a ``_job_phase_session(phase="error_write")`` call."""
+    return (
+        isinstance(node, ast.Call)
+        and getattr(node.func, "id", None) == "_job_phase_session"
+        and any(
+            kw.arg == "phase"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value == "error_write"
             for kw in node.keywords
-            if kw.arg == "phase" and isinstance(kw.value, ast.Constant)
-        ]
-        if phases != ["error_write"]:
-            continue
-        for kw in node.keywords:
-            if kw.arg == "lock_and_statement_timeout_ms":
-                return getattr(kw.value, "id", None)
-        return None
-    raise AssertionError("ingest_raster no longer opens an error_write bracket")
+        )
+    )
+
+
+def _bracket_budget(module) -> str | None:
+    """The name *module*'s error-write bracket passes as its budget."""
+    tree = ast.parse(Path(module.__file__).read_text())
+    for node in ast.walk(tree):
+        if _is_error_write_bracket(node):
+            for kw in node.keywords:
+                if kw.arg == "lock_and_statement_timeout_ms":
+                    return getattr(kw.value, "id", None)
+            return None
+    raise AssertionError(f"{module.__name__} opens no error_write bracket")
 
 
 class TestTheBoundIsWhereTheBlockingStatementIs:
@@ -61,33 +107,12 @@ class TestTheBoundIsWhereTheBlockingStatementIs:
 
     def test_the_shared_helper_arms_between_its_rollback_and_its_update(self) -> None:
         tree = ast.parse(inspect.getsource(_cleanup_staging_on_failure))
-        rollbacks = [
-            node.lineno
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Call)
-            and getattr(node.func, "attr", None) == "rollback"
-        ]
-        arms = [
-            node.lineno
-            for node in ast.walk(tree)
-            if isinstance(node, ast.JoinedStr)
-            and any(
-                isinstance(part, ast.Constant)
-                and isinstance(part.value, str)
-                and "SET LOCAL" in part.value
-                for part in node.values
-            )
-        ]
-        failure_update = [
-            node.lineno
-            for node in ast.walk(tree)
-            if isinstance(node, ast.keyword)
-            and node.arg == "status"
-            and isinstance(node.value, ast.Constant)
-            and node.value.value == "failed"
-        ]
-        assert len(arms) == 2, (
-            f"expected a lock_timeout and a statement_timeout arm; found {len(arms)}"
+        rollbacks = _method_call_lines(tree, "rollback")
+        commits = _method_call_lines(tree, "commit")
+        arms = _arm_call_lines(tree)
+        failure_update = _failed_status_lines(tree)
+        assert len(arms) == 1, (
+            f"expected one arm_job_error_write_budget call; found {len(arms)}"
         )
         assert min(rollbacks) < min(arms), (
             "the budget is installed before the helper's rollback, which ends "
@@ -97,12 +122,104 @@ class TestTheBoundIsWhereTheBlockingStatementIs:
             "the failure UPDATE runs before the budget is armed, so the "
             "statement that blocks on a contended job row is still unbounded"
         )
+        stranded = [
+            line
+            for line in rollbacks + commits
+            if min(arms) < line < min(failure_update)
+        ]
+        assert not stranded, (
+            f"a rollback or commit at {stranded} ends the transaction between "
+            "the arm and the failure UPDATE, so the UPDATE runs on a "
+            "transaction that carries no SET LOCAL"
+        )
 
-    def test_the_raster_tail_names_the_shared_budget(self) -> None:
-        assert _error_write_bracket_budget() == "JOB_ERROR_WRITE_TIMEOUT_MS", (
-            "ingest_raster's error-write bracket passes no "
+    @pytest.mark.parametrize(
+        "module_name", ["tasks_raster", "tasks_vector"], ids=["raster", "vector"]
+    )
+    def test_the_bracketed_tails_name_the_shared_budget(self, module_name: str) -> None:
+        import importlib
+
+        module = importlib.import_module(f"app.processing.ingest.{module_name}")
+        assert _bracket_budget(module) == "JOB_ERROR_WRITE_TIMEOUT_MS", (
+            f"{module_name}'s error-write bracket passes no "
             "lock_and_statement_timeout_ms, so _job_phase_session issues "
-            "neither SET LOCAL and the UPDATE inside it waits without end"
+            "neither SET LOCAL and the SELECT it runs before the caller gets "
+            "control can stall behind a table lock"
+        )
+
+    def test_the_raster_failure_update_is_inside_the_bounded_bracket(self) -> None:
+        """The budget belongs to a transaction, so the UPDATE's position is the gate."""
+        tree = ast.parse(Path(tasks_raster.__file__).read_text())
+        brackets = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncWith)
+            and any(_is_error_write_bracket(item.context_expr) for item in node.items)
+        ]
+        assert len(brackets) == 1, f"expected one bracket; found {len(brackets)}"
+        bracket = brackets[0]
+        inside = [
+            line
+            for line in _failed_status_lines(tree)
+            if bracket.lineno < line <= bracket.end_lineno
+        ]
+        assert inside, (
+            "ingest_raster's status=failed UPDATE is no longer inside the "
+            "bracket that installs the budget, so it runs on a transaction "
+            "carrying no SET LOCAL while the kwarg gate stays green"
+        )
+
+    def test_the_vrt_regeneration_tail_arms_before_its_writes(self) -> None:
+        """`regenerate_vrt` reaches this handler from its own bounded publish wait."""
+        import app.processing.ingest.tasks_vrt as tasks_vrt
+
+        tree = ast.parse(inspect.getsource(tasks_vrt.regenerate_vrt.func))
+        arms = _arm_call_lines(tree)
+        assert len(arms) == 1, (
+            "regenerate_vrt's failure handler opens a bare async_session() with "
+            "no budget, so a contended job row parks the worker there — and the "
+            "publish wait above it gives up after 15s and lands exactly here"
+        )
+        assert min(arms) < min(_failed_status_lines(tree)), (
+            "the budget is armed after the writes it exists to bound"
+        )
+
+    @pytest.mark.parametrize(
+        ("module_name", "task_name"),
+        [
+            ("tasks_vector", "ingest_file"),
+            ("tasks_raster", "ingest_raster"),
+            ("tasks_reupload", "reupload_file"),
+        ],
+    )
+    def test_the_terminal_status_survives_a_raised_error_write(
+        self, module_name: str, task_name: str
+    ) -> None:
+        """The reapers in each `finally` gate on it, and the error write can raise."""
+        import importlib
+
+        module = importlib.import_module(f"app.processing.ingest.{module_name}")
+        target = getattr(module, task_name)
+        tree = ast.parse(inspect.getsource(getattr(target, "func", target)))
+        protected = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Try)
+            and any(
+                isinstance(stmt, ast.Assign)
+                and any(
+                    isinstance(t, ast.Name) and t.id == "final_status"
+                    for t in stmt.targets
+                )
+                and isinstance(stmt.value, ast.Constant)
+                and stmt.value.value == "failed"
+                for stmt in node.finalbody
+            )
+        ]
+        assert protected, (
+            f"{task_name} sets final_status='failed' positionally after its "
+            "error write. That write is bounded now and can raise, leaving the "
+            "status 'pending' so the finally-block reapers return early"
         )
 
     @pytest.mark.parametrize(
@@ -159,6 +276,9 @@ class TestAHeldJobRowEndsTheFailureWrite:
         self, running_job, monkeypatch, test_db_session
     ) -> None:
         job_id, _attempt_id = running_job
+        # `arm_job_error_write_budget` reads this as a global of its OWN module,
+        # resolved per call, so no import placement elsewhere can sever the
+        # patch. The upper bound below is what proves the patch was read.
         monkeypatch.setattr(
             "app.platform.jobs.heartbeat.JOB_ERROR_WRITE_TIMEOUT_MS", _TEST_BUDGET_MS
         )
@@ -196,6 +316,12 @@ class TestAHeldJobRowEndsTheFailureWrite:
             f"the failure write gave up after {round(waited_ms)}ms against a "
             f"{_TEST_BUDGET_MS}ms budget, so this run proves nothing about it"
         )
+        assert waited_ms < _TEST_BUDGET_MS * 5, (
+            f"the failure write waited {round(waited_ms)}ms, far past the "
+            f"{_TEST_BUDGET_MS}ms this test installs. The monkeypatch did not "
+            "reach the budget the code read, so this run measures the shipped "
+            "10s constant and would pass with the patch severed entirely"
+        )
         assert sqlstate(excinfo.value) == "57014", (
             f"the held row ended the failure write with {sqlstate(excinfo.value)!r}. "
             "Both GUCs are armed at the same value and the blocking statement is "
@@ -220,7 +346,7 @@ class TestAHeldJobRowEndsTheFailureWrite:
         job_id, attempt_id = running_job
         # The budget comes from the real call site, so a bracket that stops
         # passing one fails here as well as in the structural gate.
-        budget_name = _error_write_bracket_budget()
+        budget_name = _bracket_budget(tasks_raster)
         assert budget_name is not None, "the error-write bracket passes no budget"
         monkeypatch.setattr(tasks_raster, budget_name, _TEST_BUDGET_MS)
         import app.core.db as db_module
@@ -234,7 +360,11 @@ class TestAHeldJobRowEndsTheFailureWrite:
             ) as (err_session, _err_job):
                 await err_session.execute(
                     sa_update(IngestJob)
-                    .where(IngestJob.id == job_id, IngestJob.status == "running")
+                    .where(
+                        IngestJob.id == job_id,
+                        IngestJob.attempt_id == attempt_id,
+                        IngestJob.status == "running",
+                    )
                     .values(status="failed", error_message="cog build failed")
                 )
                 await err_session.commit()
@@ -253,6 +383,11 @@ class TestAHeldJobRowEndsTheFailureWrite:
         assert waited_ms >= _TEST_BUDGET_MS * 0.8, (
             f"the failure write gave up after {round(waited_ms)}ms against a "
             f"{_TEST_BUDGET_MS}ms budget, so this run proves nothing about it"
+        )
+        assert waited_ms < _TEST_BUDGET_MS * 5, (
+            f"the failure write waited {round(waited_ms)}ms, far past the "
+            f"{_TEST_BUDGET_MS}ms this test installs, so it is measuring some "
+            "budget other than the one it set"
         )
         assert sqlstate(excinfo.value) == "57014", (
             f"the held row ended the failure write with {sqlstate(excinfo.value)!r}; "

--- a/backend/tests/test_job_error_write_bound_1950.py
+++ b/backend/tests/test_job_error_write_bound_1950.py
@@ -14,6 +14,7 @@ import uuid
 from pathlib import Path
 
 import pytest
+import structlog.testing
 from sqlalchemy import delete, select, text
 from sqlalchemy.exc import DBAPIError
 
@@ -42,6 +43,25 @@ def _arm_call_lines(tree: ast.AST) -> list[int]:
         if isinstance(node, ast.Call)
         and getattr(node.func, "id", None) == "arm_job_error_write_budget"
     ]
+
+
+def _task_source(module_name: str, task_name: str) -> str:
+    """The source of a Procrastinate task's undecorated function."""
+    import importlib
+
+    module = importlib.import_module(f"app.processing.ingest.{module_name}")
+    target = getattr(module, task_name)
+    return inspect.getsource(getattr(target, "func", target))
+
+
+def _call_names(nodes) -> set[str]:
+    """Every bare function name called anywhere under *nodes*."""
+    found = set()
+    for node in nodes:
+        for child in ast.walk(node):
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name):
+                found.add(child.func.id)
+    return found
 
 
 def _method_call_lines(tree: ast.AST, attr: str) -> list[int]:
@@ -185,6 +205,42 @@ class TestTheBoundIsWhereTheBlockingStatementIs:
         )
 
     @pytest.mark.parametrize(
+        ("owner", "getter"),
+        [
+            ("_cleanup_staging_on_failure", lambda: _cleanup_staging_on_failure),
+            ("ingest_raster", lambda: _task_source("tasks_raster", "ingest_raster")),
+            (
+                "regenerate_vrt",
+                lambda: _task_source("tasks_vrt", "regenerate_vrt"),
+            ),
+        ],
+    )
+    def test_every_error_write_swallows_its_own_failure(self, owner, getter) -> None:
+        """A secondary write must never replace the cause its caller is handling."""
+        target = getter()
+        source = target if isinstance(target, str) else inspect.getsource(target)
+        handlers = [
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.ExceptHandler)
+            and getattr(node.type, "id", None) == "DBAPIError"
+        ]
+        assert len(handlers) == 1, (
+            f"{owner} has {len(handlers)} DBAPIError handlers around its failure "
+            "write. Without exactly one, an expired budget leaves this frame and "
+            "becomes the task's outcome in place of the ingest error"
+        )
+        body = handlers[0].body
+        assert not [n for n in ast.walk(handlers[0]) if isinstance(n, ast.Raise)], (
+            f"{owner} re-raises inside its DBAPIError handler, so the timeout is "
+            "still what the worker reports"
+        )
+        assert _call_names(body) & {"log_job_error_write_failure"}, (
+            f"{owner} swallows the failure without recording it, trading a "
+            "visible hang for an invisible one"
+        )
+
+    @pytest.mark.parametrize(
         ("module_name", "task_name"),
         [
             ("tasks_vector", "ingest_file"),
@@ -296,7 +352,7 @@ class TestAHeldJobRowEndsTheFailureWrite:
                         select(IngestJob).where(IngestJob.id == job_id)
                     )
                 ).scalar_one()
-                with pytest.raises(DBAPIError) as excinfo:
+                with structlog.testing.capture_logs() as captured:
                     await asyncio.wait_for(
                         _cleanup_staging_on_failure(
                             err_session,
@@ -322,8 +378,12 @@ class TestAHeldJobRowEndsTheFailureWrite:
             "reach the budget the code read, so this run measures the shipped "
             "10s constant and would pass with the patch severed entirely"
         )
-        assert sqlstate(excinfo.value) == "57014", (
-            f"the held row ended the failure write with {sqlstate(excinfo.value)!r}. "
+        expired = [r for r in captured if r.get("event") == "job_error_write_timeout"]
+        assert len(expired) == 1, (
+            f"expected one job_error_write_timeout event; got {captured}"
+        )
+        assert expired[0]["sqlstate"] == "57014", (
+            f"the held row ended the failure write with {expired[0]['sqlstate']!r}. "
             "Both GUCs are armed at the same value and the blocking statement is "
             "the UPDATE, so statement_timeout holds the earlier deadline; 55P03 "
             "would mean only lock_timeout was armed"
@@ -458,6 +518,108 @@ class TestWhyTheBoundIsNotOnTheBracket:
                 await holder.rollback()
                 await asyncio.wait_for(blocked, timeout=30)
                 await waiter.rollback()
+
+
+class _IngestFailed(RuntimeError):
+    """A recognisable stand-in for whatever the pipeline actually raised."""
+
+
+class TestTheTimeoutDoesNotReplaceTheCause:
+    """The bound must not trade a hang for the wrong diagnosis."""
+
+    @staticmethod
+    async def _tail_shape(session, job, cause: BaseException, seen: list) -> None:
+        """`ingest_file`'s handler shape: the helper in a try/finally, then raise."""
+        final_status = "pending"
+        try:
+            await _cleanup_staging_on_failure(
+                session,
+                staging_table="",
+                job=job,
+                exc=cause,
+                task_name="ingest_file",
+                attempt_id=None,
+            )
+        finally:
+            final_status = "failed"
+            seen.append(final_status)
+        raise cause
+
+    async def test_the_original_exception_is_what_leaves_the_tail(
+        self, running_job, monkeypatch, test_db_session
+    ) -> None:
+        job_id, _attempt_id = running_job
+        monkeypatch.setattr(
+            "app.platform.jobs.heartbeat.JOB_ERROR_WRITE_TIMEOUT_MS", _TEST_BUDGET_MS
+        )
+        import app.core.db as db_module
+        import app.platform.notifications.events as events_module
+
+        emitted: list[str] = []
+
+        async def _record(*, event_key, build):  # noqa: ANN001 - test double
+            emitted.append(event_key)
+
+        monkeypatch.setattr(events_module, "emit_event_safe", _record)
+        cause = _IngestFailed("ogr2ogr could not read the layer")
+        seen: list[str] = []
+
+        async with db_module.async_session() as holder:
+            await holder.execute(
+                select(IngestJob.id).where(IngestJob.id == job_id).with_for_update()
+            )
+            async with db_module.async_session() as err_session:
+                err_job = (
+                    await err_session.execute(
+                        select(IngestJob).where(IngestJob.id == job_id)
+                    )
+                ).scalar_one()
+                with structlog.testing.capture_logs() as captured:
+                    with pytest.raises(_IngestFailed) as excinfo:
+                        await asyncio.wait_for(
+                            self._tail_shape(err_session, err_job, cause, seen),
+                            timeout=30,
+                        )
+                await err_session.rollback()
+            await holder.rollback()
+
+        assert seen == ["failed"], (
+            "the `finally` that carries the terminal status did not run on the "
+            "timeout route, so the staging reapers would return early"
+        )
+        assert excinfo.value is cause, (
+            "the timed-out error write replaced the ingest failure as the task's "
+            "outcome, so the operator is handed a lock timeout instead of the "
+            "reason the ingest failed"
+        )
+        timeouts = [r for r in captured if r.get("event") == "job_error_write_timeout"]
+        assert len(timeouts) == 1, (
+            f"expected one job_error_write_timeout event; got {captured}"
+        )
+        assert timeouts[0]["log_level"] == "warning"
+        assert timeouts[0]["sqlstate"] == "57014"
+        assert timeouts[0]["budget_ms"] == _TEST_BUDGET_MS
+        assert timeouts[0]["task"] == "ingest_file"
+
+        reported = [r for r in captured if r.get("event") == "Ingest task failed"]
+        assert len(reported) == 1, (
+            "the timeout route skipped the failure logger, so nothing in the log "
+            "says the ingest failed at all"
+        )
+        assert emitted == ["ingest_failed"], (
+            "the timeout route skipped the operator notification, which is the "
+            "only signal an operator with failure mail on would have seen"
+        )
+
+        test_db_session.expire_all()
+        unchanged = (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.id == job_id)
+            )
+        ).scalar_one()
+        assert unchanged.status == "running", (
+            "the write that gave up still recorded a status"
+        )
 
 
 def test_the_shared_budget_is_ten_seconds() -> None:

--- a/backend/tests/test_job_error_write_bound_1950.py
+++ b/backend/tests/test_job_error_write_bound_1950.py
@@ -1,0 +1,330 @@
+"""fix(#1950): the bound on a worker's terminal failure write.
+
+Five ingest tails settle a failed job by UPDATEing its ``ingest_jobs`` row on a
+fresh session. That UPDATE runs under a 10-second budget, so a held row ends it
+instead of parking the worker while the heartbeat reports the job alive.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import delete, select, text
+from sqlalchemy.exc import DBAPIError
+
+import app.processing.ingest.tasks_raster as tasks_raster
+from app.core.db.sqlstate import sqlstate
+from app.modules.auth.models import User
+from app.platform.jobs.heartbeat import JOB_ERROR_WRITE_TIMEOUT_MS
+from app.platform.jobs.models import IngestJob
+from app.processing.ingest.tasks_common import (
+    _cleanup_staging_on_failure,
+    _job_phase_session,
+)
+
+pytestmark = pytest.mark.anyio
+
+# Short enough to measure a give-up inside a test, long enough that a healthy
+# uncontended write never reaches it.
+_TEST_BUDGET_MS = 400
+
+
+def _error_write_bracket_budget() -> str | None:
+    """The name ``ingest_raster``'s error-write bracket passes as its budget."""
+    tree = ast.parse(Path(tasks_raster.__file__).read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if getattr(node.func, "id", None) != "_job_phase_session":
+            continue
+        phases = [
+            kw.value.value
+            for kw in node.keywords
+            if kw.arg == "phase" and isinstance(kw.value, ast.Constant)
+        ]
+        if phases != ["error_write"]:
+            continue
+        for kw in node.keywords:
+            if kw.arg == "lock_and_statement_timeout_ms":
+                return getattr(kw.value, "id", None)
+        return None
+    raise AssertionError("ingest_raster no longer opens an error_write bracket")
+
+
+class TestTheBoundIsWhereTheBlockingStatementIs:
+    """Pure AST — no database."""
+
+    def test_the_shared_helper_arms_between_its_rollback_and_its_update(self) -> None:
+        tree = ast.parse(inspect.getsource(_cleanup_staging_on_failure))
+        rollbacks = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "attr", None) == "rollback"
+        ]
+        arms = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.JoinedStr)
+            and any(
+                isinstance(part, ast.Constant)
+                and isinstance(part.value, str)
+                and "SET LOCAL" in part.value
+                for part in node.values
+            )
+        ]
+        failure_update = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.keyword)
+            and node.arg == "status"
+            and isinstance(node.value, ast.Constant)
+            and node.value.value == "failed"
+        ]
+        assert len(arms) == 2, (
+            f"expected a lock_timeout and a statement_timeout arm; found {len(arms)}"
+        )
+        assert min(rollbacks) < min(arms), (
+            "the budget is installed before the helper's rollback, which ends "
+            "the transaction and discards every SET LOCAL on it"
+        )
+        assert max(arms) < min(failure_update), (
+            "the failure UPDATE runs before the budget is armed, so the "
+            "statement that blocks on a contended job row is still unbounded"
+        )
+
+    def test_the_raster_tail_names_the_shared_budget(self) -> None:
+        assert _error_write_bracket_budget() == "JOB_ERROR_WRITE_TIMEOUT_MS", (
+            "ingest_raster's error-write bracket passes no "
+            "lock_and_statement_timeout_ms, so _job_phase_session issues "
+            "neither SET LOCAL and the UPDATE inside it waits without end"
+        )
+
+    @pytest.mark.parametrize(
+        ("module_name", "task_name"),
+        [
+            ("tasks_vector", "ingest_file"),
+            ("tasks_vector", "ingest_service"),
+            ("tasks_reupload", "reupload_file"),
+            ("tasks_reupload", "reupload_service"),
+        ],
+    )
+    def test_the_four_helper_routed_tails_still_route_there(
+        self, module_name: str, task_name: str
+    ) -> None:
+        """Each tail's bound is the shared helper's, so it must still call it."""
+        import importlib
+
+        module = importlib.import_module(f"app.processing.ingest.{module_name}")
+        target = getattr(module, task_name)
+        source = inspect.getsource(getattr(target, "func", target))
+        assert "_cleanup_staging_on_failure" in source, (
+            f"{module_name}.{task_name} writes its own terminal failure row "
+            "again, so the budget in the shared helper no longer covers it"
+        )
+
+
+async def _admin_id(session) -> uuid.UUID:
+    return (
+        await session.execute(select(User.id).where(User.username == "admin"))
+    ).scalar_one()
+
+
+@pytest.fixture
+async def running_job(test_db_session):
+    """A claimed ``ingest_jobs`` row, deleted when the test ends."""
+    job = IngestJob(
+        source_filename=f"error_write_{uuid.uuid4().hex[:8]}.geojson",
+        created_by=await _admin_id(test_db_session),
+        status="running",
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+    await test_db_session.refresh(job)
+    ids = (job.id, job.attempt_id)
+    yield ids
+    await test_db_session.execute(delete(IngestJob).where(IngestJob.id == ids[0]))
+    await test_db_session.commit()
+
+
+class TestAHeldJobRowEndsTheFailureWrite:
+    """Against PostgreSQL, with the row held by another transaction."""
+
+    async def test_the_shared_helper_gives_up(
+        self, running_job, monkeypatch, test_db_session
+    ) -> None:
+        job_id, _attempt_id = running_job
+        monkeypatch.setattr(
+            "app.platform.jobs.heartbeat.JOB_ERROR_WRITE_TIMEOUT_MS", _TEST_BUDGET_MS
+        )
+        import app.core.db as db_module
+
+        async with db_module.async_session() as holder:
+            await holder.execute(
+                select(IngestJob.id).where(IngestJob.id == job_id).with_for_update()
+            )
+            loop = asyncio.get_running_loop()
+            started = loop.time()
+            async with db_module.async_session() as err_session:
+                err_job = (
+                    await err_session.execute(
+                        select(IngestJob).where(IngestJob.id == job_id)
+                    )
+                ).scalar_one()
+                with pytest.raises(DBAPIError) as excinfo:
+                    await asyncio.wait_for(
+                        _cleanup_staging_on_failure(
+                            err_session,
+                            staging_table="",
+                            job=err_job,
+                            exc=RuntimeError("ogr2ogr could not read the layer"),
+                            task_name="ingest_file",
+                            attempt_id=None,
+                        ),
+                        timeout=30,
+                    )
+                waited_ms = (loop.time() - started) * 1000
+                await err_session.rollback()
+            await holder.rollback()
+
+        assert waited_ms >= _TEST_BUDGET_MS * 0.8, (
+            f"the failure write gave up after {round(waited_ms)}ms against a "
+            f"{_TEST_BUDGET_MS}ms budget, so this run proves nothing about it"
+        )
+        assert sqlstate(excinfo.value) == "57014", (
+            f"the held row ended the failure write with {sqlstate(excinfo.value)!r}. "
+            "Both GUCs are armed at the same value and the blocking statement is "
+            "the UPDATE, so statement_timeout holds the earlier deadline; 55P03 "
+            "would mean only lock_timeout was armed"
+        )
+        test_db_session.expire_all()
+        unchanged = (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.id == job_id)
+            )
+        ).scalar_one()
+        assert unchanged.status == "running", (
+            "the write that gave up still recorded a status, so the trade this "
+            "bound makes is not the one the docstring states"
+        )
+
+    async def test_the_raster_tail_gives_up(self, running_job, monkeypatch) -> None:
+        """``ingest_raster`` writes its own UPDATE inside the bracket's budget."""
+        from sqlalchemy import update as sa_update
+
+        job_id, attempt_id = running_job
+        # The budget comes from the real call site, so a bracket that stops
+        # passing one fails here as well as in the structural gate.
+        budget_name = _error_write_bracket_budget()
+        assert budget_name is not None, "the error-write bracket passes no budget"
+        monkeypatch.setattr(tasks_raster, budget_name, _TEST_BUDGET_MS)
+        import app.core.db as db_module
+
+        async def _write_the_failure() -> None:
+            async with _job_phase_session(
+                job_id,
+                phase="error_write",
+                attempt_id=attempt_id,
+                lock_and_statement_timeout_ms=getattr(tasks_raster, budget_name),
+            ) as (err_session, _err_job):
+                await err_session.execute(
+                    sa_update(IngestJob)
+                    .where(IngestJob.id == job_id, IngestJob.status == "running")
+                    .values(status="failed", error_message="cog build failed")
+                )
+                await err_session.commit()
+
+        async with db_module.async_session() as holder:
+            await holder.execute(
+                select(IngestJob.id).where(IngestJob.id == job_id).with_for_update()
+            )
+            loop = asyncio.get_running_loop()
+            started = loop.time()
+            with pytest.raises(DBAPIError) as excinfo:
+                await asyncio.wait_for(_write_the_failure(), timeout=30)
+            waited_ms = (loop.time() - started) * 1000
+            await holder.rollback()
+
+        assert waited_ms >= _TEST_BUDGET_MS * 0.8, (
+            f"the failure write gave up after {round(waited_ms)}ms against a "
+            f"{_TEST_BUDGET_MS}ms budget, so this run proves nothing about it"
+        )
+        assert sqlstate(excinfo.value) == "57014", (
+            f"the held row ended the failure write with {sqlstate(excinfo.value)!r}; "
+            "see the sibling assertion for why 55P03 is the wrong-arming signal"
+        )
+
+
+class TestWhyTheBoundIsNotOnTheBracket:
+    """A budget on the phase bracket does not reach the statement that blocks."""
+
+    async def test_the_helpers_rollback_discards_an_upstream_budget(
+        self, running_job
+    ) -> None:
+        job_id, attempt_id = running_job
+        async with _job_phase_session(
+            job_id,
+            phase="error_write",
+            attempt_id=attempt_id,
+            lock_and_statement_timeout_ms=_TEST_BUDGET_MS,
+        ) as (session, job):
+            assert job is not None
+            armed = (
+                await session.execute(text("SELECT current_setting('lock_timeout')"))
+            ).scalar()
+            await session.rollback()
+            after = (
+                await session.execute(text("SELECT current_setting('lock_timeout')"))
+            ).scalar()
+        assert armed != "0", "the bracket kwarg no longer arms lock_timeout at all"
+        assert after == "0", (
+            "a budget installed by the bracket survives the rollback the shared "
+            "failure helper opens with, which would make arming it there the fix"
+        )
+
+    async def test_an_unbounded_update_never_ends_on_a_held_row(
+        self, running_job
+    ) -> None:
+        """The behaviour an unset ``lock_timeout`` gives, measured not assumed."""
+        from sqlalchemy import update as sa_update
+
+        job_id, _attempt_id = running_job
+        import app.core.db as db_module
+
+        async def _unbounded_failure_update(session) -> None:
+            await session.execute(
+                sa_update(IngestJob)
+                .where(IngestJob.id == job_id)
+                .values(status="failed")
+            )
+
+        async with db_module.async_session() as holder:
+            await holder.execute(
+                select(IngestJob.id).where(IngestJob.id == job_id).with_for_update()
+            )
+            async with db_module.async_session() as waiter:
+                await waiter.execute(
+                    text(f"SET LOCAL lock_timeout = {_TEST_BUDGET_MS}")
+                )
+                await waiter.rollback()
+                blocked = asyncio.create_task(_unbounded_failure_update(waiter))
+                done, _pending = await asyncio.wait(
+                    {blocked}, timeout=(_TEST_BUDGET_MS / 1000) * 5
+                )
+                assert not done, (
+                    "the UPDATE ended on its own, so the budget the rollback "
+                    "discarded was still in force and this measures nothing"
+                )
+                await holder.rollback()
+                await asyncio.wait_for(blocked, timeout=30)
+                await waiter.rollback()
+
+
+def test_the_shared_budget_is_ten_seconds() -> None:
+    """Every holder of the job row self-caps below this, so a longer wait is stuck."""
+    assert JOB_ERROR_WRITE_TIMEOUT_MS == 10_000

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3621,11 +3621,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1921): +66 — the post-swap catalog wait gets its own budget, a
     # restore, and events telling an expired budget from a lost deadlock.
     # Cap 2577 -> 2643, exact.
-    # fix(#1950): +14 — the shared failure helper arms the job-row budget after
-    # its own rollback, which would discard one installed upstream, and the
-    # docstring states what an expired budget leaves behind.
-    # Cap 2643 -> 2657, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2657,
+    # fix(#1950): +9 — the shared failure helper arms the job-row budget after
+    # its own rollback, and its docstring states what an expired budget leaves.
+    # Cap 2643 -> 2652, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2652,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -3729,7 +3728,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1921): +15 — the file path gets the exception-to-error_code mapper
     # its service sibling already had, and both name a contended catalog row.
     # Cap 1310 -> 1325, exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1325,
+    # fix(#1950): +4 — both failure tails bound their job-row load, and
+    # reupload_file's terminal status moved into a `finally` so a bounded write
+    # that raises still reaches the reapers. Cap 1325 -> 1329, exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1329,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is
@@ -4630,7 +4632,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1938): +58 — the publish's catalog.records wait gets a budget, a
     # restore after it, and a classified failure report whose SQLSTATE table
     # lives in catalog_locks instead. Cap 1640 -> 1698, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1698,
+    # fix(#1950): +5 — regenerate_vrt's failure handler bounds its three writes,
+    # which is where its own 15s publish wait lands when it gives up.
+    # Cap 1698 -> 1703, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1703,
     # --- entered by the inclusion rule, fix(#1937) ------------------------
     # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
     # The budget alone is six lines; the rest is what a newly failable wait
@@ -4770,7 +4775,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # nested one that stops the service-import progress heartbeat, where
     # awaiting the cancelled task re-raises anything the heartbeat body itself
     # failed with. Cap 1392 -> 1368, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1368,
+    # fix(#1950): +12 — both error-write brackets pass the job-row budget, and
+    # the terminal status moved into a `finally` so a bounded write that raises
+    # still reaches the reapers. Cap 1368 -> 1380, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1380,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3621,10 +3621,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1921): +66 — the post-swap catalog wait gets its own budget, a
     # restore, and events telling an expired budget from a lost deadlock.
     # Cap 2577 -> 2643, exact.
-    # fix(#1950): +9 — the shared failure helper arms the job-row budget after
-    # its own rollback, and its docstring states what an expired budget leaves.
-    # Cap 2643 -> 2652, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2652,
+    # fix(#1950): +25 — the shared failure helper arms the job-row budget after
+    # its own rollback, and an expiry there is logged and swallowed so the caller
+    # re-raises the ingest failure instead. Cap 2643 -> 2668, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2668,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -4632,10 +4632,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1938): +58 — the publish's catalog.records wait gets a budget, a
     # restore after it, and a classified failure report whose SQLSTATE table
     # lives in catalog_locks instead. Cap 1640 -> 1698, exact.
-    # fix(#1950): +5 — regenerate_vrt's failure handler bounds its three writes,
-    # which is where its own 15s publish wait lands when it gives up.
-    # Cap 1698 -> 1703, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1703,
+    # fix(#1950): +11 — regenerate_vrt's failure handler bounds its three writes,
+    # which is where its own 15s publish wait lands, and keeps the build failure
+    # as the task's outcome when that bound expires. Cap 1698 -> 1709, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1709,
     # --- entered by the inclusion rule, fix(#1937) ------------------------
     # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
     # The budget alone is six lines; the rest is what a newly failable wait

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3624,7 +3624,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950): +25 — the shared failure helper arms the job-row budget after
     # its own rollback, and an expiry there is logged and swallowed so the caller
     # re-raises the ingest failure instead. Cap 2643 -> 2668, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2668,
+    # fix(#1950 codex r2): +40 — `load_job_for_error_write`, the guarded job load
+    # the two re-upload tails share. Cap 2668 -> 2708, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2708,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -3731,7 +3733,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950): +4 — both failure tails bound their job-row load, and
     # reupload_file's terminal status moved into a `finally` so a bounded write
     # that raises still reaches the reapers. Cap 1325 -> 1329, exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1329,
+    # fix(#1950 codex r2): -12 — each tail's pre-helper job load moved to
+    # `tasks_common.load_job_for_error_write`, which arms the budget and
+    # swallows an expiry there. Cap 1329 -> 1317, exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1317,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is
@@ -4778,7 +4783,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950): +12 — both error-write brackets pass the job-row budget, and
     # the terminal status moved into a `finally` so a bounded write that raises
     # still reaches the reapers. Cap 1368 -> 1380, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1380,
+    # fix(#1950 codex r2): +17 — the budget also bounds the job load
+    # `_job_phase_session` runs before the helper, so both tails grew the
+    # DBAPIError handler that swallows an expiry. Cap 1380 -> 1397, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1397,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4641,7 +4641,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950): +11 — regenerate_vrt's failure handler bounds its three writes,
     # which is where its own 15s publish wait lands, and keeps the build failure
     # as the task's outcome when that bound expires. Cap 1698 -> 1709, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1709,
+    # fix(#1950 codex r4): -4 — `ingest_vrt`'s failure tail loads its job row
+    # through `tasks_common.load_job_for_error_write` instead of an inline
+    # unbounded SELECT. Cap 1709 -> 1705, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1705,
     # --- entered by the inclusion rule, fix(#1937) ------------------------
     # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
     # The budget alone is six lines; the rest is what a newly failable wait

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3621,7 +3621,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1921): +66 — the post-swap catalog wait gets its own budget, a
     # restore, and events telling an expired budget from a lost deadlock.
     # Cap 2577 -> 2643, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2643,
+    # fix(#1950): +14 — the shared failure helper arms the job-row budget after
+    # its own rollback, which would discard one installed upstream, and the
+    # docstring states what an expired budget leaves behind.
+    # Cap 2643 -> 2657, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2657,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3624,10 +3624,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950): +25 — the shared failure helper arms the job-row budget after
     # its own rollback, and an expiry there is logged and swallowed so the caller
     # re-raises the ingest failure instead. Cap 2643 -> 2668, exact.
-    # fix(#1950 codex r2, r3): +46 — `load_job_for_error_write`, the guarded job
+    # fix(#1950 codex r2-r5): +55 — `load_job_for_error_write`, the guarded job
     # load the two re-upload tails share, which also ends the transaction on a
-    # miss so the run row they write next is unbudgeted. Cap 2668 -> 2714, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2714,
+    # miss so the run row they write next is unbudgeted. Cap 2668 -> 2723, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2723,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3624,9 +3624,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950): +25 — the shared failure helper arms the job-row budget after
     # its own rollback, and an expiry there is logged and swallowed so the caller
     # re-raises the ingest failure instead. Cap 2643 -> 2668, exact.
-    # fix(#1950 codex r2): +40 — `load_job_for_error_write`, the guarded job load
-    # the two re-upload tails share. Cap 2668 -> 2708, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2708,
+    # fix(#1950 codex r2, r3): +46 — `load_job_for_error_write`, the guarded job
+    # load the two re-upload tails share, which also ends the transaction on a
+    # miss so the run row they write next is unbudgeted. Cap 2668 -> 2714, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2714,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed


### PR DESCRIPTION
A worker task that fails settles the job by opening a fresh session and writing `status="failed"` to its `ingest_jobs` row. That session carries no lock budget and the worker never installs one (`install_api_statement_timeout` has a single caller, `app/api/main.py`; `@tenant_task` sets only the tenant GUC and `SET LOCAL ROLE`). So `lock_timeout` was `0` and the write waited without a deadline on a contended row, while the heartbeat kept the job looking alive and the stale sweep did not reap it. The job neither completed nor failed.

`Closes #1950`.

## The blocking statement is the UPDATE

Measured, not assumed. `test_an_unbounded_update_never_ends_on_a_held_row` holds the job row `FOR UPDATE` in one session and issues the failure UPDATE from another with `lock_timeout` unset: the UPDATE does not end within 5x the test budget, and completes only once the holder rolls back. The SELECT ahead of it does not block — `_job_phase_session` applies `with_for_update(key_share=True)` only when `require_status` is passed, and no error-write call site passes it.

## The five sites, and where each one's bound went

| Site | Task | Reaches the UPDATE via | Bound |
| --- | --- | --- | --- |
| `tasks_vector.py:847` | `ingest_file` | `_cleanup_staging_on_failure` | helper arm **+ bracket kwarg** |
| `tasks_vector.py:1347` | `ingest_service` | `_cleanup_staging_on_failure` | helper arm **+ bracket kwarg** |
| `tasks_reupload.py:545` | `reupload_file` | `_cleanup_staging_on_failure` | helper arm **+ arm before its `select`** |
| `tasks_reupload.py:1293` | `reupload_service` | `_cleanup_staging_on_failure` | helper arm **+ arm before its `select`** |
| `tasks_raster.py:802` | `ingest_raster` | its own `sa_update` in the bracket | bracket kwarg |
| `tasks_vrt.py:1590` | `regenerate_vrt` | its own `update_ingest_job_for_attempt` | arm on the session |

`tasks_vrt.py:854` (`ingest_vrt`) is a seventh, covered for free — it routes through the shared helper.

One constant and one arming helper, `JOB_ERROR_WRITE_TIMEOUT_MS` / `arm_job_error_write_budget`, in `app/platform/jobs/heartbeat.py` — next to `update_ingest_job_for_attempt`, the fenced writer of the row they are sized against, and a module every changed file already imports. Three call shapes needed it (the shared helper, a bare session, and the bracket kwarg), so the SQL is written once.

The helper reads the constant as a global of **its own module**, resolved per call. That is what makes `monkeypatch.setattr("app.platform.jobs.heartbeat.JOB_ERROR_WRITE_TIMEOUT_MS", …)` structurally reachable: no import placement in any caller can sever it. The earlier shape depended on a deferred import inside `_cleanup_staging_on_failure`, which an ordinary hoist would have quietly broken.

No pre-existing gate matched the inline `SET LOCAL` form, so nothing was hidden by the extraction — `test_feature_lock_order_1847.py`'s `lock_catalog_rows` walks and `test_ingest_vector_failure_tails.py`'s DROP-order gate pass unchanged and no matcher of theirs was touched. This PR's own order gate changed spelling (f-string → named call) while asserting the identical property.

### Why the four go in the shared helper and not on their brackets

A budget passed at the `_job_phase_session(phase="error_write")` call site cannot reach the UPDATE in these four. `_cleanup_staging_on_failure` opens with `await session.rollback()` (there since #1778 codex r2, so a caller's dirty session cannot poison the failure write), and `SET LOCAL` is transaction-scoped. Measured in `test_the_helpers_rollback_discards_an_upstream_budget`: inside a bracket armed at 400 ms, `current_setting('lock_timeout')` reads back the budget; after the helper's `rollback()` the same read is `'0'`.

**The kwarg and the in-helper arm are complements, not alternatives, and this PR takes both.** The kwarg exists for a different statement: `_job_phase_session`'s docstring records `fix(#1778 codex r6)` — *"a SELECT can itself stall behind a lock the row's own later UPDATE would never even see (e.g. another session holding an ACCESS EXCLUSIVE lock on the table)"*. The load does not block on **row** locks, which is why the UPDATE is the statement this issue is about; it can block on **table** locks, which is what the kwarg bounds. Both vector brackets now pass it, and both reupload tails — which use a bare `async_session()` with a raw `select()`, so no kwarg exists to pass — arm their session before that load.

That exposure is narrow (a rewriting migration or trigger creation on `catalog.ingest_jobs`, or a `VACUUM FULL`/`REINDEX` from the RUNBOOK path, coinciding with a task failure), and nothing regresses without it: none of the four passed a kwarg before this PR either.

So the UPDATE's arm sits inside the helper, between the rollback and the UPDATE. `test_the_shared_helper_arms_between_its_rollback_and_its_update` pins that order in the AST, and now also refuses any `rollback()` or `commit()` **between** the arm and the UPDATE — the exact mechanism this PR turns on, which a `min(rollbacks)` comparison alone could not see.

Two consequences worth stating:

- **The staging DROP is unchanged.** It runs after `session.commit()`, and a commit ends the transaction, so the budget is gone by then (measured in the probe alongside the rollback case). A DROP that hits a lock still behaves exactly as it did, in its own guarded best-effort block.
- **`ingest_vrt` (`tasks_vrt.py:854`) is bounded too**, because it routes through the same helper.

## `tasks_reupload.py`: bound in place, do not converge onto `_job_phase_session`

The issue flags the bare `async_session()` / `_job_phase_session` split as accidental. It is real, and it is orthogonal to this defect: both spellings converge on `_cleanup_staging_on_failure` for the write in question, so converging the loader would change which helper opens the session without changing where the bound has to go. Against it:

- The reupload tails run `record_refresh_failure` (and `_record_failed_origin_contact` on the service path) **outside** the `err_job is not None` guard, on purpose — the run row is keyed on the job id and must be written even when the job row has gone. `_job_phase_session` yields `(session, None)` with a warning in that case, so the conversion is not a rename; it changes the missing-row log line and re-shapes a guard two other features depend on.
- It would re-ratchet `tasks_reupload.py` (capped at 1325) in a direction the LOC gate checks exactly, for no behavioural gain.

Worth its own change if someone wants the uniformity; not worth bundling into a bound.

## The budget: 10 seconds

Sized against holders of the **job** row, which is a different question from #1937's phase budget (holders of the catalog rows) and gets its own constant, as #1947 did. The conclusion matches #1947's; the reason is not the one an earlier revision of this body gave.

**A long holder does exist.** A phase-2 bracket takes `FOR NO KEY UPDATE` on the job row (`require_status="running"`, `tasks_common.py`) and holds it across object-storage puts — `tasks_raster.py:469` through the COG and quicklook uploads, same shape at `tasks_vector.py:693` and `:1224`. Minutes, not milliseconds. "Same attempt, runs strictly before its own error write" covers only the intra-attempt case; a retry after a stale-sweep fail puts a *different* attempt's bracket on that row.

**What keeps this write out of that queue is the attempt fence.** Every UPDATE bounded here carries `WHERE attempt_id = <this attempt>` (and a status predicate). A later attempt's bracket can only be holding the row after that attempt's claim committed, so under READ COMMITTED the fence fails at scan time and no lock wait ever starts.

What is left really does self-cap or never queue:

- `cancel_job` (`platform/jobs/router.py:1224`) runs its whole transition under `SET LOCAL lock_timeout = '2s'` and holds the row from its CAS to commit — pure database work, no object storage.
- The stale sweep (`sweep.py:1181`) and the worker's startup recovery (`worker.py:122`) both take candidates through a `FOR UPDATE SKIP LOCKED` subquery, so they skip a held row rather than queueing on it.
- The remaining writers are request handlers (the job-status lease auto-fail, retry), whose transactions end with the request under the API's own `statement_timeout`.

So a wait past 10 s means stuck, not busy. `regenerate_vrt`'s `RasterAsset` and `VrtGeneration` writes share the budget but not the fence; their holders are short request transactions and the sweep.

## The behaviour change, stated

If the bound expires, **the job never records its failure**. It stays `running` with no `error_message`, and settles only when the stale sweep reaps it after the heartbeat stops (each tail's `finally` stops the heartbeat, so nothing keeps it looking alive). That is worse than a recorded failure and better than a worker that hangs forever. It is a real trade, not a pure fix.

**The task still reports the error that actually failed it.** There is no handler between the arm and the failure UPDATE by default, so an expiry would escape each tail before its bare `raise` and become the task's outcome — an operator handed a lock timeout where they needed the GDAL or source error, with the shared helper's failure logger and `ingest_failed` notification skipped along with it. That would turn "hang, cause unrecorded" into "fail, wrong cause recorded", which is worse in the one dimension that matters for diagnosis.

So each error write catches `DBAPIError` around itself, records it through `log_job_error_write_failure` (`heartbeat.py`) and returns, letting the caller re-raise what it was already handling:

- `job_error_write_timeout` for the two SQLSTATEs the budget produces (`57014`, `55P03`), `job_error_write_failed` for anything else — a database problem during the secondary write should not replace the cause either.
- Both carry `job_id`, `task`, `sqlstate` and `budget_ms`, so the contention stays visible. Swallowing it silently would trade one blind spot for another.
- The shared helper gates its ORM mirror and its `rowcount` check on whether the write landed, and reaches its failure logger and notification on both routes. Those calls sit **outside** the `except` block, so `sys.exc_info()` there is the original exception and `.exception()` logs the right traceback.

`test_the_original_exception_is_what_leaves_the_tail` pins it: it holds the row, drives the tail shape with a recognisable `_IngestFailed`, and asserts `excinfo.value is cause` — identity, not a message match — alongside the timeout event, the failure log line and the notification.

**Three further writes are skipped with it**, because they sit after the failure write inside the same block:

- `record_refresh_failure` on both reupload tails, so the `dataset_refresh_runs` row stays `running` until the refresh sweep cancels it (~1 h). No sweep owns `last_checked_at`, so `_record_failed_origin_contact` on the service path simply does not date the contact.
- `regenerate_vrt`'s `RasterAsset` and `VrtGeneration` writes share one transaction with its job write, so an expiry aborts all three and leaves the asset row pointing at a dead generation. That end state is what a hang leaves today, minus the hang — see the follow-up note below. The build failure is still what the task reports.

**The terminal status survives either route.** It lives in a `finally`, so it runs whether the write lands or is swallowed — asserted in the same test rather than assumed.

**The terminal status survives the new raise.** `final_status = "failed"` sat *after* the error write in three tails, so a bound that raises would have skipped it and left it `"pending"`; both `reap_presigned_staging_object` and `reap_downloaded_staging_source` return early on a non-terminal status, which for `reupload_file` permanently orphans the frozen staging copy and the client's still-live presigned PUT key (`_retry_capability` refuses reupload jobs and the stale purge exempts them). The assignment moves into a `finally` at `tasks_vector.py` (`ingest_file`), `tasks_raster.py` (`ingest_raster`) and `tasks_reupload.py` (`reupload_file`), so the invariant `fix(#1213 review r1)` records stops depending on position. Firing those reapers early is correct: the attempt is genuinely terminal (`retry=0`, exception propagating, heartbeat stopped), and a later retry replays from the frozen copy, which both ordinary-import tails retain via `failed_source_replayable=True`. `reupload_service` and `ingest_vrt` need nothing — neither has a `final_status`-keyed reaper.

It is stated at every code site (the `heartbeat.py` constant, the `_cleanup_staging_on_failure` docstring, the `tasks_raster.py` and `tasks_vrt.py` call sites) and asserted: `test_the_shared_helper_gives_up` re-reads the row after the give-up and requires `status == "running"`.

The expiry reports SQLSTATE **`57014`**, asserted exactly rather than as a set. Both GUCs are armed at the same value and the blocking statement is the UPDATE, so `statement_timeout` holds the earlier deadline; a `55P03` here would mean only `lock_timeout` was armed, which is the arming bug the test exists to catch. Nothing on these paths stores `str(exc)` for a user: the helper raises before `record_refresh_failure` runs, and the exception propagates to the queue.

## More than five sites

The issue's list of five is incomplete. The same class has five more, all writing `ingest_jobs` on a fresh unbounded session:

- `tasks_vrt.py:854` — `ingest_vrt`. **Fixed here for free** (routes through the shared helper).
- `tasks_vrt.py:1590` — `regenerate_vrt`. **Fixed here explicitly**, and it should never have been deferred: #1947 put `_PUBLISH_CATALOG_TIMEOUT = "15s"` on the `lock_catalog_rows` call at `tasks_vrt.py:1433`, which is inside `regenerate_vrt`, not `ingest_vrt`. A metadata edit holding `catalog.records` makes that wait raise `CatalogLockConflict` with `publish_committed` still `False`, which is precisely how control reaches this handler. **It is on #1947's path**, and an earlier revision of this body said no deferred site was. That claim was wrong.
- `tasks_postgis_refresh.py:1103` — `refresh_postgis`, a direct `update_ingest_job_for_attempt`.
- `tasks_stac_refresh.py:767` — `refresh_stac`, direct.
- `processing/analysis/tasks.py:211` and `:872` — the analysis cancel and failure writes, direct.

The last three are deferred: none is downstream of a bounded wait the way `regenerate_vrt` is, and each needs its own cap ratchet. Worth a follow-up issue.

The same follow-up should fold `tasks_raster_replace.py`'s `_ERROR_WRITE_TIMEOUT_MS` (#1947, merged as a3f21abe5) into `JOB_ERROR_WRITE_TIMEOUT_MS`. Same value, same derivation, two copies now; that file's cap was set exactly by #1947 and re-ratcheting it belongs with the rest of the sweep rather than here.

### Follow-up worth filing: split `regenerate_vrt`'s failure transaction

Its handler writes the job row, `RasterAsset` and `VrtGeneration` in one transaction, so the bound aborts all three together and leaves the asset pointing at a dead generation. Not fixed here, deliberately: that end state is identical to today's hang minus the hang, so the bound is strictly an improvement and ships alone. Splitting it needs a product decision about which of the three must be recorded first.

The same follow-up should fold `tasks_raster_replace.py`'s `_ERROR_WRITE_TIMEOUT_MS` (#1947, merged as a3f21abe5) into `JOB_ERROR_WRITE_TIMEOUT_MS`. Same value, same derivation, two copies now; that file's cap was set exactly by #1947 and re-ratcheting it belongs with the rest of the sweep rather than here.

## Caps

| File | Cap | What the lines bought |
| --- | --- | --- |
| `tasks_common.py` | 2643 -> **2668** | the arm, and the guarded write that keeps an expiry from replacing the cause |
| `tasks_vector.py` | 1368 -> **1380** | both bracket kwargs and the `finally` around the terminal status |
| `tasks_reupload.py` | 1325 -> **1329** | both session arms and `reupload_file`'s `finally` |
| `tasks_vrt.py` | 1698 -> **1709** | `regenerate_vrt`'s arm over its three writes, and its own expiry handler |

`tasks_raster.py` (941) and `heartbeat.py` (357) stay under `_RATCHET_INCLUSION_LOC`; `test_module_loc_cap_inclusion_rule_is_complete` passes.

`backend/tests/finding_markers.py`: `processing/ingest/tasks_raster.py` **37 -> 35**. The `try` this PR wraps its error write in pulled `REMED-03 / P2-05` into the same comment unit as a `fix(#1950)` anchor, which anchors them. That ledger is exact in both directions, so the reduction has to be recorded. One pre-existing 7-line comment in `regenerate_vrt` (`fix(#1778 codex r1)`) was re-indented by the same wrap and trimmed to the three-line convention; its anchor and invariant are kept, the surrounding narration is not.

## Verification

Host Postgres at `localhost:5434`, run from a worktree wrapper script, gated on pytest's exit status. Re-run after rebasing onto `ddedd151e`.

| Command | Result |
| --- | --- |
| `uv run ruff check . && uv run ruff format --check .` | pass (1192 files) |
| `pytest tests/test_job_error_write_bound_1950.py` | 21 passed, exit 0 |
| `pytest …_1950 …_layering …_unscoped_finding_markers …_feature_lock_order_1847 …_ingest_vector_failure_tails …_tasks_common_phase_brackets …_raster_replace_phase_budget_1937 …_vrt_publish_catalog_wait_1938` | 220 passed, 1 skipped, exit 0 |
| `pytest tests/test_raster_ingest.py tests/test_reupload.py tests/test_reupload_service.py tests/test_ingest.py tests/test_ingest_progress.py tests/test_manifest_apply_vrt.py tests/test_vrt_catalog_175.py tests/test_ingest_staging_cleanup_gap018.py tests/test_1755_cleanup_step.py tests/test_presigned_staging_reap_1202.py tests/test_reupload_completion_contract_1207.py tests/test_jobs_router.py tests/test_event_ingest.py` | 278 passed, exit 0 |
| `pytest tests/test_ingest_job_attempt_fencing.py tests/test_phase_2_commit_boundary.py tests/test_failed_job_token_purge_1746.py tests/test_service_token_redaction_1277.py` | pass, exit 0 |

### Counterfactuals

Every bound, every handler and every gate, mutated in turn and restored afterwards with a verified-clean tree.

| Mutation | Result |
| --- | --- |
| Delete the arm from `_cleanup_staging_on_failure` | `test_the_shared_helper_gives_up` fails on the 30 s outer `wait_for` (34 s run); the order gate fails with `found 0`. |
| Delete `lock_and_statement_timeout_ms` from `tasks_raster.py`'s bracket | the naming gate fails **and** `test_the_raster_tail_gives_up` fails, because it reads its budget from the real call site. |
| Delete the arm from `regenerate_vrt` | `test_the_vrt_regeneration_tail_arms_before_its_writes` fails. |
| Move `final_status = "failed"` out of the `finally` at all three tails | `test_the_terminal_status_survives_a_raised_error_write` fails for `ingest_file`, `ingest_raster` and `reupload_file`. |
| Insert a `rollback()` between the arm and the failure UPDATE | the order gate fails naming line 64, **and** `test_the_shared_helper_gives_up` times out — the stranded-transaction hole is real, not theoretical. |
| Move `ingest_raster`'s UPDATE outside the bracket, kwarg left in place | the new position gate fails while the other 11 structural tests stay green — exactly the hole it was added for. |
| Inline the constant in `arm_job_error_write_budget` so the monkeypatch cannot reach it | `test_the_shared_helper_gives_up` fails: *"waited 10062ms, far past the 400ms this test installs"*. Before the upper bound was added, this run passed. |
| Re-raise from the shared helper's `DBAPIError` handler (the P2 as reported) | three tests fail, including `test_the_original_exception_is_what_leaves_the_tail`. |
| Swallow the timeout without logging it | the same three fail — a silent swallow is not an acceptable substitute. |
| Delete the `DBAPIError` handler from `ingest_raster` and `regenerate_vrt` | `test_every_error_write_swallows_its_own_failure` fails for both. |
