### PR TITLE
fix(ci): derive dep-audit's node/python/nginx pins from the Dockerfile

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -93,8 +93,36 @@ jobs:
           # npx license-checker --production --onlyAllow \
           #   'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0;CC0-1.0;Unlicense;Python-2.0;PSF-2.0;BlueOak-1.0.0;0BSD;OFL-1.1;MPL-2.0;CUSTOM'
 
+  resolve-docker-audit-matrix:
+    name: Resolve docker-audit image pins
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      # fix(#1983): node/python/nginx are Dockerfile FROM tags Dependabot
+      # bumps; deriving them here (not a second literal copy) is the single
+      # source of truth, so this matrix can't drift behind the Dockerfile.
+      - name: Derive matrix from Dockerfile FROM tags
+        id: matrix
+        run: |
+          set -euo pipefail
+          node_image=$(grep -m1 '^FROM node:' Dockerfile | awk '{print $2}')
+          python_image=$(grep -m1 '^FROM python:' Dockerfile | awk '{print $2}')
+          nginx_image=$(grep -m1 '^FROM nginxinc/nginx-unprivileged:' Dockerfile | awk '{print $2}')
+          for name in node_image python_image nginx_image; do
+            if [ -z "${!name}" ]; then
+              echo "::error::no Dockerfile FROM line matched for $name" >&2
+              exit 1
+            fi
+          done
+          include=$(printf '[{"image":"%s","enforce":"1"},{"image":"%s","enforce":"1"},{"image":"%s","enforce":"1"},{"image":"postgis/postgis:18-3.6","enforce":"0"}]' \
+            "$node_image" "$python_image" "$nginx_image")
+          echo "include=$include" >> "$GITHUB_OUTPUT"
+
   docker-audit:
     name: Docker image scan (Trivy)
+    needs: resolve-docker-audit-matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -102,24 +130,16 @@ jobs:
         # `enforce: "1"` fails the job on a fixable CRITICAL CVE; `enforce: "0"`
         # is report-only. The slim/alpine images we pin (node/python/nginx) are
         # controllable — a CRITICAL there is actionable (bump the tag), so they
-        # ENFORCE — keep these three pins matched to the Dockerfile `FROM` tags
-        # they mirror (bump together). postgis/postgis:18-3.6 is an
-        # uncontrollable third-party fat
+        # ENFORCE; their tags come from the Dockerfile `FROM` lines via the
+        # resolve-docker-audit-matrix job above, so this can't drift out of
+        # sync. postgis/postgis:18-3.6 is an uncontrollable third-party fat
         # Debian-13 image whose CRITICAL set is dominated by CVEs in baked-in Go
         # binaries that only the upstream maintainer can rebuild — and that set
         # shifts with every Trivy DB update. Gating on it would make CI red on
         # upstream timing, not on our code, so it is scanned + REPORTED but not
         # gated (tracked via Dependabot + this report; revisit at each postgis
         # base bump).
