### PR TITLE
fix(datasets): route tab changes through the router so the unsaved-edit blocker arms

### DIFF
--- a/frontend/src/hooks/use-unsaved-guard.ts
+++ b/frontend/src/hooks/use-unsaved-guard.ts
@@ -19,12 +19,9 @@ export function useUnsavedGuard(hasUnsavedChanges: boolean) {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [hasUnsavedChanges]);
 
-  // Block in-app navigation. Use the FUNCTION form so we only block on real
-  // route (PATHNAME) changes — not hash-only navigation. DatasetPage drives its
-  // tab state via the URL hash; a boolean blocker fought that hash navigation
-  // and triggered react-router's "blocker on POP navigation not created by
-  // @remix-run/router" warning. Pathname-based callers (e.g. the map builder)
-  // are unaffected — leaving the builder route still blocks. (#13)
+  // Block in-app navigation. The FUNCTION form blocks on PATHNAME changes
+  // only, so DatasetPage's hash-driven tabs stay navigable with edits pending
+  // while leaving the builder route still blocks (#13, #1991).
   const blocker = useBlocker(
     useCallback(
       ({ currentLocation, nextLocation }) =>

--- a/frontend/src/pages/DatasetPage.tsx
+++ b/frontend/src/pages/DatasetPage.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useState, useCallback, useEffect, useMemo, useRef } from 'react';
-import { useParams, Link } from 'react-router';
+import { useParams, Link, useNavigate, useLocation } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { AlertTriangle, ArrowLeft, Download, Trash2, Upload, Globe, GlobeLock, Layers, Eye, EyeOff, ShieldAlert, Database } from 'lucide-react';
@@ -183,6 +183,8 @@ export function DatasetPage() {
   const { data: validationData } = useValidation(token ? id : undefined);
   const { data: featureFlags } = useFeatureFlags();
   const [activeTab, setActiveTab] = useState(getInitialTab);
+  const navigate = useNavigate();
+  const location = useLocation();
   const [pendingNavigationAnchor, setPendingNavigationAnchor] = useState<string | null>(null);
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const { effectiveGid, setReadOnlyFeatureGid } = useFeatureGid();
@@ -249,13 +251,20 @@ export function DatasetPage() {
   // or created via a non-ingest path.
   const { data: datasetJob } = useDatasetJobStatus(id ?? null);
 
-  const handleTabChange = useCallback((value: string) => {
-    setActiveTab(value);
-    window.location.hash = value;
-    if (value !== 'data') {
-      setIsDataTabExpanded(false);
-    }
-  }, []);
+  const handleTabChange = useCallback(
+    (value: string) => {
+      setActiveTab(value);
+      // fix(#1991): router navigation, not a raw `window.location.hash` write.
+      // The raw write is a POP the data router did not create, which disarms
+      // useUnsavedGuard's blocker. `search` is passed because a partial `to`
+      // defaults it to empty and would drop the query string.
+      navigate({ search: location.search, hash: value });
+      if (value !== 'data') {
+        setIsDataTabExpanded(false);
+      }
+    },
+    [navigate, location.search],
+  );
 
   const updateDataset = useUpdateDataset();
   const hasUnsavedChanges = metadataPendingCount > 0 || isGeometryEditDirty;


### PR DESCRIPTION
## The bug

`DatasetPage` changed tabs by assigning `window.location.hash` directly. React Router treats that as a POP navigation it did not create and warns:

> You are trying to use a blocker on a POP navigation to a location that was not created by @remix-run/router. This will fail silently in production.

`DatasetPage` registers a blocker through `useUnsavedGuard` whenever the metadata editor has pending edits, so this is the guard that "fails silently": the prompt users rely on before losing edits was not reliably armed.

The comment in `use-unsaved-guard.ts` claimed the function-form blocker had already resolved this warning. Under react-router 8 it does not, which is how the stale claim survived.

## The fix

Navigate through the router. `search` is passed explicitly because `resolvePath` destructures `search = ""`, so a partial `to` carrying only `hash` silently drops the query string.

The function-form blocker stays: it is still what keeps hash-only tab navigation from being blocked while pathname changes (leaving the builder) still are. Its comment is trimmed to that invariant.

## Verification

Before and after on the same page and the same click, with the dev stack serving this branch:

| tab change via | console |
| --- | --- |
| `window.location.hash = value` (before) | blocker warning present |
| `navigate({ search, hash })` (after) | clean |

I reverted the fix in place to confirm the warning returned, then restored it, so the result is attributable to this change and not to session state.

```
npm run typecheck                                            # clean
npm run lint                                                 # clean
npx vitest run src/pages/__tests__/ src/components/dataset/   # 60 files, 527 passed
```

No test asserted on `window.location.hash` after a tab change; the one hash assertion covers legacy hash normalisation, which still uses `history.replaceState` and is untouched.
