### PR TITLE
fix(gates): give the ponytail: denylist hook a same-line anchor escape

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,30 +114,34 @@ repos:
         files: '^backend/(app/.*|tests/finding_markers)\.py$'
 
       - id: no-agent-tag-markers
-        name: "AGENTS.md — no `ponytail:` literal anywhere in a python/ts/tsx/js/shell file"
+        name: "AGENTS.md — a `ponytail:` tag needs a same-line fix(#N) anchor outside backend/app"
         description: >
           The denylist half of the same rule, for the file types the AST
-          detector above does not parse (frontend/, e2e/, cli/, mcp/). One
-          case-insensitive literal, grepped over the whole file rather than
-          its comments — that is all this hook checks and all it claims. The
-          general class is enforced for backend/app, and only there, by
-          no-unscoped-finding-markers.
+          detector above does not parse (frontend/, e2e/, cli/, mcp/, plus
+          markdown/sql/yaml/json anywhere in the tree). A case-insensitive
+          literal grepped over the whole file rather than its comments — that
+          is all this hook checks and all it claims. A `ponytail:` tag is
+          legal only when the same line also carries a `fix(#<issue>)`
+          anchor; a bare tag fails everywhere. The general class is enforced
+          for backend/app, and only there, by no-unscoped-finding-markers.
         language: system
         entry: >-
           bash -c '
           rc=0;
           for f in "$@"; do
-            if grep -nFi "ponytail:" "$f"; then
+            if grep -nFi "ponytail:" "$f" | grep -viE "fix\(#[0-9]+\)"; then
               echo "FAIL: $f has an unscoped finding marker (see above).";
-              echo "  Use fix(#<issue>): <context>, or remove the tag.";
+              echo "  Use fix(#<issue>) ponytail: <context> on the same line, or remove the tag.";
               echo "  See AGENTS.md > Inline review-comment convention.";
               rc=1;
             fi;
           done;
           exit $rc;
           ' --
-        types_or: [python, ts, tsx, javascript, shell]
-        exclude: '^(sdks/|frontend/node_modules/)'
+        types_or: [python, ts, tsx, javascript, shell, markdown, sql, yaml, json]
+        # This file's own name/description/entry name the literal it forbids;
+        # it defines the rule rather than being subject to it.
+        exclude: '^(sdks/|frontend/node_modules/|\.pre-commit-config\.yaml)'
 
       # --- Lint + format (shift-left; CI backend-lint also enforces these) ---
       - id: ruff-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Frontend change: from the worktree run `cd frontend && API_PROXY_TARGET=http://l
 - API schema changes, including published route docstrings/Pydantic field descriptions, require `make sdks` (refreshes OpenAPI and both SDKs), then `cd frontend && npm run types:generate`. Frontend drift gate: `npm run types:check`. Commit generated changes only when source changes require them.
 - Never hand-edit generated SDK code or `frontend/src/types/api.generated.ts`. SDK auth/entry wrappers (`auth.py`, `__init__.py`, `auth.ts`, `index.ts`) are hand-maintained; CLI and MCP wrap the SDK.
 - New UI strings use `t()` with keys in all four locales (en/es/fr/de); run `cd frontend && npm run test:i18n`. `defaultValue` is insufficient. Keep plural suffixes consistent; `_many` does not fall back to `_other`. French count 0 uses `_one`, so interpolate `{{count}}` instead of hardcoding 1.
-- Comments explain non-obvious reasons/traps; docstrings state contracts. Avoid narration/history. Review references need an issue/PR anchor plus the invariant, at most three lines: `// fix(#1234): suppress basemap row click during multi-selection`. Bare private tracker IDs fail finding-marker checks.
+- Comments explain non-obvious reasons/traps; docstrings state contracts. Avoid narration/history. Review references need an issue/PR anchor plus the invariant, at most three lines: `// fix(#1234): suppress basemap row click during multi-selection`. Bare private tracker IDs fail finding-marker checks. Outside `backend/app/`, `no-agent-tag-markers` needs the `fix(#issue)` anchor on the same line as the tag; a bare tag fails there too.
 - Put `# broad: <reason>` on the same line as every `except Exception`. Follow CodeQL marker placement below.
 
 ## Security

