### PR TITLE
chore(repo): streamline agent guidance and patch js-yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,109 +1,115 @@
 # Repository Guidelines
 
-## Project Structure
+Shared instructions live here; keep `CLAUDE.md` as only `@AGENTS.md`. Retain actionable conventions and traps; link to existing sources for detail.
 
-GeoLens mixes Python and TypeScript. Backend source is `backend/app/`: `modules/` (domain areas), `platform/` (shared services), `processing/` (ingest/export/tiles), `standards/` (OGC/STAC/DCAT), `core/` (config, DB, permissions, edition). Migrations are in `backend/alembic/`, tests in `backend/tests/`. The React/Vite frontend is `frontend/src/` (`components/`, `pages/`, `hooks/`, `stores/`, `api/`, `i18n/`, colocated `__tests__/`); Playwright specs are in `e2e/`. The CLI is `cli/geolens_cli/`, the read-only MCP server `mcp/geolens_mcp/`, generated SDKs `sdks/`, operations files `scripts/`, `db/`, `.github/`.
+## Project Map
 
-## Architecture
+Backend: `backend/app/{api,core,modules,platform,processing,standards}/`; migrations: `backend/alembic/`; tests: `backend/tests/`. React/Vite frontend: `frontend/src/` (builder: `builder/`, colocated Vitest tests); Playwright: `e2e/`. CLI: `cli/geolens_cli/`; read-only MCP server: `mcp/geolens_mcp/`; generated SDKs: `sdks/`; operations: `scripts/`, `db/`, `.github/`.
 
-Nginx (Vite proxy in dev) fronts the FastAPI `api` (catalog, search, OGC/STAC, vector tiles) and Titiler (COG raster tiles). A `worker` runs GDAL/ogr2ogr ingestion via the Procrastinate queue, which lives inside PostgreSQL. PostgreSQL 18 (PostGIS, pgvector, pg_trgm) is the single source of truth; MinIO/S3 holds objects; Valkey caches tiles and queries.
+FastAPI serves catalog, standards and vector tiles; Titiler serves COG tiles. The worker runs Procrastinate jobs using PostgreSQL as its queue. Storage defaults to local files, with S3/MinIO and Azure options; Valkey provides caching. See [.github/ARCHITECTURE.md](.github/ARCHITECTURE.md) for topology and extension seams; manifests/lockfiles own dependency versions.
 
-Backend: `catalog` is the core module (`datasets`/`collections`/`records`/`features`/`maps`/`layers`/`search`/`sources`/`validation`); access control is `catalog/authorization.py`. The `datasets` domain splits into `api/` (routers) and `domain/`, where `service_X` sub-modules sit behind the façade `domain/service.py`. Import the façade, never a sub-module; `backend/tests/test_layering.py` enforces this and the other layer boundaries.
+Import domain service façades, never another domain's split internals (datasets: `backend/app/modules/catalog/datasets/domain/service.py`). `backend/tests/test_layering.py` enforces boundaries, including no `app.processing.*` imports from catalog. Shared security helpers belong in `platform/`.
 
-Frontend (React 19, `@vis.gl/react-maplibre` v8, maplibre-gl v6, TanStack Query, zustand, Tailwind): the map builder is `builder/`; every API call goes through `apiFetch()` in `api/client.ts`; the auth token lives in `useAuthStore` (persisted `geolens-auth`; outside React read `useAuthStore.getState().token`); reuse `components/ui/`.
+Frontend API calls use `apiFetch()` in `frontend/src/api/client.ts`. Auth comes from `useAuthStore` (persisted as `geolens-auth`); outside React use `useAuthStore.getState().token`. Reuse `components/ui/`, TanStack Query and existing zustand stores.
 
-SDKs are generated from `backend/openapi.json` with `make sdks`; never hand-edit generated files (only the `auth.*`, `__init__` and `index` wrappers are hand-maintained). The CLI and MCP server are hand-maintained and wrap the SDK.
+## Working Principles
 
-## Commands
+- Inspect relevant code and the working tree; preserve unrelated edits. Build requested behavior with the smallest correct diff; avoid speculative features and unrelated refactors.
+- Prefer project helpers, standard library/native platform features, then installed dependencies. Add a dependency only when these cannot reasonably meet the need; explain why and update its manifest and lockfile together.
+- Avoid abstractions, factories and configuration without a current need. Keep one definition per domain fact; a small copy beats violating a layer boundary.
+- Preserve validation, authorization, SSRF defenses, accessibility and error handling that prevents data loss. Test non-trivial behavior, not implementation trivia.
+- Use `rg`/`rg --files` and bounded reads. Load detailed docs/skills when relevant; avoid dumping generated files or entire trees into context.
 
-- `make dev` / `make down`: start or stop the Docker Compose stack.
-- `make migrate`: run Alembic migrations in the API container; `make alembic-check` catches model/migration drift (run it for schema changes).
-- `make test` / `make test-cov`: backend pytest and coverage. `make ai-evals`: live NL→SQL evals (costs tokens, needs `ANTHROPIC_API_KEY` and the dev DB).
-- `cd frontend && npm ci && npm run dev`; gates: `npm run build && npm run lint && npm run typecheck && npm run test:coverage` (`npx tsc --noEmit` is a no-op; `typecheck` is the real gate).
-- `npm run e2e` / `npm run e2e:smoke`: Playwright.
-- `make openapi-check`, `make sdks-check`, `make cli-test`: API snapshot and SDK/CLI drift.
-- `make bump VERSION=X.Y.Z` rewrites every version site; never edit one by hand (`make version-check` is the CI gate).
+### Subagents
 
-Single tests: host backend `cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_foo.py -v` (Postgres at localhost:5434); in-container `docker compose exec api env UV_CACHE_DIR=/app/staging/uv-cache UV_PROJECT_ENVIRONMENT=/app/staging/geolens-api-test-venv uv run pytest -o cache_dir=/app/staging/.pytest_cache tests/test_foo.py::test_bar -v`; frontend `cd frontend && npx vitest run src/path/foo.test.ts`; e2e `npx playwright test e2e/foo.spec.ts --project=chromium`.
+- Keep small or tightly coupled tasks local. Delegate bounded independent work; avoid duplicate exploration and unnecessary nested delegation.
+- Pass the objective, owned files, constraints, relevant paths and expected verification. Prefer a concise brief over full conversation history when supported; ensure applicable `AGENTS.md` instructions are available without copying them twice.
+- Tell workers they share the workspace: preserve others' edits and avoid overlapping ownership. Coordinate shared files and generated artifacts through the parent.
+- Request concise findings/changes, file references, checks/results and blockers. Reuse agents for follow-ups; the parent runs shared gates after integration, repeating only when changes or failures warrant it.
 
-After touching anything under `backend/app/`, run the tree-wide gates a focused run cannot see:
+## Commands and Verification
+
+Commands start at the repository root unless specified. Setup: [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md). Reuse existing environments; run `npm ci` in the relevant package when dependencies need installing/syncing.
+
+- Stack: `make dev-init` bootstraps; `make dev` starts; `make down` stops.
+- Schema changes: `make migrate`, then `make alembic-check` against a compatible DB at migration heads.
+- Backend: `make test` / `make test-cov` use the API container. Python changes require `cd backend && uv run ruff check . && uv run ruff format --check .`. Coverage floor: 80%; McCabe limit: 15; `backend/pyproject.toml`'s `per-file-ignores` may only shrink.
+- Frontend: `cd frontend && API_PROXY_TARGET=http://localhost:8001 npm run dev`. Gates: `npm run build && npm run lint && npm run typecheck && npm run test:coverage` from `frontend/`; `npx tsc --noEmit` does not check this project. Focused test: `npx vitest run src/path/foo.test.ts`.
+- E2E needs a running stack: `npm run e2e` / `npm run e2e:smoke`; focused: `npx playwright test e2e/foo.spec.ts --project=chromium`. Run relevant smoke groups for user-flow changes; see the contributor guide.
+- Contracts: `make openapi-check`, `make sdks-check` (regenerates files), `make cli-test` (includes DB integration), `make mcp-test`.
+- Versions: `make bump VERSION=X.Y.Z`; never edit versions individually. Gate: `make version-check`.
+
+Run focused tests during development and affected package gates before completion. Documentation-only edits need link/command checks and `git diff --check`, not application suites. Report failed or unrun checks accurately.
+
+Host backend: `make env-test` creates gitignored `.env.test` without overwriting it. DB-backed tests need matching test DB credentials/port (template: 5434). `docker compose up -d --wait db` starts the dev DB; generated dev credentials may differ from the test template.
 
 ```bash
-cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q
-python3 tests/finding_markers.py
+(cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_foo.py -v)
 ```
 
-Neither needs a database. A missing `.env.test` (gitignored; `make env-test` creates it) kills `test_layering.py` before collection, which looks like a gate failure and is not. Two ledgers are exact in both directions: `_MODULE_LOC_CAPS` (module line counts) and `UNANCHORED_MARKER_DEBT` (bare tracker ids per module). When a file grows or shrinks, set its entry to the new value in the same commit with a line saying what the change bought.
+Container tests require writable paths:
+
+```bash
+docker compose exec api env UV_CACHE_DIR=/app/staging/uv-cache UV_PROJECT_ENVIRONMENT=/app/staging/geolens-api-test-venv uv run pytest -o cache_dir=/app/staging/.pytest_cache tests/test_foo.py::test_bar -v
+```
+
+After any `backend/app/` edit, also run these database-free gates (pytest still needs test environment settings):
+
+```bash
+make env-test
+(cd backend && set -a && source ../.env.test && set +a && uv run pytest tests/test_layering.py -q)
+python3 backend/tests/finding_markers.py
+```
+
+Keep tracked `_MODULE_LOC_CAPS` entries in `test_layering.py` at exact line counts with a brief rationale; follow its inclusion test for newly oversized modules. `UNANCHORED_MARKER_DEBT` in `finding_markers.py` counts markers, not lines: lower/delete entries when debt is removed; never increase them to pass a gate.
+
+`make ai-evals` costs live provider tokens and needs the dev DB/provider key (normally `ANTHROPIC_API_KEY`). Ensure `.env.test`, if present, does not override working dev credentials.
 
 ### Worktrees
 
-The dev stack bind-mounts the main checkout, so `localhost:8080` and the API on `:8001` always serve `main`. Playwright refuses to run from a linked worktree unless `E2E_ALLOW_WORKTREE=1`; it does not try to detect whether your change is in the stack. Frontend change: run Vite on the host at `:5174` with `API_PROXY_TARGET=http://localhost:8001`, then `E2E_ALLOW_WORKTREE=1 E2E_BASE_URL=http://localhost:5174 npx playwright test` (backend is still main's). Backend change: build a stack from the worktree (own compose project or a host-run API). Spec-only change: the shared stack is valid with the flag set. The host pytest recipe cannot `source` outside the worktree, so run `make env-test` inside it and call pytest from a wrapper script.
+The shared stack serves the checkout it bind-mounts, usually the primary checkout, regardless of your linked worktree's branch. Template ports: frontend 8080, API 8001, DB 5434; verify configured ports. `E2E_ALLOW_WORKTREE=1` acknowledges this risk; it does not select the code under test.
 
-## Coding Principles
+Frontend change: from the worktree run `cd frontend && API_PROXY_TARGET=http://localhost:8001 npm run dev -- --port 5174 --strictPort`; from its root run `E2E_ALLOW_WORKTREE=1 E2E_BASE_URL=http://localhost:5174 npx playwright test`. The API still serves the shared checkout. Backend changes need a worktree Compose project with separate ports or a host API. Spec-only changes may use the shared stack. Run `make env-test` inside each worktree before host pytest.
 
-- Build what was asked, nothing speculative. The shortest correct diff wins; deletion beats addition; boring beats clever.
-- Reach for what exists, in order: the standard library, a native platform feature (a Postgres constraint over an application check, HTML and CSS over JavaScript), a dependency already installed, then new code. Never add a dependency for what a few lines do.
-- Keep it simple: no interface with one implementation, no factory for one product, no configuration for a value that never changes, no scaffolding for later.
-- One definition per fact inside a domain. Reuse `platform/` helpers, the service façades, `components/ui/` and `apiFetch()` before writing a sibling. Where a layer boundary forbids the import, a small copy beats a violation.
-- Never simplify away a trust boundary: input validation, access checks, SSRF gating, error handling that prevents data loss, accessibility basics.
-- Non-trivial logic ships with the one test that fails if it breaks, and no fixtures or suites the change does not need.
+## Contracts and Comments
 
-## Style
+- API schema changes, including published route docstrings/Pydantic field descriptions, require `make sdks` (refreshes OpenAPI and both SDKs), then `cd frontend && npm run types:generate`. Frontend drift gate: `npm run types:check`. Commit generated changes only when source changes require them.
+- Never hand-edit generated SDK code or `frontend/src/types/api.generated.ts`. SDK auth/entry wrappers (`auth.py`, `__init__.py`, `auth.ts`, `index.ts`) are hand-maintained; CLI and MCP wrap the SDK.
+- New UI strings use `t()` with keys in all four locales (en/es/fr/de); run `cd frontend && npm run test:i18n`. `defaultValue` is insufficient. Keep plural suffixes consistent; `_many` does not fall back to `_other`. French count 0 uses `_one`, so interpolate `{{count}}` instead of hardcoding 1.
+- Comments explain non-obvious reasons/traps; docstrings state contracts. Avoid narration/history. Review references need an issue/PR anchor plus the invariant, at most three lines: `// fix(#1234): suppress basemap row click during multi-selection`. Bare private tracker IDs fail finding-marker checks.
+- Put `# broad: <reason>` on the same line as every `except Exception`. Follow CodeQL marker placement below.
 
-Python: 4 spaces, `cd backend && uv run ruff check . && uv run ruff format --check .` before a change is complete. The McCabe gate is 15; the `per-file-ignores` baseline in `backend/pyproject.toml` may shrink, never grow. Frontend: TypeScript, ESLint, React Hooks and JSX a11y rules; `PascalCase` components, `use*` hooks, `_` prefix for intentionally unused names.
+## Security
 
-### Comments and docstrings
+Apply these rules to data access, URL fetching, ingestion and credential changes. Structural checks supplement behavioral tests; they do not prove every path is authorized.
 
-Every comment and docstring is read by every agent on every turn, so each line has a recurring token cost. Write the fewest lines that stop a reader from making a mistake.
+**Rule 1 — Access control.** Guard each handler's `Dataset`, `Record`, `Map`, `RecordEmbedding` and `IngestJob` fetch using sanctioned domain checks in `backend/tests/test_rule1_structural.py`. Dataset guards live in `backend/app/modules/catalog/authorization.py`:
 
-- A comment says why, never what. If the code needs a what, rename or split the code.
-- A docstring is the contract: one summary line, then only what a caller cannot infer from the signature (a non-obvious input, output or error, and the one trap). No narrative, motivation or history. A private helper whose name says it all gets none; a module docstring is a few lines on what the module holds.
-- A trap comment naming a concrete failure the code guards against (a lock order, a race, a driver quirk) stays, in one to three lines.
-- Route handler docstrings and Pydantic `Field(description=...)` strings are the published OpenAPI text. Editing one changes `backend/openapi.json`, both SDKs and `frontend/src/types/api.generated.ts`, so regenerate all four, and never write an absolute you cannot trace to a line.
-- Pinned markers: `# codeql[...]` on its own line directly above the line it covers (prose goes above the marker); `# broad: <reason>` on the same line as every `except Exception`.
+- Reads: `check_dataset_access_or_anonymous(...)`, or `check_dataset_access(...)` for authenticated callers; denial is 404. The latter checks visibility only and cannot authorize writes.
+- Mutations: `check_dataset_write_access(...)` enforces visibility (404) and owner/admin rights (403).
+- Lists: execute the statement returned by `apply_visibility_filter(...)`; discarding its return provides no protection. Use corresponding sanctioned guards for maps, records and tiles.
 
-### Inline review-comment convention
+Invalid supplied credentials must not silently become anonymous access; preserve `get_optional_user` behavior and exceptions pinned in `backend/tests/test_optional_auth_failure_mode_1518.py`.
 
-A comment that references a review or audit finding carries a stable anchor (a PR or issue number) plus the invariant the code now holds, three lines at most:
+**Rule 2 — SSRF and GDAL.** Redirect-following `httpx.AsyncClient` instances come from `make_safe_client()` in `backend/app/platform/security.py` for per-hop validation and connection-time IP pinning. Pass `credential_header` when forwarding custom credential headers. Keep submission-time `validate_url_for_ssrf` checks.
 
-```
-// fix(#1234): suppress basemap row click during multi-selection
-```
+GDAL/ogr2ogr/rasterio need structural defenses; never add the ineffective `GDAL_HTTP_FOLLOWLOCATION`:
 
-The history behind it goes in the PR or issue the anchor names. Never write a comment that restates the next line, and trim any comment you touch to this rule. Bare tracker ids that only resolve in a private tracker are refused by the `no-unscoped-finding-markers` hook and `backend/tests/finding_markers.py`.
+1. Prefer managed storage (`/vsis3/`, `/vsiaz/`, validated local keys); never probe caller-controlled remote sources in-process.
+2. Remote service imports/previews require URL validation, `gdal_service_safe_env()` and worker egress restrictions.
+3. Raster subprocesses/opens use `gdal_safe_env()` / `gdal_safe_open_env()` from `backend/app/processing/raster/vrt.py`. Local vector subprocesses require both `local_input_driver_args()` from `processing/ingest/gdal_drivers.py` and `gdal_vector_safe_env()` from `platform/gdal_env.py` (paths under `backend/app/`). Service drivers use the service environment. `GDAL_SKIP` splits on spaces/commas; unknown driver names only warn.
+4. GPKG/SQLite virtual tables can follow pointers. Preserve `validate_content_directives()` in `processing/ingest/validation.py` at upload and staged-upload GDAL entry points: read raw `sqlite_master.sql` read-only/immutable, allow only sanctioned virtual-table modules, identify SQLite archive members by bytes and reject VRT despite disguised names/BOMs. Run `validate_zip_safety` first under a shared byte budget. `PRAGMA`, `SPATIALITE_SECURITY=strict`, `OGR_SQLITE_LOAD_EXTENSIONS=NONE` and `OGR_SQLITE_LIST_ALL_TABLES=NO` are not substitutes.
 
-## Testing
+Run `backend/tests/test_rule2_structural.py` and relevant `backend/tests/test_gdal_driver_clamp_1846.py` tests for these changes; the latter needs real GDAL. Only the GDAL CLI exception allowlist is empty; rasterio exceptions are separately counted.
 
-Backend: pytest with AnyIO, `test_*.py`, 80% coverage floor (`fail_under` in `backend/pyproject.toml`); DB-backed tests need `docker compose up -d --wait db` and the variables in `.env.test.example`. Frontend: Vitest and Testing Library, `*.test.ts(x)` or `__tests__/`. E2E: Playwright, `e2e/*.spec.ts`.
+**Rule 3 — Credentials.** Never introduce known-public credential literals as defaults, fallbacks, examples or new test values; `validate_known_bad_credentials` in `backend/app/core/config.py` rejects them. MinIO credentials are outside `Settings`: preserve entrypoint blank-credential rejection and parse-safe `${MINIO_ROOT_USER:-}` / `${MINIO_ROOT_PASSWORD:-}` in `docker-compose.yml`; `:?required` breaks parsing even with the profile inactive.
 
-New `t()` keys go in all four locales (en/es/fr/de); a `defaultValue` alone fails `npm run test:i18n`. Plural suffixes follow the same all-four-or-none rule: there is no `_many`→`_other` fallback, and French resolves count 0 to `_one`, so `_one` values interpolate `{{count}}` rather than hardcoding "1".
+**CodeQL.** Suppress `py/sql-injection` only where dynamic identifiers are validated. Put `# codeql[py/sql-injection]` on its own line directly above the `text()` site; trailing markers are ignored. Preserve `.github/codeql/python-suppression/` and `.github/workflows/codeql.yml`; verify with `backend/tests/test_codeql_qtable_suppressions.py`.
 
-## Commits, PRs and Docs
+## Commits and Documentation
 
-Conventional Commit subjects with a meaningful scope, e.g. `feat(sharing): add schema gates for advanced sharing`. PRs describe the change, call out schema/API/config impacts, link issues, include screenshots for UI work and list verification commands. Commit `backend/openapi.json` or SDK output only when the source change requires it.
+Use scoped Conventional Commits and DCO sign-off (`git commit -s`). Follow `.github/PULL_REQUEST_TEMPLATE.md`: describe behavior, link issues, note schema/API/config impacts, list verification and include screenshots for UI work.
 
-Root docs are single-purpose: `README.md` (public overview), `SUPPORT.md`, `CHANGELOG.md` (release-note source of truth), `EDITIONS.md` (open-core boundary, REL-01) and `RUNBOOK.md` (operator recovery, BKP-04). README images live in `.github/assets/`, contributor docs under `.github/`, product docs on docs.getgeolens.com, private notes in ignored `docs-internal/`. Do not reintroduce a root `docs/` directory or narrative feature docs that duplicate the docs site. Brand assets come from a tagged release of the sibling `geolens-io/branding` repo, never re-authored here; changes propagate branding → this repo → marketing → docs.
+Root docs: `README.md` (overview), `SUPPORT.md`, `CHANGELOG.md` (release notes), `EDITIONS.md` (open-core boundary), `RUNBOOK.md` (recovery). Contributor docs: `.github/`; README images: `.github/assets/`; product docs: docs.getgeolens.com; private notes: ignored `docs-internal/`. Do not add root `docs/` or duplicate product docs. Brand assets come from a tagged `geolens-io/branding` release; changes flow branding → this repo → marketing → docs.
 
-## Security & Configuration
-
-Use `.env.example` and `.env.test.example` as templates. Never commit secrets, coverage output, Playwright reports, virtual environments or dependency directories. `.gitignore` covers assistant and internal-notes directories (`.claude/`, `.planning/`, `docs-internal/`); untrack any that slip in before committing.
-
-### Security pre-commit checklist
-
-Any change touching catalog data access, external URL fetching or boot-time credential validation must satisfy these.
-
-**Rule 1: Visibility-filter coverage.** Any new FastAPI handler that fetches a `Record`, `Dataset`, `Map` or `RecordEmbedding` by ID does ONE of: `check_dataset_access_or_anonymous(db, dataset, dataset_id, user)` (reads), `check_dataset_access(...)` (writes; 404 on denial), `check_dataset_write_access(...)` (owner-or-admin mutations), all from `backend/app/modules/catalog/authorization.py`, or `apply_visibility_filter(stmt, user, user_roles, Record, DatasetGrant)` on its own `Select` (list endpoints). Reference: `standards/ogc/router.py`, `standards/stac/router.py` (read), `catalog/datasets/api/router_metadata.py` (write). Enforced by a pre-commit grep and, per handler, by `backend/tests/test_rule1_structural.py` (#822).
-
-**Rule 2: SSRF redirect-revalidation.** Any `httpx.AsyncClient` with `follow_redirects=True` comes from `make_safe_client()` in `backend/app/platform/security.py`, which re-runs `validate_url_for_ssrf` on every 3xx `Location`. A pre-commit grep enforces this half. `security.py` and `gdal_env.py` stay in `platform/`: their callers span auth, config_ops, catalog and processing, and `modules/catalog/` may not import `app.processing.*` (#435, #1857).
-
-GDAL, ogr2ogr and rasterio cannot be made redirect-safe from the inside. `GDAL_HTTP_FOLLOWLOCATION` is not a GDAL option, setting it does nothing (#937), and no test catches it: never re-add it. The defenses are structural, in this order, and `backend/tests/test_rule2_structural.py` (#936) enforces them per call and per argv with an EMPTY allowlist (#1857):
-
-1. Prefer never handing a caller-controlled URL to GDAL. Read managed storage only (`/vsis3/`, `/vsiaz/`, validated local keys) and never probe remote sources in-process.
-2. Where a user-supplied service URL must be fetched (`run_ogr2ogr_service`, `sources/preview.py`), `validate_url_for_ssrf` gates it at submission, the subprocess runs under `gdal_service_safe_env()`, and the worker egress firewall bounds the rest.
-3. Subprocess envs come from `gdal_safe_env()` / `gdal_safe_open_env()` (`backend/app/processing/raster/vrt.py`).
-4. A vector argv also bounds WHICH driver may open its source, because several OGR drivers treat the document as instructions naming somewhere else to read. Both halves are required: `local_input_driver_args()` (`backend/app/processing/ingest/gdal_drivers.py`) adds `-if <driver>` arguments from the declared extension, and `gdal_vector_safe_env()` / `gdal_service_safe_env()` (`backend/app/platform/gdal_env.py`) set `GDAL_SKIP` so pointer-following and network drivers never register. Traps: `GDAL_SKIP` tokenises on spaces, and an unrecognised driver name is a silent warning (#1846). `backend/tests/test_gdal_driver_clamp_1846.py` measures both halves against a real GDAL.
-5. `GPKG` and `SQLite` are pointer-following through virtual tables and cannot be clamped, because GeoPackage is the primary upload format. `validate_content_directives()` (`backend/app/processing/ingest/validation.py`) reads `sqlite_master` through the stdlib driver (read-only, immutable) and refuses any virtual-table module outside a small allowlist, for top-level databases and for every archive member whose BYTES are one. Identify members by content, never by name (GDAL never reads the name; the OGR VRT driver finds its root by substring search, so a BOM hides nothing). It also refuses VRT-shaped members, runs `validate_zip_safety` first under one byte budget, and runs at the upload doors AND the three staged-upload GDAL entry points. Read the raw `sql` column, never `PRAGMA`. Measured ineffective: `SPATIALITE_SECURITY=strict`, `OGR_SQLITE_LOAD_EXTENSIONS=NONE`, `OGR_SQLITE_LIST_ALL_TABLES=NO` (#1846).
-
-**Rule 3: Known-public credential literals.** A few demo credentials leaked through git history and are public knowledge; never reintroduce one as a default, fallback, example or test value. `validate_known_bad_credentials` in `backend/app/core/config.py` holds the list and refuses to boot when `JWT_SECRET_KEY`, `GEOLENS_ADMIN_PASSWORD` or `POSTGRES_PASSWORD` matches. MinIO credentials are not `Settings` fields; the minio entrypoint in `docker-compose.yml` refuses blank `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` instead, referenced as parse-safe `${MINIO_ROOT_USER:-}` because `:?required` broke `compose config` even with the profile inactive (INST-01).
-
-**Standing CodeQL policy** (2026-08-03, adopted in #1615): a validated-identifier `py/sql-injection` alert on a dynamic `text()` site is suppressed with `# codeql[py/sql-injection]` on its own line directly above the site; a trailing marker is silently ignored. `.github/codeql/python-suppression/` holds the vendored query (the stock one reads every `# noqa` as a bare `lgtm`) and `.github/workflows/codeql.yml` dismisses what it marks, because GitHub does not honour SARIF `suppressions[]` on its own. `backend/tests/test_codeql_qtable_suppressions.py` pins all of it.
+Use `.env.example` / `.env.test.example` as templates. Never commit secrets, environments, dependencies, coverage or Playwright output. Keep ignored assistant/internal directories (`.claude/`, `.planning/`, `docs-internal/`) out of tracked changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-The canonical guide is AGENTS.md, imported below so its full contents load into context automatically. Keep shared guidance in AGENTS.md, not here.
-
 @AGENTS.md

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6493,9 +6493,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -436,9 +436,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -42,7 +42,7 @@
     "typescript": "5.9.3"
   },
   "overrides": {
-    "js-yaml": "^4.3.0"
+    "js-yaml": "^4.3.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Correct repository instructions that mislabeled dataset visibility checks as write authorization, conflated marker debt with line-count limits, and omitted frontend API type generation. Tighten KISS, dependency and subagent guidance while reducing AGENTS.md from 1,999 to 1,558 words (22%).

Update the frontend and TypeScript SDK tooling dependency `js-yaml` from 4.3.1 to 4.3.2 to address [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh), which caused both dependency audit jobs to fail.

## Changes

- Correct access-control, storage, worktree, test-environment and GDAL guidance while preserving security safeguards.
- Prefer existing helpers and dependencies; require a rationale for additions. Give subagents bounded tasks, minimal context and clear ownership, and avoid duplicated exploration and checks.
- Add missing regeneration and DCO sign-off instructions; replace repeated history/version details with existing references.
- Reduce CLAUDE.md to the single `@AGENTS.md` import, following the [official Claude Code guidance](https://code.claude.com/docs/en/memory#agentsmd).
- Update only the `js-yaml` entries in both lockfiles and raise the SDK's existing override minimum to `^4.3.2`.

No new packages, application source, API, database schema or generated-client changes. Dependency configuration impact: the existing SDK override now requires the patched release.

## Area

- [x] Docs / Config
- [x] Frontend (tooling dependency only)
- TypeScript SDK tooling dependency

## Testing

- Clean `npm ci` installs in both packages: zero vulnerabilities.
- Frontend: `node ../scripts/js-audit-gate.mjs`, `npm run build`, `npm run lint`, `npm run typecheck`, `npm run test:coverage` — passed; 456 test files and 6,021 tests passed.
- TypeScript SDK: `node ../../scripts/js-audit-gate.mjs`, `npm run build`, `npm test`, `npm run verify:esm` — passed; all 7 tests passed.
- `make sdks` succeeded; `git diff --exit-code -- backend/openapi.json sdks/python sdks/typescript/src` confirmed no generated changes.
- Verified that `js-yaml` is the only changed lockfile package and both installed versions are 4.3.2.
- Verified documented commands and referenced repository paths/links, plus the exact CLAUDE.md import.
- `git diff --check` and applicable pre-commit hooks passed.

## Checklist

- [x] Changes follow existing project conventions.
- [x] Frontend lint and typecheck pass.
- [x] No secrets or credentials in the diff.
- i18n, migrations, screenshots and deployment checks are not applicable: no UI strings, application source or deployment changes.
