### PR TITLE
fix(layers): validate geometry_type at the sink, and mark three false-positive SQL alerts

### DIFF
--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -974,6 +974,7 @@ async def update_feature(
     sql = _update_capturing_prior_bounds(
         get_catalog_port().quote_table(table_name), sets
     )
+    # codeql[py/sql-injection] fix(#1615): every assigned column is an existing column_info name matching _COLUMN_NAME_RE; values travel as bound params; table via quote_table
     result = await db.execute(text(sql).bindparams(**params))
     prior = result.first()
     if prior is None:

--- a/backend/app/modules/catalog/layers/service.py
+++ b/backend/app/modules/catalog/layers/service.py
@@ -16,6 +16,7 @@ from app.modules.catalog.datasets.domain.models import AttributeMetadata, Datase
 from app.modules.catalog.datasets.domain.service import create_dataset
 from app.modules.catalog.layers.schemas import (
     ALLOWED_COLUMN_TYPES,
+    ALLOWED_GEOMETRY_TYPES,
     COLUMN_NAME_RE,
     RESERVED_COLUMNS,
 )
@@ -80,6 +81,12 @@ async def create_layer(
     reader_role = tenant_reader_role(tenant_id)
     table_ref = get_catalog_port().quote_table(table_name, schema=data_schema)
 
+    # fix(#1988): checked HERE, not only in the request schema. This value is
+    # interpolated into DDL, and the schema validator only guards the one route
+    # that reaches this function today.
+    if geometry_type not in ALLOWED_GEOMETRY_TYPES:
+        raise ValueError(f"Geometry type {geometry_type!r} is not allowed.")
+
     col_defs = "gid SERIAL PRIMARY KEY, geom geometry({geom_type}, 4326)".format(
         geom_type=geometry_type,
     )
@@ -91,6 +98,7 @@ async def create_layer(
             col_defs += f", {_qcol(col.name)} {pg_type}"
 
     ddl = f"CREATE TABLE {table_ref} ({col_defs})"
+    # codeql[py/sql-injection] fix(#1615): geometry_type is allowlisted above; column names match COLUMN_NAME_RE and types come from ALLOWED_COLUMN_TYPES; table via quote_table
     await session.execute(text(ddl))
 
     # Adds geom_4326 and its index; source is already 4326, so the copy needs
@@ -358,6 +366,7 @@ async def alter_column_type(
         f"ALTER TABLE {table_ref} ALTER COLUMN {_qcol(column_name)} TYPE {pg_type} "
         f"USING {_qcol(column_name)}::{pg_type}"
     )
+    # codeql[py/sql-injection] fix(#1615): column exists on the layer and is quoted by _qcol; pg_type comes from ALLOWED_COLUMN_TYPES; table via quote_table
     await session.execute(text(ddl))
 
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)
@@ -413,6 +422,7 @@ async def drop_column(
 
     table_ref = get_catalog_port().quote_table(dataset.table_name)
     ddl = f"ALTER TABLE {table_ref} DROP COLUMN {_qcol(column_name)}"
+    # codeql[py/sql-injection] fix(#1615): column matches COLUMN_NAME_RE, is not reserved, exists on the layer, and is quoted by _qcol; table via quote_table
     await session.execute(text(ddl))
 
     column_info = await get_catalog_port().get_column_info(session, dataset.table_name)

--- a/backend/app/modules/catalog/layers/service.py
+++ b/backend/app/modules/catalog/layers/service.py
@@ -83,8 +83,10 @@ async def create_layer(
 
     # fix(#1988): checked HERE, not only in the request schema. This value is
     # interpolated into DDL, and the schema validator only guards the one route
-    # that reaches this function today.
-    if geometry_type not in ALLOWED_GEOMETRY_TYPES:
+    # that reaches this function today. Case-insensitive because direct callers
+    # pass the PostGIS spelling ("POINT") while the route passes the schema's
+    # ("Point"); both reach the same six tokens.
+    if geometry_type.upper() not in {t.upper() for t in ALLOWED_GEOMETRY_TYPES}:
         raise ValueError(f"Geometry type {geometry_type!r} is not allowed.")
 
     col_defs = "gid SERIAL PRIMARY KEY, geom geometry({geom_type}, 4326)".format(

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -6237,7 +6237,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # prove only the rows in hand. That reasoning is most of the added lines.
     # Cap 1507 -> 1541, exact.
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1560, exact.
-    "backend/app/modules/catalog/features/service.py": 1388,
+    # fix(#1988): +1. The `# codeql[py/sql-injection]` marker above the
+    # feature-update sink. Cap 1388 -> 1389, exact.
+    "backend/app/modules/catalog/features/service.py": 1389,
 }
 
 

--- a/backend/tests/test_layers.py
+++ b/backend/tests/test_layers.py
@@ -471,3 +471,24 @@ class TestCreateLayerAllGeometryTypes:
 
         # Cleanup
         await _cleanup_layer(client, admin_auth_header, data["id"], name)
+
+
+@pytest.mark.anyio
+async def test_create_layer_service_rejects_unallowlisted_geometry_type(
+    test_db_session,
+):
+    """fix(#1988): the guard is on the service, not only the request schema.
+
+    ``geometry_type`` is interpolated into the CREATE TABLE statement. The
+    schema validator only covers the one route that reaches this function
+    today, so a second caller would otherwise interpolate an unchecked string.
+    """
+    from app.modules.catalog.layers.service import create_layer
+
+    with pytest.raises(ValueError, match="is not allowed"):
+        await create_layer(
+            test_db_session,
+            name="guard probe",
+            geometry_type="Point); DROP TABLE catalog.datasets; --",
+            created_by=uuid.uuid4(),
+        )


### PR DESCRIPTION
## What

Four `py/sql-injection` alerts are open on main. All four sit at sites that were dismissed before; the comment trim in #1986 moved their lines, and code-scanning dismissals are pinned to a location, so they reopened. I read each one rather than re-dismissing the set, and they are not all the same.

**Three are genuine false positives** and now carry a `# codeql[py/sql-injection]` marker naming the check that makes them safe, per the standing policy in AGENTS.md:

- Column type change: the column must exist on the layer and is quoted by `_qcol`; the type comes from `ALLOWED_COLUMN_TYPES`.
- Column drop: the column matches `COLUMN_NAME_RE`, is not reserved, must exist, and is quoted.
- Feature update: every assigned column is an existing `column_info` name matching `_COLUMN_NAME_RE`, and values travel as bound parameters.

**The fourth was not a false positive.** `create_layer` interpolates `geometry_type` straight into `CREATE TABLE ... geometry(<type>, 4326)`, and nothing in the function checked it. The only guard was a Pydantic validator on the request schema, which covers the single route that reaches the function today. A second caller, a service-layer call or a future CLI path, would have interpolated an unchecked string into DDL. The allowlist check now runs in the service, next to the interpolation.

That alert had been open at high severity since 2026-09-03, before the comment trim, and had not been triaged.

## Verification

- `tests/test_layers.py::test_create_layer_service_rejects_unallowlisted_geometry_type` is a real gate: it passes with the guard and fails when the guard is removed, confirmed by removing it and re-running.
- 328 passed across the layers, feature, column-ops and authz suites.
- `test_codeql_qtable_suppressions.py` passes, which pins that a marker sits on its own line directly above the site it covers.
- `test_layering.py` passes; the features cap is ratcheted 1388 to 1389 for the added marker line.
- `finding_markers.py` clean; `ruff format --check` and `ruff check` clean.

Closes the four open alerts once the dismissal step runs on main.