--- a/backend/tests/test_agent_tag_marker_hook.py
+++ b/backend/tests/test_agent_tag_marker_hook.py
@@ -1,0 +1,106 @@
+"""Wiring test for the ``no-agent-tag-markers`` pre-commit hook.
+
+gh#1960: the denylist half of AGENTS.md's inline review-comment convention
+covers the file types finding_markers.py's AST detector does not parse
+(frontend/, e2e/, cli/, mcp/, plus markdown/sql/yaml/json). It must accept
+the same fix(#<issue>) anchor the AST half accepts for that tag in
+backend/app, so the convention is not anchorable in one half of the repo and
+forbidden outright in the other.
+
+This runs the hook's actual `entry` command against fixture files, the same
+way pre-commit invokes it (shlex-split entry, filenames appended as further
+argv), rather than reimplementing its grep in Python — a rewrite of the
+escape hatch or the pattern breaks this test the same way it breaks the hook.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRE_COMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+HOOK_ID = "no-agent-tag-markers"
+
+# Built by concatenation, not written contiguously, so this source file does
+# not itself become a bare-tag hit under the hook it is testing.
+TAG = "pony" + "tail:"
+
+
+def _hook() -> dict:
+    config = yaml.safe_load(PRE_COMMIT_CONFIG.read_text(encoding="utf-8"))
+    for repo in config["repos"]:
+        if repo["repo"] != "local":
+            continue
+        for hook in repo["hooks"]:
+            if hook["id"] == HOOK_ID:
+                return hook
+    raise AssertionError(f"{HOOK_ID} is gone from {PRE_COMMIT_CONFIG.name}")
+
+
+HOOK = _hook()
+ARGV = shlex.split(HOOK["entry"])
+
+
+def _run(path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ARGV + [str(path)], capture_output=True, text=True, check=False
+    )
+
+
+class TestEscapeHatch:
+    """A same-line fix(#N) anchor is legal everywhere this hook runs; a bare tag never is."""
+
+    def test_bare_tag_in_a_frontend_ts_file_fails(self, tmp_path):
+        f = tmp_path / "a.ts"
+        f.write_text(f"// {TAG} skip the retry loop\n")
+        result = _run(f)
+        assert result.returncode == 1
+        assert "unscoped finding marker" in result.stdout
+
+    def test_anchored_tag_in_a_frontend_ts_file_passes(self, tmp_path):
+        f = tmp_path / "a.ts"
+        f.write_text(f"// fix(#1960) {TAG} skip the retry loop\n")
+        result = _run(f)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_bare_tag_in_a_markdown_file_fails(self, tmp_path):
+        """Coverage gap from gh#1960: markdown was not in types_or before this fix."""
+        f = tmp_path / "notes.md"
+        f.write_text(f"<!-- {TAG} skip the retry loop -->\n")
+        result = _run(f)
+        assert result.returncode == 1
+
+    def test_anchor_on_a_different_line_does_not_scope_it(self, tmp_path):
+        """The escape hatch is same-line only: an anchor two lines away does not count."""
+        f = tmp_path / "a.ts"
+        f.write_text(f"// fix(#1960) see below\n// {TAG} skip the retry loop\n")
+        result = _run(f)
+        assert result.returncode == 1
+
+    def test_each_line_is_judged_on_its_own_anchor(self, tmp_path):
+        """One bare line fails even when a sibling line in the same file is anchored."""
+        f = tmp_path / "a.ts"
+        f.write_text(f"// {TAG} bare, line 1\n// fix(#1960) {TAG} anchored, line 2\n")
+        result = _run(f)
+        assert result.returncode == 1
+        assert "bare, line 1" in result.stdout
+        assert "anchored, line 2" not in result.stdout
+
+
+class TestHookWiring:
+    """The hook covers the file types AGENTS.md and gh#1960 name."""
+
+    def test_widened_types_cover_markdown_sql_yaml_json(self):
+        for file_type in ("markdown", "sql", "yaml", "json"):
+            assert file_type in HOOK["types_or"], (
+                f"{HOOK_ID} must cover {file_type!r} (gh#1960 coverage gap)"
+            )
+
+    def test_original_types_still_covered(self):
+        for file_type in ("python", "ts", "tsx", "javascript", "shell"):
+            assert file_type in HOOK["types_or"]


### PR DESCRIPTION
Closes #1960.

## Problem

`no-agent-tag-markers` greps the bare `ponytail:` literal outside `backend/app`, with no way to scope it. `no-unscoped-finding-markers` (the AST detector, `backend/app` only) accepts `fix(#1234) ponytail: ...` as a legal anchored marker, so the identical comment passed in `backend/app` and failed everywhere else. An agent following the `ponytail-debt` convention could not satisfy both the plugin's own workflow and this repo outside `backend/app`.

## Fix

- `no-agent-tag-markers`'s entry now requires the same line to also carry a `fix(#<issue>)` anchor. A bare tag still fails everywhere; an anchored one now passes everywhere.
- Widened `types_or` to include `markdown`, `sql`, `yaml` and `json`, which were previously unchecked (issue's "coverage gap").
- Excluded `.pre-commit-config.yaml` itself from the hook. Widening to markdown/yaml made the hook self-referential: its own name/description/entry necessarily name the literal it forbids, and none of those mentions carry a real numeric anchor. That file defines the rule rather than being subject to it.
- One clarifying sentence in AGENTS.md's Contracts and Comments section, since the anchor escape hatch outside `backend/app/` wasn't documented there before.

## Tests

`backend/tests/test_agent_tag_marker_hook.py` runs the hook's actual `entry` command (shlex-split, same way pre-commit invokes it) against fixture files, rather than reimplementing the grep in Python. Covers: bare tag in a `.ts` file fails, the anchored form passes, a bare tag in a `.md` file now fails (the coverage gap), an anchor two lines away does not scope a bare tag on its own line, and one bare line fails even when a sibling line in the same file is anchored. Also pins that `types_or` carries the four new file types alongside the original five.

## Verification

```
$ cd backend && uv run ruff check . && uv run ruff format --check .
All checks passed!

$ uv run pytest tests/test_agent_tag_marker_hook.py tests/test_unscoped_finding_markers.py tests/test_layering.py -q
87 passed

$ python3 backend/tests/finding_markers.py; echo $?
0

$ SKIP=ruff-check,ruff-format,gitleaks pre-commit run --all-files
AGENTS.md — a `ponytail:` tag needs a same-line fix(#N) anchor outside backend/app ... Passed
(all other hooks Passed)
```

Negative control, run against the tree before the fix (`git stash`) and reverted: the anchored form (`fix(#1960) ponytail: ...`) failed in a `.ts` fixture, and `markdown` was absent from `types_or`, reproducing the issue exactly. Both are fixed on this branch.

No CHANGELOG entry: internal contributor gate, no user-facing behavior.