-        include:
-          - image: "node:26.8.1-alpine"
-            enforce: "1"
-          - image: "python:3.14.6-slim"
-            enforce: "1"
-          - image: "nginxinc/nginx-unprivileged:1.31.5-alpine"
-            enforce: "1"
-          - image: "postgis/postgis:18-3.6"
-            enforce: "0"
+        include: ${{ fromJson(needs.resolve-docker-audit-matrix.outputs.include) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       # Scope is CRITICAL (not HIGH): these scan UPSTREAM base images, whose HIGH

--- a/backend/tests/test_docker_audit_regressions.py
+++ b/backend/tests/test_docker_audit_regressions.py
@@ -1,9 +1,11 @@
 """Regression tests for production container hardening invariants."""
 
+import json
 import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import yaml
@@ -86,23 +88,62 @@ def test_backup_base_is_digest_pinned():
     )
 
 
-def test_docker_audit_matrix_pins_match_dockerfile_from_tags():
-    # fix(#1778): dep-audit.yml's own comment says the node/python/nginx
-    # pins must be "matched to the Dockerfile FROM tags they mirror (bump
-    # together)" because Dependabot bumps the Dockerfile but cannot touch
-    # this inline matrix string — the two drifted (node 26.5.0 vs the
-    # Dockerfile's 26.7.0+, nginx 1.31.1 vs 1.31.3+) with nothing catching it.
-    matrix = yaml.safe_load(DEP_AUDIT_WORKFLOW.read_text())["jobs"]["docker-audit"][
-        "strategy"
-    ]["matrix"]["include"]
-    enforced_images = [entry["image"] for entry in matrix if entry["enforce"] == "1"]
+def test_docker_audit_matrix_is_derived_not_a_second_literal_copy():
+    # fix(#1983): dep-audit.yml derives node/python/nginx from the Dockerfile
+    # at run time instead of a second literal matrix copy (#1778 drifted,
+    # #1975 needed a manual fix) — assert it stays derived, not reverted.
+    workflow = yaml.safe_load(DEP_AUDIT_WORKFLOW.read_text())["jobs"]
+    docker_audit = workflow["docker-audit"]
+
+    assert docker_audit["needs"] == "resolve-docker-audit-matrix"
+    matrix_include = docker_audit["strategy"]["matrix"]["include"]
+    assert isinstance(matrix_include, str) and "fromJson(" in matrix_include, (
+        "docker-audit's matrix.include must reference the resolved job "
+        "output, not a literal list of images — a literal list is exactly "
+        "the second copy that drifted behind the Dockerfile in #1778/#1983"
+    )
+
+
+def test_docker_audit_matrix_resolver_pins_match_dockerfile_from_tags():
+    # fix(#1983): runs the real resolve-docker-audit-matrix step against the
+    # Dockerfile, so a broken grep pattern or renamed stage fails here
+    # instead of silently emitting an empty or stale pin in CI.
+    steps = yaml.safe_load(DEP_AUDIT_WORKFLOW.read_text())["jobs"][
+        "resolve-docker-audit-matrix"
+    ]["steps"]
+    matrix_step = next(step for step in steps if step.get("id") == "matrix")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_file = Path(tmp_dir) / "github_output"
+        output_file.touch()
+        subprocess.run(
+            ["bash", "-c", matrix_step["run"]],
+            cwd=REPO_ROOT,
+            env={**os.environ, "GITHUB_OUTPUT": str(output_file)},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        output_line = next(
+            line
+            for line in output_file.read_text().splitlines()
+            if line.startswith("include=")
+        )
+        resolved = json.loads(output_line[len("include=") :])
+
+    enforced_images = {entry["image"] for entry in resolved if entry["enforce"] == "1"}
     assert enforced_images
 
     dockerfile_text = DOCKERFILE.read_text()
     for image in enforced_images:
         assert re.search(
             rf"^FROM {re.escape(image)}(\s|$)", dockerfile_text, re.MULTILINE
-        ), f"{image} (dep-audit.yml) has no matching FROM line in Dockerfile"
+        ), (
+            f"{image} (resolved by dep-audit.yml) has no matching FROM line in Dockerfile"
+        )
+
+    report_only = [entry for entry in resolved if entry["enforce"] == "0"]
+    assert report_only == [{"image": "postgis/postgis:18-3.6", "enforce": "0"}]
 
 
 def test_backend_runtime_does_not_recursively_chown_application_tree():


### PR DESCRIPTION
## Summary

docker-audit's Trivy scan matrix kept its own copy of the node/python/nginx image tags next to the Dockerfile's `FROM` lines. Dependabot's docker ecosystem only bumps the Dockerfile, so the matrix drifted behind it — #1975 needed a manual companion commit to catch up, and every future bump would need the same. A test could only catch the drift after it already happened.

Closes #1983.

## Changes

- Add a `resolve-docker-audit-matrix` job to `.github/workflows/dep-audit.yml` that greps the node/python/nginx tags straight out of `Dockerfile` and emits them as a job output; `docker-audit` now consumes that output via `fromJson(...)` instead of a literal `include:` list. `postgis/postgis` stays a static, report-only entry since it has no Dockerfile `FROM` line to derive from.
- Replace `test_docker_audit_matrix_pins_match_dockerfile_from_tags` in `backend/tests/test_docker_audit_regressions.py` with two tests: one asserting `docker-audit` consumes the resolved output rather than a literal list, and one that runs the real derivation step against the Dockerfile and checks its output.

## Area

- [x] Infrastructure (Docker, nginx)

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)

Ran `backend/tests/test_docker_audit_regressions.py` (13 passed), executed the workflow's derivation script directly against the repo's Dockerfile to confirm its output, validated the workflow with `python3 -c 'import yaml; yaml.safe_load(...)'` and `actionlint`, and ran two counterfactuals: reverting `docker-audit`'s matrix to a literal list, and breaking the nginx grep pattern — both fail the corresponding new test, then were reverted.

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff