### PR TITLE
fix(tests): scope manifest reservation reads to their dataset key

### DIFF
--- a/backend/tests/test_manifest_apply_service.py
+++ b/backend/tests/test_manifest_apply_service.py
@@ -1258,7 +1258,15 @@ class TestManifestApplyService:
         queue.assert_not_awaited()
         # fix(#1814): the reservation is inserted before the download, so a
         # denial after it leaves that row settled rather than leaving none.
-        reservation = (await test_db_session.execute(select(IngestJob))).scalar_one()
+        # fix(#1984): scoped to this key, not order-dependent on a lone row.
+        reservation = (
+            await test_db_session.execute(
+                select(IngestJob).where(
+                    IngestJob.user_metadata["manifest_key"].astext
+                    == "manifest-http-quota"
+                )
+            )
+        ).scalar_one()
         assert reservation.status == "failed"
         assert reservation.file_path is None
         assert reservation.user_metadata["manifest_key"] == "manifest-http-quota"
@@ -1352,7 +1360,15 @@ class TestManifestApplyService:
         assert "database unavailable" in response.results[0].message
         assert not staged.exists()
         queue.assert_not_awaited()
-        reservation = (await test_db_session.execute(select(IngestJob))).scalar_one()
+        # fix(#1984): scoped to this key, not order-dependent on a lone row.
+        reservation = (
+            await test_db_session.execute(
+                select(IngestJob).where(
+                    IngestJob.user_metadata["manifest_key"].astext
+                    == "manifest-http-persist-failure"
+                )
+            )
+        ).scalar_one()
         assert reservation.status == "failed"
         assert reservation.file_path is None
 


### PR DESCRIPTION
## Summary

Two assertions in `test_manifest_apply_service.py` read back the reservation `IngestJob` they had just created with an unfiltered `select(IngestJob)...scalar_one()`. That only holds while the worker's database contains exactly one `ingest_jobs` row for the whole test. `clean_tables` truncates a handful of catalog tables via `TRUNCATE ... CASCADE`, and it reaches `ingest_jobs` only when it cascades from a truncated `datasets` row; a dataset-less leftover job committed by an earlier test on the same xdist worker survives and makes `scalar_one()` raise `MultipleResultsFound`.

## Changes

- Filter both reservation reads to `IngestJob.user_metadata["manifest_key"].astext == <the test's own key>`, matching the filtering convention already used by `app/processing/ingest/manifest_reservation.py` and every other `select(IngestJob)` read in `backend/tests/`.
- Grepped `backend/tests/` for other unfiltered `scalar_one()` / `one()` reads of `IngestJob`, `Dataset`, `Map`, `Record`, `RecordEmbedding`, and `User` assuming a single row. These two were the only ones; every other occurrence in the suite already filters by id or another unique column.

## Area

- [x] Backend (API, services, models)

## Testing

- [x] Unit tests pass (`pytest`)
- [ ] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)

Reproduced the failure directly: with the unfiltered select restored and a second `ingest_jobs` row committed ahead of the assertion (simulating a leftover row from an earlier test on the same xdist worker), `test_downloaded_http_source_is_removed_if_staging_bind_fails` fails with `sqlalchemy.exc.MultipleResultsFound: Multiple rows were found when exactly one was required`. With the fix applied, the same scenario passes.

Ran:
- `backend/tests/test_manifest_apply_service.py` (51 passed)
- `pytest tests/ -n 4 -k "reupload or ingest or error_write or staging or heartbeat or vrt"` (1338 passed, 6 skipped) — the selection from the issue, confirming no regression at the original scale
- `ruff check` / `ruff format --check` on backend
- `test_layering.py` and `finding_markers.py`

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [ ] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing