### PR TITLE
fix(api): make strict_cog settable and drop tracker ids from published descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and releases use semantic versioning.
   request body omitted the field, so it was dropped before the raster path ever read it and every
   import converted a non-COG GeoTIFF regardless of what was asked for. The field is now part of
   the published body, and sending `true` fails the job instead of rewriting the file. (#1949)
+- Field and query descriptions in the API document, both SDKs and the generated TypeScript types
+  cited internal tracker ids as the reason for a limit — "Phase 269 H-24" for a page size,
+  "(PERF-N16)" for another — which no reader outside the project can resolve. Those descriptions
+  now state the constraint itself. (#1946)
 - A service token refused for control characters or whitespace now answers with the same
   `invalid_service_token` code the other credential refusals carry, so the app and the CLI show
   the token-specific message on every service door instead of a generic validation error. (#1924)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and releases use semantic versioning.
 - The import-commit door accepted a service token with no length limit of its own, while every
   other service door caps one at 1000 characters. An over-long token is now refused with 422
   before anything is reserved or staged. (#1923)
+- The import endpoint published a `strict_cog` raster option no caller could set. The commit
+  request body omitted the field, so it was dropped before the raster path ever read it and every
+  import converted a non-COG GeoTIFF regardless of what was asked for. The field is now part of
+  the published body, and sending `true` fails the job instead of rewriting the file. (#1949)
 - A service token refused for control characters or whitespace now answers with the same
   `invalid_service_token` code the other credential refusals carry, so the app and the CLI show
   the token-specific message on every service door instead of a generic validation error. (#1924)

--- a/backend/app/modules/catalog/datasets/api/router_metadata.py
+++ b/backend/app/modules/catalog/datasets/api/router_metadata.py
@@ -422,7 +422,7 @@ async def list_dataset_relationships(
         100,
         ge=1,
         le=1000,
-        description="Maximum number of relationships to return (PERF-N16).",
+        description="Maximum number of relationships to return. Capped at 1000.",
     ),
     user: Identity | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),

--- a/backend/app/modules/catalog/features/router.py
+++ b/backend/app/modules/catalog/features/router.py
@@ -336,8 +336,8 @@ async def list_features(
         0,
         ge=0,
         description=(
-            "Legacy offset-based pagination. Phase 269 H-24 lowered the "
-            "max limit to 200 from 1000."
+            "Legacy offset-based pagination. The companion limit is capped "
+            "at 200 per page, and a high offset is costly to serve."
         ),
     ),
     bbox: str | None = Query(None, description="Bounding box: minx,miny,maxx,maxy"),

--- a/backend/app/modules/catalog/maps/schemas.py
+++ b/backend/app/modules/catalog/maps/schemas.py
@@ -559,17 +559,17 @@ class BasemapConfig(BaseModel):
         default=None,
         description=(
             "Per-sublayer style overrides keyed by semantic sublayer ID "
-            "(e.g. 'road', 'boundary', 'building'). Key set is opaque — "
-            "unknown future sublayer IDs are accepted without rejection. "
-            "See CONTEXT.md D-01."
+            "(e.g. 'road', 'boundary', 'building'). The key set is opaque: "
+            "a sublayer ID this release does not know is accepted and "
+            "stored rather than rejected."
         ),
     )
     basemap_position: BasemapPosition | None = Field(
         default=None,
         description=(
             "Whether the basemap renders above ('top') or below ('bottom', "
-            "default) the data layers. null/undefined loads as 'bottom' on the "
-            "client. Phase 1051 UX-03 (jsonb-additive, no migration)."
+            "default) the data layers. null/undefined loads as 'bottom' on "
+            "the client."
         ),
     )
     projection: BasemapProjection | None = Field(
@@ -961,8 +961,8 @@ class MapUpdate(BaseModel):
         default=None,
         max_length=120,
         description=(
-            "Custom map-level legend title. Null/empty leaves the legend "
-            "without a heading override (ENH-06)."
+            "Custom map-level legend title. Null or empty leaves the legend "
+            "without a heading override. At most 120 characters."
         ),
     )
 

--- a/backend/app/modules/catalog/sources/schemas.py
+++ b/backend/app/modules/catalog/sources/schemas.py
@@ -187,10 +187,10 @@ class LayerInfo(BaseModel):
         default="vector",
         description=(
             "Backend-classified layer kind. 'vector' = point/line/polygon feature data. "
-            "'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. "
-            "Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, "
-            "or layer has coverage_format/bands/mediaType:image/*. Everything else (including "
-            "geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'."
+            "'raster' = imagery/coverage. Classified as 'raster' when geometry_type "
+            "contains 'raster', the adapter is STAC, or the layer declares "
+            "coverage_format, bands, or a mediaType of image/*. Everything else, "
+            "including a layer with no geometry_type at all, defaults to 'vector'."
         ),
     )
 

--- a/backend/app/modules/catalog/sources/schemas.py
+++ b/backend/app/modules/catalog/sources/schemas.py
@@ -188,9 +188,10 @@ class LayerInfo(BaseModel):
         description=(
             "Backend-classified layer kind. 'vector' = point/line/polygon feature data. "
             "'raster' = imagery/coverage. Classified as 'raster' when geometry_type "
-            "contains 'raster', the adapter is STAC, or the layer declares "
-            "coverage_format, bands, or a mediaType of image/*. Everything else, "
-            "including a layer with no geometry_type at all, defaults to 'vector'."
+            "contains 'raster', the adapter is STAC, the layer declares "
+            "coverage_format or bands, or one of its links has a media type of "
+            "image/*. Everything else, including a layer with no geometry_type at "
+            "all, defaults to 'vector'."
         ),
     )
 

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -1693,7 +1693,7 @@ async def discover_tables(
         1000,
         ge=1,
         le=5000,
-        description="Maximum number of tables to return (PERF-11 bound).",
+        description="Maximum number of tables to return. Capped at 5000.",
     ),
     user: Identity = Depends(require_permission("upload")),
     db: AsyncSession = Depends(get_db),

--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -223,12 +223,11 @@ class RasterCommitRequest(BaseCommitRequest):
     strict_cog: bool = Field(
         default=False,
         description=(
-            "Raster only: reject non-COG TIFFs at commit time instead of "
-            "converting them. Default False preserves the existing "
-            "auto-convert behavior. When True, the ingest job fails fast "
-            "with a clear error before the COG conversion subprocess runs. "
-            "Use this when ingesting an externally-produced COG catalog "
-            "where on-the-fly rewriting is undesirable. (ING-07 / P2-09)"
+            "Raster only: reject a non-COG TIFF instead of converting it. "
+            "False (the default) converts the source to a COG during ingest; "
+            "True fails the job before the conversion runs. Use it when "
+            "ingesting an externally-produced COG catalog where rewriting is "
+            "undesirable."
         ),
     )
 
@@ -343,9 +342,21 @@ class CommitRequest(BaseModel):
     )
     # feat(#1746 B2b): the handler re-validates ServiceCommitRequest from THIS
     # model's dump, so a field absent here is dropped before the subclass ever
-    # sees it. Declared last for the positional-slot reason above.
+    # sees it. Appended, never inserted, for the positional-slot reason above.
     auth: ServiceAuthRequest | None = Field(
         default=None, description=SERVICE_AUTH_FIELD_DESCRIPTION
+    )
+    # fix(#1949): appended for that same reason rather than placed beside the
+    # other raster fields, which would move five existing positional slots.
+    strict_cog: bool = Field(
+        default=False,
+        description=(
+            "Raster only: reject a non-COG TIFF instead of converting it. "
+            "False (the default) converts the source to a COG during ingest; "
+            "True fails the job before the conversion runs. Use it when "
+            "ingesting an externally-produced COG catalog where rewriting is "
+            "undesirable."
+        ),
     )
     _reject_auth_conflict = model_validator(mode="after")(reject_service_auth_conflict)
 

--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -224,10 +224,11 @@ class RasterCommitRequest(BaseCommitRequest):
         default=False,
         description=(
             "Raster only: reject a non-COG TIFF instead of converting it. "
-            "False (the default) converts the source to a COG during ingest; "
-            "True fails the job before the conversion runs. Use it when "
-            "ingesting an externally-produced COG catalog where rewriting is "
-            "undesirable."
+            "False (the default) converts the source to a COG during ingest. "
+            "True fails the job when the source is not already a compliant "
+            "COG. Setting compression, resampling, nodata_override or "
+            "srid_override still rewrites the file even when the strict "
+            "check passes, because each of those is applied by a conversion."
         ),
     )
 
@@ -352,10 +353,11 @@ class CommitRequest(BaseModel):
         default=False,
         description=(
             "Raster only: reject a non-COG TIFF instead of converting it. "
-            "False (the default) converts the source to a COG during ingest; "
-            "True fails the job before the conversion runs. Use it when "
-            "ingesting an externally-produced COG catalog where rewriting is "
-            "undesirable."
+            "False (the default) converts the source to a COG during ingest. "
+            "True fails the job when the source is not already a compliant "
+            "COG. Setting compression, resampling, nodata_override or "
+            "srid_override still rewrites the file even when the strict "
+            "check passes, because each of those is applied by a conversion."
         ),
     )
     _reject_auth_conflict = model_validator(mode="after")(reject_service_auth_conflict)

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -688,8 +688,8 @@ async def get_collection_items(
         None,
         ge=0,
         description=(
-            "Keyset cursor: returns features with gid > after_gid. Phase 269 H-24 "
-            "primary pagination path; use the rel=next link for follow-up pages."
+            "Keyset cursor: returns features with gid > after_gid. The preferred "
+            "pagination path; use the rel=next link for follow-up pages."
         ),
     ),
     bbox: str | None = Query(None, description="Bounding box: minx,miny,maxx,maxy"),

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -998,9 +998,9 @@ async def get_collection_items(
         0,
         ge=0,
         description=(
-            "Legacy offset-based pagination. Phase 269 H-24 lowered the "
-            f"max limit to {_STAC_MAX_LIMIT} and recommends keyset cursors via "
-            "the rel=next link for deep paging."
+            "Legacy offset-based pagination. The page size is capped at "
+            f"{_STAC_MAX_LIMIT}; prefer the rel=next link for deep paging, "
+            "which does not get more expensive as the offset grows."
         ),
     ),
 ) -> JSONResponse:
@@ -1654,9 +1654,9 @@ async def search_get(
         None,
         max_length=10000,
         description=(
-            "GeoJSON geometry for spatial intersection. SEC-FU-05 (sec-audit-20260519.md): "
-            "max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier — fits ~150-vertex "
-            "polygons at 2-decimal-place lat/lon coordinates."
+            "GeoJSON geometry for spatial intersection. At most 10000 characters, "
+            "which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon "
+            "coordinates."
         ),
     ),
     limit: int = Query(
@@ -1672,8 +1672,8 @@ async def search_get(
         0,
         ge=0,
         description=(
-            "Legacy offset-based pagination. Phase 269 H-24 lowered the "
-            f"max limit to {_STAC_MAX_LIMIT} from 1000 to bound deep-paging cost."
+            "Legacy offset-based pagination. The page size is capped at "
+            f"{_STAC_MAX_LIMIT}; a high offset is costly to serve."
         ),
     ),
 ) -> JSONResponse:

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -999,8 +999,8 @@ async def get_collection_items(
         ge=0,
         description=(
             "Legacy offset-based pagination. The page size is capped at "
-            f"{_STAC_MAX_LIMIT}; prefer the rel=next link for deep paging, "
-            "which does not get more expensive as the offset grows."
+            f"{_STAC_MAX_LIMIT}; the rel=next link advances one page at a "
+            "time, and a high offset is costly to serve."
         ),
     ),
 ) -> JSONResponse:
@@ -1655,8 +1655,8 @@ async def search_get(
         max_length=10000,
         description=(
             "GeoJSON geometry for spatial intersection. At most 10000 characters, "
-            "which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon "
-            "coordinates."
+            "which fits a polygon of several hundred vertices at 2-decimal-place "
+            "lat/lon coordinates."
         ),
     ),
     limit: int = Query(

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8646,7 +8646,7 @@
           },
           "kind": {
             "default": "vector",
-            "description": "Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC, or the layer declares coverage_format, bands, or a mediaType of image/*. Everything else, including a layer with no geometry_type at all, defaults to 'vector'.",
+            "description": "Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC, the layer declares coverage_format or bands, or one of its links has a media type of image/*. Everything else, including a layer with no geometry_type at all, defaults to 'vector'.",
             "enum": [
               "vector",
               "raster"
@@ -57208,13 +57208,13 @@
             }
           },
           {
-            "description": "Legacy offset-based pagination. The page size is capped at 200; prefer the rel=next link for deep paging, which does not get more expensive as the offset grows.",
+            "description": "Legacy offset-based pagination. The page size is capped at 200; the rel=next link advances one page at a time, and a high offset is costly to serve.",
             "in": "query",
             "name": "offset",
             "required": false,
             "schema": {
               "default": 0,
-              "description": "Legacy offset-based pagination. The page size is capped at 200; prefer the rel=next link for deep paging, which does not get more expensive as the offset grows.",
+              "description": "Legacy offset-based pagination. The page size is capped at 200; the rel=next link advances one page at a time, and a high offset is costly to serve.",
               "minimum": 0,
               "title": "Offset",
               "type": "integer"
@@ -57698,7 +57698,7 @@
             }
           },
           {
-            "description": "GeoJSON geometry for spatial intersection. At most 10000 characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon coordinates.",
+            "description": "GeoJSON geometry for spatial intersection. At most 10000 characters, which fits a polygon of several hundred vertices at 2-decimal-place lat/lon coordinates.",
             "in": "query",
             "name": "intersects",
             "required": false,
@@ -57712,7 +57712,7 @@
                   "type": "null"
                 }
               ],
-              "description": "GeoJSON geometry for spatial intersection. At most 10000 characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon coordinates.",
+              "description": "GeoJSON geometry for spatial intersection. At most 10000 characters, which fits a polygon of several hundred vertices at 2-decimal-place lat/lon coordinates.",
               "title": "Intersects"
             }
           },

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3930,6 +3930,12 @@
               }
             ],
             "description": "Structured credential for a protected service. Mutually exclusive with the token field."
+          },
+          "strict_cog": {
+            "default": false,
+            "description": "Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest; True fails the job before the conversion runs. Use it when ingesting an externally-produced COG catalog where rewriting is undesirable.",
+            "title": "Strict Cog",
+            "type": "boolean"
           }
         },
         "required": [

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3933,7 +3933,7 @@
           },
           "strict_cog": {
             "default": false,
-            "description": "Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest; True fails the job before the conversion runs. Use it when ingesting an externally-produced COG catalog where rewriting is undesirable.",
+            "description": "Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG. Setting compression, resampling, nodata_override or srid_override still rewrites the file even when the strict check passes, because each of those is applied by a conversion.",
             "title": "Strict Cog",
             "type": "boolean"
           }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1917,7 +1917,7 @@
                 "type": "null"
               }
             ],
-            "description": "Per-sublayer style overrides keyed by semantic sublayer ID (e.g. 'road', 'boundary', 'building'). Key set is opaque \u2014 unknown future sublayer IDs are accepted without rejection. See CONTEXT.md D-01.",
+            "description": "Per-sublayer style overrides keyed by semantic sublayer ID (e.g. 'road', 'boundary', 'building'). The key set is opaque: a sublayer ID this release does not know is accepted and stored rather than rejected.",
             "title": "Sublayer Overrides"
           },
           "basemap_position": {
@@ -1929,7 +1929,7 @@
                 "type": "null"
               }
             ],
-            "description": "Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no migration)."
+            "description": "Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client."
           },
           "projection": {
             "anyOf": [
@@ -8646,7 +8646,7 @@
           },
           "kind": {
             "default": "vector",
-            "description": "Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image/*. Everything else (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'.",
+            "description": "Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC, or the layer declares coverage_format, bands, or a mediaType of image/*. Everything else, including a layer with no geometry_type at all, defaults to 'vector'.",
             "enum": [
               "vector",
               "raster"
@@ -11063,7 +11063,7 @@
                 "type": "null"
               }
             ],
-            "description": "Custom map-level legend title. Null/empty leaves the legend without a heading override (ENH-06).",
+            "description": "Custom map-level legend title. Null or empty leaves the legend without a heading override. At most 120 characters.",
             "title": "Legend Title"
           }
         },
@@ -29789,7 +29789,7 @@
             }
           },
           {
-            "description": "Keyset cursor: returns features with gid > after_gid. Phase 269 H-24 primary pagination path; use the rel=next link for follow-up pages.",
+            "description": "Keyset cursor: returns features with gid > after_gid. The preferred pagination path; use the rel=next link for follow-up pages.",
             "in": "query",
             "name": "after_gid",
             "required": false,
@@ -29803,7 +29803,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Keyset cursor: returns features with gid > after_gid. Phase 269 H-24 primary pagination path; use the rel=next link for follow-up pages.",
+              "description": "Keyset cursor: returns features with gid > after_gid. The preferred pagination path; use the rel=next link for follow-up pages.",
               "title": "After Gid"
             }
           },
@@ -35148,13 +35148,13 @@
             }
           },
           {
-            "description": "Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 from 1000.",
+            "description": "Legacy offset-based pagination. The companion limit is capped at 200 per page, and a high offset is costly to serve.",
             "in": "query",
             "name": "offset",
             "required": false,
             "schema": {
               "default": 0,
-              "description": "Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 from 1000.",
+              "description": "Legacy offset-based pagination. The companion limit is capped at 200 per page, and a high offset is costly to serve.",
               "minimum": 0,
               "title": "Offset",
               "type": "integer"
@@ -38082,13 +38082,13 @@
             }
           },
           {
-            "description": "Maximum number of relationships to return (PERF-N16).",
+            "description": "Maximum number of relationships to return. Capped at 1000.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 100,
-              "description": "Maximum number of relationships to return (PERF-N16).",
+              "description": "Maximum number of relationships to return. Capped at 1000.",
               "maximum": 1000,
               "minimum": 1,
               "title": "Limit",
@@ -41340,13 +41340,13 @@
         "operationId": "discover_tables_ingest_discover__get",
         "parameters": [
           {
-            "description": "Maximum number of tables to return (PERF-11 bound).",
+            "description": "Maximum number of tables to return. Capped at 5000.",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 1000,
-              "description": "Maximum number of tables to return (PERF-11 bound).",
+              "description": "Maximum number of tables to return. Capped at 5000.",
               "maximum": 5000,
               "minimum": 1,
               "title": "Limit",
@@ -57208,13 +57208,13 @@
             }
           },
           {
-            "description": "Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 and recommends keyset cursors via the rel=next link for deep paging.",
+            "description": "Legacy offset-based pagination. The page size is capped at 200; prefer the rel=next link for deep paging, which does not get more expensive as the offset grows.",
             "in": "query",
             "name": "offset",
             "required": false,
             "schema": {
               "default": 0,
-              "description": "Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 and recommends keyset cursors via the rel=next link for deep paging.",
+              "description": "Legacy offset-based pagination. The page size is capped at 200; prefer the rel=next link for deep paging, which does not get more expensive as the offset grows.",
               "minimum": 0,
               "title": "Offset",
               "type": "integer"
@@ -57698,7 +57698,7 @@
             }
           },
           {
-            "description": "GeoJSON geometry for spatial intersection. SEC-FU-05 (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier \u2014 fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.",
+            "description": "GeoJSON geometry for spatial intersection. At most 10000 characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon coordinates.",
             "in": "query",
             "name": "intersects",
             "required": false,
@@ -57712,7 +57712,7 @@
                   "type": "null"
                 }
               ],
-              "description": "GeoJSON geometry for spatial intersection. SEC-FU-05 (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier \u2014 fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.",
+              "description": "GeoJSON geometry for spatial intersection. At most 10000 characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon coordinates.",
               "title": "Intersects"
             }
           },
