### PR TITLE
test(auth): guard the authlib httpx2 switch that would unpin the OAuth SSRF transport

### DIFF
--- a/backend/app/modules/auth/oauth/router.py
+++ b/backend/app/modules/auth/oauth/router.py
@@ -4,6 +4,10 @@ import uuid
 from urllib.parse import urlparse
 
 import structlog
+
+# authlib 1.8 deprecated this module for httpx2. Installing httpx2 would
+# switch the client's base class while make_safe_transport() still builds an
+# httpx transport, unpinning the SSRF guard below rather than erroring (#1990).
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from authlib.integrations.starlette_client import OAuth
 from authlib.integrations.starlette_client.apps import StarletteOAuth2App

--- a/backend/tests/test_oauth_destination_security.py
+++ b/backend/tests/test_oauth_destination_security.py
@@ -581,6 +581,19 @@ async def test_authlib_sessions_receive_fresh_safe_transports(
     assert len(set(id(transport) for transport in transports)) == 4
 
 
+def test_authlib_oauth_client_is_httpx_backed() -> None:
+    """The SSRF transport pin holds only while authlib builds on httpx.
+
+    fix(#1990): authlib 1.8 deprecated its httpx integration in favour
+    of httpx2 and will drop the fallback. ``_SSRFSafeOAuth2Client`` hands
+    ``make_safe_transport()``'s httpx transport to that client, so the switch
+    would leave the pin type-mismatched instead of failing loudly.
+    """
+    from app.modules.auth.oauth.router import _SSRFSafeOAuth2Client
+
+    assert issubclass(_SSRFSafeOAuth2Client, httpx.AsyncClient)
+
+
 async def _client_for(db: AsyncSession, provider) -> tuple:
     """Build the router's authlib client with the row-level check stubbed out.
 


### PR DESCRIPTION
## What changed

authlib 1.8.0 (bumped in #1979) replaced its httpx integration with an httpx2 shim. With httpx2 absent it falls back to httpx and logs `AuthlibDeprecationWarning: The httpx module is deprecated; please use httpx2 instead.` at every boot. authlib documents the fallback as temporary.

## Why that is more than warning noise here

`_SSRFSafeOAuth2Client` subclasses authlib's `AsyncOAuth2Client` and pins `make_safe_transport()` into it, which is what keeps the token exchange and the userinfo fetch (the two requests carrying the client secret and the access token) on the IP-pinning transport (#1861).

That client is `httpx.AsyncClient` underneath today. If httpx2 arrives, either because something installs it or because authlib drops the fallback, the base class changes while `make_safe_transport()` still returns an httpx transport. The pin would stop matching the client rather than raising, so the failure would be quiet.

## What this adds

One assertion that the client is still httpx-backed, and a trap comment at the import naming the coupling. No dependency added, no runtime behaviour changed.

## What this deliberately does not do

The httpx2 migration itself. `platform/security.py` and the other 18 httpx call sites would have to move together, since splitting them leaves two SSRF helpers for one trust boundary, and httpx2 is at 2.12.0 under new maintainers. That belongs in its own change with its own security review.

## Verification

```
cd backend && set -a && . ../.env.test && set +a && uv run pytest tests/test_oauth_destination_security.py -q   # 29 passed
uv run pytest tests/test_layering.py -q                                                                        # 50 passed
python3 tests/finding_markers.py                                                                               # exit 0
uv run ruff check . && uv run ruff format --check .                                                            # clean
```

Positive control on the new assertion: it is `True` against the current base class and `False` against a stand-in rebased onto another client, so it is not vacuously true.
