### PR TITLE
fix(db): disable psql's .psqlrc so init stays fail-closed

### DIFF
--- a/backend/tests/test_runtime_db_role.py
+++ b/backend/tests/test_runtime_db_role.py
@@ -98,6 +98,14 @@ def test_init_db_is_one_entrypoint_for_container_and_managed_postgres() -> None:
         assert var in source, f"init-db.sh no longer honours {var}"
     assert 'psql "${psql_args[@]}"' in source
 
+    # fix(#1992): a host .psqlrc can `\set ON_ERROR_STOP off`, so -v
+    # ON_ERROR_STOP=1 alone does not guarantee a failed statement aborts
+    # the run; -X must precede it in the same psql_args assignment.
+    args_line = next(
+        line for line in source.splitlines() if line.startswith("psql_args=")
+    )
+    assert args_line.index("-X") < args_line.index("ON_ERROR_STOP=1")
+
     probe = source.index("pg_available_extensions")
     create = source.index("CREATE EXTENSION IF NOT EXISTS pg_stat_statements;\n", probe)
     assert probe < create, "pg_stat_statements must stay behind the availability probe"
@@ -239,6 +247,18 @@ def test_compose_passes_explicit_bundled_migration_owner_to_local_db() -> None:
             services["migrate"]["environment"]["GEOLENS_MIGRATION_DB_ROLE"]
             == "local_migrator"
         )
+
+
+def test_role_script_disables_host_psqlrc() -> None:
+    """fix(#1992): the reconciler also runs directly from a host (not just
+    mounted in-container), so it needs the same -X guard as init-db.sh."""
+    source = ROLE_SCRIPT.read_text(encoding="utf-8")
+
+    args_line = next(line for line in source.splitlines() if line.strip() == "-X")
+    args_block_start = source.index("psql_args=(")
+    assert source.index(args_line, args_block_start) < source.index(
+        "ON_ERROR_STOP=1", args_block_start
+    )
 
 
 def test_role_script_keeps_password_out_of_argv_and_catalog_ownership() -> None:

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -20,7 +20,9 @@ set -e
 : "${POSTGRES_USER:?POSTGRES_USER is required}"
 : "${POSTGRES_DB:?POSTGRES_DB is required}"
 
-psql_args=(-v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
+# fix(#1992): -X skips a host .psqlrc that could `\set ON_ERROR_STOP off` and
+# let a failed statement below fall through, so the script exits 0 unfixed.
+psql_args=(-X -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 if [ -n "${POSTGRES_HOST:-}" ]; then
     psql_args+=(--host "$POSTGRES_HOST")
 elif [ -n "${PGHOST:-}" ]; then


### PR DESCRIPTION
## Summary

Refs #1992. `scripts/init-db.sh` passes `-v ON_ERROR_STOP=1` to psql, but a `.psqlrc` in the invoking user's home directory can override that setting with `\set ON_ERROR_STOP off`. When that happens, a failed statement no longer aborts the script and it exits 0 as if bootstrap succeeded. This adds `-X` (`--no-psqlrc`) so the script ignores any host `.psqlrc` and stays fail-closed.

## Changes

- Add `-X` to the `psql_args` array in `scripts/init-db.sh`.
- Audited every other `psql` invocation under `scripts/` and `backend/scripts/`. `scripts/lib/configure-runtime-db-role.sh` already carries `-X`, so no change was needed there; added a structural test pinning it so it can't regress.
- Added a structural test asserting `init-db.sh`'s `psql_args` carries `-X` ahead of `ON_ERROR_STOP=1`.
- A few other host-invoked `psql` call sites elsewhere under `scripts/` still lack `-X` (a local dev-database helper and parts of the backup/restore roundtrip test). Those files are outside this PR's scope; flagging for a follow-up pass.

## Area

- [x] Infrastructure (Docker, nginx)
- [x] Backend (API, services, models)

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)

Ran `backend/tests/test_runtime_db_role.py` and `backend/tests/test_layering.py` against the local test database; all pass. Confirmed the new assertion fails against the pre-fix script and passes with the fix. Also demonstrated the underlying psql behavior directly: with a temporary home directory containing `\set ON_ERROR_STOP off` and a deliberately failing statement, psql without `-X` continues past the error and exits 0, while psql with `-X` stops at the error and exits non-zero.

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing