### PR TITLE
fix(db): one init script for the bundled and managed database

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -462,10 +462,27 @@ which identities previously relied on `PUBLIC`. Leave the role in place during
 rollback: dropping it before re-owning `data.*` relations is destructive and
 unnecessary.
 
-For managed/external PostgreSQL, run privileged migrations first, then run
-`scripts/lib/configure-runtime-db-role.sh` from the host with `POSTGRES_HOST`,
-`POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_DB`, `PGPASSWORD`, and the two
-`GEOLENS_RUNTIME_DB_*` variables exported. Also export
+For managed/external PostgreSQL, run `scripts/init-db.sh` from the host with
+`POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_DB`, `PGPASSWORD`
+and the two `GEOLENS_RUNTIME_DB_*` variables exported. It is the same script the
+bundled database runs on a fresh volume: it adds the host/port arguments only
+when they are set, creates the extensions and schemas, and then chains to
+`scripts/lib/configure-runtime-db-role.sh` itself, so there is no separate SQL
+snippet to keep in step. It is idempotent, so re-running it is safe. Run it
+before the first migration: migration `0001_baseline` verifies `postgis`,
+`pg_trgm`, `vector` and `unaccent` and aborts if any is missing rather than
+creating them.
+
+`postgis` and `vector` are not PostgreSQL "trusted" extensions, so the
+connecting identity needs superuser-equivalent authority (`rds_superuser`,
+`cloudsqlsuperuser`); `pg_trgm` and `unaccent` are trusted and need only CREATE
+on the database. On Azure Flexible Server every one of them must first be
+allowlisted in the `azure.extensions` server parameter, which no client-side SQL
+can do for you. `pg_stat_statements` is optional and is skipped with a notice
+where the provider does not ship it.
+
+To reconcile roles and grants alone on an existing install, run
+`scripts/lib/configure-runtime-db-role.sh` with the same variables. Also export
 `GEOLENS_MIGRATION_DB_ROLE` as the username in
 `MIGRATION_DATABASE_URL_OVERRIDE`; it may differ from the provider admin used by
 the script. The provider credential must be able to create roles, change

--- a/backend/tests/test_runtime_db_role.py
+++ b/backend/tests/test_runtime_db_role.py
@@ -84,6 +84,29 @@ def test_bootstrap_restore_and_upgrade_share_one_role_reconciler() -> None:
     assert "cannot reuse that" in runbook
 
 
+def test_init_db_is_one_entrypoint_for_container_and_managed_postgres() -> None:
+    """fix(#1992): one bootstrap script, both deployments.
+
+    Host/port args are conditional so the in-container socket path (where
+    neither is set) keeps working, and pg_stat_statements is probed before
+    creation because `CREATE EXTENSION IF NOT EXISTS` still ERRORs on an
+    unavailable extension and would abort the run under ON_ERROR_STOP=1.
+    """
+    source = (ROOT / "scripts" / "init-db.sh").read_text(encoding="utf-8")
+
+    for var in ("POSTGRES_HOST", "PGHOST", "POSTGRES_PORT", "PGPORT"):
+        assert var in source, f"init-db.sh no longer honours {var}"
+    assert 'psql "${psql_args[@]}"' in source
+
+    probe = source.index("pg_available_extensions")
+    create = source.index("CREATE EXTENSION IF NOT EXISTS pg_stat_statements;\n", probe)
+    assert probe < create, "pg_stat_statements must stay behind the availability probe"
+
+    # the required four stay unguarded: a missing one is a hard stop, not a skip
+    for ext in ("postgis", "pg_trgm", "vector", "unaccent"):
+        assert f"CREATE EXTENSION IF NOT EXISTS {ext};" in source
+
+
 def test_clean_db_migration_smoke_mounts_role_reconciler_read_only() -> None:
     source = (ROOT / "backend/scripts/test_alembic_upgrade_clean_db.sh").read_text(
         encoding="utf-8"

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -13,7 +13,26 @@ set -e
 # (which builds a
 # fresh DB on every run) finally exercised init-db.sh against a clean
 # volume.
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-'EOSQL'
+# Runs both as the container's docker-entrypoint-initdb.d hook (local socket,
+# no host/port set) and from a host against a managed database (POSTGRES_HOST
+# etc. exported). Host/port args are added only when set, which is what keeps
+# the in-container socket path working; same pattern as the role reconciler.
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+
+psql_args=(-v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
+if [ -n "${POSTGRES_HOST:-}" ]; then
+    psql_args+=(--host "$POSTGRES_HOST")
+elif [ -n "${PGHOST:-}" ]; then
+    psql_args+=(--host "$PGHOST")
+fi
+if [ -n "${POSTGRES_PORT:-}" ]; then
+    psql_args+=(--port "$POSTGRES_PORT")
+elif [ -n "${PGPORT:-}" ]; then
+    psql_args+=(--port "$PGPORT")
+fi
+
+psql "${psql_args[@]}" <<-'EOSQL'
     -- Extensions
     CREATE EXTENSION IF NOT EXISTS postgis;
     CREATE EXTENSION IF NOT EXISTS pg_trgm;
@@ -33,7 +52,17 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-'
     --        CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
     --   Without step 1's preload, CREATE EXTENSION succeeds but the view stays
     --   empty / errors on query -- preload is mandatory for this extension.
-    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+    -- Optional, and guarded: IF NOT EXISTS only suppresses "already exists",
+    -- so an unavailable extension still ERRORs and would abort this whole
+    -- script under ON_ERROR_STOP=1 on a provider that does not ship it.
+    DO $$ BEGIN
+        IF EXISTS (SELECT 1 FROM pg_available_extensions
+                   WHERE name = 'pg_stat_statements') THEN
+            CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+        ELSE
+            RAISE NOTICE 'pg_stat_statements unavailable; skipping (profiling only)';
+        END IF;
+    END $$;
     CREATE EXTENSION IF NOT EXISTS unaccent;
 
     -- Schemas
@@ -45,4 +74,10 @@ EOSQL
 # One canonical reconciliation path owns geolens_reader plus the opt-in
 # GEOLENS_RUNTIME_DB_ROLE. It is mounted separately so restore.sh and an
 # existing install can run the identical grants without replaying extensions.
-bash /usr/local/bin/configure-runtime-db-role
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+if [ -r "${script_dir}/lib/configure-runtime-db-role.sh" ]; then
+    role_reconciler="${script_dir}/lib/configure-runtime-db-role.sh"
+else
+    role_reconciler=/usr/local/bin/configure-runtime-db-role
+fi
+bash "$role_reconciler"


### PR DESCRIPTION
## Why

`scripts/init-db.sh` only worked as the bundled database's initdb hook, because it called `psql` with no host or port. Managed deployments therefore had to paste equivalent SQL out of the docs, and that copy had already drifted: the published `ALTER DEFAULT PRIVILEGES IN SCHEMA data ...` omits the `FOR ROLE` the reconciler emits, which silently leaves newly ingested `data.*` tables unreadable by `geolens_reader` once an operator adopts the opt-in runtime role.

The role and grant half was already portable and shared by three callers. Only the extensions and schemas block was container-bound, so this closes that gap rather than adding a second script.

## What changed

Host and port arguments are appended only when `POSTGRES_HOST`/`PGHOST` or `POSTGRES_PORT`/`PGPORT` are set, the same pattern `configure-runtime-db-role.sh` already uses. Neither is set inside the db container, so the socket path is unchanged. The reconciler is resolved from the checkout first, falling back to the container mount.

`pg_stat_statements` moves behind a `pg_available_extensions` probe. `CREATE EXTENSION IF NOT EXISTS` only suppresses "already exists", so an unavailable extension still ERRORs, and under `ON_ERROR_STOP=1` that aborted the entire bootstrap on a provider that does not ship it. The four required extensions stay unguarded, so a missing one remains a hard stop matching migration `0001_baseline`.

## Verification

Both paths exercised end to end against real servers.

**Managed simulation** (bare Postgres, no initdb hook, script run from the host over TCP): created all four extensions, both schemas and `geolens_reader`; a second run exited 0, confirming idempotency.

**Bundled path** (fresh container, script mounted at `/docker-entrypoint-initdb.d/10-init.sh` and the reconciler at `/usr/local/bin/...`, exactly as compose does): no errors in the hook, all five extensions present including `pg_stat_statements`, both schemas, `geolens_reader` created.

Positive control on the guard, same server:

| statement | result |
| --- | --- |
| `CREATE EXTENSION IF NOT EXISTS <unavailable>` | exit 1, `extension … is not available` |
| the same call behind the probe | `NOTICE … skipping`, exit 0 |

```
pytest tests/test_runtime_db_role.py tests/test_docker_audit_regressions.py \
       tests/test_phase_272_compose.py tests/test_ci_alembic_filter_paths.py   # 106 passed
pytest tests/test_dp_single_tenant_byte_identical.py tests/test_iso05_db_privilege_guc_survival.py  # 27 passed, 1 skipped
pytest tests/test_layering.py                                                  # 50 passed
python3 tests/finding_markers.py                                               # exit 0
shellcheck scripts/init-db.sh                                                  # clean
```

The new test is counterfactualled: removing the probe makes it fail, so it is not passing vacuously.

## Follow-up not in this PR

The docs page still publishes a hand-maintained SQL snippet. It should point at this script instead, which is what stops the `FOR ROLE` drift recurring.
