### PR TITLE
test(backend): gate finding markers reaching the published OpenAPI surface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,13 +105,19 @@ repos:
           only go down; backend/tests/test_unscoped_finding_markers.py runs the
           same check in CI and pins the detector's behaviour.
 
+          The same run also scans backend/openapi.json's `description` strings
+          (#1946): a string literal the walk above cannot see, but one that
+          still reaches the published API surface and the generated SDKs, so
+          it gets zero tolerance rather than a debt ledger.
+          backend/tests/test_openapi_finding_markers.py pins that half.
+
           Write `fix(#1234): <one line>`, or just drop the tag and let the
           sentence stand — a note about a deliberate limitation does not need a
           prefix to be understood.
         language: system
         entry: python3 backend/tests/finding_markers.py
         pass_filenames: false
-        files: '^backend/(app/.*|tests/finding_markers)\.py$'
+        files: '^backend/(app/.*\.py|openapi\.json|tests/(finding_markers|test_openapi_finding_markers)\.py)$'
 
       - id: no-agent-tag-markers
         name: "AGENTS.md — no `ponytail:` literal anywhere in a python/ts/tsx/js/shell file"

--- a/backend/app/modules/auth/oauth/schemas.py
+++ b/backend/app/modules/auth/oauth/schemas.py
@@ -345,10 +345,10 @@ class OAuthProviderResponse(BaseModel):
     The 3 non-secret SAML fields (``idp_entity_id``, ``idp_sso_url``,
     ``sp_entity_id``) ARE exposed so the admin UI can display them.
 
-    Pitfall 11 interaction: those 3 fields are declared with ``deferred=True``
-    on the OAuth ORM model so community DBs (which lack the columns) do not
-    crash on SELECT. Pydantic's ``from_attributes=True`` would normally trigger
-    an implicit deferred load on attribute access, which fails under FastAPI's
+    Those 3 fields are declared with ``deferred=True`` on the OAuth ORM
+    model so community DBs (which lack the columns) do not crash on
+    SELECT. Pydantic's ``from_attributes=True`` would normally trigger an
+    implicit deferred load on attribute access, which fails under FastAPI's
     async context with ``MissingGreenlet``. The ``model_validator(mode="before")``
     below reads the SAML fields directly from ``obj.__dict__`` so unloaded
     attributes default to None instead of triggering IO. SAML admin endpoints

--- a/backend/app/modules/catalog/maps/router.py
+++ b/backend/app/modules/catalog/maps/router.py
@@ -660,14 +660,14 @@ async def patch_map_layers_endpoint(
 ) -> MapResponse:
     """Apply incremental layer additions, patches, removals, and ordering.
 
-    v13.14 fixup: declared on both slash variants directly (mirrors the
-    Phase 280 fix on POST). FastAPI's default redirect_slashes builds a
-    relative Location header that resolves against the request's Host
-    header, which would leak the in-container ``api:8000`` hostname
-    through Vite's dev proxy on a 307 redirect. The canonical
-    (OpenAPI-published) form is the no-slash sub-collection convention
-    documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
-    the trailing-slash form is a hidden alias.
+    Declared on both slash variants directly, mirroring the POST route
+    below. FastAPI's default redirect_slashes builds a relative Location
+    header that resolves against the request's Host header, which would
+    leak the in-container ``api:8000`` hostname through Vite's dev proxy
+    on a 307 redirect. The canonical (OpenAPI-published) form is the
+    no-slash sub-collection convention documented in the GeoLens API guide
+    (https://docs.getgeolens.com/guides/api/); the trailing-slash form is
+    a hidden alias.
     """
     map_obj = await get_map(db, map_id)
     if map_obj is None:
@@ -1289,9 +1289,9 @@ async def add_layer_endpoint(
 ) -> MapLayerResponse:
     """Add a layer to a map.
 
-    Phase 280: declared on both slash variants directly so neither emits a
-    307. FastAPI's default redirect_slashes builds a relative Location
-    header that resolves against the request's Host header, leaking the
+    Declared on both slash variants directly so neither emits a 307.
+    FastAPI's default redirect_slashes builds a relative Location header
+    that resolves against the request's Host header, leaking the
     in-container ``api:8000`` hostname through Vite's dev proxy. The
     canonical (OpenAPI-published) form is the no-slash sub-collection
     convention documented in the GeoLens API guide

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -11472,7 +11472,7 @@
         "type": "object"
       },
       "OAuthProviderResponse": {
-        "description": "Response schema for OAuth/SAML provider.\n\nWrite-only credentials are never exposed:\n  - ``client_secret_encrypted`` (OAuth client secret) \u2014 excluded.\n  - ``idp_certificate`` (SAML IdP signing cert, Fernet-encrypted at rest) \u2014 excluded.\n\nThe 3 non-secret SAML fields (``idp_entity_id``, ``idp_sso_url``,\n``sp_entity_id``) ARE exposed so the admin UI can display them.\n\nPitfall 11 interaction: those 3 fields are declared with ``deferred=True``\non the OAuth ORM model so community DBs (which lack the columns) do not\ncrash on SELECT. Pydantic's ``from_attributes=True`` would normally trigger\nan implicit deferred load on attribute access, which fails under FastAPI's\nasync context with ``MissingGreenlet``. The ``model_validator(mode=\"before\")``\nbelow reads the SAML fields directly from ``obj.__dict__`` so unloaded\nattributes default to None instead of triggering IO. SAML admin endpoints\nthat need the values must use ``undefer_group(\"saml\")`` at query time.",
+        "description": "Response schema for OAuth/SAML provider.\n\nWrite-only credentials are never exposed:\n  - ``client_secret_encrypted`` (OAuth client secret) \u2014 excluded.\n  - ``idp_certificate`` (SAML IdP signing cert, Fernet-encrypted at rest) \u2014 excluded.\n\nThe 3 non-secret SAML fields (``idp_entity_id``, ``idp_sso_url``,\n``sp_entity_id``) ARE exposed so the admin UI can display them.\n\nThose 3 fields are declared with ``deferred=True`` on the OAuth ORM\nmodel so community DBs (which lack the columns) do not crash on\nSELECT. Pydantic's ``from_attributes=True`` would normally trigger an\nimplicit deferred load on attribute access, which fails under FastAPI's\nasync context with ``MissingGreenlet``. The ``model_validator(mode=\"before\")``\nbelow reads the SAML fields directly from ``obj.__dict__`` so unloaded\nattributes default to None instead of triggering IO. SAML admin endpoints\nthat need the values must use ``undefer_group(\"saml\")`` at query time.",
         "properties": {
           "id": {
             "description": "Unique provider identifier.",
@@ -47698,7 +47698,7 @@
     },
     "/maps/{map_id}/layers": {
       "patch": {
-        "description": "Apply incremental layer additions, patches, removals, and ordering.\n\nv13.14 fixup: declared on both slash variants directly (mirrors the\nPhase 280 fix on POST). FastAPI's default redirect_slashes builds a\nrelative Location header that resolves against the request's Host\nheader, which would leak the in-container ``api:8000`` hostname\nthrough Vite's dev proxy on a 307 redirect. The canonical\n(OpenAPI-published) form is the no-slash sub-collection convention\ndocumented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);\nthe trailing-slash form is a hidden alias.",
+        "description": "Apply incremental layer additions, patches, removals, and ordering.\n\nDeclared on both slash variants directly, mirroring the POST route\nbelow. FastAPI's default redirect_slashes builds a relative Location\nheader that resolves against the request's Host header, which would\nleak the in-container ``api:8000`` hostname through Vite's dev proxy\non a 307 redirect. The canonical (OpenAPI-published) form is the\nno-slash sub-collection convention documented in the GeoLens API guide\n(https://docs.getgeolens.com/guides/api/); the trailing-slash form is\na hidden alias.",
         "operationId": "patch_map_layers_endpoint_maps__map_id__layers_patch",
         "parameters": [
           {
@@ -47850,7 +47850,7 @@
         ]
       },
       "post": {
-        "description": "Add a layer to a map.\n\nPhase 280: declared on both slash variants directly so neither emits a\n307. FastAPI's default redirect_slashes builds a relative Location\nheader that resolves against the request's Host header, leaking the\nin-container ``api:8000`` hostname through Vite's dev proxy. The\ncanonical (OpenAPI-published) form is the no-slash sub-collection\nconvention documented in the GeoLens API guide\n(https://docs.getgeolens.com/guides/api/); the trailing-slash form is a\nhidden alias for callers that send the slash.",
+        "description": "Add a layer to a map.\n\nDeclared on both slash variants directly so neither emits a 307.\nFastAPI's default redirect_slashes builds a relative Location header\nthat resolves against the request's Host header, leaking the\nin-container ``api:8000`` hostname through Vite's dev proxy. The\ncanonical (OpenAPI-published) form is the no-slash sub-collection\nconvention documented in the GeoLens API guide\n(https://docs.getgeolens.com/guides/api/); the trailing-slash form is a\nhidden alias for callers that send the slash.",
         "operationId": "add_layer_endpoint_maps__map_id__layers_post",
         "parameters": [
           {

--- a/backend/tests/finding_markers.py
+++ b/backend/tests/finding_markers.py
@@ -451,6 +451,19 @@ MIN_OPENAPI_DESCRIPTIONS = 3000
 # TECHNICAL_VOCABULARY, which also bounds the source-tree debt ledger above.
 _PUBLISHED_VOCABULARY = TECHNICAL_VOCABULARY | {"ADR-002"}
 
+# MARKER_RE requires a hyphen, so a bare internal-cadence reference — "Phase
+# 280", "Pitfall 11" — reaches openapi.json invisibly. Scoped to this scan
+# only, not the shared MARKER_RE, so the source-tree debt ledger is untouched.
+_CADENCE_RE = re.compile(r"\b(?:Phase|Pitfall|Milestone|Wave|Sprint|Lane)\s+#?\d+\b")
+
+
+def _openapi_markers(line: str) -> tuple[str, ...]:
+    """Marker-shaped tokens in one description line: the shared detector's
+    hyphenated shape, plus a bare cadence reference it cannot see."""
+    found = set(markers_in(line, _PUBLISHED_VOCABULARY))
+    found.update(_CADENCE_RE.findall(line))
+    return tuple(sorted(found))
+
 
 def _openapi_descriptions(node: object, path: str = "$") -> list[tuple[str, str]]:
     """Every description string in a parsed OpenAPI document, with its JSON
@@ -476,7 +489,7 @@ def scan_openapi(spec: object) -> list[Hit]:
         lines = text.splitlines()
         anchored = [ANCHOR_RE.search(line) is not None for line in lines]
         for offset, line in enumerate(lines):
-            markers = markers_in(line, _PUBLISHED_VOCABULARY)
+            markers = _openapi_markers(line)
             if not markers:
                 continue
             low = max(0, offset - ANCHOR_WINDOW)

--- a/backend/tests/finding_markers.py
+++ b/backend/tests/finding_markers.py
@@ -436,15 +436,19 @@ def check(app_root: Path = APP_ROOT) -> list[str]:
     return problems
 
 
-# Field/Query ``description=`` strings are literals, not docstrings, so
-# nothing above sees them, though they reach openapi.json and the SDKs
-# (#1946). Only openapi.json is scanned; make sdks-check already gates drift
-# between it and the ~900 generated SDK files.
+# Field/Query ``description=``/``summary=`` strings are literals, not
+# docstrings, so nothing above sees them, though they reach openapi.json and
+# the SDKs (#1946). Only openapi.json is scanned; make sdks-check already
+# gates drift between it and the ~900 generated SDK files.
 OPENAPI_PATH = Path(__file__).resolve().parents[1] / "openapi.json"
 
-# main carries 4175 description strings; a walk that silently sees none of
-# the spec (a moved file, a renamed key) must fail loudly, not pass empty.
-MIN_OPENAPI_DESCRIPTIONS = 3000
+# Keys FastAPI publishes as reader-facing prose, not identifiers.
+_OPENAPI_TEXT_KEYS = frozenset({"description", "summary"})
+
+# main carries 4444 description/summary strings; a walk that silently sees
+# none of the spec (a moved file, a renamed key) must fail loudly, not pass
+# empty.
+MIN_OPENAPI_DESCRIPTIONS = 3500
 
 # ADR-002 (.github/ADR-002.md) is a committed, publicly readable design
 # record, as resolvable as a CVE id or a GH-NNNN issue. Kept separate from
@@ -474,15 +478,15 @@ def _openapi_markers(line: str) -> tuple[str, ...]:
     return tuple(sorted(found))
 
 
-def _openapi_descriptions(node: object, path: str = "$") -> list[tuple[str, str]]:
-    """Every description string in a parsed OpenAPI document, with its JSON
-    path."""
-    found: list[tuple[str, str]] = []
+def _openapi_descriptions(node: object, path: str = "$") -> list[tuple[str, str, str]]:
+    """Every description/summary string in a parsed OpenAPI document, with
+    its JSON path and which key it came from."""
+    found: list[tuple[str, str, str]] = []
     if isinstance(node, dict):
         for key, value in node.items():
             child = f"{path}.{key}"
-            if key == "description" and isinstance(value, str):
-                found.append((child, value))
+            if key in _OPENAPI_TEXT_KEYS and isinstance(value, str):
+                found.append((child, key, value))
             else:
                 found.extend(_openapi_descriptions(value, child))
     elif isinstance(node, list):
@@ -492,9 +496,10 @@ def _openapi_descriptions(node: object, path: str = "$") -> list[tuple[str, str]
 
 
 def scan_openapi(spec: object) -> list[Hit]:
-    """Unanchored marker-bearing lines in every ``description`` in ``spec``."""
+    """Unanchored marker-bearing lines in every ``description``/``summary``
+    in ``spec``."""
     hits: list[Hit] = []
-    for json_path, text in _openapi_descriptions(spec):
+    for json_path, key, text in _openapi_descriptions(spec):
         lines = text.splitlines()
         anchored = [ANCHOR_RE.search(line) is not None for line in lines]
         for offset, line in enumerate(lines):
@@ -505,7 +510,7 @@ def scan_openapi(spec: object) -> list[Hit]:
             high = offset + ANCHOR_WINDOW + 1
             if any(anchored[low:high]):
                 continue
-            hits.append(Hit(json_path, offset + 1, "openapi-description", markers))
+            hits.append(Hit(json_path, offset + 1, f"openapi-{key}", markers))
     return hits
 
 
@@ -520,9 +525,9 @@ def check_openapi(openapi_path: Path = OPENAPI_PATH) -> list[str]:
     description_count = len(_openapi_descriptions(spec))
     if description_count < MIN_OPENAPI_DESCRIPTIONS:
         problems.append(
-            f"read {description_count} description strings from {openapi_path},"
-            f" floor is {MIN_OPENAPI_DESCRIPTIONS} — the scan is not seeing the"
-            " spec"
+            f"read {description_count} description/summary strings from"
+            f" {openapi_path}, floor is {MIN_OPENAPI_DESCRIPTIONS} — the scan"
+            " is not seeing the spec"
         )
 
     hits = scan_openapi(spec)

--- a/backend/tests/finding_markers.py
+++ b/backend/tests/finding_markers.py
@@ -456,12 +456,21 @@ _PUBLISHED_VOCABULARY = TECHNICAL_VOCABULARY | {"ADR-002"}
 # only, not the shared MARKER_RE, so the source-tree debt ledger is untouched.
 _CADENCE_RE = re.compile(r"\b(?:Phase|Pitfall|Milestone|Wave|Sprint|Lane)\s+#?\d+\b")
 
+# A private planning-doc filename: the literal ``CONTEXT.md`` or a numbered
+# ``NNN-NN-NAME.md`` note (see backend/app/processing/ingest/tasks_common.py
+# for the shape). A real published doc (AGENTS.md, ADR-002.md) has no digit
+# prefix, so this does not need to exempt them.
+_PLANNING_DOC_RE = re.compile(
+    r"\bCONTEXT\.md\b|\b\d{2,4}-\d{2,4}-[A-Z][A-Z0-9-]*\.md\b"
+)
+
 
 def _openapi_markers(line: str) -> tuple[str, ...]:
     """Marker-shaped tokens in one description line: the shared detector's
-    hyphenated shape, plus a bare cadence reference it cannot see."""
+    hyphenated shape, plus a bare reference it cannot see."""
     found = set(markers_in(line, _PUBLISHED_VOCABULARY))
     found.update(_CADENCE_RE.findall(line))
+    found.update(_PLANNING_DOC_RE.findall(line))
     return tuple(sorted(found))
 
 

--- a/backend/tests/finding_markers.py
+++ b/backend/tests/finding_markers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ast
 import io
+import json
 import re
 import sys
 import tokenize
@@ -158,9 +159,11 @@ def iter_units(source: str, module: str) -> list[Unit]:
     return _comment_units(source, module) + _docstring_units(source, module)
 
 
-def markers_in(text: str) -> tuple[str, ...]:
+def markers_in(
+    text: str, vocabulary: frozenset[str] = TECHNICAL_VOCABULARY
+) -> tuple[str, ...]:
     """Finding markers in one unit, vocabulary removed, sorted and deduped."""
-    found = {t for t in MARKER_RE.findall(text) if t not in TECHNICAL_VOCABULARY}
+    found = {t for t in MARKER_RE.findall(text) if t not in vocabulary}
     found.update(m.group(1) for m in AGENT_TAG_RE.finditer(text))
     return tuple(sorted(found))
 
@@ -433,12 +436,95 @@ def check(app_root: Path = APP_ROOT) -> list[str]:
     return problems
 
 
+# Field/Query ``description=`` strings are literals, not docstrings, so
+# nothing above sees them, though they reach openapi.json and the SDKs
+# (#1946). Only openapi.json is scanned; make sdks-check already gates drift
+# between it and the ~900 generated SDK files.
+OPENAPI_PATH = Path(__file__).resolve().parents[1] / "openapi.json"
+
+# main carries 4175 description strings; a walk that silently sees none of
+# the spec (a moved file, a renamed key) must fail loudly, not pass empty.
+MIN_OPENAPI_DESCRIPTIONS = 3000
+
+# ADR-002 (.github/ADR-002.md) is a committed, publicly readable design
+# record, as resolvable as a CVE id or a GH-NNNN issue. Kept separate from
+# TECHNICAL_VOCABULARY, which also bounds the source-tree debt ledger above.
+_PUBLISHED_VOCABULARY = TECHNICAL_VOCABULARY | {"ADR-002"}
+
+
+def _openapi_descriptions(node: object, path: str = "$") -> list[tuple[str, str]]:
+    """Every description string in a parsed OpenAPI document, with its JSON
+    path."""
+    found: list[tuple[str, str]] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child = f"{path}.{key}"
+            if key == "description" and isinstance(value, str):
+                found.append((child, value))
+            else:
+                found.extend(_openapi_descriptions(value, child))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            found.extend(_openapi_descriptions(value, f"{path}[{index}]"))
+    return found
+
+
+def scan_openapi(spec: object) -> list[Hit]:
+    """Unanchored marker-bearing lines in every ``description`` in ``spec``."""
+    hits: list[Hit] = []
+    for json_path, text in _openapi_descriptions(spec):
+        lines = text.splitlines()
+        anchored = [ANCHOR_RE.search(line) is not None for line in lines]
+        for offset, line in enumerate(lines):
+            markers = markers_in(line, _PUBLISHED_VOCABULARY)
+            if not markers:
+                continue
+            low = max(0, offset - ANCHOR_WINDOW)
+            high = offset + ANCHOR_WINDOW + 1
+            if any(anchored[low:high]):
+                continue
+            hits.append(Hit(json_path, offset + 1, "openapi-description", markers))
+    return hits
+
+
+def check_openapi(openapi_path: Path = OPENAPI_PATH) -> list[str]:
+    """Every unanchored marker reaching the published OpenAPI surface."""
+    try:
+        spec = json.loads(openapi_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"could not read {openapi_path}: {exc}"]
+
+    problems: list[str] = []
+    description_count = len(_openapi_descriptions(spec))
+    if description_count < MIN_OPENAPI_DESCRIPTIONS:
+        problems.append(
+            f"read {description_count} description strings from {openapi_path},"
+            f" floor is {MIN_OPENAPI_DESCRIPTIONS} — the scan is not seeing the"
+            " spec"
+        )
+
+    hits = scan_openapi(spec)
+    if hits:
+        problems.append(
+            f"{openapi_path} publishes finding markers with no #issue anchor —"
+            " an integrator reading the generated SDK docstring has nothing to"
+            " resolve them against. Rewrite the Field/Query description to"
+            " state the constraint itself, then run `make sdks`:"
+        )
+        problems.extend(f"    {hit.describe()}" for hit in hits)
+
+    return problems
+
+
 def main() -> int:
     """Print every violation and return 1, or return 0 on a clean tree."""
-    problems = check()
+    problems = check() + check_openapi()
     if not problems:
         return 0
-    print("FAIL: unscoped finding markers in backend/app comments or docstrings")
+    print(
+        "FAIL: unscoped finding markers in backend/app comments/docstrings or"
+        " backend/openapi.json descriptions"
+    )
     for line in problems:
         print(f"  {line}")
     print("  See AGENTS.md > Inline review-comment convention.")

--- a/backend/tests/test_openapi_finding_markers.py
+++ b/backend/tests/test_openapi_finding_markers.py
@@ -88,6 +88,12 @@ class TestDetector:
         spec = {"description": "See AGENTS.md for the convention."}
         assert not fm.scan_openapi(spec)
 
+    def test_a_route_summary_fails_too(self):
+        spec = {"paths": {"/x": {"get": {"summary": "Bound is PERF-N16"}}}}
+        hits = fm.scan_openapi(spec)
+        assert [h.markers for h in hits] == [("PERF-N16",)]
+        assert hits[0].kind == "openapi-summary"
+
     def test_nested_paths_are_walked(self):
         spec = {
             "paths": {

--- a/backend/tests/test_openapi_finding_markers.py
+++ b/backend/tests/test_openapi_finding_markers.py
@@ -1,0 +1,83 @@
+"""Structural gate for #1946: markers reaching the published OpenAPI surface.
+
+A Pydantic/FastAPI ``description=`` string is a string literal, not a
+docstring, so backend/tests/finding_markers.py's comment/docstring walk never
+reads it. This gate scans backend/openapi.json directly, the artifact those
+descriptions actually reach.
+"""
+
+import json
+
+from tests import finding_markers as fm
+
+
+class TestPublishedSurface:
+    """The gate over the real backend/openapi.json."""
+
+    def test_the_real_spec_is_clean(self):
+        problems = fm.check_openapi()
+        assert not problems, "\n".join(problems)
+
+    def test_scan_reaches_the_real_spec(self):
+        spec = json.loads(fm.OPENAPI_PATH.read_text(encoding="utf-8"))
+        assert fm.MIN_OPENAPI_DESCRIPTIONS > 0
+        assert len(fm._openapi_descriptions(spec)) >= fm.MIN_OPENAPI_DESCRIPTIONS
+
+    def test_collapsed_spec_fails_instead_of_passing_empty(self, tmp_path):
+        empty = tmp_path / "openapi.json"
+        empty.write_text("{}", encoding="utf-8")
+        problems = fm.check_openapi(empty)
+        assert problems
+
+    def test_unreadable_spec_is_reported(self, tmp_path):
+        bad = tmp_path / "openapi.json"
+        bad.write_text("not json", encoding="utf-8")
+        problems = fm.check_openapi(bad)
+        assert problems
+
+    def test_a_new_marker_fails_the_gate(self, tmp_path):
+        spec_path = tmp_path / "openapi.json"
+        spec_path.write_text(
+            json.dumps({"description": "Bound is PERF-N16."}), encoding="utf-8"
+        )
+        problems = fm.check_openapi(spec_path)
+        assert any("PERF-N16" in problem for problem in problems)
+
+
+class TestDetector:
+    """What the openapi.json scan reads, and what it exempts."""
+
+    def test_a_bare_marker_in_a_description_fails(self):
+        hits = fm.scan_openapi({"description": "Maximum rows returned (PERF-N16)."})
+        assert [h.markers for h in hits] == [("PERF-N16",)]
+
+    def test_an_issue_anchor_scopes_it(self):
+        spec = {"description": "Maximum rows returned (PERF-N16, see #1234)."}
+        assert not fm.scan_openapi(spec)
+
+    def test_a_gh_anchor_scopes_itself(self):
+        spec = {"description": "Delivered as a cookie instead (GH-1302)."}
+        assert not fm.scan_openapi(spec)
+
+    def test_adr_002_is_a_resolvable_citation(self):
+        spec = {"description": "One refresh attempt (ADR-002 Decision 4)."}
+        assert not fm.scan_openapi(spec)
+
+    def test_shares_technical_vocabulary_with_the_source_scan(self):
+        spec = {"description": "Digest as SHA-256, decoded as UTF-8."}
+        assert not fm.scan_openapi(spec)
+
+    def test_nested_paths_are_walked(self):
+        spec = {
+            "paths": {
+                "/x": {"get": {"parameters": [{"description": "PERF-N16 bound"}]}}
+            }
+        }
+        hits = fm.scan_openapi(spec)
+        assert len(hits) == 1
+        assert hits[0].module == "$.paths./x.get.parameters[0].description"
+
+    def test_a_further_anchor_does_not_scope_it(self):
+        spec = {"description": "Bound (PERF-N16).\n\nl2\nl3\nl4\nSee #1927."}
+        hits = fm.scan_openapi(spec)
+        assert [h.markers for h in hits] == [("PERF-N16",)]

--- a/backend/tests/test_openapi_finding_markers.py
+++ b/backend/tests/test_openapi_finding_markers.py
@@ -67,6 +67,27 @@ class TestDetector:
         spec = {"description": "Digest as SHA-256, decoded as UTF-8."}
         assert not fm.scan_openapi(spec)
 
+    def test_a_bare_cadence_reference_fails(self):
+        hits = fm.scan_openapi({"description": "Fixed in Phase 280."})
+        assert [h.markers for h in hits] == [("Phase 280",)]
+
+    def test_a_cadence_reference_with_an_anchor_is_scoped(self):
+        spec = {"description": "Fixed in Phase 280 (#1946)."}
+        assert not fm.scan_openapi(spec)
+
+    def test_context_md_fails(self):
+        hits = fm.scan_openapi({"description": "See CONTEXT.md for the decision."})
+        assert [h.markers for h in hits] == [("CONTEXT.md",)]
+
+    def test_a_numbered_planning_doc_fails(self):
+        spec = {"description": "Per 216-04-DECISION-LOG.md, this defaults to null."}
+        hits = fm.scan_openapi(spec)
+        assert [h.markers for h in hits] == [("216-04-DECISION-LOG.md",)]
+
+    def test_agents_md_is_a_real_published_doc(self):
+        spec = {"description": "See AGENTS.md for the convention."}
+        assert not fm.scan_openapi(spec)
+
     def test_nested_paths_are_walked(self):
         spec = {
             "paths": {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3845,9 +3845,9 @@ export interface paths {
          * Add Layer Endpoint
          * @description Add a layer to a map.
          *
-         *     Phase 280: declared on both slash variants directly so neither emits a
-         *     307. FastAPI's default redirect_slashes builds a relative Location
-         *     header that resolves against the request's Host header, leaking the
+         *     Declared on both slash variants directly so neither emits a 307.
+         *     FastAPI's default redirect_slashes builds a relative Location header
+         *     that resolves against the request's Host header, leaking the
          *     in-container ``api:8000`` hostname through Vite's dev proxy. The
          *     canonical (OpenAPI-published) form is the no-slash sub-collection
          *     convention documented in the GeoLens API guide
@@ -3862,14 +3862,14 @@ export interface paths {
          * Patch Map Layers Endpoint
          * @description Apply incremental layer additions, patches, removals, and ordering.
          *
-         *     v13.14 fixup: declared on both slash variants directly (mirrors the
-         *     Phase 280 fix on POST). FastAPI's default redirect_slashes builds a
-         *     relative Location header that resolves against the request's Host
-         *     header, which would leak the in-container ``api:8000`` hostname
-         *     through Vite's dev proxy on a 307 redirect. The canonical
-         *     (OpenAPI-published) form is the no-slash sub-collection convention
-         *     documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
-         *     the trailing-slash form is a hidden alias.
+         *     Declared on both slash variants directly, mirroring the POST route
+         *     below. FastAPI's default redirect_slashes builds a relative Location
+         *     header that resolves against the request's Host header, which would
+         *     leak the in-container ``api:8000`` hostname through Vite's dev proxy
+         *     on a 307 redirect. The canonical (OpenAPI-published) form is the
+         *     no-slash sub-collection convention documented in the GeoLens API guide
+         *     (https://docs.getgeolens.com/guides/api/); the trailing-slash form is
+         *     a hidden alias.
          */
         patch: operations["patch_map_layers_endpoint_maps__map_id__layers_patch"];
         trace?: never;
@@ -10346,10 +10346,10 @@ export interface components {
          *     The 3 non-secret SAML fields (``idp_entity_id``, ``idp_sso_url``,
          *     ``sp_entity_id``) ARE exposed so the admin UI can display them.
          *
-         *     Pitfall 11 interaction: those 3 fields are declared with ``deferred=True``
-         *     on the OAuth ORM model so community DBs (which lack the columns) do not
-         *     crash on SELECT. Pydantic's ``from_attributes=True`` would normally trigger
-         *     an implicit deferred load on attribute access, which fails under FastAPI's
+         *     Those 3 fields are declared with ``deferred=True`` on the OAuth ORM
+         *     model so community DBs (which lack the columns) do not crash on
+         *     SELECT. Pydantic's ``from_attributes=True`` would normally trigger an
+         *     implicit deferred load on attribute access, which fails under FastAPI's
          *     async context with ``MissingGreenlet``. The ``model_validator(mode="before")``
          *     below reads the SAML fields directly from ``obj.__dict__`` so unloaded
          *     attributes default to None instead of triggering IO. SAML admin endpoints

--- a/sdks/python/geolens/api/maps/add_layer_endpoint_maps_map_id_layers_post.py
+++ b/sdks/python/geolens/api/maps/add_layer_endpoint_maps_map_id_layers_post.py
@@ -116,9 +116,9 @@ def sync_detailed(
 
      Add a layer to a map.
 
-    Phase 280: declared on both slash variants directly so neither emits a
-    307. FastAPI's default redirect_slashes builds a relative Location
-    header that resolves against the request's Host header, leaking the
+    Declared on both slash variants directly so neither emits a 307.
+    FastAPI's default redirect_slashes builds a relative Location header
+    that resolves against the request's Host header, leaking the
     in-container ``api:8000`` hostname through Vite's dev proxy. The
     canonical (OpenAPI-published) form is the no-slash sub-collection
     convention documented in the GeoLens API guide
@@ -159,9 +159,9 @@ def sync(
 
      Add a layer to a map.
 
-    Phase 280: declared on both slash variants directly so neither emits a
-    307. FastAPI's default redirect_slashes builds a relative Location
-    header that resolves against the request's Host header, leaking the
+    Declared on both slash variants directly so neither emits a 307.
+    FastAPI's default redirect_slashes builds a relative Location header
+    that resolves against the request's Host header, leaking the
     in-container ``api:8000`` hostname through Vite's dev proxy. The
     canonical (OpenAPI-published) form is the no-slash sub-collection
     convention documented in the GeoLens API guide
@@ -197,9 +197,9 @@ async def asyncio_detailed(
 
      Add a layer to a map.
 
-    Phase 280: declared on both slash variants directly so neither emits a
-    307. FastAPI's default redirect_slashes builds a relative Location
-    header that resolves against the request's Host header, leaking the
+    Declared on both slash variants directly so neither emits a 307.
+    FastAPI's default redirect_slashes builds a relative Location header
+    that resolves against the request's Host header, leaking the
     in-container ``api:8000`` hostname through Vite's dev proxy. The
     canonical (OpenAPI-published) form is the no-slash sub-collection
     convention documented in the GeoLens API guide
@@ -238,9 +238,9 @@ async def asyncio(
 
      Add a layer to a map.
 
-    Phase 280: declared on both slash variants directly so neither emits a
-    307. FastAPI's default redirect_slashes builds a relative Location
-    header that resolves against the request's Host header, leaking the
+    Declared on both slash variants directly so neither emits a 307.
+    FastAPI's default redirect_slashes builds a relative Location header
+    that resolves against the request's Host header, leaking the
     in-container ``api:8000`` hostname through Vite's dev proxy. The
     canonical (OpenAPI-published) form is the no-slash sub-collection
     convention documented in the GeoLens API guide

--- a/sdks/python/geolens/api/maps/patch_map_layers_endpoint_maps_map_id_layers_patch.py
+++ b/sdks/python/geolens/api/maps/patch_map_layers_endpoint_maps_map_id_layers_patch.py
@@ -116,14 +116,14 @@ def sync_detailed(
 
      Apply incremental layer additions, patches, removals, and ordering.
 
-    v13.14 fixup: declared on both slash variants directly (mirrors the
-    Phase 280 fix on POST). FastAPI's default redirect_slashes builds a
-    relative Location header that resolves against the request's Host
-    header, which would leak the in-container ``api:8000`` hostname
-    through Vite's dev proxy on a 307 redirect. The canonical
-    (OpenAPI-published) form is the no-slash sub-collection convention
-    documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
-    the trailing-slash form is a hidden alias.
+    Declared on both slash variants directly, mirroring the POST route
+    below. FastAPI's default redirect_slashes builds a relative Location
+    header that resolves against the request's Host header, which would
+    leak the in-container ``api:8000`` hostname through Vite's dev proxy
+    on a 307 redirect. The canonical (OpenAPI-published) form is the
+    no-slash sub-collection convention documented in the GeoLens API guide
+    (https://docs.getgeolens.com/guides/api/); the trailing-slash form is
+    a hidden alias.
 
     Args:
         map_id (UUID):
@@ -159,14 +159,14 @@ def sync(
 
      Apply incremental layer additions, patches, removals, and ordering.
 
-    v13.14 fixup: declared on both slash variants directly (mirrors the
-    Phase 280 fix on POST). FastAPI's default redirect_slashes builds a
-    relative Location header that resolves against the request's Host
-    header, which would leak the in-container ``api:8000`` hostname
-    through Vite's dev proxy on a 307 redirect. The canonical
-    (OpenAPI-published) form is the no-slash sub-collection convention
-    documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
-    the trailing-slash form is a hidden alias.
+    Declared on both slash variants directly, mirroring the POST route
+    below. FastAPI's default redirect_slashes builds a relative Location
+    header that resolves against the request's Host header, which would
+    leak the in-container ``api:8000`` hostname through Vite's dev proxy
+    on a 307 redirect. The canonical (OpenAPI-published) form is the
+    no-slash sub-collection convention documented in the GeoLens API guide
+    (https://docs.getgeolens.com/guides/api/); the trailing-slash form is
+    a hidden alias.
 
     Args:
         map_id (UUID):
@@ -197,14 +197,14 @@ async def asyncio_detailed(
 
      Apply incremental layer additions, patches, removals, and ordering.
 
-    v13.14 fixup: declared on both slash variants directly (mirrors the
-    Phase 280 fix on POST). FastAPI's default redirect_slashes builds a
-    relative Location header that resolves against the request's Host
-    header, which would leak the in-container ``api:8000`` hostname
-    through Vite's dev proxy on a 307 redirect. The canonical
-    (OpenAPI-published) form is the no-slash sub-collection convention
-    documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
-    the trailing-slash form is a hidden alias.
+    Declared on both slash variants directly, mirroring the POST route
+    below. FastAPI's default redirect_slashes builds a relative Location
+    header that resolves against the request's Host header, which would
+    leak the in-container ``api:8000`` hostname through Vite's dev proxy
+    on a 307 redirect. The canonical (OpenAPI-published) form is the
+    no-slash sub-collection convention documented in the GeoLens API guide
+    (https://docs.getgeolens.com/guides/api/); the trailing-slash form is
+    a hidden alias.
 
     Args:
         map_id (UUID):
@@ -238,14 +238,14 @@ async def asyncio(
 
      Apply incremental layer additions, patches, removals, and ordering.
 
-    v13.14 fixup: declared on both slash variants directly (mirrors the
-    Phase 280 fix on POST). FastAPI's default redirect_slashes builds a
-    relative Location header that resolves against the request's Host
-    header, which would leak the in-container ``api:8000`` hostname
-    through Vite's dev proxy on a 307 redirect. The canonical
-    (OpenAPI-published) form is the no-slash sub-collection convention
-    documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
-    the trailing-slash form is a hidden alias.
+    Declared on both slash variants directly, mirroring the POST route
+    below. FastAPI's default redirect_slashes builds a relative Location
+    header that resolves against the request's Host header, which would
+    leak the in-container ``api:8000`` hostname through Vite's dev proxy
+    on a 307 redirect. The canonical (OpenAPI-published) form is the
+    no-slash sub-collection convention documented in the GeoLens API guide
+    (https://docs.getgeolens.com/guides/api/); the trailing-slash form is
+    a hidden alias.
 
     Args:
         map_id (UUID):

--- a/sdks/python/geolens/models/o_auth_provider_response.py
+++ b/sdks/python/geolens/models/o_auth_provider_response.py
@@ -33,10 +33,10 @@ class OAuthProviderResponse:
     The 3 non-secret SAML fields (``idp_entity_id``, ``idp_sso_url``,
     ``sp_entity_id``) ARE exposed so the admin UI can display them.
 
-    Pitfall 11 interaction: those 3 fields are declared with ``deferred=True``
-    on the OAuth ORM model so community DBs (which lack the columns) do not
-    crash on SELECT. Pydantic's ``from_attributes=True`` would normally trigger
-    an implicit deferred load on attribute access, which fails under FastAPI's
+    Those 3 fields are declared with ``deferred=True`` on the OAuth ORM
+    model so community DBs (which lack the columns) do not crash on
+    SELECT. Pydantic's ``from_attributes=True`` would normally trigger an
+    implicit deferred load on attribute access, which fails under FastAPI's
     async context with ``MissingGreenlet``. The ``model_validator(mode="before")``
     below reads the SAML fields directly from ``obj.__dict__`` so unloaded
     attributes default to None instead of triggering IO. SAML admin endpoints

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -4135,14 +4135,14 @@ export const getMapHistoryEndpointMapsMapIdHistoryGet = <ThrowOnError extends bo
  *
  * Apply incremental layer additions, patches, removals, and ordering.
  *
- * v13.14 fixup: declared on both slash variants directly (mirrors the
- * Phase 280 fix on POST). FastAPI's default redirect_slashes builds a
- * relative Location header that resolves against the request's Host
- * header, which would leak the in-container ``api:8000`` hostname
- * through Vite's dev proxy on a 307 redirect. The canonical
- * (OpenAPI-published) form is the no-slash sub-collection convention
- * documented in the GeoLens API guide (https://docs.getgeolens.com/guides/api/);
- * the trailing-slash form is a hidden alias.
+ * Declared on both slash variants directly, mirroring the POST route
+ * below. FastAPI's default redirect_slashes builds a relative Location
+ * header that resolves against the request's Host header, which would
+ * leak the in-container ``api:8000`` hostname through Vite's dev proxy
+ * on a 307 redirect. The canonical (OpenAPI-published) form is the
+ * no-slash sub-collection convention documented in the GeoLens API guide
+ * (https://docs.getgeolens.com/guides/api/); the trailing-slash form is
+ * a hidden alias.
  */
 export const patchMapLayersEndpointMapsMapIdLayersPatch = <ThrowOnError extends boolean = false>(options: Options<PatchMapLayersEndpointMapsMapIdLayersPatchData, ThrowOnError>): RequestResult<PatchMapLayersEndpointMapsMapIdLayersPatchResponses, PatchMapLayersEndpointMapsMapIdLayersPatchErrors, ThrowOnError> => (options.client ?? client).patch<PatchMapLayersEndpointMapsMapIdLayersPatchResponses, PatchMapLayersEndpointMapsMapIdLayersPatchErrors, ThrowOnError>({
     security: [
@@ -4167,9 +4167,9 @@ export const patchMapLayersEndpointMapsMapIdLayersPatch = <ThrowOnError extends 
  *
  * Add a layer to a map.
  *
- * Phase 280: declared on both slash variants directly so neither emits a
- * 307. FastAPI's default redirect_slashes builds a relative Location
- * header that resolves against the request's Host header, leaking the
+ * Declared on both slash variants directly so neither emits a 307.
+ * FastAPI's default redirect_slashes builds a relative Location header
+ * that resolves against the request's Host header, leaking the
  * in-container ``api:8000`` hostname through Vite's dev proxy. The
  * canonical (OpenAPI-published) form is the no-slash sub-collection
  * convention documented in the GeoLens API guide

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -6699,10 +6699,10 @@ export type OAuthProviderPublic = {
  * The 3 non-secret SAML fields (``idp_entity_id``, ``idp_sso_url``,
  * ``sp_entity_id``) ARE exposed so the admin UI can display them.
  *
- * Pitfall 11 interaction: those 3 fields are declared with ``deferred=True``
- * on the OAuth ORM model so community DBs (which lack the columns) do not
- * crash on SELECT. Pydantic's ``from_attributes=True`` would normally trigger
- * an implicit deferred load on attribute access, which fails under FastAPI's
+ * Those 3 fields are declared with ``deferred=True`` on the OAuth ORM
+ * model so community DBs (which lack the columns) do not crash on
+ * SELECT. Pydantic's ``from_attributes=True`` would normally trigger an
+ * implicit deferred load on attribute access, which fails under FastAPI's
  * async context with ``MissingGreenlet``. The ``model_validator(mode="before")``
  * below reads the SAML fields directly from ``obj.__dict__`` so unloaded
  * attributes default to None instead of triggering IO. SAML admin endpoints


### PR DESCRIPTION
## Summary

Closes #1946. A Pydantic `Field(description=...)` or FastAPI `Query(description=...)`/`summary=` argument is a string literal, not a docstring, so `backend/tests/finding_markers.py`'s comment/docstring walk never reads it, even though the text still reaches `backend/openapi.json` and, from there, the generated SDK docstrings.

The prior fix for the originally reported markers (`Phase 268`/`269`, the bare `PERF-*`/`D-*` ids, `CLASS-07`, and so on) had already landed on `main`. What was missing was a gate, and three codex review rounds on this PR found three more ways a marker can reach the surface undetected: a bare non-hyphenated cadence reference, a bare planning-doc filename, and the `summary=` field. All three are now covered, and three live instances of the first kind (in real published descriptions) were rewritten.

## Changes

- `backend/tests/finding_markers.py`: a second scan, `check_openapi()`/`scan_openapi()`, walks every `description` and `summary` string in `backend/openapi.json`. It reuses the existing marker regex and `TECHNICAL_VOCABULARY` from the source-tree scan, plus three scan-local additions that the shared `MARKER_RE` (hyphenated shapes only) cannot see: a cadence-word regex (`Phase 280`, `Pitfall 11`), a planning-doc-filename regex (`CONTEXT.md`, `216-04-DECISION-LOG.md`), and now both OpenAPI text keys, not just `description`. None of these touch the shared `MARKER_RE` or `TECHNICAL_VOCABULARY`, so the source-tree debt ledger in the same file is untouched. A published description carries no debt ledger of its own: any unanchored marker fails outright, since an integrator reading a generated SDK docstring has no project context to resolve a bare internal id against.
- A narrow, separate allowance: `ADR-002` is treated as resolvable, because `.github/ADR-002.md` is a committed, publicly readable design record, the same kind of citation as a CVE id or a `GH-NNNN` issue reference.
- Three live instances found and fixed: `OAuthProviderResponse`'s schema docstring cited "Pitfall 11", and two `/maps/{map_id}/layers` route docstrings cited "Phase 280"/"v13.14 fixup" — all rewritten to state the constraint without the internal reference.
- `backend/tests/test_openapi_finding_markers.py` (new): pins the detector's behaviour against synthetic specs (including each of the three follow-up findings) and asserts the real `openapi.json` is clean.
- `.pre-commit-config.yaml`: documents the extended scope and adds `backend/openapi.json` to the hook's trigger pattern.
- Regenerated `backend/openapi.json`, both SDKs, and `frontend/src/types/api.generated.ts` for the three source rewrites.

## Area

- [x] Backend (API, services, models)

## Testing

- [x] Unit tests pass (`pytest`)
- Counterfactuals (one per fix, planted then reverted): a bare hyphenated marker in a live description, a bare cadence reference ("Phase 999") in a live summary field, and (via unit tests) `CONTEXT.md`/a numbered planning filename with no source instance to plant against.
- `python3 backend/tests/finding_markers.py` — clean
- `pytest backend/tests/test_openapi_finding_markers.py backend/tests/test_unscoped_finding_markers.py backend/tests/test_layering.py backend/tests/test_sdks_round_trip.py` — all passing
- `ruff check .` / `ruff format --check .` — clean
- `make openapi-check` / `make sdks-check` (including the TypeScript SDK's own build + test suite) — clean
- `frontend && npm run types:check` — clean

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de) — n/a
- [x] No new lint warnings (`ruff check`, `eslint`)
- [ ] TypeScript compiles without errors — n/a, backend-only (SDK build verified via `make sdks-check`)
- [ ] Migration included (if DB schema changed) — n/a
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys — n/a