### PR TITLE
fix(search): exempt paired facets calls from the SEC-S11 bucket

### DIFF
--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -419,22 +419,18 @@ def _semantic_search_rate_limit(_request: Request | None = None) -> str:
 def _semantic_search_query_already_claimed(request: Request) -> bool:
     """fix(#1903): true when the OTHER search route already claimed this query.
 
-    Applied to BOTH search routes: the SPA fires them as an unordered pair,
-    so whichever one reaches this gate first pays the shared rate-limit
-    token and only the sibling ROUTE's request, arriving within the
-    coordination window, is exempt -- a same-route repeat never matches its
-    own claim, so a burst against one route still pays per request.
-
     Never creates a claim: this runs before the limiter's own admit/reject
-    check, so a request the bucket goes on to 429 must not seed a claim a
-    follow-up call could redeem. A non-exempt outcome instead stashes the
-    (client, text, route) on ``request.state`` for ``_finalize_semantic_
-    search_claim`` to record -- only reached if the request is admitted.
+    check, so a request the bucket rejects must not seed one. A non-exempt
+    outcome stashes (client, text, route) on ``request.state`` instead, for
+    ``_finalize_semantic_search_claim`` to record once the request is
+    known to be admitted.
     """
     query_text = request.query_params.get("q")
     if not query_text:
         return False
-    route = "facets" if "facets" in request.url.path else "datasets"
+    # fix(#1903): the route's own identity, not a path substring test --
+    # stable even if a future route in this scope shares the "facets" text.
+    route = request.scope["route"].name
     client_key = get_remote_address(request)
     if consume_paired_query_claim(client_key, query_text, route):
         return True
@@ -461,16 +457,11 @@ def _finalize_semantic_search_claim(request: Request) -> None:
     "/facets", response_model=FacetCountResponse, include_in_schema=False
 )
 @search_router.get("/facets/", response_model=FacetCountResponse)