@@ -57730,13 +57730,13 @@
             }
           },
           {
-            "description": "Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 from 1000 to bound deep-paging cost.",
+            "description": "Legacy offset-based pagination. The page size is capped at 200; a high offset is costly to serve.",
             "in": "query",
             "name": "offset",
             "required": false,
             "schema": {
               "default": 0,
-              "description": "Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 from 1000 to bound deep-paging cost.",
+              "description": "Legacy offset-based pagination. The page size is capped at 200; a high offset is costly to serve.",
               "minimum": 0,
               "title": "Offset",
               "type": "integer"

--- a/backend/tests/test_commit_request_schemas.py
+++ b/backend/tests/test_commit_request_schemas.py
@@ -260,7 +260,7 @@ class TestTheFlatUnionPublishesWhatTheSubclassesEnforce:
         for prefix in accepted:
             assert prefix in description, prefix
 
-    def test_the_union_omits_only_strict_cog(self) -> None:
+    def test_the_union_omits_no_subclass_field(self) -> None:
         """A subclass field absent from the union cannot be set by a caller:
         the handler re-validates the subclass from this model's dump."""
         omitted = {
@@ -273,4 +273,27 @@ class TestTheFlatUnionPublishesWhatTheSubclassesEnforce:
             for name in model.model_fields
             if name not in CommitRequest.model_fields
         }
-        assert omitted == {"strict_cog"}
+        assert omitted == set()
+
+    def test_the_union_declares_its_fields_in_the_published_order(self) -> None:
+        """The generated Python SDK gives each field a positional slot in this
+        order, so a field inserted rather than appended moves a caller's
+        argument. Same rule as TestAuthIsDeclaredLast in the #1746 suite."""
+        assert list(CommitRequest.model_fields) == [
+            "title",
+            "summary",
+            "visibility",
+            "srid_override",
+            "token",
+            "temporal_start",
+            "temporal_end",
+            "compression",
+            "resampling",
+            "nodata_override",
+            "layer_name",
+            "x_column",
+            "y_column",
+            "geom_column",
+            "auth",
+            "strict_cog",
+        ]

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -1505,6 +1505,36 @@ class TestCommitImportDispatch:
         assert job.user_metadata["compression"] == "LZW"
         assert job.user_metadata["resampling"] == "bilinear"
 
+    @pytest.mark.parametrize("sent", [True, False])
+    async def test_strict_cog_sent_by_a_caller_reaches_the_worker(
+        self, client, admin_auth_header, test_db_session, mock_ingest_task, sent
+    ) -> None:
+        """``user_metadata["strict_cog"]`` is what the raster tasks read."""
+        result = await test_db_session.execute(
+            select(User).where(User.username == "admin")
+        )
+        admin = result.scalar_one()
+
+        job = IngestJob(
+            source_filename="dem.tif",
+            file_path="/tmp/fake.tif",
+            created_by=admin.id,
+            status="pending",
+            user_metadata={"file_type": "raster"},
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+
+        resp = await client.post(
+            f"/ingest/commit/{job.id}",
+            json={"title": "Elevation", "strict_cog": sent},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 202, resp.text
+        await test_db_session.refresh(job)
+        assert job.user_metadata["strict_cog"] is sent
+
     async def test_service_job_commits_with_service_body(
         self, client, admin_auth_header, test_db_session, mock_ingest_task
     ) -> None:

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -6277,12 +6277,12 @@ export interface components {
             background_color?: string | null;
             /**
              * Sublayer Overrides
-             * @description Per-sublayer style overrides keyed by semantic sublayer ID (e.g. 'road', 'boundary', 'building'). Key set is opaque — unknown future sublayer IDs are accepted without rejection. See CONTEXT.md D-01.
+             * @description Per-sublayer style overrides keyed by semantic sublayer ID (e.g. 'road', 'boundary', 'building'). The key set is opaque: a sublayer ID this release does not know is accepted and stored rather than rejected.
              */
             sublayer_overrides?: {
                 [key: string]: components["schemas"]["SublayerOverride"];
             } | null;
-            /** @description Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no migration). */
+            /** @description Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. */
             basemap_position?: components["schemas"]["BasemapPosition"] | null;
             /** @description Map projection: 'mercator' (default) or experimental 'globe'. null/undefined loads as 'mercator' on the client. */
             projection?: components["schemas"]["BasemapProjection"] | null;
@@ -9239,7 +9239,7 @@ export interface components {
             object_id_field?: string | null;
             /**
              * Kind
-             * @description Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image/*. Everything else (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'.
+             * @description Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC, or the layer declares coverage_format, bands, or a mediaType of image/*. Everything else, including a layer with no geometry_type at all, defaults to 'vector'.
              * @default vector
              * @enum {string}
              */
@@ -10069,7 +10069,7 @@ export interface components {
             plugins?: string[] | null;
             /**
              * Legend Title
-             * @description Custom map-level legend title. Null/empty leaves the legend without a heading override (ENH-06).
+             * @description Custom map-level legend title. Null or empty leaves the legend without a heading override. At most 120 characters.
              */
             legend_title?: string | null;
         };
@@ -20941,7 +20941,7 @@ export interface operations {
                 limit?: number;
                 /** @description Legacy offset-based pagination. Prefer `after_gid` keyset cursor (via the `next` link) — offset is retained for backward compatibility but is O(N) at high values. */
                 offset?: number;
-                /** @description Keyset cursor: returns features with gid > after_gid. Phase 269 H-24 primary pagination path; use the rel=next link for follow-up pages. */
+                /** @description Keyset cursor: returns features with gid > after_gid. The preferred pagination path; use the rel=next link for follow-up pages. */
                 after_gid?: number | null;
                 /** @description Bounding box: minx,miny,maxx,maxy */
                 bbox?: string | null;
@@ -24520,7 +24520,7 @@ export interface operations {
         parameters: {
             query?: {
                 limit?: number;
-                /** @description Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 from 1000. */
+                /** @description Legacy offset-based pagination. The companion limit is capped at 200 per page, and a high offset is costly to serve. */
                 offset?: number;
                 /** @description Bounding box: minx,miny,maxx,maxy */
                 bbox?: string | null;
@@ -26287,7 +26287,7 @@ export interface operations {
             query?: {
                 /** @description Number of relationships to skip. */
                 skip?: number;
-                /** @description Maximum number of relationships to return (PERF-N16). */
+                /** @description Maximum number of relationships to return. Capped at 1000. */
                 limit?: number;
             };
             header?: never;
@@ -28558,7 +28558,7 @@ export interface operations {
     discover_tables_ingest_discover__get: {
         parameters: {
             query?: {
-                /** @description Maximum number of tables to return (PERF-11 bound). */
+                /** @description Maximum number of tables to return. Capped at 5000. */
                 limit?: number;
             };
             header?: never;
@@ -39649,7 +39649,7 @@ export interface operations {
                 datetime?: string | null;
                 /** @description Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation. */
                 limit?: number;
-                /** @description Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 and recommends keyset cursors via the rel=next link for deep paging. */
+                /** @description Legacy offset-based pagination. The page size is capped at 200; prefer the rel=next link for deep paging, which does not get more expensive as the offset grows. */
                 offset?: number;
             };
             header?: never;
@@ -39944,11 +39944,11 @@ export interface operations {
                 collections?: string | null;
                 /** @description Comma-separated item IDs */
                 ids?: string | null;
-                /** @description GeoJSON geometry for spatial intersection. SEC-FU-05 (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier — fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates. */
+                /** @description GeoJSON geometry for spatial intersection. At most 10000 characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon coordinates. */
                 intersects?: string | null;
                 /** @description Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation. */
                 limit?: number;
-                /** @description Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 from 1000 to bound deep-paging cost. */
+                /** @description Legacy offset-based pagination. The page size is capped at 200; a high offset is costly to serve. */
                 offset?: number;
             };
             header?: never;

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -9239,7 +9239,7 @@ export interface components {
             object_id_field?: string | null;
             /**
              * Kind
-             * @description Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC, or the layer declares coverage_format, bands, or a mediaType of image/*. Everything else, including a layer with no geometry_type at all, defaults to 'vector'.
+             * @description Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC, the layer declares coverage_format or bands, or one of its links has a media type of image/*. Everything else, including a layer with no geometry_type at all, defaults to 'vector'.
              * @default vector
              * @enum {string}
              */
@@ -39649,7 +39649,7 @@ export interface operations {
                 datetime?: string | null;
                 /** @description Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation. */
                 limit?: number;
-                /** @description Legacy offset-based pagination. The page size is capped at 200; prefer the rel=next link for deep paging, which does not get more expensive as the offset grows. */
+                /** @description Legacy offset-based pagination. The page size is capped at 200; the rel=next link advances one page at a time, and a high offset is costly to serve. */
                 offset?: number;
             };
             header?: never;
@@ -39944,7 +39944,7 @@ export interface operations {
                 collections?: string | null;
                 /** @description Comma-separated item IDs */
                 ids?: string | null;
-                /** @description GeoJSON geometry for spatial intersection. At most 10000 characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon coordinates. */
+                /** @description GeoJSON geometry for spatial intersection. At most 10000 characters, which fits a polygon of several hundred vertices at 2-decimal-place lat/lon coordinates. */
                 intersects?: string | null;
                 /** @description Maximum number of items returned. Values above 200 are clamped to 200, per the STAC Item Search spec's clamp-don't-reject recommendation. */
                 limit?: number;

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7091,6 +7091,12 @@ export interface components {
             geom_column?: string | null;
             /** @description Structured credential for a protected service. Mutually exclusive with the token field. */
             auth?: components["schemas"]["ServiceAuthRequest"] | null;
+            /**
+             * Strict Cog
+             * @description Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest; True fails the job before the conversion runs. Use it when ingesting an externally-produced COG catalog where rewriting is undesirable.
+             * @default false
+             */
+            strict_cog: boolean;
         };
         /** CommitResponse */
         CommitResponse: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7093,7 +7093,7 @@ export interface components {
             auth?: components["schemas"]["ServiceAuthRequest"] | null;
             /**
              * Strict Cog
-             * @description Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest; True fails the job before the conversion runs. Use it when ingesting an externally-produced COG catalog where rewriting is undesirable.
+             * @description Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG. Setting compression, resampling, nodata_override or srid_override still rewrites the file even when the strict check passes, because each of those is applied by a conversion.
              * @default false
              */
             strict_cog: boolean;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -922,6 +922,7 @@ export interface CommitImportRequest {
   compression?: string | null;
   resampling?: string | null;
   nodata_override?: number | string | null;
+  strict_cog?: boolean;
   layer_name?: string;
   x_column?: string | null;
   y_column?: string | null;

--- a/sdks/python/geolens/api/datasets/discover_tables_ingest_discover_get.py
+++ b/sdks/python/geolens/api/datasets/discover_tables_ingest_discover_get.py
@@ -117,7 +117,7 @@ def sync_detailed(
     thousands of orphan tables don't blow up the response payload.
 
     Args:
-        limit (int | Unset): Maximum number of tables to return (PERF-11 bound). Default: 1000.
+        limit (int | Unset): Maximum number of tables to return. Capped at 5000. Default: 1000.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -153,7 +153,7 @@ def sync(
     thousands of orphan tables don't blow up the response payload.
 
     Args:
-        limit (int | Unset): Maximum number of tables to return (PERF-11 bound). Default: 1000.
+        limit (int | Unset): Maximum number of tables to return. Capped at 5000. Default: 1000.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -184,7 +184,7 @@ async def asyncio_detailed(
     thousands of orphan tables don't blow up the response payload.
 
     Args:
-        limit (int | Unset): Maximum number of tables to return (PERF-11 bound). Default: 1000.
+        limit (int | Unset): Maximum number of tables to return. Capped at 5000. Default: 1000.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -218,7 +218,7 @@ async def asyncio(
     thousands of orphan tables don't blow up the response payload.
 
     Args:
-        limit (int | Unset): Maximum number of tables to return (PERF-11 bound). Default: 1000.
+        limit (int | Unset): Maximum number of tables to return. Capped at 5000. Default: 1000.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/api/datasets_metadata/list_dataset_relationships_datasets_dataset_id_relationships_get.py
+++ b/sdks/python/geolens/api/datasets_metadata/list_dataset_relationships_datasets_dataset_id_relationships_get.py
@@ -130,7 +130,8 @@ def sync_detailed(
     Args:
         dataset_id (UUID):
         skip (int | Unset): Number of relationships to skip. Default: 0.
-        limit (int | Unset): Maximum number of relationships to return (PERF-N16). Default: 100.
+        limit (int | Unset): Maximum number of relationships to return. Capped at 1000. Default:
+            100.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -173,7 +174,8 @@ def sync(
     Args:
         dataset_id (UUID):
         skip (int | Unset): Number of relationships to skip. Default: 0.
-        limit (int | Unset): Maximum number of relationships to return (PERF-N16). Default: 100.
+        limit (int | Unset): Maximum number of relationships to return. Capped at 1000. Default:
+            100.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -211,7 +213,8 @@ async def asyncio_detailed(
     Args:
         dataset_id (UUID):
         skip (int | Unset): Number of relationships to skip. Default: 0.
-        limit (int | Unset): Maximum number of relationships to return (PERF-N16). Default: 100.
+        limit (int | Unset): Maximum number of relationships to return. Capped at 1000. Default:
+            100.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -252,7 +255,8 @@ async def asyncio(
     Args:
         dataset_id (UUID):
         skip (int | Unset): Number of relationships to skip. Default: 0.
-        limit (int | Unset): Maximum number of relationships to return (PERF-N16). Default: 100.
+        limit (int | Unset): Maximum number of relationships to return. Capped at 1000. Default:
+            100.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/api/features/list_features_datasets_dataset_id_features_get.py
+++ b/sdks/python/geolens/api/features/list_features_datasets_dataset_id_features_get.py
@@ -152,8 +152,8 @@ def sync_detailed(
     Args:
         dataset_id (UUID):
         limit (int | Unset):  Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 from 1000. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The companion limit is capped at 200
+            per page, and a high offset is costly to serve. Default: 0.
         bbox (None | str | Unset): Bounding box: minx,miny,maxx,maxy
         include_geometry (bool | Unset): Include geometry in response Default: True.
 
@@ -206,8 +206,8 @@ def sync(
     Args:
         dataset_id (UUID):
         limit (int | Unset):  Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 from 1000. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The companion limit is capped at 200
+            per page, and a high offset is costly to serve. Default: 0.
         bbox (None | str | Unset): Bounding box: minx,miny,maxx,maxy
         include_geometry (bool | Unset): Include geometry in response Default: True.
 
@@ -253,8 +253,8 @@ async def asyncio_detailed(
     Args:
         dataset_id (UUID):
         limit (int | Unset):  Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 from 1000. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The companion limit is capped at 200
+            per page, and a high offset is costly to serve. Default: 0.
         bbox (None | str | Unset): Bounding box: minx,miny,maxx,maxy
         include_geometry (bool | Unset): Include geometry in response Default: True.
 
@@ -305,8 +305,8 @@ async def asyncio(
     Args:
         dataset_id (UUID):
         limit (int | Unset):  Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 from 1000. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The companion limit is capped at 200
+            per page, and a high offset is costly to serve. Default: 0.
         bbox (None | str | Unset): Bounding box: minx,miny,maxx,maxy
         include_geometry (bool | Unset): Include geometry in response Default: True.
 

--- a/sdks/python/geolens/api/ogc_features/get_collection_items_collections_dataset_id_items_get.py
+++ b/sdks/python/geolens/api/ogc_features/get_collection_items_collections_dataset_id_items_get.py
@@ -213,8 +213,8 @@ def sync_detailed(
         offset (int | Unset): Legacy offset-based pagination. Prefer `after_gid` keyset cursor
             (via the `next` link) — offset is retained for backward compatibility but is O(N) at high
             values. Default: 0.
-        after_gid (int | None | Unset): Keyset cursor: returns features with gid > after_gid.
-            Phase 269 H-24 primary pagination path; use the rel=next link for follow-up pages.
+        after_gid (int | None | Unset): Keyset cursor: returns features with gid > after_gid. The
+            preferred pagination path; use the rel=next link for follow-up pages.
         bbox (None | str | Unset): Bounding box: minx,miny,maxx,maxy
         datetime_ (None | str | Unset): OGC datetime interval: instant, start/end, ../end,
             start/..
@@ -298,8 +298,8 @@ def sync(
         offset (int | Unset): Legacy offset-based pagination. Prefer `after_gid` keyset cursor
             (via the `next` link) — offset is retained for backward compatibility but is O(N) at high
             values. Default: 0.
-        after_gid (int | None | Unset): Keyset cursor: returns features with gid > after_gid.
-            Phase 269 H-24 primary pagination path; use the rel=next link for follow-up pages.
+        after_gid (int | None | Unset): Keyset cursor: returns features with gid > after_gid. The
+            preferred pagination path; use the rel=next link for follow-up pages.
         bbox (None | str | Unset): Bounding box: minx,miny,maxx,maxy
         datetime_ (None | str | Unset): OGC datetime interval: instant, start/end, ../end,
             start/..
@@ -377,8 +377,8 @@ async def asyncio_detailed(
         offset (int | Unset): Legacy offset-based pagination. Prefer `after_gid` keyset cursor
             (via the `next` link) — offset is retained for backward compatibility but is O(N) at high
             values. Default: 0.
-        after_gid (int | None | Unset): Keyset cursor: returns features with gid > after_gid.
-            Phase 269 H-24 primary pagination path; use the rel=next link for follow-up pages.
+        after_gid (int | None | Unset): Keyset cursor: returns features with gid > after_gid. The
+            preferred pagination path; use the rel=next link for follow-up pages.
         bbox (None | str | Unset): Bounding box: minx,miny,maxx,maxy
         datetime_ (None | str | Unset): OGC datetime interval: instant, start/end, ../end,
             start/..
@@ -460,8 +460,8 @@ async def asyncio(
         offset (int | Unset): Legacy offset-based pagination. Prefer `after_gid` keyset cursor
             (via the `next` link) — offset is retained for backward compatibility but is O(N) at high
             values. Default: 0.
-        after_gid (int | None | Unset): Keyset cursor: returns features with gid > after_gid.
-            Phase 269 H-24 primary pagination path; use the rel=next link for follow-up pages.
+        after_gid (int | None | Unset): Keyset cursor: returns features with gid > after_gid. The
+            preferred pagination path; use the rel=next link for follow-up pages.
         bbox (None | str | Unset): Bounding box: minx,miny,maxx,maxy
         datetime_ (None | str | Unset): OGC datetime interval: instant, start/end, ../end,
             start/..

--- a/sdks/python/geolens/api/stac/get_collection_items_stac_collections_collection_id_items_get.py
+++ b/sdks/python/geolens/api/stac/get_collection_items_stac_collections_collection_id_items_get.py
@@ -129,9 +129,9 @@ def sync_detailed(
         datetime_ (None | str | Unset): OGC datetime interval
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200;
-            prefer the rel=next link for deep paging, which does not get more expensive as the offset
-            grows. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200; the
+            rel=next link advances one page at a time, and a high offset is costly to serve. Default:
+            0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -175,9 +175,9 @@ def sync(
         datetime_ (None | str | Unset): OGC datetime interval
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200;
-            prefer the rel=next link for deep paging, which does not get more expensive as the offset
-            grows. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200; the
+            rel=next link advances one page at a time, and a high offset is costly to serve. Default:
+            0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -216,9 +216,9 @@ async def asyncio_detailed(
         datetime_ (None | str | Unset): OGC datetime interval
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200;
-            prefer the rel=next link for deep paging, which does not get more expensive as the offset
-            grows. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200; the
+            rel=next link advances one page at a time, and a high offset is costly to serve. Default:
+            0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -260,9 +260,9 @@ async def asyncio(
         datetime_ (None | str | Unset): OGC datetime interval
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200;
-            prefer the rel=next link for deep paging, which does not get more expensive as the offset
-            grows. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200; the
+            rel=next link advances one page at a time, and a high offset is costly to serve. Default:
+            0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/api/stac/get_collection_items_stac_collections_collection_id_items_get.py
+++ b/sdks/python/geolens/api/stac/get_collection_items_stac_collections_collection_id_items_get.py
@@ -129,8 +129,9 @@ def sync_detailed(
         datetime_ (None | str | Unset): OGC datetime interval
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 and recommends keyset cursors via the rel=next link for deep paging. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200;
+            prefer the rel=next link for deep paging, which does not get more expensive as the offset
+            grows. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -174,8 +175,9 @@ def sync(
         datetime_ (None | str | Unset): OGC datetime interval
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 and recommends keyset cursors via the rel=next link for deep paging. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200;
+            prefer the rel=next link for deep paging, which does not get more expensive as the offset
+            grows. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -214,8 +216,9 @@ async def asyncio_detailed(
         datetime_ (None | str | Unset): OGC datetime interval
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 and recommends keyset cursors via the rel=next link for deep paging. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200;
+            prefer the rel=next link for deep paging, which does not get more expensive as the offset
+            grows. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -257,8 +260,9 @@ async def asyncio(
         datetime_ (None | str | Unset): OGC datetime interval
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 and recommends keyset cursors via the rel=next link for deep paging. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200;
+            prefer the rel=next link for deep paging, which does not get more expensive as the offset
+            grows. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/api/stac/search_get_stac_search_get.py
+++ b/sdks/python/geolens/api/stac/search_get_stac_search_get.py
@@ -151,7 +151,7 @@ def sync_detailed(
         collections (None | str | Unset): Comma-separated collection IDs
         ids (None | str | Unset): Comma-separated item IDs
         intersects (None | str | Unset): GeoJSON geometry for spatial intersection. At most 10000
-            characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon
+            characters, which fits a polygon of several hundred vertices at 2-decimal-place lat/lon
             coordinates.
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
@@ -204,7 +204,7 @@ def sync(
         collections (None | str | Unset): Comma-separated collection IDs
         ids (None | str | Unset): Comma-separated item IDs
         intersects (None | str | Unset): GeoJSON geometry for spatial intersection. At most 10000
-            characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon
+            characters, which fits a polygon of several hundred vertices at 2-decimal-place lat/lon
             coordinates.
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
@@ -252,7 +252,7 @@ async def asyncio_detailed(
         collections (None | str | Unset): Comma-separated collection IDs
         ids (None | str | Unset): Comma-separated item IDs
         intersects (None | str | Unset): GeoJSON geometry for spatial intersection. At most 10000
-            characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon
+            characters, which fits a polygon of several hundred vertices at 2-decimal-place lat/lon
             coordinates.
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
@@ -303,7 +303,7 @@ async def asyncio(
         collections (None | str | Unset): Comma-separated collection IDs
         ids (None | str | Unset): Comma-separated item IDs
         intersects (None | str | Unset): GeoJSON geometry for spatial intersection. At most 10000
-            characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon
+            characters, which fits a polygon of several hundred vertices at 2-decimal-place lat/lon
             coordinates.
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.

--- a/sdks/python/geolens/api/stac/search_get_stac_search_get.py
+++ b/sdks/python/geolens/api/stac/search_get_stac_search_get.py
@@ -150,13 +150,13 @@ def sync_detailed(
         datetime_ (None | str | Unset): OGC datetime interval
         collections (None | str | Unset): Comma-separated collection IDs
         ids (None | str | Unset): Comma-separated item IDs
-        intersects (None | str | Unset): GeoJSON geometry for spatial intersection. SEC-FU-05
-            (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier —
-            fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.
+        intersects (None | str | Unset): GeoJSON geometry for spatial intersection. At most 10000
+            characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon
+            coordinates.
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 from 1000 to bound deep-paging cost. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200; a
+            high offset is costly to serve. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -203,13 +203,13 @@ def sync(
         datetime_ (None | str | Unset): OGC datetime interval
         collections (None | str | Unset): Comma-separated collection IDs
         ids (None | str | Unset): Comma-separated item IDs
-        intersects (None | str | Unset): GeoJSON geometry for spatial intersection. SEC-FU-05
-            (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier —
-            fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.
+        intersects (None | str | Unset): GeoJSON geometry for spatial intersection. At most 10000
+            characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon
+            coordinates.
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 from 1000 to bound deep-paging cost. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200; a
+            high offset is costly to serve. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -251,13 +251,13 @@ async def asyncio_detailed(
         datetime_ (None | str | Unset): OGC datetime interval
         collections (None | str | Unset): Comma-separated collection IDs
         ids (None | str | Unset): Comma-separated item IDs
-        intersects (None | str | Unset): GeoJSON geometry for spatial intersection. SEC-FU-05
-            (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier —
-            fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.
+        intersects (None | str | Unset): GeoJSON geometry for spatial intersection. At most 10000
+            characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon
+            coordinates.
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 from 1000 to bound deep-paging cost. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200; a
+            high offset is costly to serve. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -302,13 +302,13 @@ async def asyncio(
         datetime_ (None | str | Unset): OGC datetime interval
         collections (None | str | Unset): Comma-separated collection IDs
         ids (None | str | Unset): Comma-separated item IDs
-        intersects (None | str | Unset): GeoJSON geometry for spatial intersection. SEC-FU-05
-            (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier —
-            fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.
+        intersects (None | str | Unset): GeoJSON geometry for spatial intersection. At most 10000
+            characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon
+            coordinates.
         limit (int | Unset): Maximum number of items returned. Values above 200 are clamped to
             200, per the STAC Item Search spec's clamp-don't-reject recommendation. Default: 10.
-        offset (int | Unset): Legacy offset-based pagination. Phase 269 H-24 lowered the max limit
-            to 200 from 1000 to bound deep-paging cost. Default: 0.
+        offset (int | Unset): Legacy offset-based pagination. The page size is capped at 200; a
+            high offset is costly to serve. Default: 0.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/sdks/python/geolens/models/basemap_config.py
+++ b/sdks/python/geolens/models/basemap_config.py
@@ -46,11 +46,10 @@ class BasemapConfig:
         background_color (None | str | Unset): Map canvas background color in #RRGGBB hex format, or null to use the
             basemap default.
         sublayer_overrides (BasemapConfigSublayerOverridesType0 | None | Unset): Per-sublayer style overrides keyed by
-            semantic sublayer ID (e.g. 'road', 'boundary', 'building'). Key set is opaque — unknown future sublayer IDs are
-            accepted without rejection. See CONTEXT.md D-01.
+            semantic sublayer ID (e.g. 'road', 'boundary', 'building'). The key set is opaque: a sublayer ID this release
+            does not know is accepted and stored rather than rejected.
         basemap_position (BasemapPosition | None | Unset): Whether the basemap renders above ('top') or below ('bottom',
-            default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no
-            migration).
+            default) the data layers. null/undefined loads as 'bottom' on the client.
         projection (BasemapProjection | None | Unset): Map projection: 'mercator' (default) or experimental 'globe'.
             null/undefined loads as 'mercator' on the client.
     """

--- a/sdks/python/geolens/models/commit_request.py
+++ b/sdks/python/geolens/models/commit_request.py
@@ -65,8 +65,9 @@ class CommitRequest:
             auth (None | ServiceAuthRequest | Unset): Structured credential for a protected service. Mutually exclusive with
                 the token field.
             strict_cog (bool | Unset): Raster only: reject a non-COG TIFF instead of converting it. False (the default)
-                converts the source to a COG during ingest; True fails the job before the conversion runs. Use it when ingesting
-                an externally-produced COG catalog where rewriting is undesirable. Default: False.
+                converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG.
+                Setting compression, resampling, nodata_override or srid_override still rewrites the file even when the strict
+                check passes, because each of those is applied by a conversion. Default: False.
     """
 
     title: str

--- a/sdks/python/geolens/models/commit_request.py
+++ b/sdks/python/geolens/models/commit_request.py
@@ -64,6 +64,9 @@ class CommitRequest:
                 x_column/y_column).
             auth (None | ServiceAuthRequest | Unset): Structured credential for a protected service. Mutually exclusive with
                 the token field.
+            strict_cog (bool | Unset): Raster only: reject a non-COG TIFF instead of converting it. False (the default)
+                converts the source to a COG during ingest; True fails the job before the conversion runs. Use it when ingesting
+                an externally-produced COG catalog where rewriting is undesirable. Default: False.
     """
 
     title: str
@@ -81,6 +84,7 @@ class CommitRequest:
     y_column: None | str | Unset = UNSET
     geom_column: None | str | Unset = UNSET
     auth: None | ServiceAuthRequest | Unset = UNSET
+    strict_cog: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -176,6 +180,8 @@ class CommitRequest:
         else:
             auth = self.auth
 
+        strict_cog = self.strict_cog
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -211,6 +217,8 @@ class CommitRequest:
             field_dict["geom_column"] = geom_column
         if auth is not UNSET:
             field_dict["auth"] = auth
+        if strict_cog is not UNSET:
+            field_dict["strict_cog"] = strict_cog
 
         return field_dict
 
@@ -369,6 +377,8 @@ class CommitRequest:
 
         auth = _parse_auth(d.pop("auth", UNSET))
 
+        strict_cog = d.pop("strict_cog", UNSET)
+
         commit_request = cls(
             title=title,
             summary=summary,
@@ -385,6 +395,7 @@ class CommitRequest:
             y_column=y_column,
             geom_column=geom_column,
             auth=auth,
+            strict_cog=strict_cog,
         )
 
         commit_request.additional_properties = d

--- a/sdks/python/geolens/models/layer_info.py
+++ b/sdks/python/geolens/models/layer_info.py
@@ -30,8 +30,8 @@ class LayerInfo:
         object_id_field (None | str | Unset): ArcGIS object ID field name, used for stable pagination.
         kind (LayerInfoKind | Unset): Backend-classified layer kind. 'vector' = point/line/polygon feature data.
             'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC,
-            or the layer declares coverage_format, bands, or a mediaType of image/*. Everything else, including a layer with
-            no geometry_type at all, defaults to 'vector'. Default: 'vector'.
+            the layer declares coverage_format or bands, or one of its links has a media type of image/*. Everything else,
+            including a layer with no geometry_type at all, defaults to 'vector'. Default: 'vector'.
     """
 
     name: str

--- a/sdks/python/geolens/models/layer_info.py
+++ b/sdks/python/geolens/models/layer_info.py
@@ -29,9 +29,9 @@ class LayerInfo:
         layer_id (int | None | str | Unset): Numeric or string layer ID used by ArcGIS services.
         object_id_field (None | str | Unset): ArcGIS object ID field name, used for stable pagination.
         kind (LayerInfoKind | Unset): Backend-classified layer kind. 'vector' = point/line/polygon feature data.
-            'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type
-            contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image/*. Everything else
-            (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'. Default: 'vector'.
+            'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC,
+            or the layer declares coverage_format, bands, or a mediaType of image/*. Everything else, including a layer with
+            no geometry_type at all, defaults to 'vector'. Default: 'vector'.
     """
 
     name: str

--- a/sdks/python/geolens/models/map_update.py
+++ b/sdks/python/geolens/models/map_update.py
@@ -40,8 +40,8 @@ class MapUpdate:
         visibility (MapVisibility | None | Unset): private, internal, or public
         layers (list[MapLayerInput] | None | Unset): Full replacement layer list (max 200 layers)
         plugins (list[str] | None | Unset): Enabled plugin IDs, e.g. ['measurement']
-        legend_title (None | str | Unset): Custom map-level legend title. Null/empty leaves the legend without a heading
-            override (ENH-06).
+        legend_title (None | str | Unset): Custom map-level legend title. Null or empty leaves the legend without a
+            heading override. At most 120 characters.
     """
 
     name: None | str | Unset = UNSET

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -2334,7 +2334,7 @@ export type CommitRequest = {
     /**
      * Strict Cog
      *
-     * Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest; True fails the job before the conversion runs. Use it when ingesting an externally-produced COG catalog where rewriting is undesirable.
+     * Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG. Setting compression, resampling, nodata_override or srid_override still rewrites the file even when the strict check passes, because each of those is applied by a conversion.
      */
     strict_cog?: boolean;
 };

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -1159,13 +1159,13 @@ export type BasemapConfig = {
     /**
      * Sublayer Overrides
      *
-     * Per-sublayer style overrides keyed by semantic sublayer ID (e.g. 'road', 'boundary', 'building'). Key set is opaque — unknown future sublayer IDs are accepted without rejection. See CONTEXT.md D-01.
+     * Per-sublayer style overrides keyed by semantic sublayer ID (e.g. 'road', 'boundary', 'building'). The key set is opaque: a sublayer ID this release does not know is accepted and stored rather than rejected.
      */
     sublayer_overrides?: {
         [key: string]: SublayerOverride;
     } | null;
     /**
-     * Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no migration).
+     * Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client.
      */
     basemap_position?: BasemapPosition | null;
     /**
@@ -5163,7 +5163,7 @@ export type LayerInfo = {
     /**
      * Kind
      *
-     * Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image*. Everything else (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'.
+     * Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC, or the layer declares coverage_format, bands, or a mediaType of image*. Everything else, including a layer with no geometry_type at all, defaults to 'vector'.
      */
     kind?: 'vector' | 'raster';
 };
@@ -6391,7 +6391,7 @@ export type MapUpdate = {
     /**
      * Legend Title
      *
-     * Custom map-level legend title. Null/empty leaves the legend without a heading override (ENH-06).
+     * Custom map-level legend title. Null or empty leaves the legend without a heading override. At most 120 characters.
      */
     legend_title?: string | null;
 };
@@ -15703,7 +15703,7 @@ export type GetCollectionItemsCollectionsDatasetIdItemsGetData = {
         /**
          * After Gid
          *
-         * Keyset cursor: returns features with gid > after_gid. Phase 269 H-24 primary pagination path; use the rel=next link for follow-up pages.
+         * Keyset cursor: returns features with gid > after_gid. The preferred pagination path; use the rel=next link for follow-up pages.
          */
         after_gid?: number | null;
         /**
@@ -18000,7 +18000,7 @@ export type ListFeaturesDatasetsDatasetIdFeaturesGetData = {
         /**
          * Offset
          *
-         * Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 from 1000.
+         * Legacy offset-based pagination. The companion limit is capped at 200 per page, and a high offset is costly to serve.
          */
         offset?: number;
         /**
@@ -19261,7 +19261,7 @@ export type ListDatasetRelationshipsDatasetsDatasetIdRelationshipsGetData = {
         /**
          * Limit
          *
-         * Maximum number of relationships to return (PERF-N16).
+         * Maximum number of relationships to return. Capped at 1000.
          */
         limit?: number;
     };
@@ -20619,7 +20619,7 @@ export type DiscoverTablesIngestDiscoverGetData = {
         /**
          * Limit
          *
-         * Maximum number of tables to return (PERF-11 bound).
+         * Maximum number of tables to return. Capped at 5000.
          */
         limit?: number;
     };
@@ -27316,7 +27316,7 @@ export type GetCollectionItemsStacCollectionsCollectionIdItemsGetData = {
         /**
          * Offset
          *
-         * Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 and recommends keyset cursors via the rel=next link for deep paging.
+         * Legacy offset-based pagination. The page size is capped at 200; prefer the rel=next link for deep paging, which does not get more expensive as the offset grows.
          */
         offset?: number;
     };
@@ -27529,7 +27529,7 @@ export type SearchGetStacSearchGetData = {
         /**
          * Intersects
          *
-         * GeoJSON geometry for spatial intersection. SEC-FU-05 (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier — fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.
+         * GeoJSON geometry for spatial intersection. At most 10000 characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon coordinates.
          */
         intersects?: string | null;
         /**
@@ -27541,7 +27541,7 @@ export type SearchGetStacSearchGetData = {
         /**
          * Offset
          *
-         * Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 from 1000 to bound deep-paging cost.
+         * Legacy offset-based pagination. The page size is capped at 200; a high offset is costly to serve.
          */
         offset?: number;
     };

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -5163,7 +5163,7 @@ export type LayerInfo = {
     /**
      * Kind
      *
-     * Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC, or the layer declares coverage_format, bands, or a mediaType of image*. Everything else, including a layer with no geometry_type at all, defaults to 'vector'.
+     * Backend-classified layer kind. 'vector' = point/line/polygon feature data. 'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC, the layer declares coverage_format or bands, or one of its links has a media type of image*. Everything else, including a layer with no geometry_type at all, defaults to 'vector'.
      */
     kind?: 'vector' | 'raster';
 };
@@ -27316,7 +27316,7 @@ export type GetCollectionItemsStacCollectionsCollectionIdItemsGetData = {
         /**
          * Offset
          *
-         * Legacy offset-based pagination. The page size is capped at 200; prefer the rel=next link for deep paging, which does not get more expensive as the offset grows.
+         * Legacy offset-based pagination. The page size is capped at 200; the rel=next link advances one page at a time, and a high offset is costly to serve.
          */
         offset?: number;
     };
@@ -27529,7 +27529,7 @@ export type SearchGetStacSearchGetData = {
         /**
          * Intersects
          *
-         * GeoJSON geometry for spatial intersection. At most 10000 characters, which fits roughly a 150-vertex polygon at 2-decimal-place lat/lon coordinates.
+         * GeoJSON geometry for spatial intersection. At most 10000 characters, which fits a polygon of several hundred vertices at 2-decimal-place lat/lon coordinates.
          */
         intersects?: string | null;
         /**

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -2331,6 +2331,12 @@ export type CommitRequest = {
      * Structured credential for a protected service. Mutually exclusive with the token field.
      */
     auth?: ServiceAuthRequest | null;
+    /**
+     * Strict Cog
+     *
+     * Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest; True fails the job before the conversion runs. Use it when ingesting an externally-produced COG catalog where rewriting is undesirable.
+     */
+    strict_cog?: boolean;
 };
 
 /**


### PR DESCRIPTION
Two changes to the same published contract, kept as separate commits because the reasoning does not overlap. They are in one PR because both regenerate the same four artifacts.

Closes #1949. For #1946 this closes the **published half only** — the detector question (whether #1934's gate grows a string-literal mode) stays open, and so do the seventeen internal sites.

---

## Commit 1 — `strict_cog` was unsettable (#1949)

`RasterCommitRequest` declares `strict_cog`; the flat `CommitRequest` the commit route publishes as its body did not. Pydantic ignores unknown keys by default, so a caller sending `strict_cog` had it dropped at body validation before `_pick_commit_subclass(job)` ever re-validated. The worker's `um.get("strict_cog")` therefore read the default on every request, and a non-COG GeoTIFF was always converted.

### Evidence the omission was an oversight, not a decision

- The commit that introduced the field, `0baf8e1f8` (`feat(1076-05): add strict_cog field to RasterCommitRequest`), ends its message with *"Wire contract for ING-07 / P2-09"* — but it touched only the subclass. `CommitRequest`'s own docstring is the thing that says *"This flat class is the wire contract, not an implementation detail."* The commit stated the intent and then edited the wrong model.
- Its three sibling raster-only fields — `compression`, `resampling`, `nodata_override` — are all mirrored into the flat union with byte-identical descriptions. `strict_cog` is the only raster field that is not.
- `_enforce_strict_cog`'s own docstring says *"When the user opted in via `RasterCommitRequest.strict_cog=True`"*. The worker was written expecting an opt-in that no caller could perform.
- `git log -S strict_cog` over `schemas.py` returns exactly two commits (the initial import and `0baf8e1f8`). Nothing in the history records a decision to withhold it.

### Nothing downstream depends on the current `False`

- `commit.model_dump(exclude={"token", "auth"})` already writes `strict_cog: false` into `user_metadata` for every raster commit, because the key is in `RasterCommitRequest.model_fields`. The key is present in the JSONB today; only its value changes.
- The default stays `False`, so no existing caller's behaviour moves. Both readers (`tasks_raster.py`, `tasks_raster_replace.py`) do `bool(um.get("strict_cog"))`, which is unchanged for an absent key and for `false`.
- No frontend, CLI, SDK, MCP or manifest call site references the field (`grep -rn strict_cog` over `backend frontend/src sdks cli mcp` returns only the schema, the two worker readers, the helper, and their tests).

### Placement — this deviates from the brief, deliberately

The brief asked for the field "alongside the other raster fields". I appended it after `auth` instead. `openapi-python-client` gives every model field a positional slot in declaration order, so inserting it beside `nodata_override` would move the slots of `layer_name`, `x_column`, `y_column`, `geom_column` and `auth` in the generated Python SDK — the exact regression `TestAuthIsDeclaredLast` in `test_service_auth_contract_1746.py` exists to prevent (#1760). Appending cannot move a slot that already exists. The generated diff confirms it: `strict_cog: bool | Unset = False` lands after `auth`, and no other line in the constructor moves.

`CommitRequest.auth`'s existing comment said "Declared last for the positional-slot reason above"; that clause is now "Appended, never inserted, for the positional-slot reason above", which is the invariant that was actually meant.

### Test

`test_strict_cog_sent_by_a_caller_reaches_the_worker`, parametrised over `True`/`False`, posts to `POST /ingest/commit/{job_id}` on a raster job and asserts `job.user_metadata["strict_cog"] is sent` — the end state the worker reads, not the schema shape.

Negative control, run against `origin/main`'s `schemas.py` with everything else from this branch:

```
FAILED tests/test_ingest.py::...::test_strict_cog_sent_by_a_caller_reaches_the_worker[True]
1 failed, 1 passed
```

The `[False]` case passes either way, which is the point: the defect was invisible to any test that did not send `true`.

Also added: `test_the_union_omits_no_subclass_field` (the guard #1948 pins as `omitted == {"strict_cog"}`; if #1948 lands first these collapse into one) and `test_the_union_declares_its_fields_in_the_published_order`, which pins the positional order so the next person cannot insert.

The field's description is written without the `ING-07 / P2-09` marker the subclass carried, and the subclass now states the same text — publishing the field must not publish a new unresolvable id. That is why this one rewrite is in commit 1 rather than commit 2: the string is unpublished today (0 occurrences of either token in `openapi.json`) and only becomes published because of this change.

---

## Commit 2 — published descriptions cite the constraint, not a tracker id (#1946)

### On the count

The brief said ten, the issue said ten, #1934's body said "nine real markers plus that URL", the sibling lane's artifact-side sweep said twelve instances in eleven strings, and the coordinator's own sweep said twenty-four across nineteen. **The number moves with the token vocabulary, so the enumeration below is the deliverable, not a count.**

My rule, stated so it can be re-derived: #1934's `MARKER_RE` (`\b[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*-[A-Z]?[0-9]+[A-Z0-9]*\b`), its `TECHNICAL_VOCABULARY` exemptions, its `ANCHOR_RE` and its two-line `ANCHOR_WINDOW` — run over the exact complement of its scope, i.e. string literals that are **not** documentation units — then restricted to literals reaching a `Field`/`Query`/`Path`/`Body`/`Header`/`Form` `description=`. That yields **eleven strings** published today, plus the unpublished `strict_cog` one handled in commit 1.

Cross-check from the artifact side, which is the direction that does not depend on the vocabulary. #1934's body states "21 token occurrences in `openapi.json`" for the published set. Walking the pre-change document by path rather than counting matches, those 21 split:

```
20  Field/Query description strings                    <- the eleven below
 1  components/schemas/SublayerOverride/description     <- D-01, a class docstring
```

So the eleven strings account for 20, and the 21st is the docstring the #1934 gate already covers and has frozen. That is the sharp form of the boundary: twenty of the twenty-one published marker occurrences sit exactly where the detector cannot look, and the one it does cover is the one left in place.

The residue after this change is the check on that arithmetic — `D-01` and `CONTEXT.md` each still appear once in the regenerated artifacts, and that surviving occurrence is the 21st. Had all 21 come from the eleven strings, the artifacts would now read zero.

(An earlier revision of this description attributed all 21 to the eleven strings. That was off by one, caught by #1934's lane on review.)

Line numbers are my own; the sibling lane retracted its earlier ones (its script added an offset into a joined string value, which does not map to physical lines for an implicitly-concatenated `description=(...)`) and confirmed mine.

### The eleven, before and after

| # | Site | Token(s) |
|---|---|---|
| 1 | `modules/catalog/datasets/api/router_metadata.py:425` | `PERF-N16` |
| 2 | `modules/catalog/features/router.py:339` | `H-24` |
| 3 | `modules/catalog/maps/schemas.py:564` | `D-01` |
| 4 | `modules/catalog/maps/schemas.py:572` | `UX-03` |
| 5 | `modules/catalog/maps/schemas.py:965` | `ENH-06` |
| 6 | `modules/catalog/sources/schemas.py:190,193` | `CLASS-07`, `D-09`, `D-05` |
| 7 | `processing/ingest/router.py:1696` | `PERF-11` |
| 8 | `standards/ogc/router.py:691` | `H-24` |
| 9 | `standards/stac/router.py:1001` | `H-24` |
| 10 | `standards/stac/router.py:1657` | `SEC-FU-05` |
| 11 | `standards/stac/router.py:1675` | `H-24` |

**1.** `Maximum number of relationships to return (PERF-N16).`
→ `Maximum number of relationships to return. Capped at 1000.` *(the declared `le=1000`)*

**2.** `Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to 200 from 1000.`
→ `Legacy offset-based pagination. The companion limit is capped at 200 per page, and a high offset is costly to serve.` *(the cap the sentence was really about is on the sibling `limit`, `le=200`; this handler has no keyset path, so none is promised)*

**3.** `Per-sublayer style overrides keyed by semantic sublayer ID (e.g. 'road', 'boundary', 'building'). Key set is opaque — unknown future sublayer IDs are accepted without rejection. See CONTEXT.md D-01.`
→ `Per-sublayer style overrides keyed by semantic sublayer ID (e.g. 'road', 'boundary', 'building'). The key set is opaque: a sublayer ID this release does not know is accepted and stored rather than rejected.` *(`CONTEXT.md` does not exist anywhere in this repository, let alone for a schema consumer)*

**4.** `Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client. Phase 1051 UX-03 (jsonb-additive, no migration).`
→ `Whether the basemap renders above ('top') or below ('bottom', default) the data layers. null/undefined loads as 'bottom' on the client.` *("jsonb-additive, no migration" is a storage note with nothing in it for a caller)*

**5.** `Custom map-level legend title. Null/empty leaves the legend without a heading override (ENH-06).`
→ `Custom map-level legend title. Null or empty leaves the legend without a heading override. At most 120 characters.` *(the declared `max_length=120`, which neither SDK generator emits as a constraint)*

**6.** `Backend-classified layer kind. 'vector' = … Per Phase 1057 CLASS-07 D-09. Classification rule: raster IFF geometry_type contains 'raster', adapter is STAC, or layer has coverage_format/bands/mediaType:image/*. Everything else (including geometry_type=None after D-05 ogrinfo drop) defaults to 'vector'.`
→ `Backend-classified layer kind. 'vector' = … 'raster' = imagery/coverage. Classified as 'raster' when geometry_type contains 'raster', the adapter is STAC, the layer declares coverage_format or bands, or one of its links has a media type of image/*. Everything else, including a layer with no geometry_type at all, defaults to 'vector'.` *(the whole rule is kept; `D-05`'s "after the ogrinfo drop" is history, and the reader only needs the current behaviour)*

**7.** `Maximum number of tables to return (PERF-11 bound).`
→ `Maximum number of tables to return. Capped at 5000.` *(the declared `le=5000`)*

**8.** `Keyset cursor: returns features with gid > after_gid. Phase 269 H-24 primary pagination path; use the rel=next link for follow-up pages.`
→ `Keyset cursor: returns features with gid > after_gid. The preferred pagination path; use the rel=next link for follow-up pages.`

**9.** `Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to {_STAC_MAX_LIMIT} and recommends keyset cursors via the rel=next link for deep paging.`
→ `Legacy offset-based pagination. The page size is capped at {_STAC_MAX_LIMIT}; the rel=next link advances one page at a time, and a high offset is costly to serve.` *(corrected in the third commit — see below)*

**10.** `GeoJSON geometry for spatial intersection. SEC-FU-05 (sec-audit-20260519.md): max_length=10000 caps a multi-megabyte GeoJSON DoS-amplifier — fits ~150-vertex polygons at 2-decimal-place lat/lon coordinates.`
→ `GeoJSON geometry for spatial intersection. At most 10000 characters, which fits a polygon of several hundred vertices at 2-decimal-place lat/lon coordinates.` *(the old ~150 figure was inherited and wrong — see below)*
This is the one judgement call worth flagging. `sec-audit-20260519.md` at least names a document, so it is less indefensible than a bare id — but that document is not in the repository either, and the old text also published the threat model the cap defends against, which a generated SDK docstring is not the place for. The useful half (the length and what fits in it) is kept.

**11.** `Legacy offset-based pagination. Phase 269 H-24 lowered the max limit to {_STAC_MAX_LIMIT} from 1000 to bound deep-paging cost.`
→ `Legacy offset-based pagination. The page size is capped at {_STAC_MAX_LIMIT}; a high offset is costly to serve.`

### The false positives, deliberately left

| Site | Token | Why |
|---|---|---|
| `api/main.py:862` | `LICENSE-2` | the Apache licence URL, `…/licenses/LICENSE-2.0` |
| `modules/admin/schemas.py:79,179,205` and `modules/auth/schemas.py:51,316` | `UTF-8` ×5 | an encoding name in a password-policy sentence |
| `processing/ingest/manifest_schemas.py:103` | `SHA-256` | a hash algorithm |

Two more excluded for reasons other than being false positives, both verified rather than assumed:

- `modules/catalog/maps/schemas.py:482` — `CORR-01` is already anchored: `(builder-audit #338 CORR-01)` carries its `#338` on the same physical line, inside the two-line window.
- `modules/auth/schemas.py:28` — `GH-1302` is an anchor form in `ANCHOR_RE`, not a marker.

### Scope boundary — string literals only

The same tokens also reach `openapi.json` through **documentation units**, which are a different class and a different PR. Located precisely by walking the document rather than the source:

```
components/schemas/SublayerOverride/description        D-14, CONTEXT.md, D-01   (class docstring)
components/schemas/OgImageUploadRequest/description    D-03                     (class docstring)
paths//audit/…/column-ddl/get/description              FU-08                    (route docstring)
paths//auth/oauth/…/callback/get/description           H-27                     (route docstring)
paths//auth/oauth/…/login/get/description              H-27                     (route docstring)
paths//maps/…/layers/bulk-delete/post/description      PERF-03                  (route docstring)
```

Those are inside #1934's gate and frozen in its `UNANCHORED_MARKER_DEBT` map. Whoever picks them up must lower the map entries for `maps/schemas.py`, `datasets/api/router_audit.py`, `auth/oauth/router.py` and `maps/router.py` in the same commit — the map is exact in both directions, so removing a marker without lowering the number fails the gate. It fails loudly and names the number to write. #1934 is reviewed and queued, so editing any of them would move an entry in a map that is already reviewed and turn it red. **This PR touches no docstring in any of those files.** That is also why `D-01` and `CONTEXT.md` still appear once each in the regenerated artifacts: the surviving occurrence is `SublayerOverride`'s docstring, left to sequence after #1934.

Hand-written frontend comments (`frontend/src/types/api.ts`, `components/map-plugins/types.ts`) carry `ENH-06`, `UX-03` and `CLASS-07` too. They are internal source comments outside both #1934's scope (`backend/app/` only) and this issue's published half.

### Verified empty afterwards

Re-running the complement detector over `backend/app/` reports **0 published sites** (down from 12 including `strict_cog`); the 15 internal sites are untouched. Every rewritten token is at 0 word-boundary occurrences across all four artifacts: `PERF-N16`, `H-24`, `UX-03`, `ENH-06`, `CLASS-07`, `D-09`, `D-05`, `PERF-11`, `SEC-FU-05`, `ING-07`, `P2-09`.

---

## Third commit — three claims corrected after review (`da5007d6e`)

Review caught that rewrite **9** promised a property the STAC collection-items route does not have. `rel=next` there is `_stac_page_url(base_href, offset + limit, limit, ...)` and the query applies `stmt.offset(offset)`, so every next page is a deeper scan. The "does not get more expensive" claim is true of the **OGC Features** route, which has a real `WHERE gid > :after_gid` cursor and builds its next link with `_page_url_keyset`; it was transplanted from there. Verified both sites before changing anything.

Re-reading the rest against the code rather than against the old text found two more, both inherited from the strings being replaced rather than introduced by the de-tokenising:

- **10** claimed the 10000-character cap "fits roughly a 150-vertex polygon at 2-decimal-place lat/lon coordinates". Measured by construction: the cap admits **585** vertices at 3-digit negative coordinates, **663** at 2-digit ones, **829** at 1-digit. Low by about a factor of four. Now "several hundred", which holds across the whole coordinate range.
- **6** described the image signal as "a mediaType of image/\*". `classify_layer_kind` reads `layer["links"]`, requires a list, and matches an entry whose `type` starts with `image/`. There is no `mediaType` key in the rule. Now names the links.

The general lesson, which is why this was worth a commit rather than a squash: removing an internal id from a published description means **writing new published documentation**, and it deserves the same verification as new code. The old text was unhelpful; a fluent replacement that is false is worse.

### Every rewrite re-verified against its implementation

| # | Claim | Checked against |
|---|---|---|
| 1 | capped at 1000 | `le=1000` on the `limit` Query |
| 2 | limit capped at 200, high offset costly | `le=200`; route exposes no `after_gid`, service takes the `LIMIT + OFFSET` branch |
| 3 | key set opaque, unknown ID stored not rejected | `dict[str, SublayerOverride]`, no key validator on the model |
| 4 | null/undefined loads as 'bottom' | `UnifiedStackPanel.tsx:373` default parameter `basemapPosition = 'bottom'`; every other site tests `=== 'top'` |
| 5 | at most 120 characters | `max_length=120` |
| 6 | classification rule | `classify_layer_kind` rules 1-5, **corrected** |
| 7 | capped at 5000 | `le=5000` |
| 8 | preferred pagination path, rel=next | real keyset: `WHERE gid > :after_gid`, `_page_url_keyset` builds rel=next |
| 9 | cap, rel=next advances one page, offset costly | `_stac_page_url(offset + limit)`, `stmt.offset`, **corrected** |
| 10 | at most 10000 chars, several hundred vertices | `max_length=10000`; vertex figure measured, **corrected** |
| 11 | cap, high offset costly | `_STAC_MAX_LIMIT = 200`, offset scan — already correct |

## Fourth commit — the mirror, and strict mode's real guarantee (`a1463fac9`)

Two consequences of exposing the flag at all, both caught in review round 2.

**`frontend/src/types/api.ts` is hand-maintained, not generated,** and `commitImport()` takes `CommitImportRequest` from it. That interface carried `compression`, `resampling` and `nodata_override` but not `strict_cog`, so an in-repo TypeScript caller passing the flag got an excess-property error and the option this branch exists to publish was unreachable from the app. Exposing an option no in-repo caller can pass is not exposing it, so this is #1949's job. Added beside its three raster siblings — the mirror keys by name, so none of the positional-slot constraint that puts the field last in the Python SDK applies here. `npm run types:check` and `npm run typecheck` both pass.

**The description over-promised, and I verified that from the source rather than taking it.** `check_and_prepare_cog` (`backend/app/processing/raster/cog.py:663`) computes:

```python
has_custom_opts = (compression != "DEFLATE" or resampling is not None
                   or nodata is not None or assign_crs is not None)
if not has_custom_opts:
    compliant, reason = check_cog_compliance(file_path, expected_compression=compression)
    if compliant:
        return file_path, "verified"
# falls through to convert_to_cog(...) -> "converted"
```

The compliance check is consulted **only** when no custom option is set; otherwise the file is converted unconditionally. `_enforce_strict_cog` runs earlier in `tasks_raster.py` and against the same `user_compression`, so a genuinely compliant LZW COG committed with `compression="LZW"` passes the strict gate and is then rewritten anyway. `resampling` and `nodata_override` reach the predicate directly, and `srid_override` reaches it as `assign_crs` — `resolve_crs_assignment` returns non-`None` only when an override was supplied (`cog.py:155`), so those four published fields are exactly the triggers, no more and no fewer.

So the old sentence "Use it when ingesting an externally-produced COG catalog where rewriting is undesirable" promised something the pipeline does not deliver. The description now reads:

> "Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG. Setting compression, resampling, nodata_override or srid_override still rewrites the file even when the strict check passes, because each of those is applied by a conversion."

**The conversion behaviour is deliberately untouched.** Whether strict mode should bypass conversion, or refuse options that require one, is a product call and a different review surface. It predates this branch and is newly *reachable* only because callers can now set the flag — the same shape as #1940 and #1950. Being filed separately. What this PR owes is a description that does not ship a fresh instance of the exact defect it exists to correct.

## Artifacts regenerated

All four, in the required order (`dump_openapi.py` → `make sdks` → `npm run types:generate`; each downstream generator reads `backend/openapi.json`, and the frontend gate lives in a different CI job from the SDK drift gate):

1. `backend/openapi.json`
2. `sdks/python/` — 10 modules across the two commits
3. `sdks/typescript/src/client/types.gen.ts`
4. `frontend/src/types/api.generated.ts`

No generated file was hand-edited.

## LOC caps

Three touched modules carry an exact `_MODULE_LOC_CAPS` entry. All three are byte-for-byte the same length after the rewrite, so no cap moves in either direction:

```
modules/catalog/maps/schemas.py   actual=1465  cap=1465
processing/ingest/router.py       actual=2180  cap=2180
standards/stac/router.py          actual=1869  cap=1869
```

## Interaction with #1948

#1948 (open at the time of writing) touches `CommitRequest.token` and `ServiceCommitRequest` in the same file, and adds `test_the_union_omits_only_strict_cog`. This branch touches neither its `token` hunk nor its docstring, and its pinned set becomes `set()` — `test_the_union_omits_no_subclass_field` here is the same assertion, so whichever lands second should collapse the two into one test rather than keeping both.

## Verification

All post-commit, since the drift gates compare against `HEAD`. Every pytest run gated on pytest's own exit status.

```
$ cd backend && uv run ruff check . && uv run ruff format --check .
All checks passed! / 1187 files already formatted                          exit 0

$ pytest tests/test_layering.py tests/test_sdks_round_trip.py \
         tests/test_api_contract_openapi.py tests/test_openapi_overlay_boundary.py \
         tests/test_openapi_property_order.py tests/test_commit_request_schemas.py \
         tests/test_ingest.py -q
165 passed, 2 skipped                                                       exit 0

$ pytest tests/test_ogc_features.py tests/test_ogc_discovery.py tests/test_features_crud.py \
         tests/test_maps.py tests/test_fk_relationships.py \
         tests/test_stac_search_validation.py tests/test_stac_search_dos_sec023.py -q
289 passed                                                                  exit 0

$ pytest tests/test_strict_cog_enforcement.py tests/test_service_auth_contract_1746.py -q
(within the 147-passed run above)                                           exit 0

$ JWT_SECRET_KEY=… PYTHONPATH=. uv run python scripts/dump_openapi.py --check
(no drift)                                                                  exit 0

$ make sdks-check
7 SDK tests pass, no drift                                                  exit 0

$ cd frontend && npm run types:check
(no drift)                                                                  exit 0

$ make cli-test
8 passed, 2 skipped                                                         exit 0
```

Re-run after rebasing onto `a3f21abe5`: `dump_openapi.py --check` exit 0, `test_layering.py + test_commit_request_schemas.py + test_sdks_round_trip.py` 89 passed exit 0, and all three LOC caps still exact.
