### PR TITLE
refactor(sandbox): bind tenant schemas by replacing schema spans

### DIFF
--- a/backend/app/platform/sandbox/executor.py
+++ b/backend/app/platform/sandbox/executor.py
@@ -30,24 +30,19 @@ DEFAULT_TIMEOUT_MS = 10_000
 _SINGLE_TENANT_READER_ROLE = "geolens_reader"
 
 
-def _logical_data_span(
-    identifier: exp.Expression | None, sql: str
-) -> tuple[int, int] | None:
-    """Source offsets of one logical ``data`` schema qualifier in ``sql``.
+def _is_logical_data_schema(identifier: exp.Identifier) -> bool:
+    """True when ``identifier`` folds to the logical ``data`` schema: unquoted
+    folds to lowercase, quoted keeps its case, so quoted ``"DATA"`` is not it."""
+    name = identifier.name if identifier.quoted else identifier.name.lower()
+    return name == "data"
 
-    ``None`` when the qualifier names another schema. An unquoted identifier
-    folds to lowercase as PostgreSQL folds it, so every spelling of ``data``
-    is the logical schema while quoted ``"DATA"`` stays a different one
-    (fix(#1891)).
+
+def _logical_data_span(identifier: exp.Identifier, sql: str) -> tuple[int, int]:
+    """Source offsets of one logical ``data`` schema qualifier in ``sql``.
 
     fix(#1892): the slice must spell exactly what sqlglot parsed. An absent or
     shifted offset would move an unrelated span, so it fails closed instead.
     """
-    if not isinstance(identifier, exp.Identifier):
-        return None
-    if (identifier.name if identifier.quoted else identifier.name.lower()) != "data":
-        return None
-
     start = identifier.meta.get("start")
     end = identifier.meta.get("end")
     spelling = f'"{identifier.name}"' if identifier.quoted else identifier.name
@@ -57,7 +52,9 @@ def _logical_data_span(
         or not 0 <= start <= end < len(sql)
         or sql[start : end + 1] != spelling
     ):
-        logger.error("sandbox.schema_span_unusable", sql=sql)
+        logger.warning(
+            "sandbox.schema_span_unusable", start=start, end=end, length=len(sql)
+        )
         raise SandboxError("query_failed", "Query failed")
     return start, end
 
@@ -80,26 +77,36 @@ def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
     only a normalized UUID-derived identifier in multi-tenant mode.
     """
     try:
-        statement = sqlglot.parse_one(sql, dialect="postgres")
+        statements = sqlglot.parse(sql, dialect="postgres")
     except sqlglot.errors.SqlglotError as exc:
         # execute_safe receives validated SQL in normal operation.  Keep direct
         # callers fail-closed if that contract is accidentally violated (covers
         # both tokenize and parse failures).
         raise SandboxError("invalid_query", "Invalid SQL syntax") from exc
 
+    # fix(#1892): `parse`, not `parse_one`, which reports a second statement as
+    # one Block and would rewrite a caller-supplied `a; b` in both halves.
+    statements = [statement for statement in statements if statement is not None]
+    if len(statements) != 1:
+        logger.warning("sandbox.rewrite_multi_statement", count=len(statements))
+        raise SandboxError("invalid_query", "Only single statements are allowed")
+
     spans: set[tuple[int, int]] = set()
-    for node in statement.walk():
-        if isinstance(node, (exp.Table, exp.Column)):
-            span = _logical_data_span(node.args.get("db"), sql)
-            if span is not None:
-                spans.add(span)
+    for node in statements[0].walk():
+        if not isinstance(node, (exp.Table, exp.Column)):
+            continue
+        identifier = node.args.get("db")
+        if isinstance(identifier, exp.Identifier) and _is_logical_data_schema(
+            identifier
+        ):
+            spans.add(_logical_data_span(identifier, sql))
 
     replacement = '"' + physical_schema.replace('"', '""') + '"'
     tail = len(sql)
     for start, end in sorted(spans, reverse=True):
         if end >= tail:
             # Overlapping spans would splice into text already replaced.
-            logger.error("sandbox.schema_span_overlap", sql=sql)
+            logger.warning("sandbox.schema_span_overlap", start=start, end=end)
             raise SandboxError("query_failed", "Query failed")
         sql = sql[:start] + replacement + sql[end + 1 :]
         tail = start

--- a/backend/app/platform/sandbox/executor.py
+++ b/backend/app/platform/sandbox/executor.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import structlog
 import sqlglot
 from sqlglot import exp
-from sqlglot.tokens import TokenType
 from sqlalchemy import text
 from sqlalchemy.exc import DataError, InternalError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,96 +29,81 @@ DEFAULT_TIMEOUT_MS = 10_000
 # the legacy best-effort fallback and the feat(#565) fail-closed binding.
 _SINGLE_TENANT_READER_ROLE = "geolens_reader"
 
-# fix(#557): sqlglot's postgres dialect mis-parses the pgvector cosine
-# operator `<=>` as NullSafeEQ, so re-serializing the AST silently rewrites
-# it to `IS NOT DISTINCT FROM` — turning nearest-neighbor ranking into a
-# boolean equality test. The multi-tenant schema rewrite MUST re-render (the
-# logical `data.` schema has no physical table), so it can't bail to the
-# original SQL like the optional guard (#556) does. Instead we swap the
-# `<=>` operator for a sentinel that round-trips (`&&`, rejected by the
-# validator as array_overlaps so it never appears in real validated SQL),
-# rewrite the schema on the parsed AST, then restore the operator. The swap
-# uses sqlglot's own tokenizer, so `<=>`/`&&` inside a string literal of ANY
-# quoting form (`'...'`, `E'...'`, `$$...$$`) tokenizes as a string and is
-# left untouched (fix(#559): a naive substring swap corrupted dollar-quoted
-# literals). `IS NOT DISTINCT FROM` tokenizes as keywords, not NULLSAFE_EQ,
-# so a legitimate null-safe comparison is never rewritten. `<->` (L2)
-# already round-trips and `<#>` fails parse upstream, so `<=>` is the only
-# operator vulnerable here.
-_COSINE_OP = "<=>"
-_COSINE_SENTINEL = "&&"
 
+def _logical_data_span(
+    identifier: exp.Expression | None, sql: str
+) -> tuple[int, int] | None:
+    """Source offsets of one logical ``data`` schema qualifier in ``sql``.
 
-def _swap_operator_tokens(sql: str, token_type: TokenType, replacement: str) -> str:
-    """Replace every operator token of ``token_type`` with ``replacement``.
+    ``None`` when the qualifier names another schema. An unquoted identifier
+    folds to lowercase as PostgreSQL folds it, so every spelling of ``data``
+    is the logical schema while quoted ``"DATA"`` stays a different one
+    (fix(#1891)).
 
-    Uses sqlglot's tokenizer so only genuine operator tokens are rewritten —
-    the same characters inside a string literal (any quoting form) tokenize
-    as a string and pass through untouched. Runs back-to-front so earlier
-    source offsets stay valid.
+    fix(#1892): the slice must spell exactly what sqlglot parsed. An absent or
+    shifted offset would move an unrelated span, so it fails closed instead.
     """
-    spans = [
-        (t.start, t.end)
-        for t in sqlglot.tokenize(sql, dialect="postgres")
-        if t.token_type == token_type
-    ]
-    out = sql
-    for start, end in reversed(spans):
-        out = out[:start] + replacement + out[end + 1 :]
-    return out
-
-
-def _is_logical_data_schema(identifier: exp.Expression | None) -> bool:
-    """True when ``identifier`` folds to the logical ``data`` schema: unquoted
-    folds to lowercase, quoted keeps its case, so quoted ``"DATA"`` is not it."""
     if not isinstance(identifier, exp.Identifier):
-        return False
-    name = identifier.name if identifier.quoted else identifier.name.lower()
-    return name == "data"
+        return None
+    if (identifier.name if identifier.quoted else identifier.name.lower()) != "data":
+        return None
+
+    start = identifier.meta.get("start")
+    end = identifier.meta.get("end")
+    spelling = f'"{identifier.name}"' if identifier.quoted else identifier.name
+    if (
+        not isinstance(start, int)
+        or not isinstance(end, int)
+        or not 0 <= start <= end < len(sql)
+        or sql[start : end + 1] != spelling
+    ):
+        logger.error("sandbox.schema_span_unusable", sql=sql)
+        raise SandboxError("query_failed", "Query failed")
+    return start, end
 
 
 def _rewrite_logical_data_schema(sql: str, physical_schema: str) -> str:
-    """Rewrite validated ``data.*`` references to one physical tenant schema.
+    """Bind validated ``data.*`` references to one physical tenant schema.
 
-    The validator exposes a stable logical ``data`` schema to the LLM and
-    rejects every other real-table schema; multi-tenant storage uses a
-    per-tenant physical schema, so execution translates the logical name
-    after validation. Rewriting the parsed AST (not a string replace) avoids
-    corrupting literals, comments, aliases, or identifiers that merely
-    contain the word ``data``.
+    The validator exposes a stable logical ``data`` schema and rejects every
+    other real-table schema; multi-tenant storage is per-tenant, so execution
+    translates the logical name after validation.
+
+    fix(#1892): only the schema identifier spans of the ORIGINAL text are
+    replaced, right to left. Serializing the parsed tree instead re-rendered
+    the whole statement, which is why the pgvector cosine operator (sqlglot
+    parses ``<=>`` as NullSafeEQ) needed a sentinel swap; every other byte now
+    reaches PostgreSQL as the caller wrote it, as it already does in
+    single-tenant.
 
     ``physical_schema`` comes from :func:`tenant_data_schema`, which accepts
     only a normalized UUID-derived identifier in multi-tenant mode.
     """
     try:
-        guarded = _swap_operator_tokens(sql, TokenType.NULLSAFE_EQ, _COSINE_SENTINEL)
-        statement = sqlglot.parse_one(guarded, dialect="postgres")
+        statement = sqlglot.parse_one(sql, dialect="postgres")
     except sqlglot.errors.SqlglotError as exc:
         # execute_safe receives validated SQL in normal operation.  Keep direct
         # callers fail-closed if that contract is accidentally violated (covers
         # both tokenize and parse failures).
         raise SandboxError("invalid_query", "Invalid SQL syntax") from exc
 
-    # protect only when a real `<=>` operator was swapped; a literal `<=>` (any
-    # quoting form) tokenizes as a string and leaves `guarded` unchanged.
-    protect_cosine = guarded != sql
+    spans: set[tuple[int, int]] = set()
+    for node in statement.walk():
+        if isinstance(node, (exp.Table, exp.Column)):
+            span = _logical_data_span(node.args.get("db"), sql)
+            if span is not None:
+                spans.add(span)
 
-    # fix(#1891): fold like the validator, so unquoted DATA is rewritten too.
-    for table in statement.find_all(exp.Table):
-        if _is_logical_data_schema(table.args.get("db")):
-            table.set("db", exp.to_identifier(physical_schema, quoted=True))
-
-    for column in statement.find_all(exp.Column):
-        if _is_logical_data_schema(column.args.get("db")):
-            column.set("db", exp.to_identifier(physical_schema, quoted=True))
-
-    rendered = statement.sql(dialect="postgres")
-    if protect_cosine:
-        # The rendered `&&` operators can only be the ones swapped in above (the
-        # validator rejects `&&` as a real operator), so restoring every DAMP
-        # token back to `<=>` is exact.
-        rendered = _swap_operator_tokens(rendered, TokenType.DAMP, _COSINE_OP)
-    return rendered
+    replacement = '"' + physical_schema.replace('"', '""') + '"'
+    tail = len(sql)
+    for start, end in sorted(spans, reverse=True):
+        if end >= tail:
+            # Overlapping spans would splice into text already replaced.
+            logger.error("sandbox.schema_span_overlap", sql=sql)
+            raise SandboxError("query_failed", "Query failed")
+        sql = sql[:start] + replacement + sql[end + 1 :]
+        tail = start
+    return sql
 
 
 async def execute_safe(

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -30,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import sqlglot
 from sqlglot import exp
+from sqlglot.tokens import TokenType
 
 from app.core.identity import Identity
 from app.modules.catalog.authorization import apply_visibility_filter, get_user_roles
@@ -949,6 +950,21 @@ def _check_function_allowlist(
         _validate_function_cost(func, fn_name, sql)
 
 
+def _strip_statement_terminator(sql: str) -> str:
+    """Drop one trailing ``;`` and anything after it.
+
+    fix(#1892): ``execute_safe`` splices the validated SQL into
+    ``SELECT * FROM (<sql>) AS _q LIMIT n``, and a terminator inside those
+    parentheses is a syntax error. Cutting at the last SEMICOLON *token* leaves
+    a ``;`` inside a literal or a comment alone, and leaves a second statement
+    in place for the multi-statement check below to reject.
+    """
+    tokens = sqlglot.tokenize(sql, dialect="postgres")
+    if not tokens or tokens[-1].token_type != TokenType.SEMICOLON:
+        return sql
+    return sql[: tokens[-1].start].rstrip()
+
+
 def validate_sql(
     sql: str,
     *,
@@ -967,6 +983,7 @@ def validate_sql(
     Left None (off) for AI chat.
     """
     try:
+        sql = _strip_statement_terminator(sql)
         statements = sqlglot.parse(sql, dialect="postgres")
     except sqlglot.errors.SqlglotError as exc:
         # fix(#1778): TokenError (an unterminated literal, identifier, comment

--- a/backend/app/platform/sandbox/validator.py
+++ b/backend/app/platform/sandbox/validator.py
@@ -951,18 +951,22 @@ def _check_function_allowlist(
 
 
 def _strip_statement_terminator(sql: str) -> str:
-    """Drop one trailing ``;`` and anything after it.
+    """Drop the whole trailing run of ``;`` and anything after it.
 
     fix(#1892): ``execute_safe`` splices the validated SQL into
     ``SELECT * FROM (<sql>) AS _q LIMIT n``, and a terminator inside those
-    parentheses is a syntax error. Cutting at the last SEMICOLON *token* leaves
-    a ``;`` inside a literal or a comment alone, and leaves a second statement
-    in place for the multi-statement check below to reject.
+    parentheses is a syntax error. Cutting at the first of the trailing
+    SEMICOLON *tokens* takes ``;;`` and ``; ;`` (ordinary paste damage) with it,
+    leaves a ``;`` inside a literal or a comment alone, and leaves a second
+    statement in place for the multi-statement check below to reject.
     """
     tokens = sqlglot.tokenize(sql, dialect="postgres")
-    if not tokens or tokens[-1].token_type != TokenType.SEMICOLON:
+    index = len(tokens)
+    while index and tokens[index - 1].token_type == TokenType.SEMICOLON:
+        index -= 1
+    if index == len(tokens):
         return sql
-    return sql[: tokens[-1].start].rstrip()
+    return sql[: tokens[index].start].rstrip()
 
 
 def validate_sql(

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5864,10 +5864,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reopen it. The rest is the TokenError note at the parse site. Cap
     # 1871 -> 1934, exact.
     # chore(#1873): review-history comments trimmed. Cap 1934 -> 1673, exact.
-    # fix(#1892): +17 — _strip_statement_terminator cuts at the last SEMICOLON
-    # token, so a trailing `;` cannot break the executor's LIMIT wrapper and one
-    # inside a literal or comment is left alone. Cap 1670 -> 1687, exact.
-    "backend/app/platform/sandbox/validator.py": 1687,
+    # fix(#1892): +21 — _strip_statement_terminator cuts at the first of the
+    # trailing SEMICOLON tokens, so no `;` run can break the executor's LIMIT
+    # wrapper and one inside a literal or comment is left alone. Cap 1670 ->
+    # 1691, exact.
+    "backend/app/platform/sandbox/validator.py": 1691,
     # fix(#1778): crossed the 1000-line inclusion threshold, so it joins
     # the ratchet at its exact size. The growth is the token accounting on
     # the two map-generation failure exits (an exhausted or timed-out loop

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5864,7 +5864,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # reopen it. The rest is the TokenError note at the parse site. Cap
     # 1871 -> 1934, exact.
     # chore(#1873): review-history comments trimmed. Cap 1934 -> 1673, exact.
-    "backend/app/platform/sandbox/validator.py": 1670,
+    # fix(#1892): +17 — _strip_statement_terminator cuts at the last SEMICOLON
+    # token, so a trailing `;` cannot break the executor's LIMIT wrapper and one
+    # inside a literal or comment is left alone. Cap 1670 -> 1687, exact.
+    "backend/app/platform/sandbox/validator.py": 1687,
     # fix(#1778): crossed the 1000-line inclusion threshold, so it joins
     # the ratchet at its exact size. The growth is the token accounting on
     # the two map-generation failure exits (an exhausted or timed-out loop

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -458,19 +458,22 @@ class TestReadOnlyTransaction:
         assert result.rows == [[1]]
         assert result.truncated is False
 
-    async def test_validated_trailing_semicolon_survives_the_limit_wrapper(
-        self, client, test_db_session
+    @pytest.mark.parametrize("suffix", [";", ";;", " ; ;"])
+    async def test_validated_terminator_run_survives_the_limit_wrapper(
+        self, client, test_db_session, suffix
     ):
         """fix(#1892): a terminator inside the wrapper's parentheses is a syntax
-        error, so the validator strips it. The raw statement is the control."""
+        error, so the validator strips the whole run. The raw statement is the
+        control."""
         from app.platform.sandbox.validator import validate_sql
 
         session = test_db_session
+        raw = f"SELECT 1 AS a{suffix}"
         with pytest.raises(SandboxError) as exc_info:
-            await execute_safe(session, "SELECT 1 AS a;")
+            await execute_safe(session, raw)
         assert exc_info.value.category == "query_failed"
 
-        result = await execute_safe(session, validate_sql("SELECT 1 AS a;").sql)
+        result = await execute_safe(session, validate_sql(raw).sql)
         assert result.rows == [[1]]
 
 

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -458,6 +458,21 @@ class TestReadOnlyTransaction:
         assert result.rows == [[1]]
         assert result.truncated is False
 
+    async def test_validated_trailing_semicolon_survives_the_limit_wrapper(
+        self, client, test_db_session
+    ):
+        """fix(#1892): a terminator inside the wrapper's parentheses is a syntax
+        error, so the validator strips it. The raw statement is the control."""
+        from app.platform.sandbox.validator import validate_sql
+
+        session = test_db_session
+        with pytest.raises(SandboxError) as exc_info:
+            await execute_safe(session, "SELECT 1 AS a;")
+        assert exc_info.value.category == "query_failed"
+
+        result = await execute_safe(session, validate_sql("SELECT 1 AS a;").sql)
+        assert result.rows == [[1]]
+
 
 # ---------------------------------------------------------------------------
 # SAND-03: Row limit truncation (integration, needs DB)

--- a/backend/tests/test_sandbox_tenant_schema.py
+++ b/backend/tests/test_sandbox_tenant_schema.py
@@ -155,7 +155,7 @@ def test_rewrite_refuses_unusable_source_offsets(monkeypatch, meta):
         identifier = table.args["db"]
         identifier.meta.clear()
         identifier.meta.update(meta)
-    monkeypatch.setattr(sqlglot, "parse_one", lambda *args, **kwargs: statement)
+    monkeypatch.setattr(sqlglot, "parse", lambda *args, **kwargs: [statement])
 
     with pytest.raises(SandboxError) as exc_info:
         executor._rewrite_logical_data_schema(sql, _SCHEMA_A)
@@ -192,26 +192,39 @@ def test_analysis_preview_sql_binds_to_the_tenant_schema():
     )
 
 
-def test_validator_strips_a_trailing_statement_terminator():
+@pytest.mark.parametrize("suffix", [";", " ;  ", ";;", " ; ;", ";;;", ";; -- pasted"])
+def test_validator_strips_the_trailing_terminator_run(suffix):
     """fix(#1892): execute_safe splices validated SQL inside a LIMIT wrapper, so
-    a surviving ``;`` is a syntax error. A ``;`` in a comment is not a terminator,
-    and a second statement is still rejected."""
+    any surviving ``;`` is a syntax error. ``;;`` is ordinary paste damage."""
     from app.platform.sandbox.validator import validate_sql
 
-    assert validate_sql("SELECT id FROM data.roads;").sql == (
+    assert validate_sql(f"SELECT id FROM data.roads{suffix}").sql == (
         "SELECT id FROM data.roads"
     )
-    assert validate_sql("SELECT id FROM data.roads ;  ").sql == (
-        "SELECT id FROM data.roads"
-    )
-    assert validate_sql("SELECT id FROM data.roads --;").sql == (
-        "SELECT id FROM data.roads --;"
-    )
-    assert validate_sql("SELECT ';' AS a FROM data.roads").sql == (
-        "SELECT ';' AS a FROM data.roads"
-    )
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT id FROM data.roads --;",
+        "SELECT ';' AS a FROM data.roads",
+        "SELECT ';;' AS a FROM data.roads",
+    ],
+)
+def test_validator_keeps_a_semicolon_that_is_not_a_terminator(sql):
+    from app.platform.sandbox.validator import validate_sql
+
+    assert validate_sql(sql).sql == sql
+
+
+@pytest.mark.parametrize("sql", ["SELECT 1; SELECT 2;", ";", ";;"])
+def test_validator_still_rejects_what_the_strip_leaves(sql):
+    """Stripping the run leaves a second statement in place, and reduces a bare
+    terminator to nothing; both fail the single-statement check."""
+    from app.platform.sandbox.validator import validate_sql
+
     with pytest.raises(SandboxError) as exc_info:
-        validate_sql("SELECT 1; SELECT 2;")
+        validate_sql(sql)
     assert exc_info.value.category == "invalid_query"
 
 
@@ -301,11 +314,21 @@ async def test_multi_tenant_rewrites_only_logical_data_schema(monkeypatch):
     assert "'data.alpha'" in query
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT id FROM data.alpha WHERE note = 'unterminated",
+        # fix(#1892): parse_one reports a second statement as one Block, so the
+        # rewrite used to pass `a; b` through and rewrite both halves.
+        "SELECT 1; DROP TABLE data.alpha",
+        "SELECT id FROM data.alpha; SELECT * FROM data.beta",
+    ],
+)
 @pytest.mark.asyncio
-async def test_multi_tenant_rejects_invalid_sql_before_connecting(monkeypatch):
-    """fix(#1892): the rewrite parses before anything is executed, so a
-    statement it cannot parse raises SandboxError with no connection opened.
-    execute_safe has direct callers that skip the validator."""
+async def test_multi_tenant_rejects_unusable_sql_before_connecting(monkeypatch, sql):
+    """fix(#1892): the rewrite parses before anything is executed, so SQL it
+    cannot bind raises SandboxError with no connection opened. execute_safe has
+    direct callers that skip the validator."""
     monkeypatch.setattr("app.platform.sandbox.executor.is_multi_tenant", lambda: True)
     monkeypatch.setattr("app.core.tenancy.is_multi_tenant", lambda: True)
 
@@ -318,9 +341,7 @@ async def test_multi_tenant_rejects_invalid_sql_before_connecting(monkeypatch):
     try:
         with patch.object(db_module, "engine", engine):
             with pytest.raises(SandboxError) as exc_info:
-                await execute_safe(
-                    MagicMock(), "SELECT id FROM data.alpha WHERE note = 'unterminated"
-                )
+                await execute_safe(MagicMock(), sql)
     finally:
         current_tenant_var.reset(token)
 

--- a/backend/tests/test_sandbox_tenant_schema.py
+++ b/backend/tests/test_sandbox_tenant_schema.py
@@ -51,94 +51,168 @@ def _mock_engine(executed: list[str], *, fail_role: str | None = None) -> MagicM
     return engine
 
 
-def test_schema_rewrite_preserves_pgvector_cosine_operator():
-    """fix(#557): the rewrite re-renders the parsed AST, and sqlglot mis-parses
-    pgvector ``<=>`` as NullSafeEQ. Without the sentinel guard the schema rewrite
-    silently turns cosine nearest-neighbor ranking into ``IS NOT DISTINCT FROM``,
-    returning the wrong rows in multi-tenant. The operator must survive and the
-    logical ``data`` schema must still be translated."""
+# (original SQL, expected rewrite) with ``<S>`` standing in for the physical
+# tenant schema. Exact text: the rewrite replaces schema identifier spans and
+# nothing else, so single-tenant behaviour and multi-tenant behaviour agree.
+_SPAN_CASES = [
+    (
+        "SELECT marker FROM data.roads WHERE id = 1",
+        'SELECT marker FROM "<S>".roads WHERE id = 1',
+    ),
+    (
+        'SELECT "data"."roads".marker FROM "data"."roads"',
+        'SELECT "<S>"."roads".marker FROM "<S>"."roads"',
+    ),
+    (
+        "SELECT DATA.ROADS.marker FROM DATA.ROADS",
+        'SELECT "<S>".ROADS.marker FROM "<S>".ROADS',
+    ),
+    (
+        'SELECT data."Roads".marker FROM data."Roads"',
+        'SELECT "<S>"."Roads".marker FROM "<S>"."Roads"',
+    ),
+    # fix(#559): a literal that spells a table reference or an operator, in any
+    # quoting form, is not SQL and must survive byte for byte.
+    (
+        "SELECT 'data.roads <=> &&' AS lit, marker FROM data.roads",
+        "SELECT 'data.roads <=> &&' AS lit, marker FROM \"<S>\".roads",
+    ),
+    (
+        "SELECT $$data.roads <=> &&$$ AS lit, marker FROM data.roads",
+        'SELECT $$data.roads <=> &&$$ AS lit, marker FROM "<S>".roads',
+    ),
+    (
+        "SELECT E'\\x41' AS lit, marker FROM data.roads",
+        "SELECT E'\\x41' AS lit, marker FROM \"<S>\".roads",
+    ),
+    (
+        "SELECT 'e\u00e9\U0001f5fa' AS lit, marker FROM data /* c */ . roads -- tail",
+        "SELECT 'e\u00e9\U0001f5fa' AS lit, marker FROM \"<S>\" /* c */ . roads -- tail",
+    ),
+    # fix(#557): sqlglot parses the pgvector cosine operator as NullSafeEQ, so
+    # re-rendering the tree turned ranking into IS NOT DISTINCT FROM.
+    (
+        "SELECT embedding <=> '[1]'::vector AS cos, embedding <-> '[2]'::vector AS l2 "
+        "FROM data.roads",
+        "SELECT embedding <=> '[1]'::vector AS cos, embedding <-> '[2]'::vector AS l2 "
+        'FROM "<S>".roads',
+    ),
+    (
+        "SELECT a IS NOT DISTINCT FROM b, embedding <=> '[1]'::vector FROM data.roads",
+        "SELECT a IS NOT DISTINCT FROM b, embedding <=> '[1]'::vector "
+        'FROM "<S>".roads',
+    ),
+    # fix(#1892): the deleted sentinel swap restored EVERY `&&` as `<=>` once a
+    # real cosine operator was present, so a PostGIS bbox overlap beside one was
+    # rewritten into a distance operator.
+    (
+        "SELECT id FROM data.roads WHERE geom && ST_MakeEnvelope(0, 0, 1, 1, 4326) "
+        "ORDER BY embedding <=> '[1]'::vector",
+        'SELECT id FROM "<S>".roads WHERE geom && ST_MakeEnvelope(0, 0, 1, 1, 4326) '
+        "ORDER BY embedding <=> '[1]'::vector",
+    ),
+    (
+        "WITH roads AS (SELECT 1 AS x) SELECT marker FROM data.roads",
+        'WITH roads AS (SELECT 1 AS x) SELECT marker FROM "<S>".roads',
+    ),
+    # A CTE named `data` qualifies columns, not schemas: only the inner table
+    # reference is a schema qualifier.
+    (
+        "WITH data AS (SELECT marker FROM data.roads) SELECT data.marker FROM data",
+        'WITH data AS (SELECT marker FROM "<S>".roads) SELECT data.marker FROM data',
+    ),
+    (
+        "SELECT a.marker FROM data.roads AS a JOIN data.roads b ON a.id = b.id",
+        'SELECT a.marker FROM "<S>".roads AS a JOIN "<S>".roads b ON a.id = b.id',
+    ),
+    ('SELECT * FROM "DATA".roads', 'SELECT * FROM "DATA".roads'),
+]
+
+
+@pytest.mark.parametrize(("sql", "expected"), _SPAN_CASES)
+def test_rewrite_replaces_only_schema_identifier_spans(sql, expected):
     from app.platform.sandbox.executor import _rewrite_logical_data_schema
 
-    sql = (
-        "SELECT name, embedding <=> '[1,2,3]'::vector AS distance "
-        "FROM data.records ORDER BY distance LIMIT 10"
+    assert _rewrite_logical_data_schema(sql, _SCHEMA_A) == expected.replace(
+        "<S>", _SCHEMA_A
     )
-    rewritten = _rewrite_logical_data_schema(sql, _SCHEMA_A)
-
-    assert "<=>" in rewritten
-    assert "IS NOT DISTINCT FROM" not in rewritten
-    assert f'"{_SCHEMA_A}".records' in rewritten
-    assert "data.records" not in rewritten
 
 
-def test_schema_rewrite_preserves_l2_and_cosine_together():
-    """Both advertised distance operators survive the rewrite: ``<->`` already
-    round-trips, ``<=>`` is protected by the sentinel swap."""
+@pytest.mark.parametrize(
+    "meta", [{}, {"start": 0, "end": 3}, {"start": 19, "end": 10_000}]
+)
+def test_rewrite_refuses_unusable_source_offsets(monkeypatch, meta):
+    """fix(#1892): each span is proven against the text before anything is
+    spliced, so a parser that stops reporting usable offsets fails closed."""
+    import sqlglot
+    from sqlglot import exp
+
+    import app.platform.sandbox.executor as executor
+
+    sql = "SELECT marker FROM data.roads"
+    statement = sqlglot.parse_one(sql, dialect="postgres")
+    for table in statement.find_all(exp.Table):
+        identifier = table.args["db"]
+        identifier.meta.clear()
+        identifier.meta.update(meta)
+    monkeypatch.setattr(sqlglot, "parse_one", lambda *args, **kwargs: statement)
+
+    with pytest.raises(SandboxError) as exc_info:
+        executor._rewrite_logical_data_schema(sql, _SCHEMA_A)
+    assert exc_info.value.category == "query_failed"
+
+
+def test_analysis_preview_sql_binds_to_the_tenant_schema():
+    """service_analysis renders logical ``"data"."<table>"`` refs and calls
+    execute_safe directly, so the rewrite must reach the same statement the
+    physical schema would have rendered."""
+    from app.modules.catalog.datasets.domain.schemas import AnalysisPreviewRequest
+    from app.modules.catalog.datasets.domain.service import (
+        _safe_table_ref,
+        build_preview_sql,
+    )
+    from app.platform.analysis_sql.shared import render_bbox_predicate
     from app.platform.sandbox.executor import _rewrite_logical_data_schema
 
-    sql = (
-        "SELECT id, embedding <=> '[1]'::vector AS cos "
-        "FROM data.t ORDER BY embedding <-> '[2]'::vector LIMIT 5"
+    request = AnalysisPreviewRequest(
+        operation="buffer", distance_meters=500, bbox=[0.0, 0.0, 1.0, 1.0]
     )
-    rewritten = _rewrite_logical_data_schema(sql, _SCHEMA_A)
+    logical = build_preview_sql(_safe_table_ref("roads"), request)
+    physical = build_preview_sql(_safe_table_ref("roads", schema=_SCHEMA_A), request)
+    assert f'"{_SCHEMA_A}"."roads"' in physical
+    assert _rewrite_logical_data_schema(logical, _SCHEMA_A) == physical
 
-    assert rewritten.count("<=>") == 1
-    assert rewritten.count("<->") == 1
-    assert "IS NOT DISTINCT FROM" not in rewritten
-    assert f'"{_SCHEMA_A}".t' in rewritten
-
-
-def test_schema_rewrite_preserves_sentinel_lookalike_literals():
-    """fix(#559 review): a string literal containing the sentinel (``&&``) or the
-    cosine operator text (``<=>``) must survive the rewrite. The swap skips
-    string literals, so ``note = '&&'`` and ``note = '<=>'`` pass through verbatim
-    while the real ``<=>`` operator is still protected. A raw substring swap
-    corrupted or rejected these legitimate queries."""
-    from app.platform.sandbox.executor import _rewrite_logical_data_schema
-
-    sql = (
-        "SELECT id FROM data.t WHERE note = '&&' "
-        "ORDER BY embedding <=> '[1,2,3]'::vector LIMIT 5"
+    predicate = render_bbox_predicate([0.0, 0.0, 1.0, 1.0], src="_t")
+    count_sql = (
+        f"SELECT count(*)::bigint AS source_count "
+        f"FROM {_safe_table_ref('roads')} AS _t WHERE {predicate}"
     )
-    rewritten = _rewrite_logical_data_schema(sql, _SCHEMA_A)
-
-    assert "'&&'" in rewritten  # literal left untouched
-    assert rewritten.count("<=>") == 1  # the operator, not the literal
-    assert "IS NOT DISTINCT FROM" not in rewritten
-    assert f'"{_SCHEMA_A}".t' in rewritten
-
-    # a literal that looks like the operator is also preserved
-    sql2 = "SELECT id FROM data.t WHERE note = '<=>' ORDER BY embedding <=> '[1]'::vector LIMIT 5"
-    rewritten2 = _rewrite_logical_data_schema(sql2, _SCHEMA_A)
-    assert "'<=>'" in rewritten2
-    assert rewritten2.count("<=>") == 2  # literal + operator both intact
-    assert "IS NOT DISTINCT FROM" not in rewritten2
-
-
-def test_schema_rewrite_preserves_non_single_quoted_literals():
-    """fix(#559 review round 2): the operator swap is tokenizer-driven, so a
-    ``<=>`` inside a dollar-quoted literal — which the validator accepts —
-    tokenizes as a string and is preserved, not swapped to the sentinel. And
-    ``IS NOT DISTINCT FROM`` (keywords, not a NULLSAFE_EQ token) is never
-    rewritten into the cosine operator."""
-    from app.platform.sandbox.executor import _rewrite_logical_data_schema
-
-    # dollar-quoted literal containing the operator text, no real operator
-    out = _rewrite_logical_data_schema(
-        "SELECT id FROM data.t WHERE note = $$<=>$$ LIMIT 5", _SCHEMA_A
+    assert _rewrite_logical_data_schema(count_sql, _SCHEMA_A) == count_sql.replace(
+        '"data"."roads"', f'"{_SCHEMA_A}"."roads"'
     )
-    assert "&&" not in out  # sentinel never leaks into output
-    assert "<=>" in out  # the literal value survives (sqlglot re-quotes it)
-    assert f'"{_SCHEMA_A}".t' in out
 
-    # a legit IS NOT DISTINCT FROM alongside a real cosine operator: both survive
-    out2 = _rewrite_logical_data_schema(
-        "SELECT id FROM data.t WHERE a IS NOT DISTINCT FROM b "
-        "ORDER BY embedding <=> '[1]'::vector LIMIT 5",
-        _SCHEMA_A,
+
+def test_validator_strips_a_trailing_statement_terminator():
+    """fix(#1892): execute_safe splices validated SQL inside a LIMIT wrapper, so
+    a surviving ``;`` is a syntax error. A ``;`` in a comment is not a terminator,
+    and a second statement is still rejected."""
+    from app.platform.sandbox.validator import validate_sql
+
+    assert validate_sql("SELECT id FROM data.roads;").sql == (
+        "SELECT id FROM data.roads"
     )
-    assert "IS NOT DISTINCT FROM" in out2
-    assert out2.count("<=>") == 1
+    assert validate_sql("SELECT id FROM data.roads ;  ").sql == (
+        "SELECT id FROM data.roads"
+    )
+    assert validate_sql("SELECT id FROM data.roads --;").sql == (
+        "SELECT id FROM data.roads --;"
+    )
+    assert validate_sql("SELECT ';' AS a FROM data.roads").sql == (
+        "SELECT ';' AS a FROM data.roads"
+    )
+    with pytest.raises(SandboxError) as exc_info:
+        validate_sql("SELECT 1; SELECT 2;")
+    assert exc_info.value.category == "invalid_query"
 
 
 @pytest.mark.parametrize(
@@ -228,6 +302,34 @@ async def test_multi_tenant_rewrites_only_logical_data_schema(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_multi_tenant_rejects_invalid_sql_before_connecting(monkeypatch):
+    """fix(#1892): the rewrite parses before anything is executed, so a
+    statement it cannot parse raises SandboxError with no connection opened.
+    execute_safe has direct callers that skip the validator."""
+    monkeypatch.setattr("app.platform.sandbox.executor.is_multi_tenant", lambda: True)
+    monkeypatch.setattr("app.core.tenancy.is_multi_tenant", lambda: True)
+
+    executed: list[str] = []
+    import app.core.db as db_module
+    from app.platform.sandbox.executor import execute_safe
+
+    engine = _mock_engine(executed)
+    token = current_tenant_var.set(_TENANT_A)
+    try:
+        with patch.object(db_module, "engine", engine):
+            with pytest.raises(SandboxError) as exc_info:
+                await execute_safe(
+                    MagicMock(), "SELECT id FROM data.alpha WHERE note = 'unterminated"
+                )
+    finally:
+        current_tenant_var.reset(token)
+
+    assert exc_info.value.category == "invalid_query"
+    assert executed == []
+    engine.connect.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_multi_tenant_role_binding_failure_is_fatal(monkeypatch):
     monkeypatch.setattr("app.platform.sandbox.executor.is_multi_tenant", lambda: True)
     monkeypatch.setattr("app.core.tenancy.is_multi_tenant", lambda: True)
@@ -305,9 +407,80 @@ async def test_logical_data_query_reads_only_active_tenant_schema(monkeypatch):
                     current_tenant_var.reset(token)
                 observed[tenant_id] = result.rows[0][0]
 
+            # fix(#1892): the shape the span rewrite has to get right, run for
+            # real: unquoted DATA, a comment inside the reference, a non-ASCII
+            # literal ahead of it and a trailing line comment.
+            token = current_tenant_var.set(_TENANT_A)
+            try:
+                awkward = await execute_safe(
+                    MagicMock(),
+                    f"SELECT 'eé\U0001f5fa' AS note, "
+                    f'DATA /* c */ ."{table}".marker '
+                    f'FROM DATA."{table}" -- tail',
+                )
+            finally:
+                current_tenant_var.reset(token)
+
         assert observed == {_TENANT_A: "tenant-a", _TENANT_B: "tenant-b"}
+        assert awkward.rows == [["eé\U0001f5fa", "tenant-a"]]
     finally:
         async with engine.begin() as conn:
             await conn.execute(sa.text(f'DROP TABLE IF EXISTS {_SCHEMA_A}."{table}"'))
+            await conn.execute(sa.text(f'DROP TABLE IF EXISTS {_SCHEMA_B}."{table}"'))
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+@_requires_test_db
+async def test_tenant_reader_role_refuses_another_tenants_schema(monkeypatch):
+    """The reader role, not the rewrite, is the isolation boundary: a statement
+    naming another tenant's physical schema is refused, and the same statement
+    under that tenant returns the row."""
+    monkeypatch.setattr("app.platform.sandbox.executor.is_multi_tenant", lambda: True)
+    monkeypatch.setattr("app.core.tenancy.is_multi_tenant", lambda: True)
+
+    from app.core.config import settings
+    from app.platform.sandbox.executor import execute_safe
+
+    table = f"sandbox_denial_{uuid.uuid4().hex[:12]}"
+    engine = create_async_engine(settings.test_database_url, poolclass=NullPool)
+    import app.core.db as db_module
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                sa.text(f'CREATE TABLE {_SCHEMA_B}."{table}" (marker text NOT NULL)')
+            )
+            await conn.execute(
+                sa.text(f'INSERT INTO {_SCHEMA_B}."{table}" (marker) VALUES (:m)'),
+                {"m": "tenant-b"},
+            )
+            await conn.execute(
+                sa.text(f'GRANT SELECT ON {_SCHEMA_B}."{table}" TO {_ROLE_B}')
+            )
+
+        cross_tenant_sql = f'SELECT marker FROM {_SCHEMA_B}."{table}"'
+        with patch.object(db_module, "engine", engine):
+            token = current_tenant_var.set(_TENANT_A)
+            try:
+                with pytest.raises(SandboxError) as exc_info:
+                    await execute_safe(MagicMock(), cross_tenant_sql)
+            finally:
+                current_tenant_var.reset(token)
+
+            token = current_tenant_var.set(_TENANT_B)
+            try:
+                allowed = await execute_safe(MagicMock(), cross_tenant_sql)
+                logical = await execute_safe(
+                    MagicMock(), f'SELECT marker FROM data."{table}"'
+                )
+            finally:
+                current_tenant_var.reset(token)
+
+        assert exc_info.value.category == "query_failed"
+        assert allowed.rows == [["tenant-b"]]
+        assert logical.rows == [["tenant-b"]]
+    finally:
+        async with engine.begin() as conn:
             await conn.execute(sa.text(f'DROP TABLE IF EXISTS {_SCHEMA_B}."{table}"'))
         await engine.dispose()


### PR DESCRIPTION
## Summary

Multi-tenant execution bound the logical `data` schema by re-serializing the parsed
statement, so what ran was not what the caller wrote. Comments, `AS`, `E'...'`
literals and casts were normalized, and the pgvector cosine operator needed a
sentinel swap to survive the round trip. This parses once, takes the source offsets
of the `Table` and `Column` schema identifiers, and replaces only those spans in the
original text. Single-tenant already executes the text as written, so the two modes
now agree and single-tenant coverage starts to transfer.

Design and evidence come from the 2026-09-05 tenant SQL routing investigation.

## Changes

- `_rewrite_logical_data_schema` replaces proven schema-identifier spans right to
  left instead of rendering the tree. `_swap_operator_tokens`, the `<=>` sentinel and
  the `sqlglot.tokens` import are gone.
- Each span is proven against the text before anything is spliced: the slice must
  spell the identifier sqlglot parsed, and a span overlapping one already replaced is
  refused. Both raise `SandboxError` before a connection is opened.
- The validator cuts the whole trailing run of `;` at the first of those tokens. The
  old re-render dropped every terminator; preserving one would leave it inside the
  executor's `SELECT * FROM (...) AS _q LIMIT n` wrapper, which is the syntax error
  single-tenant already gives. `;;` and `; ;` are ordinary paste damage and go the same
  way. A `;` inside a literal or a comment is left alone, a bare `;;` reduces to nothing,
  and a second statement is still rejected.
- The rewrite parses with `parse`, not `parse_one`. `parse_one` reports a second
  statement as one `Block`, so a direct caller's `a; b` passed through byte-identical
  with both halves rewritten. Anything but one statement is now refused. Not
  exploitable before this (the wrapper is a syntax error and asyncpg refuses multi
  statement), but `execute_safe` documents itself as fail-closed for direct callers.
- Unchanged: the public `data.*` contract, single-tenant behaviour, RBAC and the
  dataset allowlist, role binding, the read-only transaction, timeout, concurrency
  lock and row cap. The unquoted-`DATA` folding from #1891 stays and quoted `"DATA"`
  is still refused. No API, snapshot or SDK regeneration, since the contract did not
  move.

### A defect this removes

The sentinel restore swapped every `&&` back to `<=>` whenever a real cosine operator
was present, so a PostGIS bbox overlap beside one became a distance operator. It was
not reachable: the validator rejects `&&`, so no validated query carried both, and the
direct analysis callers that emit `&&` carry no cosine operator. It is now a
regression case with an exact-text expectation.

### Security notes

The isolation boundary is the per-tenant reader role, which holds USAGE on its own
schema only, inside a read-only transaction with a statement timeout and a row cap.
The rewrite routes; it does not authorize. A cross-tenant statement is refused by the
role, and that is asserted against the test database with a same-tenant positive
control beside it.

Executing the caller's own bytes rather than a re-render means a place where sqlglot
and PostgreSQL disagree is no longer papered over by serialization. That is the
property single-tenant has had all along, and the runtime floor above bounds it. The
classic differentials were checked against sqlglot 30.18 and the postgres dialect
agrees: backslashes are not escapes in ordinary strings, `E'...'` escapes are, block
comments nest, and `U&'...'` stays a literal.

Independent review probed this with 37 hand-built shapes plus a 14k-case fuzz over
comment styles, E-strings, dollar quoting, `U&` literals, CRLF, tabs and emoji, and
seven spellings of the schema reference, with zero failures. Both parses see the same
stripped string, and the allowlist folding matches the span folding.

Known and carried from #1892: sqlglot still rejects `<#>` before execution, and
`(data.roads).marker` is a blind spot for a span rewrite and for the old one alike,
failing closed under the tenant role.

## Area

- [x] Backend (API, services, models)
- [x] Auth / Permissions

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)
- [x] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)

Backend, from the worktree: `tests/test_sandbox_tenant_schema.py`, `tests/test_sandbox.py`,
`tests/test_analysis_preview.py`, `tests/test_dp02_read_path_binding.py`,
`tests/test_dp03_cross_tenant_privilege_gate.py`, `tests/test_dp_single_tenant_byte_identical.py`,
`tests/test_sandbox_query_endpoint_565.py`, `tests/test_layering.py`,
`tests/test_rule1_structural.py`, `tests/test_rule2_structural.py`, and the AI/SQL
suites that consume the sandbox. All green. `ruff check`, `ruff format --check` and
`python3 backend/tests/finding_markers.py` pass. `_MODULE_LOC_CAPS` for the validator
is re-measured to 1687, exact.

New coverage, each with the failure observed on `main`:

- Fifteen exact-text span cases: quoted and unquoted schema and table names, three-part
  columns, mixed-case quoted tables, single-quoted and dollar-quoted literals spelling
  `data.roads` and operators, an `E'...'` literal, Unicode ahead of the target with a
  comment inside the reference and a trailing one, cosine beside L2, a real
  `IS NOT DISTINCT FROM` beside cosine, a bbox overlap beside cosine, a CTE named after
  a dataset, a CTE named `data`, a self-join, and quoted `"DATA"`. Seven of the fifteen
  fail on `main`, on normalized comments, re-cased `E'...'`, inserted `AS`, rewritten
  casts and the `&&` corruption.
- Unusable source offsets (missing, shifted, out of range) raise `SandboxError`. On
  `main` the rewrite has no offset path, so all three pass through.
- The analysis preview statement and the bbox count statement, rewritten from logical
  refs, equal what the physical schema renders. Fails on `main`.
- A validated `;`, `;;` and `; ;` each run inside the LIMIT wrapper against the test
  database, with the raw statement as the control. On `main` the wrapper gets
  `SELECT 1 AS a;` and PostgreSQL answers "syntax error at or near ;".
- `;;`, `; ;`, `;;;` and `;; -- pasted` validate to the exact statement text, a `;` in a
  literal or comment is kept, and `;`, `;;` and a second statement are rejected.
- The rewrite refuses `SELECT 1; DROP TABLE data.alpha` and
  `SELECT id FROM data.alpha; SELECT * FROM data.beta` with no connection opened.
- Against the test database: a statement naming another tenant's schema is refused
  under tenant A and returns its row under tenant B, and the awkward shape above
  (unquoted `DATA`, an inline comment, a non-ASCII literal, a trailing line comment)
  executes and reads only the active tenant's row. Both hold on `main` as well; they
  are database-backed evidence for the preserved-text form, not regression guards.
- An unparseable statement raises `SandboxError` with no connection opened. Holds on
  `main` too; it pins acceptance criterion 2.

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [ ] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff

Closes #1892
