### PR TITLE
fix(catalog): anchor SEC-OBSV-02 marker in cog_info.py

### DIFF
--- a/backend/app/modules/catalog/sources/cog_info.py
+++ b/backend/app/modules/catalog/sources/cog_info.py
@@ -131,11 +131,9 @@ async def fetch_cog_info(url: str) -> dict | None:
     any upstream fetch), so ``last_checked_at`` is stamped only on success;
     every failure leaves it NULL for the probe to settle.
 
-    SEC-OBSV-02: dual SSRF gate, both halves required for every caller.
-    Gate 1 (caller-side): ``validate_url_for_ssrf`` before calling this.
-    Gate 2 (Titiler-side): its own CPL_VSIL_CURL_ALLOWED_EXTENSIONS clamp
-    rejects a non-raster extension that slipped past Gate 1. Removing
-    either is an SSRF regression, not a refactor side-effect (#1927).
+    SEC-OBSV-02 (#1927): dual SSRF gate, both halves required. Gate 1
+    (caller-side) is ``validate_url_for_ssrf`` before calling this; Gate 2
+    (Titiler-side) is its own CPL_VSIL_CURL_ALLOWED_EXTENSIONS clamp.
     """
     try:
         async with httpx.AsyncClient(

--- a/backend/tests/finding_markers.py
+++ b/backend/tests/finding_markers.py
@@ -291,7 +291,6 @@ UNANCHORED_MARKER_DEBT: dict[str, int] = {
     "modules/catalog/search/service_records.py": 1,
     "modules/catalog/sources/adapters/stac.py": 3,
     "modules/catalog/sources/classify.py": 4,
-    "modules/catalog/sources/cog_info.py": 1,
     "modules/catalog/sources/origin_probe.py": 2,
     "modules/catalog/sources/preview.py": 3,
     "modules/catalog/sources/probe.py": 7,


### PR DESCRIPTION
## Summary

Fixes the `SEC-OBSV-02` marker in `cog_info.py`: the `#1927` anchor sat
five lines past the token, outside the marker gate's two-line window, and
the docstring paragraph around it had drifted out of date.

## Changes

- Move the `#1927` anchor onto the `SEC-OBSV-02` token's own line and
  restate the dual-gate contract in three lines instead of five, dropping
  the stale prose the gate could not credit.
- Drop the now-zero `cog_info.py` entry from `UNANCHORED_MARKER_DEBT` in
  `backend/tests/finding_markers.py`.
- No behavior change; `backend/app/platform/storage/titiler_url.py`'s
  sibling pointer already names `fetch_cog_info` correctly and needs no
  edit.

## Area

- [x] Backend (API, services, models)

## Testing

- [x] Unit tests pass (`pytest`)
- [ ] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)

Ran `python3 backend/tests/finding_markers.py` (clean; confirmed the
pre-fix docstring left `SEC-OBSV-02` unanchored via a direct
`scan_module` check, and the fixed one anchors it), `backend/tests/test_layering.py`,
`ruff check` / `ruff format --check`, and the focused suites that cover
`cog_info.py`: `test_cog_info.py`, `test_sources_safe_client_structural.py`,
`test_titiler_url_helper.py`.

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [ ] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing

Closes #1951
Closes #1945