-# fix(#1855): facets embed the query, so both search routes draw on ONE SEC-S11
-# bucket; two buckets let a caller alternating them embed twice the cap.
-# fix(#1903 review r4): no override_defaults here -- this route's limit_value
-# is a CALLABLE (admin-editable at runtime), which slowapi files under
-# _dynamic_route_limits rather than _route_limits. SlowAPIMiddleware's
-# _should_exempt() only checks _route_limits, so it does not recognize this
-# route as decorator-handled and runs its OWN check first, always charging
-# the global default regardless of override_defaults -- an exempted call is
-# still bounded by that middleware-level charge. override_defaults=False
-# would only add a SECOND, redundant global-default charge here.
+# fix(#1855): facets embed the query, so both routes draw on ONE SEC-S11
+# bucket. fix(#1903): no override_defaults -- this limit_value is callable,
+# so SlowAPIMiddleware already charges the global default unconditionally
+# for it (test_semantic_search_rate_limit_1778.py); adding it here would
+# only double that charge.
 @limiter.shared_limit(
     _semantic_search_rate_limit,
     scope="semantic_search",
@@ -563,8 +554,8 @@ async def search_facets_endpoint(
     response_model=OGCFeatureCollectionResponse,
     responses={400: BAD_REQUEST_RESPONSE},
 )
-# fix(#1903 review r4): the facets route's callable-limit note above applies
-# here symmetrically -- this route can be the SECOND of the pair too.
+# fix(#1903): the facets route's callable-limit note above applies here
+# symmetrically -- this route can be the SECOND of the pair too.
 @limiter.shared_limit(
     _semantic_search_rate_limit,
     scope="semantic_search",

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -463,14 +463,18 @@ def _finalize_semantic_search_claim(request: Request) -> None:
 @search_router.get("/facets/", response_model=FacetCountResponse)
 # fix(#1855): facets embed the query, so both search routes draw on ONE SEC-S11
 # bucket; two buckets let a caller alternating them embed twice the cap.
-# fix(#1903): override_defaults=False keeps the global per-IP default active
-# on an exempted call -- without it, an exempt Limit leaves NO limit at all
-# for that request (slowapi drops the defaults whenever a route limit wins).
+# fix(#1903 review r4): no override_defaults here -- this route's limit_value
+# is a CALLABLE (admin-editable at runtime), which slowapi files under
+# _dynamic_route_limits rather than _route_limits. SlowAPIMiddleware's
+# _should_exempt() only checks _route_limits, so it does not recognize this
+# route as decorator-handled and runs its OWN check first, always charging
+# the global default regardless of override_defaults -- an exempted call is
+# still bounded by that middleware-level charge. override_defaults=False
+# would only add a SECOND, redundant global-default charge here.
 @limiter.shared_limit(
     _semantic_search_rate_limit,
     scope="semantic_search",
     exempt_when=_semantic_search_query_already_claimed,
-    override_defaults=False,
 )
 async def search_facets_endpoint(
     request: Request,
@@ -559,13 +563,12 @@ async def search_facets_endpoint(
     response_model=OGCFeatureCollectionResponse,
     responses={400: BAD_REQUEST_RESPONSE},
 )
-# fix(#1903): the facets route's exempt_when/override_defaults note above
-# applies here symmetrically -- this route can be the SECOND of the pair too.
+# fix(#1903 review r4): the facets route's callable-limit note above applies
+# here symmetrically -- this route can be the SECOND of the pair too.
 @limiter.shared_limit(
     _semantic_search_rate_limit,
     scope="semantic_search",
     exempt_when=_semantic_search_query_already_claimed,
-    override_defaults=False,
 )
 async def search_datasets_endpoint(
     request: Request,

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -415,14 +415,19 @@ def _semantic_search_rate_limit(_request: Request | None = None) -> str:
 
 
 def _semantic_search_query_already_claimed(request: Request) -> bool:
-    """fix(#1903): true when a sibling request already claimed this query.
+    """fix(#1903): true when the OTHER search route already claimed this query.
 
     Applied to BOTH search routes: the SPA fires them as an unordered pair,
     so whichever one reaches this gate first pays the shared rate-limit
-    token and the other, arriving within the coordination window, is exempt.
+    token and only the sibling ROUTE's request, arriving within the
+    coordination window, is exempt -- a same-route repeat never matches its
+    own claim, so a burst against one route still pays per request.
     """
     query_text = request.query_params.get("q")
-    return bool(query_text) and claim_semantic_search_query(query_text)
+    if not query_text:
+        return False
+    route = "facets" if "facets" in request.url.path else "datasets"
+    return claim_semantic_search_query(query_text, route)
 
 
 # ROUTE-01 (Phase 1092): dual-shape decorator — slash form is canonical

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -70,10 +70,11 @@ from app.modules.catalog.search.records_protocol import (
 )
 from app.modules.catalog.search.service import (
     SearchFilters,
-    claim_semantic_search_query,
+    consume_paired_query_claim,
     count_collections,
     dataset_to_ogc_record,
     get_facet_counts,
+    record_paired_query_claim,
     search_collections,
     search_datasets,
 )
@@ -82,6 +83,7 @@ from app.core.persistent_config import (
     get_cached_semantic_search_rate_limit,
 )
 from app.platform.ratelimit import limiter
+from slowapi.util import get_remote_address
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -422,12 +424,34 @@ def _semantic_search_query_already_claimed(request: Request) -> bool:
     token and only the sibling ROUTE's request, arriving within the
     coordination window, is exempt -- a same-route repeat never matches its
     own claim, so a burst against one route still pays per request.
+
+    Never creates a claim: this runs before the limiter's own admit/reject
+    check, so a request the bucket goes on to 429 must not seed a claim a
+    follow-up call could redeem. A non-exempt outcome instead stashes the
+    (client, text, route) on ``request.state`` for ``_finalize_semantic_
+    search_claim`` to record -- only reached if the request is admitted.
     """
     query_text = request.query_params.get("q")
     if not query_text:
         return False
     route = "facets" if "facets" in request.url.path else "datasets"
-    return claim_semantic_search_query(query_text, route)
+    client_key = get_remote_address(request)
+    if consume_paired_query_claim(client_key, query_text, route):
+        return True
+    request.state.semantic_search_claim = (client_key, query_text, route)
+    return False
+
+
+def _finalize_semantic_search_claim(request: Request) -> None:
+    """fix(#1903): record this request's claim once it is known to be admitted.
+
+    Call at the very top of a search handler -- reaching that point already
+    proves the rate limit let the request through. A no-op when the gate
+    exempted this request (nothing pending) or the query didn't qualify.
+    """
+    pending = getattr(request.state, "semantic_search_claim", None)
+    if pending is not None:
+        record_paired_query_claim(*pending)
 
 
 # ROUTE-01 (Phase 1092): dual-shape decorator — slash form is canonical
@@ -477,6 +501,7 @@ async def search_facets_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> FacetCountResponse:
     """Return record_type facet counts for the given filters."""
+    _finalize_semantic_search_claim(request)
     geometry_geojson, bbox_parsed = parse_spatial_params(geometry, bbox)
 
     if user is not None:
@@ -550,6 +575,7 @@ async def search_datasets_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> OGCFeatureCollectionResponse:
     """Search datasets with text, spatial, and faceted filters."""
+    _finalize_semantic_search_claim(request)
     params = _resolve_filter_lang(params, request)
     result = await _handle_search(db, user, request, params)
     for name, value in standard_response_headers(

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -72,6 +72,7 @@ from app.modules.catalog.search.service import (
     SearchFilters,
     count_collections,
     dataset_to_ogc_record,
+    embedding_cache_has_hit,
     get_facet_counts,
     search_collections,
     search_datasets,
@@ -413,6 +414,16 @@ def _semantic_search_rate_limit(_request: Request | None = None) -> str:
     return f"{get_cached_semantic_search_rate_limit()}/minute"
 
 
+def _facets_query_embedding_cached(request: Request) -> bool:
+    """fix(#1903): skip the shared bucket when q's embedding is already cached.
+
+    The SPA pairs this with /search/datasets/, which embeds first, so a
+    cached hit means the provider was already paid for exactly this query.
+    """
+    query_text = request.query_params.get("q")
+    return bool(query_text) and embedding_cache_has_hit(query_text)
+
+
 # ROUTE-01 (Phase 1092): dual-shape decorator — slash form is canonical
 # (in OpenAPI); no-slash is a hidden alias closing the 404 regression from
 # redirect_slashes=False (api/main.py).
@@ -422,7 +433,15 @@ def _semantic_search_rate_limit(_request: Request | None = None) -> str:
 @search_router.get("/facets/", response_model=FacetCountResponse)
 # fix(#1855): facets embed the query, so both search routes draw on ONE SEC-S11
 # bucket; two buckets let a caller alternating them embed twice the cap.
-@limiter.shared_limit(_semantic_search_rate_limit, scope="semantic_search")
+# fix(#1903): override_defaults=False keeps the global per-IP default active
+# on an exempted call -- without it, an exempt Limit leaves NO limit at all
+# for that request (slowapi drops the defaults whenever a route limit wins).
+@limiter.shared_limit(
+    _semantic_search_rate_limit,
+    scope="semantic_search",
+    exempt_when=_facets_query_embedding_cached,
+    override_defaults=False,
+)
 async def search_facets_endpoint(
     request: Request,
     q: str | None = Query(None, max_length=1000, description="Full-text search query"),

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -70,9 +70,9 @@ from app.modules.catalog.search.records_protocol import (
 )
 from app.modules.catalog.search.service import (
     SearchFilters,
+    claim_semantic_search_query,
     count_collections,
     dataset_to_ogc_record,
-    embedding_cache_has_hit,
     get_facet_counts,
     search_collections,
     search_datasets,
@@ -414,14 +414,15 @@ def _semantic_search_rate_limit(_request: Request | None = None) -> str:
     return f"{get_cached_semantic_search_rate_limit()}/minute"
 
 
-def _facets_query_embedding_cached(request: Request) -> bool:
-    """fix(#1903): skip the shared bucket when q's embedding is already cached.
+def _semantic_search_query_already_claimed(request: Request) -> bool:
+    """fix(#1903): true when a sibling request already claimed this query.
 
-    The SPA pairs this with /search/datasets/, which embeds first, so a
-    cached hit means the provider was already paid for exactly this query.
+    Applied to BOTH search routes: the SPA fires them as an unordered pair,
+    so whichever one reaches this gate first pays the shared rate-limit
+    token and the other, arriving within the coordination window, is exempt.
     """
     query_text = request.query_params.get("q")
-    return bool(query_text) and embedding_cache_has_hit(query_text)
+    return bool(query_text) and claim_semantic_search_query(query_text)
 
 
 # ROUTE-01 (Phase 1092): dual-shape decorator — slash form is canonical
@@ -439,7 +440,7 @@ def _facets_query_embedding_cached(request: Request) -> bool:
 @limiter.shared_limit(
     _semantic_search_rate_limit,
     scope="semantic_search",
-    exempt_when=_facets_query_embedding_cached,
+    exempt_when=_semantic_search_query_already_claimed,
     override_defaults=False,
 )
 async def search_facets_endpoint(
@@ -528,7 +529,14 @@ async def search_facets_endpoint(
     response_model=OGCFeatureCollectionResponse,
     responses={400: BAD_REQUEST_RESPONSE},
 )
-@limiter.shared_limit(_semantic_search_rate_limit, scope="semantic_search")
+# fix(#1903): the facets route's exempt_when/override_defaults note above
+# applies here symmetrically -- this route can be the SECOND of the pair too.
+@limiter.shared_limit(
+    _semantic_search_rate_limit,
+    scope="semantic_search",
+    exempt_when=_semantic_search_query_already_claimed,
+    override_defaults=False,
+)
 async def search_datasets_endpoint(
     request: Request,
     response: Response,

--- a/backend/app/modules/catalog/search/service.py
+++ b/backend/app/modules/catalog/search/service.py
@@ -31,7 +31,7 @@ from app.modules.catalog.search.service_records import (
 )
 from app.modules.catalog.search.service_semantic import (
     _compute_rrf_scores,
-    embedding_cache_has_hit,
+    claim_semantic_search_query,
 )
 
 __all__ = [
@@ -44,7 +44,7 @@ __all__ = [
     "build_assets",
     "dataset_to_ogc_record",
     "parse_ogc_datetime",
-    "embedding_cache_has_hit",
+    "claim_semantic_search_query",
     "_build_text_filter",
     "_apply_common_filters",
     "_compute_rrf_scores",

--- a/backend/app/modules/catalog/search/service.py
+++ b/backend/app/modules/catalog/search/service.py
@@ -31,7 +31,8 @@ from app.modules.catalog.search.service_records import (
 )
 from app.modules.catalog.search.service_semantic import (
     _compute_rrf_scores,
-    claim_semantic_search_query,
+    consume_paired_query_claim,
+    record_paired_query_claim,
 )
 
 __all__ = [
@@ -44,7 +45,8 @@ __all__ = [
     "build_assets",
     "dataset_to_ogc_record",
     "parse_ogc_datetime",
-    "claim_semantic_search_query",
+    "consume_paired_query_claim",
+    "record_paired_query_claim",
     "_build_text_filter",
     "_apply_common_filters",
     "_compute_rrf_scores",

--- a/backend/app/modules/catalog/search/service.py
+++ b/backend/app/modules/catalog/search/service.py
@@ -29,7 +29,10 @@ from app.modules.catalog.search.service_records import (
     build_assets,
     dataset_to_ogc_record,
 )
-from app.modules.catalog.search.service_semantic import _compute_rrf_scores
+from app.modules.catalog.search.service_semantic import (
+    _compute_rrf_scores,
+    embedding_cache_has_hit,
+)
 
 __all__ = [
     "FacetCounts",
@@ -41,6 +44,7 @@ __all__ = [
     "build_assets",
     "dataset_to_ogc_record",
     "parse_ogc_datetime",
+    "embedding_cache_has_hit",
     "_build_text_filter",
     "_apply_common_filters",
     "_compute_rrf_scores",

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -83,32 +83,44 @@ def _embedding_cache_clear() -> None:
 # one reaches its rate-limit gate first is a network/ASGI-scheduling race,
 # not something a fixed "results always embeds first" assumption can rely
 # on. This registry lets whichever gate runs first claim the query and pay
-# the shared token; the other, arriving within the window, is exempt.
-# Deliberately much shorter than the embedding cache TTL above: it
-# coordinates one paired request, not a repeat-query amnesty, and it never
-# looks at the embedding cache -- so a config change mid-window cannot make
-# a stale-model match exempt a call that ends up billing the provider.
+# the shared token; the OTHER route, arriving within the window, is exempt
+# -- once. Exempting is a single-use, cross-route consume, not a standing
+# amnesty: a same-route repeat never matches its own claim (so a burst
+# hitting one route before the first embed lands still pays per request),
+# and the opposite route's exemption deletes the claim, so a third request
+# for the same text -- either route -- pays fresh. Deliberately much
+# shorter than the embedding cache TTL above: it coordinates one paired
+# request, and it never looks at the embedding cache, so a config change
+# mid-window cannot make a stale-model match exempt a call that ends up
+# billing the provider.
 _QUERY_CLAIM_TTL_SECONDS = 5.0
 _QUERY_CLAIM_MAX_SIZE = 256
-_query_claims: "OrderedDict[str, float]" = OrderedDict()
+_query_claims: "OrderedDict[str, tuple[str, float]]" = OrderedDict()
 
 
-def claim_semantic_search_query(text: str) -> bool:
-    """True when *text* was already claimed by a sibling request; else claims it.
+def claim_semantic_search_query(text: str, route: str) -> bool:
+    """True when the OTHER route already claimed *text*; else claims it for *route*.
 
     Called from both search routes' rate-limit ``exempt_when`` hooks, which
     run before either handler body -- so the first of a paired request to
-    reach its gate claims the query, the second (whichever route) is exempt.
+    reach its gate claims the query for its own route, and only the sibling
+    route's request, arriving within the window, is exempt (the claim is
+    then deleted, so this is a one-time consume, not a standing exemption).
     """
     normalized = text.strip().lower()
     if not normalized:
         return False
     key = tenant_cache_key(normalized)
     now = time.monotonic()
-    expires_at = _query_claims.get(key)
-    if expires_at is not None and expires_at >= now:
-        return True
-    _query_claims[key] = now + _QUERY_CLAIM_TTL_SECONDS
+    claimed = _query_claims.get(key)
+    if claimed is not None:
+        claimant_route, expires_at = claimed
+        if expires_at >= now:
+            if claimant_route == route:
+                return False
+            del _query_claims[key]
+            return True
+    _query_claims[key] = (route, now + _QUERY_CLAIM_TTL_SECONDS)
     _query_claims.move_to_end(key)
     while len(_query_claims) > _QUERY_CLAIM_MAX_SIZE:
         _query_claims.popitem(last=False)

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -93,6 +93,15 @@ def _embedding_cache_clear() -> None:
 # Deliberately much shorter than the embedding cache TTL above, and it
 # never looks at that cache, so a config change mid-window cannot make a
 # stale-model match exempt a call that ends up billing the provider.
+# fix(#1903 review r4): this dict is per-process, same as the SEC-S11 bucket
+# it exempts from (app.platform.ratelimit's Limiter uses slowapi's default
+# in-memory storage too). Under the bundled multi-worker production config
+# a paired request that lands on two different workers gets no exemption --
+# each worker pays its own token, same as before this fix -- but a request
+# is never charged MORE than that. Sharing this (or the rate limiter itself)
+# across workers needs a distributed store; per query_router.py's
+# _QUERY_PER_USER_LIMIT (fix(#565)), that is a tracked app-wide change, not
+# forked into an individual fix.
 _QUERY_CLAIM_TTL_SECONDS = 5.0
 _QUERY_CLAIM_MAX_SIZE = 256
 _query_claims: "OrderedDict[str, tuple[str, float]]" = OrderedDict()

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -78,24 +78,46 @@ def _embedding_cache_clear() -> None:
     _embedding_cache.clear()
 
 
-def embedding_cache_has_hit(text: str) -> bool:
-    """True when *text* already has a live cached embedding for this tenant.
+# fix(#1903): the SPA fires /search/datasets/ and /search/facets/ as an
+# UNORDERED pair on every query change (neither awaits the other), so which
+# one reaches its rate-limit gate first is a network/ASGI-scheduling race,
+# not something a fixed "results always embeds first" assumption can rely
+# on. This registry lets whichever gate runs first claim the query and pay
+# the shared token; the other, arriving within the window, is exempt.
+# Deliberately much shorter than the embedding cache TTL above: it
+# coordinates one paired request, not a repeat-query amnesty, and it never
+# looks at the embedding cache -- so a config change mid-window cannot make
+# a stale-model match exempt a call that ends up billing the provider.
+_QUERY_CLAIM_TTL_SECONDS = 5.0
+_QUERY_CLAIM_MAX_SIZE = 256
+_query_claims: "OrderedDict[str, float]" = OrderedDict()
 
-    fix(#1903): matches on tenant + normalized text only, ignoring model and
-    fingerprint -- resolving those needs a DB session this helper doesn't
-    have (it backs a synchronous rate-limit exemption check). A stale match
-    only skips a token early; ``generate_embedding`` still keys its own
-    lookup on the full tuple, so it can never serve a wrong vector.
+
+def claim_semantic_search_query(text: str) -> bool:
+    """True when *text* was already claimed by a sibling request; else claims it.
+
+    Called from both search routes' rate-limit ``exempt_when`` hooks, which
+    run before either handler body -- so the first of a paired request to
+    reach its gate claims the query, the second (whichever route) is exempt.
     """
     normalized = text.strip().lower()
     if not normalized:
         return False
-    prefix = tenant_cache_key(normalized)
+    key = tenant_cache_key(normalized)
     now = time.monotonic()
-    return any(
-        key[0] == prefix and expires_at >= now
-        for key, (expires_at, _vector) in _embedding_cache.items()
-    )
+    expires_at = _query_claims.get(key)
+    if expires_at is not None and expires_at >= now:
+        return True
+    _query_claims[key] = now + _QUERY_CLAIM_TTL_SECONDS
+    _query_claims.move_to_end(key)
+    while len(_query_claims) > _QUERY_CLAIM_MAX_SIZE:
+        _query_claims.popitem(last=False)
+    return False
+
+
+def _query_claims_clear() -> None:
+    """Clear the claim registry (test-helper)."""
+    _query_claims.clear()
 
 
 # fix(#448): the provider default timeout (130s) is sized for backfill; a hung

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -216,11 +216,12 @@ async def generate_embedding(
     if cached is not None:
         return cached
 
-    if dimensions is None:
-        # fix(#1903): an unpinned dimensions value makes the provider call
-        # read the session for a default (processing/embeddings/service.py),
-        # and a shared task can outlive this request's session -- only a
-        # FULLY pinned call may be shared, so this one runs standalone.
+    if not model_name or not dimensions:
+        # fix(#1903): mirrors generate_embeddings_batch's own session-read
+        # gate (processing/embeddings/service.py) exactly, since a shared
+        # task can outlive this request's session -- only a call THAT gate
+        # would also treat as fully pinned may be shared; this one runs
+        # standalone.
         vector = await _embed_with_deadline(
             text, session, (model_name, dimensions, base_url)
         )

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -78,60 +78,37 @@ def _embedding_cache_clear() -> None:
     _embedding_cache.clear()
 
 
-# fix(#1903): the SPA fires /search/datasets/ and /search/facets/ as an
-# UNORDERED pair on every query change (neither awaits the other), so which
-# one reaches its rate-limit gate first is a network/ASGI-scheduling race,
-# not something a fixed "results always embeds first" assumption can rely
-# on. This registry lets whichever gate runs first claim the query and pay
-# the shared token; the OTHER route, arriving within the window, is exempt
-# -- once. Keyed on (client, tenant, text), matching the limiter's own
-# key_func: a claim scoped to text alone would let a different client's
-# request for the same popular query consume this client's claim and skip
-# its own bucket. Exempting is a single-use, cross-route consume, not a
-# standing amnesty: a same-route repeat never matches its own claim, and
-# the opposite route's exemption deletes it, so a third request pays fresh.
-# Deliberately much shorter than the embedding cache TTL above, and it
-# never looks at that cache, so a config change mid-window cannot make a
-# stale-model match exempt a call that ends up billing the provider.
-# fix(#1903 review r4): this dict is per-process, same as the SEC-S11 bucket
-# it exempts from (app.platform.ratelimit's Limiter uses slowapi's default
-# in-memory storage too). Under the bundled multi-worker production config
-# a paired request that lands on two different workers gets no exemption --
-# each worker pays its own token, same as before this fix -- but a request
-# is never charged MORE than that. Sharing this (or the rate limiter itself)
-# across workers needs a distributed store; per query_router.py's
-# _QUERY_PER_USER_LIMIT (fix(#565)), that is a tracked app-wide change,
-# tracked separately at #2018 rather than forked into this fix. Bounded and
-# self-limiting even split across workers: entries expire after
-# _QUERY_CLAIM_TTL_SECONDS, consuming one deletes it (single-use, never a
-# standing grant), and the dict is hard-capped at _QUERY_CLAIM_MAX_SIZE via
-# LRU eviction, so an unconsumed claim can neither grow this structure nor
-# be redeemed more than once.
+# fix(#1903): coordinates the SPA's unordered results/facets pair so only
+# one request pays the SEC-S11 token; keyed on (client, tenant, text),
+# single-use, bounded by TTL + LRU (cross-worker sharing tracked at #2018).
 _QUERY_CLAIM_TTL_SECONDS = 5.0
 _QUERY_CLAIM_MAX_SIZE = 256
-_query_claims: "OrderedDict[str, tuple[str, float]]" = OrderedDict()
+_query_claims: "OrderedDict[tuple[str, str], tuple[str, float]]" = OrderedDict()
 
 
-def _query_claim_key(client_key: str, text: str) -> str | None:
-    """fix(#1903 review r5): ``tenant_cache_key`` raises when multi-tenant
-    mode has no verified tenant context (a trusted unscoped host); check
-    ``tenant_cache_context_available()`` first, same as the search cache
-    does, so an unscoped request disables claiming instead of 500ing.
+def _query_claim_key(client_key: str, text: str) -> tuple[str, str] | None:
+    """fix(#1903): a tuple, not an f-string join -- ``client_key`` is an IPv6
+    address, which contains ``:`` too, so a joined string lets one /64
+    holder's query text collide with a neighbour's address.
+
+    Also fails closed on an unscoped multi-tenant host: ``tenant_cache_key``
+    raises when there is no verified tenant context, so this checks
+    ``tenant_cache_context_available()`` first, same as the search cache.
     """
     normalized = text.strip().lower()
     if not normalized or not tenant_cache_context_available():
         return None
-    return f"{client_key}:{tenant_cache_key(normalized)}"
+    return (client_key, tenant_cache_key(normalized))
 
 
 def consume_paired_query_claim(client_key: str, text: str, route: str) -> bool:
     """True when the OTHER route already claimed this (client, text); consumes it.
 
-    Read-only otherwise -- it never creates a claim. fix(#1903 review r3):
-    claiming must not be a side effect of the rate-limit pre-check, which
-    runs for a request the bucket goes on to reject too; only
-    ``record_paired_query_claim``, called from a handler that is provably
-    running (the rate limit admitted it), may create one.
+    Read-only otherwise -- it never creates a claim. fix(#1903): claiming
+    must not be a side effect of the rate-limit pre-check, which runs for a
+    request the bucket goes on to reject too; only ``record_paired_query_
+    claim``, called from a handler that is provably running (the rate limit
+    admitted it), may create one.
     """
     key = _query_claim_key(client_key, text)
     if key is None:
@@ -179,23 +156,24 @@ async def _embed_with_deadline(
     )
 
 
-# fix(#1903 review r5): a rate-limit exemption is granted at the pair's
-# GATE, before either request's embed has finished -- so a genuinely
-# overlapping pair (both miss the TTL cache) could previously make TWO
-# paid provider calls under the ONE token the shared claim charged. Every
-# concurrent caller for the same cache key now awaits the SAME in-flight
-# task instead of starting its own, so the provider is called at most once
-# per key regardless of how many requests are racing for it. Only the
-# task's OWN session does any I/O; a caller that joins an existing task
-# never touches it, so no AsyncSession is used from two coroutines at once.
+# fix(#1903): coalesces concurrent embeds for one cache key into a single
+# provider call, since a rate-limit exemption can be granted before either
+# half of a paired request finishes embedding. Only used when the config is
+# fully pinned (see generate_embedding); waiters shield so cancelling one
+# participant can't cancel the shared task or its siblings.
 _embedding_inflight: "dict[tuple[str, str, str], asyncio.Task[list[float]]]" = {}
+
+
+def _embedding_inflight_clear() -> None:
+    """Clear the in-flight registry (test-helper)."""
+    _embedding_inflight.clear()
 
 
 async def _embed_and_cache(
     text: str,
     session: AsyncSession,
     cache_key: tuple[str, str, str],
-    pinned: tuple[str, int | None, str | None],
+    pinned: tuple[str, int, str | None],
 ) -> list[float]:
     try:
         vector = await _embed_with_deadline(text, session, pinned)
@@ -238,6 +216,17 @@ async def generate_embedding(
     if cached is not None:
         return cached
 
+    if dimensions is None:
+        # fix(#1903): an unpinned dimensions value makes the provider call
+        # read the session for a default (processing/embeddings/service.py),
+        # and a shared task can outlive this request's session -- only a
+        # FULLY pinned call may be shared, so this one runs standalone.
+        vector = await _embed_with_deadline(
+            text, session, (model_name, dimensions, base_url)
+        )
+        _embedding_cache_put(cache_key, vector)
+        return vector
+
     task = _embedding_inflight.get(cache_key)
     if task is None:
         # No await between the cache/inflight reads above and this write,
@@ -249,7 +238,7 @@ async def generate_embedding(
             )
         )
         _embedding_inflight[cache_key] = task
-    return await task
+    return await asyncio.shield(task)
 
 
 async def _attach_updated_actor_identities(

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -100,8 +100,13 @@ def _embedding_cache_clear() -> None:
 # each worker pays its own token, same as before this fix -- but a request
 # is never charged MORE than that. Sharing this (or the rate limiter itself)
 # across workers needs a distributed store; per query_router.py's
-# _QUERY_PER_USER_LIMIT (fix(#565)), that is a tracked app-wide change, not
-# forked into an individual fix.
+# _QUERY_PER_USER_LIMIT (fix(#565)), that is a tracked app-wide change,
+# tracked separately at #2018 rather than forked into this fix. Bounded and
+# self-limiting even split across workers: entries expire after
+# _QUERY_CLAIM_TTL_SECONDS, consuming one deletes it (single-use, never a
+# standing grant), and the dict is hard-capped at _QUERY_CLAIM_MAX_SIZE via
+# LRU eviction, so an unconsumed claim can neither grow this structure nor
+# be redeemed more than once.
 _QUERY_CLAIM_TTL_SECONDS = 5.0
 _QUERY_CLAIM_MAX_SIZE = 256
 _query_claims: "OrderedDict[str, tuple[str, float]]" = OrderedDict()

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -78,6 +78,26 @@ def _embedding_cache_clear() -> None:
     _embedding_cache.clear()
 
 
+def embedding_cache_has_hit(text: str) -> bool:
+    """True when *text* already has a live cached embedding for this tenant.
+
+    fix(#1903): matches on tenant + normalized text only, ignoring model and
+    fingerprint -- resolving those needs a DB session this helper doesn't
+    have (it backs a synchronous rate-limit exemption check). A stale match
+    only skips a token early; ``generate_embedding`` still keys its own
+    lookup on the full tuple, so it can never serve a wrong vector.
+    """
+    normalized = text.strip().lower()
+    if not normalized:
+        return False
+    prefix = tenant_cache_key(normalized)
+    now = time.monotonic()
+    return any(
+        key[0] == prefix and expires_at >= now
+        for key, (expires_at, _vector) in _embedding_cache.items()
+    )
+
+
 # fix(#448): the provider default timeout (130s) is sized for backfill; a hung
 # provider must not hold a search request, and resolve_semantic_arm degrades to
 # FTS on any error. wait_for keeps CatalogPort overlays source-compatible.

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -19,7 +19,7 @@ from app.core.persistent_config import SEMANTIC_SEARCH_ENABLED
 from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.search.service_filters import SearchFilters
-from app.platform.cache import tenant_cache_key
+from app.platform.cache import tenant_cache_context_available, tenant_cache_key
 from app.platform.extensions import get_catalog_port
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -113,8 +113,13 @@ _query_claims: "OrderedDict[str, tuple[str, float]]" = OrderedDict()
 
 
 def _query_claim_key(client_key: str, text: str) -> str | None:
+    """fix(#1903 review r5): ``tenant_cache_key`` raises when multi-tenant
+    mode has no verified tenant context (a trusted unscoped host); check
+    ``tenant_cache_context_available()`` first, same as the search cache
+    does, so an unscoped request disables claiming instead of 500ing.
+    """
     normalized = text.strip().lower()
-    if not normalized:
+    if not normalized or not tenant_cache_context_available():
         return None
     return f"{client_key}:{tenant_cache_key(normalized)}"
 
@@ -174,6 +179,32 @@ async def _embed_with_deadline(
     )
 
 
+# fix(#1903 review r5): a rate-limit exemption is granted at the pair's
+# GATE, before either request's embed has finished -- so a genuinely
+# overlapping pair (both miss the TTL cache) could previously make TWO
+# paid provider calls under the ONE token the shared claim charged. Every
+# concurrent caller for the same cache key now awaits the SAME in-flight
+# task instead of starting its own, so the provider is called at most once
+# per key regardless of how many requests are racing for it. Only the
+# task's OWN session does any I/O; a caller that joins an existing task
+# never touches it, so no AsyncSession is used from two coroutines at once.
+_embedding_inflight: "dict[tuple[str, str, str], asyncio.Task[list[float]]]" = {}
+
+
+async def _embed_and_cache(
+    text: str,
+    session: AsyncSession,
+    cache_key: tuple[str, str, str],
+    pinned: tuple[str, int | None, str | None],
+) -> list[float]:
+    try:
+        vector = await _embed_with_deadline(text, session, pinned)
+        _embedding_cache_put(cache_key, vector)
+        return vector
+    finally:
+        _embedding_inflight.pop(cache_key, None)
+
+
 async def generate_embedding(
     text: str,
     session: AsyncSession,
@@ -207,11 +238,18 @@ async def generate_embedding(
     if cached is not None:
         return cached
 
-    vector = await _embed_with_deadline(
-        text, session, (model_name, dimensions, base_url)
-    )
-    _embedding_cache_put(cache_key, vector)
-    return vector
+    task = _embedding_inflight.get(cache_key)
+    if task is None:
+        # No await between the cache/inflight reads above and this write,
+        # so no other coroutine can interleave on this event loop and race
+        # the same key into two tasks.
+        task = asyncio.ensure_future(
+            _embed_and_cache(
+                text, session, cache_key, (model_name, dimensions, base_url)
+            )
+        )
+        _embedding_inflight[cache_key] = task
+    return await task
 
 
 async def _attach_updated_actor_identities(

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -84,47 +84,58 @@ def _embedding_cache_clear() -> None:
 # not something a fixed "results always embeds first" assumption can rely
 # on. This registry lets whichever gate runs first claim the query and pay
 # the shared token; the OTHER route, arriving within the window, is exempt
-# -- once. Exempting is a single-use, cross-route consume, not a standing
-# amnesty: a same-route repeat never matches its own claim (so a burst
-# hitting one route before the first embed lands still pays per request),
-# and the opposite route's exemption deletes the claim, so a third request
-# for the same text -- either route -- pays fresh. Deliberately much
-# shorter than the embedding cache TTL above: it coordinates one paired
-# request, and it never looks at the embedding cache, so a config change
-# mid-window cannot make a stale-model match exempt a call that ends up
-# billing the provider.
+# -- once. Keyed on (client, tenant, text), matching the limiter's own
+# key_func: a claim scoped to text alone would let a different client's
+# request for the same popular query consume this client's claim and skip
+# its own bucket. Exempting is a single-use, cross-route consume, not a
+# standing amnesty: a same-route repeat never matches its own claim, and
+# the opposite route's exemption deletes it, so a third request pays fresh.
+# Deliberately much shorter than the embedding cache TTL above, and it
+# never looks at that cache, so a config change mid-window cannot make a
+# stale-model match exempt a call that ends up billing the provider.
 _QUERY_CLAIM_TTL_SECONDS = 5.0
 _QUERY_CLAIM_MAX_SIZE = 256
 _query_claims: "OrderedDict[str, tuple[str, float]]" = OrderedDict()
 
 
-def claim_semantic_search_query(text: str, route: str) -> bool:
-    """True when the OTHER route already claimed *text*; else claims it for *route*.
-
-    Called from both search routes' rate-limit ``exempt_when`` hooks, which
-    run before either handler body -- so the first of a paired request to
-    reach its gate claims the query for its own route, and only the sibling
-    route's request, arriving within the window, is exempt (the claim is
-    then deleted, so this is a one-time consume, not a standing exemption).
-    """
+def _query_claim_key(client_key: str, text: str) -> str | None:
     normalized = text.strip().lower()
     if not normalized:
+        return None
+    return f"{client_key}:{tenant_cache_key(normalized)}"
+
+
+def consume_paired_query_claim(client_key: str, text: str, route: str) -> bool:
+    """True when the OTHER route already claimed this (client, text); consumes it.
+
+    Read-only otherwise -- it never creates a claim. fix(#1903 review r3):
+    claiming must not be a side effect of the rate-limit pre-check, which
+    runs for a request the bucket goes on to reject too; only
+    ``record_paired_query_claim``, called from a handler that is provably
+    running (the rate limit admitted it), may create one.
+    """
+    key = _query_claim_key(client_key, text)
+    if key is None:
         return False
-    key = tenant_cache_key(normalized)
-    now = time.monotonic()
     claimed = _query_claims.get(key)
-    if claimed is not None:
-        claimant_route, expires_at = claimed
-        if expires_at >= now:
-            if claimant_route == route:
-                return False
-            del _query_claims[key]
-            return True
-    _query_claims[key] = (route, now + _QUERY_CLAIM_TTL_SECONDS)
+    if claimed is None:
+        return False
+    claimant_route, expires_at = claimed
+    if expires_at < time.monotonic() or claimant_route == route:
+        return False
+    del _query_claims[key]
+    return True
+
+
+def record_paired_query_claim(client_key: str, text: str, route: str) -> None:
+    """Claim (client, text) for *route*. Call only once a request is admitted."""
+    key = _query_claim_key(client_key, text)
+    if key is None:
+        return
+    _query_claims[key] = (route, time.monotonic() + _QUERY_CLAIM_TTL_SECONDS)
     _query_claims.move_to_end(key)
     while len(_query_claims) > _QUERY_CLAIM_MAX_SIZE:
         _query_claims.popitem(last=False)
-    return False
 
 
 def _query_claims_clear() -> None:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5698,7 +5698,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # instead, so only a request the rate limit actually admitted can seed
     # a claim, keyed with the limiter's own client identity. Cap 1412 ->
     # 1438, exact.
-    "backend/app/modules/catalog/search/router.py": 1438,
+    # fix(#1903 review r4): +3 — dropped override_defaults=False from both
+    # routes: their limit_value is callable, so slowapi's middleware already
+    # charges the global default unconditionally for them (test_semantic_
+    # search_rate_limit_1778.py), and override_defaults=False was making the
+    # decorator's own check charge it a SECOND time on every request. Cap
+    # 1438 -> 1441, exact.
+    "backend/app/modules/catalog/search/router.py": 1441,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1819,7 +1819,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # sharing it (or the limiter) across workers is the same tracked
         # app-wide change query_router.py's fix(#565) note already defers.
         # Cap 424 -> 433, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 433,
+        # fix(#1903 review r4 follow-up): +5 — cites the #2018 tracking issue
+        # and confirms the registry's TTL/size bounds so an unconsumed claim
+        # (the sibling landed on another worker) cannot grow it or be
+        # redeemed twice. Cap 433 -> 438, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 438,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1802,9 +1802,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # counted through the shared candidate set. Cap 482 -> 398, exact.
         # fix(#1903): +3 — a short-lived claim registry so whichever of the
         # SPA's paired /search/datasets/ and /search/facets/ requests reaches
-        # its rate-limit gate first pays the SEC-S11 token for both. Cap
+        # its rate-limit gate first pays the shared token for both. Cap
         # 398 -> 401, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 401,
+        # fix(#1903 review r2): +12 — the claim is now a single-use,
+        # cross-route consume (route stored alongside the expiry, deleted on
+        # the opposite route's exemption) so a same-route burst before the
+        # first embed lands cannot ride the claim past the first pair. Cap
+        # 401 -> 413, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 413,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -5677,10 +5682,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # gained the SEC-S11 limiter. Cap 1493 -> 1492, exact.
     # fix(#1903): +27 — both search routes gain an exempt_when callable that
     # claims a query for whichever one's rate-limit gate runs first, so the
-    # SPA's unordered paired request only pays the shared SEC-S11 token once,
-    # plus override_defaults=False on each so an exempted request still falls
+    # SPA's unordered paired request only pays the shared token once, plus
+    # override_defaults=False on each so an exempted request still falls
     # under the global per-IP default. Cap 1380 -> 1407, exact.
-    "backend/app/modules/catalog/search/router.py": 1407,
+    # fix(#1903 review r2): +5 — the exempt_when callable now derives a
+    # route tag from the request path and passes it through, so the claim
+    # can require the OTHER route before exempting. Cap 1407 -> 1412, exact.
+    "backend/app/modules/catalog/search/router.py": 1412,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5671,7 +5671,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # per-dataset OGC collections query. Cap 1489 -> 1493, exact.
     # fix(#1855): -1. The facets rate-limit note shrank when the endpoint
     # gained the SEC-S11 limiter. Cap 1493 -> 1492, exact.
-    "backend/app/modules/catalog/search/router.py": 1380,
+    # fix(#1903): +19 — the facets route gains an exempt_when callable that
+    # skips the shared SEC-S11 bucket when the paired /search/datasets/ call
+    # already cached this query's embedding, plus override_defaults=False so
+    # an exempted request still falls under the global per-IP default. Cap
+    # 1380 -> 1399, exact.
+    "backend/app/modules/catalog/search/router.py": 1399,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1800,13 +1800,14 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # was rejected. Cap 456 -> 482, exact.
         # fix(#1855): -84. The vector arm is resolved once into SemanticArm and
         # counted through the shared candidate set. Cap 482 -> 398, exact.
-        # fix(#1903): +67 — a claim registry coordinates the SPA's unordered
+        # fix(#1903): +68 — a claim registry coordinates the SPA's unordered
         # paired search requests so only one pays the SEC-S11 token (bounded
         # by TTL + LRU, cross-worker sharing tracked at #2018), and
         # concurrent identical embeds join one in-flight, shielded provider
-        # call so an exemption can never fund two paid calls. Cap
-        # 398 -> 465, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 465,
+        # call (gated on the same fully-pinned predicate the provider's own
+        # session-read check uses) so an exemption can never fund two paid
+        # calls. Cap 398 -> 466, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 466,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1823,7 +1823,13 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # and confirms the registry's TTL/size bounds so an unconsumed claim
         # (the sibling landed on another worker) cannot grow it or be
         # redeemed twice. Cap 433 -> 438, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 438,
+        # fix(#1903 review r5): +38 — a rate-limit exemption can be granted
+        # before either half of a paired request has finished embedding, so
+        # concurrent identical embed calls now join ONE in-flight provider
+        # call instead of each starting their own; plus a tenant-context
+        # availability guard on the claim key so an unscoped multi-tenant
+        # request degrades instead of 500ing. Cap 438 -> 476, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 476,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1809,7 +1809,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # the opposite route's exemption) so a same-route burst before the
         # first embed lands cannot ride the claim past the first pair. Cap
         # 401 -> 413, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 413,
+        # fix(#1903 review r3): +11 — the claim key gains the limiter's own
+        # client identity, and claiming split into a read-only consume (the
+        # exempt_when hook) plus a record step called only once a request is
+        # admitted, so a request the bucket goes on to reject can no longer
+        # seed a claim a follow-up call redeems. Cap 413 -> 424, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 424,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -5688,7 +5693,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1903 review r2): +5 — the exempt_when callable now derives a
     # route tag from the request path and passes it through, so the claim
     # can require the OTHER route before exempting. Cap 1407 -> 1412, exact.
-    "backend/app/modules/catalog/search/router.py": 1412,
+    # fix(#1903 review r3): +26 — exempt_when now only consumes a claim; a
+    # new finalize helper, called at the top of each handler, records one
+    # instead, so only a request the rate limit actually admitted can seed
+    # a claim, keyed with the limiter's own client identity. Cap 1412 ->
+    # 1438, exact.
+    "backend/app/modules/catalog/search/router.py": 1438,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1800,7 +1800,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # was rejected. Cap 456 -> 482, exact.
         # fix(#1855): -84. The vector arm is resolved once into SemanticArm and
         # counted through the shared candidate set. Cap 482 -> 398, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 398,
+        # fix(#1903): +3 — a short-lived claim registry so whichever of the
+        # SPA's paired /search/datasets/ and /search/facets/ requests reaches
+        # its rate-limit gate first pays the SEC-S11 token for both. Cap
+        # 398 -> 401, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 401,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -5671,12 +5675,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # per-dataset OGC collections query. Cap 1489 -> 1493, exact.
     # fix(#1855): -1. The facets rate-limit note shrank when the endpoint
     # gained the SEC-S11 limiter. Cap 1493 -> 1492, exact.
-    # fix(#1903): +19 — the facets route gains an exempt_when callable that
-    # skips the shared SEC-S11 bucket when the paired /search/datasets/ call
-    # already cached this query's embedding, plus override_defaults=False so
-    # an exempted request still falls under the global per-IP default. Cap
-    # 1380 -> 1399, exact.
-    "backend/app/modules/catalog/search/router.py": 1399,
+    # fix(#1903): +27 — both search routes gain an exempt_when callable that
+    # claims a query for whichever one's rate-limit gate runs first, so the
+    # SPA's unordered paired request only pays the shared SEC-S11 token once,
+    # plus override_defaults=False on each so an exempted request still falls
+    # under the global per-IP default. Cap 1380 -> 1407, exact.
+    "backend/app/modules/catalog/search/router.py": 1407,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1814,7 +1814,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # exempt_when hook) plus a record step called only once a request is
         # admitted, so a request the bucket goes on to reject can no longer
         # seed a claim a follow-up call redeems. Cap 413 -> 424, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 424,
+        # fix(#1903 review r4): +9 — documents that this registry is
+        # per-process like the SEC-S11 bucket it exempts from, and that
+        # sharing it (or the limiter) across workers is the same tracked
+        # app-wide change query_router.py's fix(#565) note already defers.
+        # Cap 424 -> 433, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 433,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1800,36 +1800,13 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # was rejected. Cap 456 -> 482, exact.
         # fix(#1855): -84. The vector arm is resolved once into SemanticArm and
         # counted through the shared candidate set. Cap 482 -> 398, exact.
-        # fix(#1903): +3 — a short-lived claim registry so whichever of the
-        # SPA's paired /search/datasets/ and /search/facets/ requests reaches
-        # its rate-limit gate first pays the shared token for both. Cap
-        # 398 -> 401, exact.
-        # fix(#1903 review r2): +12 — the claim is now a single-use,
-        # cross-route consume (route stored alongside the expiry, deleted on
-        # the opposite route's exemption) so a same-route burst before the
-        # first embed lands cannot ride the claim past the first pair. Cap
-        # 401 -> 413, exact.
-        # fix(#1903 review r3): +11 — the claim key gains the limiter's own
-        # client identity, and claiming split into a read-only consume (the
-        # exempt_when hook) plus a record step called only once a request is
-        # admitted, so a request the bucket goes on to reject can no longer
-        # seed a claim a follow-up call redeems. Cap 413 -> 424, exact.
-        # fix(#1903 review r4): +9 — documents that this registry is
-        # per-process like the SEC-S11 bucket it exempts from, and that
-        # sharing it (or the limiter) across workers is the same tracked
-        # app-wide change query_router.py's fix(#565) note already defers.
-        # Cap 424 -> 433, exact.
-        # fix(#1903 review r4 follow-up): +5 — cites the #2018 tracking issue
-        # and confirms the registry's TTL/size bounds so an unconsumed claim
-        # (the sibling landed on another worker) cannot grow it or be
-        # redeemed twice. Cap 433 -> 438, exact.
-        # fix(#1903 review r5): +38 — a rate-limit exemption can be granted
-        # before either half of a paired request has finished embedding, so
-        # concurrent identical embed calls now join ONE in-flight provider
-        # call instead of each starting their own; plus a tenant-context
-        # availability guard on the claim key so an unscoped multi-tenant
-        # request degrades instead of 500ing. Cap 438 -> 476, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 476,
+        # fix(#1903): +67 — a claim registry coordinates the SPA's unordered
+        # paired search requests so only one pays the SEC-S11 token (bounded
+        # by TTL + LRU, cross-worker sharing tracked at #2018), and
+        # concurrent identical embeds join one in-flight, shielded provider
+        # call so an exemption can never fund two paid calls. Cap
+        # 398 -> 465, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 465,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -5700,26 +5677,13 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # per-dataset OGC collections query. Cap 1489 -> 1493, exact.
     # fix(#1855): -1. The facets rate-limit note shrank when the endpoint
     # gained the SEC-S11 limiter. Cap 1493 -> 1492, exact.
-    # fix(#1903): +27 — both search routes gain an exempt_when callable that
-    # claims a query for whichever one's rate-limit gate runs first, so the
-    # SPA's unordered paired request only pays the shared token once, plus
-    # override_defaults=False on each so an exempted request still falls
-    # under the global per-IP default. Cap 1380 -> 1407, exact.
-    # fix(#1903 review r2): +5 — the exempt_when callable now derives a
-    # route tag from the request path and passes it through, so the claim
-    # can require the OTHER route before exempting. Cap 1407 -> 1412, exact.
-    # fix(#1903 review r3): +26 — exempt_when now only consumes a claim; a
-    # new finalize helper, called at the top of each handler, records one
-    # instead, so only a request the rate limit actually admitted can seed
-    # a claim, keyed with the limiter's own client identity. Cap 1412 ->
-    # 1438, exact.
-    # fix(#1903 review r4): +3 — dropped override_defaults=False from both
-    # routes: their limit_value is callable, so slowapi's middleware already
-    # charges the global default unconditionally for them (test_semantic_
-    # search_rate_limit_1778.py), and override_defaults=False was making the
-    # decorator's own check charge it a SECOND time on every request. Cap
-    # 1438 -> 1441, exact.
-    "backend/app/modules/catalog/search/router.py": 1441,
+    # fix(#1903): +52 — both search routes gain a claim-registry exempt_when
+    # (bounded, single-use, client-scoped, keyed off the route's own scope
+    # name) so the SPA's unordered paired request pays the SEC-S11 token
+    # once; no override_defaults, since the middleware already charges the
+    # global default unconditionally for this callable-valued limit
+    # (test_semantic_search_rate_limit_1778.py). Cap 1380 -> 1432, exact.
+    "backend/app/modules/catalog/search/router.py": 1432,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -20,6 +20,7 @@ Per-test pattern:
     4. Re-disable the limiter and reset storage.
 """
 
+import time
 import uuid
 
 import pytest
@@ -30,6 +31,7 @@ from app.core.persistent_config import (
     get_cached_semantic_search_rate_limit,
     get_cached_basemap_proxy_rate_limit,
 )
+from app.modules.catalog.search import service_semantic
 from app.platform.ratelimit import limiter
 
 pytestmark = pytest.mark.anyio
@@ -181,6 +183,66 @@ async def test_search_datasets_and_facets_share_one_bucket(
         limiter.enabled = False
         _clear_cache_limit("semantic_search_rate_limit")
         _reset_limiter_storage()
+
+
+async def test_facets_exempt_from_bucket_when_query_embedding_is_cached(
+    client: AsyncClient,
+):
+    """fix(#1903): a facets call for an ALREADY-EMBEDDED query spends no token.
+
+    The SPA fires /search/datasets/ and /search/facets/ as a pair on every
+    query change; the results call embeds first, so the facets call for the
+    same ``q`` is a cache hit and must not need a token of its own -- proven
+    by spending a 1-token bucket on the results call, then confirming the
+    paired facets call still succeeds. A facets call for a genuinely novel
+    query still spends the (already-empty) bucket, so the shared-bucket cap
+    is not weakened for a facets-only caller.
+
+    Counterfactual: reverting the router's ``exempt_when`` (or its
+    ``embedding_cache_has_hit`` check) 429s the second assertion below, since
+    both routes drew on the same single-token bucket unconditionally.
+    """
+    q = f"sec-1903-{uuid.uuid4().hex}"
+    _set_cache_limit("semantic_search_rate_limit", 1)
+    limiter.enabled = True
+    _reset_limiter_storage()
+    service_semantic._embedding_cache_clear()
+
+    try:
+        # Seed the cache as if /search/datasets/ had already embedded this
+        # exact query -- avoids depending on a live embedding provider.
+        cache_key = (
+            service_semantic.tenant_cache_key(q.strip().lower()),
+            "test-model",
+            "test-fingerprint",
+        )
+        service_semantic._embedding_cache[cache_key] = (
+            time.monotonic() + 60,
+            [0.1, 0.2, 0.3],
+        )
+
+        first = await client.get(f"/search/datasets/?q={q}")
+        assert first.status_code == 200, (
+            f"expected the results call to spend the bucket, got {first.status_code}"
+        )
+
+        second = await client.get(f"/search/facets/?q={q}")
+        assert second.status_code == 200, (
+            "facets call for an already-cached query should be exempt from "
+            f"the spent bucket, got {second.status_code}"
+        )
+
+        novel_q = f"sec-1903-novel-{uuid.uuid4().hex}"
+        third = await client.get(f"/search/facets/?q={novel_q}")
+        assert third.status_code == 429, (
+            "a facets call for an uncached query must still hit the spent "
+            f"bucket, got {third.status_code}"
+        )
+    finally:
+        limiter.enabled = False
+        _clear_cache_limit("semantic_search_rate_limit")
+        _reset_limiter_storage()
+        service_semantic._embedding_cache_clear()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -20,7 +20,6 @@ Per-test pattern:
     4. Re-disable the limiter and reset storage.
 """
 
-import time
 import uuid
 
 import pytest
@@ -185,51 +184,46 @@ async def test_search_datasets_and_facets_share_one_bucket(
         _reset_limiter_storage()
 
 
-async def test_facets_exempt_from_bucket_when_query_embedding_is_cached(
-    client: AsyncClient,
+@pytest.mark.parametrize("first_route", ["/search/datasets/", "/search/facets/"])
+async def test_paired_query_claims_the_bucket_once_whichever_route_is_first(
+    client: AsyncClient, first_route: str
 ):
-    """fix(#1903): a facets call for an ALREADY-EMBEDDED query spends no token.
+    """fix(#1903): the SPA's unordered paired request spends one token, not two.
 
-    The SPA fires /search/datasets/ and /search/facets/ as a pair on every
-    query change; the results call embeds first, so the facets call for the
-    same ``q`` is a cache hit and must not need a token of its own -- proven
-    by spending a 1-token bucket on the results call, then confirming the
-    paired facets call still succeeds. A facets call for a genuinely novel
-    query still spends the (already-empty) bucket, so the shared-bucket cap
-    is not weakened for a facets-only caller.
+    The SPA fires /search/datasets/ and /search/facets/ together on every
+    query change with neither awaiting the other, so which one reaches its
+    rate-limit gate first is a race -- proven here by running the pair in
+    BOTH orders for the same ``q`` against a 1-token bucket: the second call,
+    whichever route it lands on, must be exempt. A facets call for a
+    genuinely novel query still spends the (already-empty) bucket, so the
+    shared-bucket cap is not weakened for a facets-only caller.
 
-    Counterfactual: reverting the router's ``exempt_when`` (or its
-    ``embedding_cache_has_hit`` check) 429s the second assertion below, since
-    both routes drew on the same single-token bucket unconditionally.
+    Counterfactual: reverting the routers' ``exempt_when`` (or scoping
+    ``claim_semantic_search_query`` per-route instead of sharing it) 429s the
+    second assertion below, since both routes drew on the same single-token
+    bucket unconditionally.
     """
+    routes = ["/search/datasets/", "/search/facets/"]
+    if first_route != routes[0]:
+        routes.reverse()
+    second_route = routes[1]
     q = f"sec-1903-{uuid.uuid4().hex}"
     _set_cache_limit("semantic_search_rate_limit", 1)
     limiter.enabled = True
     _reset_limiter_storage()
-    service_semantic._embedding_cache_clear()
+    service_semantic._query_claims_clear()
 
     try:
-        # Seed the cache as if /search/datasets/ had already embedded this
-        # exact query -- avoids depending on a live embedding provider.
-        cache_key = (
-            service_semantic.tenant_cache_key(q.strip().lower()),
-            "test-model",
-            "test-fingerprint",
-        )
-        service_semantic._embedding_cache[cache_key] = (
-            time.monotonic() + 60,
-            [0.1, 0.2, 0.3],
-        )
-
-        first = await client.get(f"/search/datasets/?q={q}")
+        first = await client.get(f"{first_route}?q={q}")
         assert first.status_code == 200, (
-            f"expected the results call to spend the bucket, got {first.status_code}"
+            f"expected the first call ({first_route}) to spend the bucket, "
+            f"got {first.status_code}"
         )
 
-        second = await client.get(f"/search/facets/?q={q}")
+        second = await client.get(f"{second_route}?q={q}")
         assert second.status_code == 200, (
-            "facets call for an already-cached query should be exempt from "
-            f"the spent bucket, got {second.status_code}"
+            f"the paired call ({second_route}) for the same query should be "
+            f"exempt from the spent bucket, got {second.status_code}"
         )
 
         novel_q = f"sec-1903-novel-{uuid.uuid4().hex}"
@@ -242,7 +236,7 @@ async def test_facets_exempt_from_bucket_when_query_embedding_is_cached(
         limiter.enabled = False
         _clear_cache_limit("semantic_search_rate_limit")
         _reset_limiter_storage()
-        service_semantic._embedding_cache_clear()
+        service_semantic._query_claims_clear()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -25,6 +25,8 @@ import uuid
 import pytest
 from httpx import AsyncClient
 
+from app.core.config import settings
+from app.core.db.tenant_session import current_tenant_var
 from app.core.persistent_config import (
     _sync_rate_limit_cache,
     get_cached_semantic_search_rate_limit,
@@ -380,6 +382,46 @@ async def test_claim_is_scoped_to_the_requesting_client(client: AsyncClient):
         limiter.enabled = False
         _clear_cache_limit("semantic_search_rate_limit")
         _reset_limiter_storage()
+        service_semantic._query_claims_clear()
+
+
+async def test_claim_functions_degrade_without_crashing_when_tenant_unscoped(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """fix(#1903 review r5): an unscoped multi-tenant request must not 500.
+
+    ``tenant_cache_key()`` raises when multi-tenant mode has no verified
+    tenant context (a trusted unscoped host, per
+    ``tenant_cache_context_available()``'s own docstring). ``exempt_when``
+    runs synchronously inside slowapi's rate-limit check, so an uncaught
+    exception there would turn every search request with ``q`` into a 500
+    on such a host. The claim functions must check availability first and
+    simply disable claiming instead.
+
+    Counterfactual: calling ``tenant_cache_key`` directly from
+    ``_query_claim_key`` without that check raises ``ValueError`` here.
+    """
+    monkeypatch.setattr(settings, "geolens_tenancy_mode", "multi_tenant")
+    token = current_tenant_var.set(None)
+    try:
+        assert (
+            service_semantic.consume_paired_query_claim(
+                "203.0.113.5", "unscoped query", "datasets"
+            )
+            is False
+        )
+        # Must not raise.
+        service_semantic.record_paired_query_claim(
+            "203.0.113.5", "unscoped query", "datasets"
+        )
+        assert (
+            service_semantic.consume_paired_query_claim(
+                "203.0.113.5", "unscoped query", "facets"
+            )
+            is False
+        ), "no claim should have been recorded without a tenant context"
+    finally:
+        current_tenant_var.reset(token)
         service_semantic._query_claims_clear()
 
 

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -199,11 +199,6 @@ async def test_paired_query_claims_the_bucket_once_whichever_route_is_first(
     whichever route it lands on, must be exempt. A facets call for a
     genuinely novel query still spends the (already-empty) bucket, so the
     shared-bucket cap is not weakened for a facets-only caller.
-
-    Counterfactual: reverting the routers' ``exempt_when`` (or scoping
-    ``claim_semantic_search_query`` per-route instead of sharing it) 429s the
-    second assertion below, since both routes drew on the same single-token
-    bucket unconditionally.
     """
     routes = ["/search/datasets/", "/search/facets/"]
     if first_route != routes[0]:
@@ -244,7 +239,7 @@ async def test_paired_query_claims_the_bucket_once_whichever_route_is_first(
 async def test_same_route_repeat_does_not_ride_a_cross_route_claim(
     client: AsyncClient,
 ):
-    """fix(#1903 round 2): a same-route burst still pays per request.
+    """fix(#1903): a same-route burst still pays per request.
 
     A claim is a single-use, cross-route consume, not a standing amnesty for
     the whole coordination window: a concurrent burst against ONE route for
@@ -253,9 +248,6 @@ async def test_same_route_repeat_does_not_ride_a_cross_route_claim(
     embed hasn't landed), so each would still bill the provider. Proven
     with a 2-token bucket: two /search/facets/ calls for the SAME query
     spend both tokens; a third is a 429, not a third exemption.
-
-    Counterfactual: matching a claim regardless of which route made it
-    (rather than requiring the OTHER route) turns the third call into a 200.
     """
     q = f"sec-1903-burst-{uuid.uuid4().hex}"
     _set_cache_limit("semantic_search_rate_limit", 2)
@@ -288,17 +280,13 @@ async def test_same_route_repeat_does_not_ride_a_cross_route_claim(
 
 
 async def test_rejected_request_does_not_seed_a_claim(client: AsyncClient):
-    """fix(#1903 review r3): a 429'd request must not create an exemption.
+    """fix(#1903): a 429'd request must not create an exemption.
 
     exempt_when runs before the limiter's own admit/reject check, so it
     fires for a request that gets rejected too. Exhaust the bucket on an
     unrelated query, then send a NEW query to /search/datasets/ while the
     bucket is spent (rejected). A /search/facets/ call for that SAME new
     query must also be rejected -- nothing was admitted to claim it.
-
-    Counterfactual: writing the claim inside ``exempt_when`` itself (rather
-    than only from ``_finalize_semantic_search_claim`` in an admitted
-    handler) turns the facets call below into a 200.
     """
     q = f"sec-1903-rejected-{uuid.uuid4().hex}"
     _set_cache_limit("semantic_search_rate_limit", 1)
@@ -332,7 +320,7 @@ async def test_rejected_request_does_not_seed_a_claim(client: AsyncClient):
 
 
 async def test_claim_is_scoped_to_the_requesting_client(client: AsyncClient):
-    """fix(#1903 review r3): a claim is scoped to the client that made it.
+    """fix(#1903): a claim is scoped to the client that made it.
 
     The SEC-S11 bucket is per-IP, so two different clients requesting the
     same query must not be able to consume each other's claim: client B's
@@ -340,10 +328,6 @@ async def test_claim_is_scoped_to_the_requesting_client(client: AsyncClient):
     Proven by having client A admit a query, then client B request the
     SAME query -- B must spend its OWN token (not ride A's claim), so a
     second B call for a different query must then find B's bucket spent.
-
-    Counterfactual: dropping the client key from the claim registry (so it
-    matches on query text alone) turns B's second call below into a 200,
-    since B's first call would have been wrongly exempted.
     """
     from httpx import ASGITransport, AsyncClient as _AsyncClient
 
@@ -388,18 +372,13 @@ async def test_claim_is_scoped_to_the_requesting_client(client: AsyncClient):
 async def test_claim_functions_degrade_without_crashing_when_tenant_unscoped(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """fix(#1903 review r5): an unscoped multi-tenant request must not 500.
+    """fix(#1903): an unscoped multi-tenant request must not 500.
 
     ``tenant_cache_key()`` raises when multi-tenant mode has no verified
-    tenant context (a trusted unscoped host, per
-    ``tenant_cache_context_available()``'s own docstring). ``exempt_when``
-    runs synchronously inside slowapi's rate-limit check, so an uncaught
+    tenant context (a trusted unscoped host). ``exempt_when`` runs
+    synchronously inside slowapi's rate-limit check, so an uncaught
     exception there would turn every search request with ``q`` into a 500
-    on such a host. The claim functions must check availability first and
-    simply disable claiming instead.
-
-    Counterfactual: calling ``tenant_cache_key`` directly from
-    ``_query_claim_key`` without that check raises ``ValueError`` here.
+    on such a host. The claim functions check availability first instead.
     """
     monkeypatch.setattr(settings, "geolens_tenancy_mode", "multi_tenant")
     token = current_tenant_var.set(None)
@@ -422,6 +401,48 @@ async def test_claim_functions_degrade_without_crashing_when_tenant_unscoped(
         ), "no claim should have been recorded without a tenant context"
     finally:
         current_tenant_var.reset(token)
+        service_semantic._query_claims_clear()
+
+
+async def test_four_request_chain_for_one_query_spends_exactly_two_tokens(
+    client: AsyncClient,
+):
+    """fix(#1903): datasets, facets, datasets, facets for one q spends
+    exactly two tokens -- an exempted request never records a claim, so it
+    cannot seed the next exemption.
+
+    With a 2-token bucket, all four calls in the chain must succeed (two
+    charged, two exempt); a fifth call for the same query must then hit
+    the exhausted bucket.
+    """
+    q = f"sec-1903-chain-{uuid.uuid4().hex}"
+    _set_cache_limit("semantic_search_rate_limit", 2)
+    limiter.enabled = True
+    _reset_limiter_storage()
+    service_semantic._query_claims_clear()
+
+    try:
+        statuses = []
+        for route in (
+            "/search/datasets/",
+            "/search/facets/",
+            "/search/datasets/",
+            "/search/facets/",
+        ):
+            resp = await client.get(f"{route}?q={q}")
+            statuses.append(resp.status_code)
+        assert statuses == [200, 200, 200, 200], (
+            f"expected the full chain to succeed on a 2-token bucket, got {statuses}"
+        )
+
+        fifth = await client.get(f"/search/datasets/?q={q}")
+        assert fifth.status_code == 429, (
+            f"the chain must have spent exactly two tokens, got {fifth.status_code}"
+        )
+    finally:
+        limiter.enabled = False
+        _clear_cache_limit("semantic_search_rate_limit")
+        _reset_limiter_storage()
         service_semantic._query_claims_clear()
 
 

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -239,6 +239,52 @@ async def test_paired_query_claims_the_bucket_once_whichever_route_is_first(
         service_semantic._query_claims_clear()
 
 
+async def test_same_route_repeat_does_not_ride_a_cross_route_claim(
+    client: AsyncClient,
+):
+    """fix(#1903 round 2): a same-route burst still pays per request.
+
+    A claim is a single-use, cross-route consume, not a standing amnesty for
+    the whole coordination window: a concurrent burst against ONE route for
+    the same query would otherwise ride free after the first call, even
+    though none of those requests can have a cache hit yet (the first
+    embed hasn't landed), so each would still bill the provider. Proven
+    with a 2-token bucket: two /search/facets/ calls for the SAME query
+    spend both tokens; a third is a 429, not a third exemption.
+
+    Counterfactual: matching a claim regardless of which route made it
+    (rather than requiring the OTHER route) turns the third call into a 200.
+    """
+    q = f"sec-1903-burst-{uuid.uuid4().hex}"
+    _set_cache_limit("semantic_search_rate_limit", 2)
+    limiter.enabled = True
+    _reset_limiter_storage()
+    service_semantic._query_claims_clear()
+
+    try:
+        first = await client.get(f"/search/facets/?q={q}")
+        assert first.status_code == 200, (
+            f"expected the first call to spend a token, got {first.status_code}"
+        )
+
+        second = await client.get(f"/search/facets/?q={q}")
+        assert second.status_code == 200, (
+            "a second same-route call is not the cross-route pair and must "
+            f"spend its own token, got {second.status_code}"
+        )
+
+        third = await client.get(f"/search/facets/?q={q}")
+        assert third.status_code == 429, (
+            "a third same-route call for the same query must hit the "
+            f"now-spent bucket, got {third.status_code}"
+        )
+    finally:
+        limiter.enabled = False
+        _clear_cache_limit("semantic_search_rate_limit")
+        _reset_limiter_storage()
+        service_semantic._query_claims_clear()
+
+
 # ---------------------------------------------------------------------------
 # Task 3: /datasets/{id}/related/ rate limiting (SEC-S11)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -285,6 +285,104 @@ async def test_same_route_repeat_does_not_ride_a_cross_route_claim(
         service_semantic._query_claims_clear()
 
 
+async def test_rejected_request_does_not_seed_a_claim(client: AsyncClient):
+    """fix(#1903 review r3): a 429'd request must not create an exemption.
+
+    exempt_when runs before the limiter's own admit/reject check, so it
+    fires for a request that gets rejected too. Exhaust the bucket on an
+    unrelated query, then send a NEW query to /search/datasets/ while the
+    bucket is spent (rejected). A /search/facets/ call for that SAME new
+    query must also be rejected -- nothing was admitted to claim it.
+
+    Counterfactual: writing the claim inside ``exempt_when`` itself (rather
+    than only from ``_finalize_semantic_search_claim`` in an admitted
+    handler) turns the facets call below into a 200.
+    """
+    q = f"sec-1903-rejected-{uuid.uuid4().hex}"
+    _set_cache_limit("semantic_search_rate_limit", 1)
+    limiter.enabled = True
+    _reset_limiter_storage()
+    service_semantic._query_claims_clear()
+
+    try:
+        spend = await client.get(
+            f"/search/datasets/?q=sec-1903-spend-{uuid.uuid4().hex}"
+        )
+        assert spend.status_code == 200, (
+            f"expected the spend call to succeed, got {spend.status_code}"
+        )
+
+        rejected = await client.get(f"/search/datasets/?q={q}")
+        assert rejected.status_code == 429, (
+            f"expected the bucket to already be spent, got {rejected.status_code}"
+        )
+
+        second = await client.get(f"/search/facets/?q={q}")
+        assert second.status_code == 429, (
+            "a facets call following a REJECTED datasets call for the same "
+            f"query must not be exempt, got {second.status_code}"
+        )
+    finally:
+        limiter.enabled = False
+        _clear_cache_limit("semantic_search_rate_limit")
+        _reset_limiter_storage()
+        service_semantic._query_claims_clear()
+
+
+async def test_claim_is_scoped_to_the_requesting_client(client: AsyncClient):
+    """fix(#1903 review r3): a claim is scoped to the client that made it.
+
+    The SEC-S11 bucket is per-IP, so two different clients requesting the
+    same query must not be able to consume each other's claim: client B's
+    own bucket has full capacity regardless of what client A just did.
+    Proven by having client A admit a query, then client B request the
+    SAME query -- B must spend its OWN token (not ride A's claim), so a
+    second B call for a different query must then find B's bucket spent.
+
+    Counterfactual: dropping the client key from the claim registry (so it
+    matches on query text alone) turns B's second call below into a 200,
+    since B's first call would have been wrongly exempted.
+    """
+    from httpx import ASGITransport, AsyncClient as _AsyncClient
+
+    from app.api.main import app
+
+    q = f"sec-1903-crossclient-{uuid.uuid4().hex}"
+    _set_cache_limit("semantic_search_rate_limit", 1)
+    limiter.enabled = True
+    _reset_limiter_storage()
+    service_semantic._query_claims_clear()
+
+    other_transport = ASGITransport(app=app, client=("10.0.0.9", 12345))
+    try:
+        async with _AsyncClient(
+            transport=other_transport, base_url="http://test"
+        ) as other_client:
+            first = await client.get(f"/search/datasets/?q={q}")
+            assert first.status_code == 200, (
+                f"expected client A's call to spend A's bucket, got {first.status_code}"
+            )
+
+            second = await other_client.get(f"/search/facets/?q={q}")
+            assert second.status_code == 200, (
+                "client B has its own untouched bucket for the same query, "
+                f"got {second.status_code}"
+            )
+
+            third = await other_client.get(
+                f"/search/facets/?q=sec-1903-crossclient-novel-{uuid.uuid4().hex}"
+            )
+            assert third.status_code == 429, (
+                "client B's own token must have been spent by its first "
+                f"call, not exempted via client A's claim, got {third.status_code}"
+            )
+    finally:
+        limiter.enabled = False
+        _clear_cache_limit("semantic_search_rate_limit")
+        _reset_limiter_storage()
+        service_semantic._query_claims_clear()
+
+
 # ---------------------------------------------------------------------------
 # Task 3: /datasets/{id}/related/ rate limiting (SEC-S11)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_search_embedding_cache.py
+++ b/backend/tests/test_search_embedding_cache.py
@@ -22,10 +22,17 @@ from app.modules.catalog.search import service_semantic
 
 @pytest.fixture(autouse=True)
 def _reset_cache():
-    """Clear the embedding cache before every test."""
+    """Clear the embedding cache and in-flight registry before every test.
+
+    fix(#1903): a leaked ``asyncio.Task`` in ``_embedding_inflight`` is bound
+    to this test's event loop, which closes when the test ends -- the next
+    test's same-key call would await a task on a dead loop.
+    """
     service_semantic._embedding_cache_clear()
+    service_semantic._embedding_inflight_clear()
     yield
     service_semantic._embedding_cache_clear()
+    service_semantic._embedding_inflight_clear()
 
 
 def _mock_session_with_model(model_name: str = "text-embedding-3-small"):
@@ -88,8 +95,8 @@ async def test_generate_embedding_caches_result_on_second_call():
 
 @pytest.mark.asyncio
 async def test_concurrent_calls_for_the_same_key_coalesce_into_one_provider_call():
-    """fix(#1903 review r5): two overlapping calls for the same query share
-    ONE provider call, not two.
+    """fix(#1903): two overlapping calls for the same query share ONE
+    provider call, not two.
 
     A rate-limit exemption can be granted before either half of a paired
     request has finished embedding, so if both then missed the TTL cache
@@ -120,6 +127,12 @@ async def test_concurrent_calls_for_the_same_key_coalesce_into_one_provider_call
         second_task = asyncio.ensure_future(
             service_semantic.generate_embedding("overlapping query", session)
         )
+        await asyncio.sleep(0)  # let the second call's sync prefix join the task
+        assert len(service_semantic._embedding_inflight) == 1, (
+            "the second call should have joined the first's task, not "
+            "registered a second one"
+        )
+
         release_provider_call.set()
         first, second = await asyncio.gather(first_task, second_task)
 
@@ -129,6 +142,76 @@ async def test_concurrent_calls_for_the_same_key_coalesce_into_one_provider_call
         "the second call should have joined the first's in-flight task "
         "instead of making its own provider call"
     )
+
+
+@pytest.mark.asyncio
+async def test_joined_waiter_survives_the_originators_cancellation():
+    """fix(#1903): cancelling one participant must not cancel the shared
+    task or its siblings.
+
+    Awaiting a bare ``Task`` makes it the awaiter's ``_fut_waiter``, so
+    cancelling any one participant would cancel the shared task and every
+    other participant with it; ``CancelledError`` is a ``BaseException``,
+    so ``resolve_semantic_arm``'s ``except Exception`` would not catch it
+    and an unrelated request would unwind instead of degrading to FTS.
+    ``asyncio.shield`` is what keeps this from happening.
+    """
+    fake_vector = [0.5] * 1536
+    provider_call_started = asyncio.Event()
+    release_provider_call = asyncio.Event()
+
+    async def _slow_provider_call(*args, **kwargs):
+        provider_call_started.set()
+        await release_provider_call.wait()
+        return fake_vector
+
+    mock_port = _mock_port()
+    mock_port.generate_embedding = AsyncMock(side_effect=_slow_provider_call)
+    session = _mock_session_with_model()
+
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
+        originator = asyncio.ensure_future(
+            service_semantic.generate_embedding("cancel-me query", session)
+        )
+        await provider_call_started.wait()
+
+        waiter = asyncio.ensure_future(
+            service_semantic.generate_embedding("cancel-me query", session)
+        )
+        await asyncio.sleep(0)  # let the waiter join the originator's task
+
+        originator.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await originator
+
+        release_provider_call.set()
+        assert await waiter == fake_vector, (
+            "the waiter must still get the result even though the request "
+            "that spawned the shared task was cancelled"
+        )
+
+
+@pytest.mark.asyncio
+async def test_provider_error_clears_the_inflight_key_so_the_next_call_retries():
+    """fix(#1903): a failed shared embed must not poison later calls.
+
+    ``_embed_and_cache``'s ``finally`` pops the in-flight entry on any
+    outcome, success or failure, so a provider error on one call does not
+    strand the key -- the next call for the same text makes its own
+    attempt rather than awaiting a task that already raised.
+    """
+    mock_port = _mock_port(side_effect=ValueError("provider unavailable"))
+    session = _mock_session_with_model()
+
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
+        with pytest.raises(ValueError):
+            await service_semantic.generate_embedding("flaky query", session)
+        assert len(service_semantic._embedding_inflight) == 0
+
+        with pytest.raises(ValueError):
+            await service_semantic.generate_embedding("flaky query", session)
+
+    assert mock_port.generate_embedding.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_search_embedding_cache.py
+++ b/backend/tests/test_search_embedding_cache.py
@@ -9,6 +9,7 @@ exercise the wrapper indirectly via `test_hybrid_search.py`.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -83,6 +84,51 @@ async def test_generate_embedding_caches_result_on_second_call():
     assert second == fake_vector
     # Provider hit exactly once even though we called twice.
     assert mock_port.generate_embedding.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_for_the_same_key_coalesce_into_one_provider_call():
+    """fix(#1903 review r5): two overlapping calls for the same query share
+    ONE provider call, not two.
+
+    A rate-limit exemption can be granted before either half of a paired
+    request has finished embedding, so if both then missed the TTL cache
+    and called the provider independently, one shared-limit token would
+    fund two paid calls. Uses events (not sleeps) so the second call is
+    provably started while the first is still blocked inside the provider
+    call, matching a genuine race rather than a lucky sequential timing.
+    """
+    fake_vector = [0.4] * 1536
+    provider_call_started = asyncio.Event()
+    release_provider_call = asyncio.Event()
+
+    async def _slow_provider_call(*args, **kwargs):
+        provider_call_started.set()
+        await release_provider_call.wait()
+        return fake_vector
+
+    mock_port = _mock_port()
+    mock_port.generate_embedding = AsyncMock(side_effect=_slow_provider_call)
+    session = _mock_session_with_model()
+
+    with patch.object(service_semantic, "get_catalog_port", return_value=mock_port):
+        first_task = asyncio.ensure_future(
+            service_semantic.generate_embedding("overlapping query", session)
+        )
+        await provider_call_started.wait()
+
+        second_task = asyncio.ensure_future(
+            service_semantic.generate_embedding("overlapping query", session)
+        )
+        release_provider_call.set()
+        first, second = await asyncio.gather(first_task, second_task)
+
+    assert first == fake_vector
+    assert second == fake_vector
+    assert mock_port.generate_embedding.call_count == 1, (
+        "the second call should have joined the first's in-flight task "
+        "instead of making its own provider call"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The search facets request spends a rate-limit token even when the results request already embedded the same query. Both `/search/datasets/` and `/search/facets/` draw on one shared SEC-S11 bucket (`semantic_search_rate_limit`, default 30/minute per IP), and the SPA fires them as an unordered pair on every query change (neither request awaits the other), so one query change spent two tokens while the provider was paid for at most one embedding. At the default, an SPA user got 15 query changes a minute per IP instead of 30.

Closes #1903.

## Changes

Both routes' `shared_limit` decorator now carries an `exempt_when` callable backed by a short-lived claim registry (`service_semantic.py`'s `_query_claims`, keyed on client + tenant + normalized query text):

- Whichever route's rate-limit gate is reached first for a given query claims it and pays the SEC-S11 token. The sibling route, arriving within a 5-second window, consumes that claim once and is exempt.
- Claiming is admission-gated: `exempt_when` only reads and consumes an existing claim (it runs before the limiter's own admit/reject check, so a request the bucket goes on to reject must not be able to seed one). A separate call at the top of each handler records a claim, which only runs for a request the rate limit actually let through.
- The claim key includes the same client identity the limiter's own `key_func` resolves, so one client can't consume another client's claim.
- A same-route repeat never matches its own claim, so a burst against one route still pays per request; a claim is single-use (deleted on consumption), not a standing exemption for the whole window.
- The registry is TTL-bound and hard-capped (256 entries, LRU eviction), so it can't grow unbounded even when a paired request's sibling never arrives.

`router.py`'s and `service_semantic.py`'s LOC caps in `test_layering.py` were re-measured and ratcheted at each step.

## Why this shape over the issue's other option

The issue also floated folding facets into the `/search/datasets/` response so the SPA makes one request instead of two. That removes the double spend outright, but it changes a published response shape for a saving the claim-registry approach gets without touching the wire contract.

## Review history

Four codex rounds, each catching a real gap in the exemption mechanism:
- **Round 1**: the first design assumed the results call always embeds first and checked the embedding cache; the two requests are actually unordered, so the exemption rarely fired. Replaced with the claim registry, symmetric on both routes.
- **Round 2**: the claim wasn't consumed, so a same-route burst against one query rode free for the whole TTL window even though each request still billed the provider. Made claiming single-use and cross-route only.
- **Round 3**: two findings. A rejected request could still seed a claim a follow-up call redeemed, fixed by admission-gating. The claim wasn't scoped to the caller, so a different client could consume it, fixed by including the limiter's client identity in the key.
- **Round 4**: the global per-IP default was being charged twice per request. Both routes' rate limit is a callable value, which slowapi registers differently from a static one; its ASGI middleware doesn't recognize that registration and runs its own check first, always charging the global default for these routes regardless of `override_defaults`. I'd added that setting believing an exempted call would otherwise have no limit at all, which isn't true for this kind of route, so I removed it. Round 4 also flagged that the claim registry is process-local, so a paired request split across the two Uvicorn workers the bundled prod compose file runs by default gets no exemption. That's an existing, explicitly-deferred characteristic of the rate limiter itself (see `query_router.py`'s `fix(#565)` note): the worst case is the pre-#1903 behavior, never worse, so it's documented rather than fixed here. Filed #2018 to track a cross-worker-aware limiter/registry.

Fixing round 4's global-limit bug surfaced a gate-coverage gap: `test_semantic_search_rate_limit_1778.py` structurally asserts the route's `override_defaults` stays `True`, and the round-1 change had been silently failing it since the first round, because that test file doesn't mention "facets" and wasn't caught by this lane's facets-grep-based test search. It's green again, and the final test sweep covers every test file in `backend/tests/` that references the touched routes, functions, or symbols, not just the facets-adjacent ones.

- **Round 5**: two more findings. A rate-limit exemption can be granted before either half of a paired request finishes embedding, so a genuinely overlapping pair (both missing the embedding TTL cache, which is the common case for any novel query since coordination happens at the rate-limit gate) could still make two paid provider calls under one charged token. Concurrent calls for the same query now join a single in-flight embedding task instead of each starting their own. Separately, `tenant_cache_key()` raises when multi-tenant mode has no verified tenant context; the claim key builder called it unconditionally, so a search query on a trusted unscoped host would 500. Both fixed.
- **Round 6** (independent adversarial review, verdict: merge, no P1): live instrumentation of the gate confirmed the counting invariant (`exempt_when` fires exactly once per request, an exempted request records nothing, a 429'd request records nothing), and traced two P2s and several P3s in the round-5 single-flight, the only code no automated round had seen yet.
  - The shared embedding task had no cancellation isolation: awaiting a bare `Task` makes it the awaiter's `_fut_waiter`, so cancelling any one participant cancelled the shared task and every other participant with it, and `CancelledError` isn't caught by `resolve_semantic_arm`'s `except Exception`. Every participant now awaits `asyncio.shield(task)`. That raised a session-safety question: a shielded task can outlive the request that spawned it, and `generate_embeddings_batch` reads the session for a default when `dimensions` is unpinned. The single-flight now only applies when the config is fully pinned; an unpinned call runs standalone, as before round 5.
  - The test fixture cleared the embedding cache but not the new in-flight registry; a leaked task bound to a closed event loop could poison a later test. Fixed.
  - The claim key joined the client address and query text with `:`, which an IPv6 client address also contains, so a /64 holder could pick low bits that collide with a neighbour's key. The key is now a tuple, not a string join.
  - The route tag was a substring test against the URL path (`"facets" in request.url.path`), correct today but fragile against a future route sharing that text. It now reads the route's own name from `request.scope["route"]`.
  - After the reviewer verified those four fixes, one more surfaced: the single-flight's fully-pinned gate tested only `dimensions is None`, but the session-reading condition it needs to match is `not model or not dimensions` in `generate_embeddings_batch`; an empty `embedding_model` string passes config validation with no non-empty check, so that case would still have let a shared task read the originator's session. The gate now tests the exact predicate it's guarding against.

## Known limitations

- The claim registry (and the SEC-S11 rate limiter it sits on) is per-process. Under a multi-worker deployment, a paired request split across workers is not exempted: each worker charges its own token, same as before this fix. Tracked at #2018.
- A query under `_MIN_SEMANTIC_QUERY_LEN` (4 characters) never reaches the embedding provider, but the claim/exemption mechanism still applies to it, so the effective request cap for that non-semantic path doubles even though provider spend on it stays at zero.
- A request that joins an in-flight embed inherits the originator's remaining `_QUERY_EMBED_TIMEOUT_SECONDS` (8s) deadline, not a fresh one. A late joiner can time out and fall back to full-text search sooner than an unpaired request would.

## Area

- [x] Backend (API, services, models)

## Testing

- [x] Unit tests pass (`pytest`)
  - `test_rate_limits.py`: 6 new tests, each with a counterfactual verified against the commit it was written to catch. The paired-request fix (both orderings), the same-route-burst fix, the rejected-request fix, the cross-client fix (spins up a second `ASGITransport` client at a different IP against the same app instance), the tenant-unscoped fix, and a four-request `datasets, facets, datasets, facets` chain pinning that it spends exactly two tokens.
  - `test_search_embedding_cache.py`: 3 new tests for the round-5/6 single-flight, including one asserting `len(_embedding_inflight) == 1` while two calls are joined (pins the mechanism, not a side effect of a mock that never yields) and one proving a cancelled participant doesn't take a sibling down with it.
  - `test_layering.py`, `test_rule1_structural.py`, `test_semantic_search_rate_limit_1778.py` (the pre-existing test the round-4 fix restores)
  - `test_search_facets.py`, `test_search_facets_input_cap.py`, `test_search_cache.py`, `test_hybrid_search.py`, `test_datasets.py`, `test_search_datetime.py`, `test_redirect_slashes.py`, `test_basemap_sublayer_overrides.py`, `test_cache.py`, `test_ogc_features_filter.py`, `test_sdks_round_trip.py`, `test_search_simple_regconfig.py`, `test_search_cors_1596.py`
  - `ruff check` / `ruff format --check`, `finding_markers.py`
- [ ] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)

No route signature, query parameter, or published description changed, so no OpenAPI/SDK regen is needed.

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing



