### PR TITLE
fix(refresh): enforce ADR-002's raw-exception clause at every failure sink

### DIFF
--- a/.github/ADR-002.md
+++ b/.github/ADR-002.md
@@ -90,13 +90,20 @@ sent.
 **The clause is enforced at the sink.** `redact_failure_reason` in
 `backend/app/core/failure_reason.py` is the one door every sink writes through, because
 a rule applied at the caller only holds until the next careless one. It decides by
-provenance: an exception class defined outside `app.` carries text a library wrote, not
-text this codebase composed, so it stores the code `internal_error` instead. Free text
-keeps its first line only, which is where an exception's own summary ends and its
-payload dump begins, and both paths still run the credential redaction. A rollback that
-wants to say what broke uses `coded_failure_reason`, which names the exception's class
-and never its message, the durable form of the argument #1755 made for
-`DeferFailed.cause_class`.
+provenance: an exception is admitted when its class is defined under `app.`, or when it
+is a `ValueError`, which is this tree's spelling for a refusal the user is meant to
+read. Anything else renders library internals, so the sink stores the code
+`internal_error` instead of it. Free text keeps its first line only, which is where an
+exception's own summary ends and its payload dump begins. A rollback that wants to say what broke uses
+`coded_failure_reason`, which names the exception's class and never its message, the
+durable form of the argument #1755 made for `DeferFailed.cause_class`.
+
+Provenance is not on its own a promise about the text, and the redaction is what makes
+up the difference. `IngestionError` is defined under `app.` and is built from GDAL's
+stderr, which echoes the `PG:` destination it was handed, and that DSN carries a
+`password=` field that is neither a URL nor a registered request credential. So every
+reason runs all three scrubbers: URL credentials, registered secrets by exact value,
+and libpq keyword values.
 
 The live case this closes (#1947): a bounded catalog wait expired as SQLSTATE `57014`,
 which is not a lock conflict, so a bare `DBAPIError` propagated and its rendering was

--- a/.github/ADR-002.md
+++ b/.github/ADR-002.md
@@ -101,9 +101,11 @@ durable form of the argument #1755 made for `DeferFailed.cause_class`.
 Provenance is not on its own a promise about the text, and the redaction is what makes
 up the difference. `IngestionError` is defined under `app.` and is built from GDAL's
 stderr, which echoes the `PG:` destination it was handed, and that DSN carries a
-`password=` field that is neither a URL nor a registered request credential. So every
-reason runs all three scrubbers: URL credentials, registered secrets by exact value,
-and libpq keyword values.
+`password=` field that is neither a URL nor a registered request credential, beside the
+host and database it names. So every reason runs four scrubbers: URL credentials,
+registered secrets by exact value, libpq keyword values, and absolute paths, which is
+what carries the GDAL command line clause and the `/vsi` handles with it. A URL keeps
+its own path, since there the slash follows a host rather than a space.
 
 Choosing the summary line and scrubbing it are also not independent. A credential broken
 across a line break reaches the scrubbers as half of itself, and half a URL still carries

--- a/.github/ADR-002.md
+++ b/.github/ADR-002.md
@@ -105,6 +105,13 @@ stderr, which echoes the `PG:` destination it was handed, and that DSN carries a
 reason runs all three scrubbers: URL credentials, registered secrets by exact value,
 and libpq keyword values.
 
+Choosing the summary line and scrubbing it are also not independent. A credential broken
+across a line break reaches the scrubbers as half of itself, and half a URL still carries
+its password; scrubbing the whole text first is no answer either, because `urlsplit`
+deletes the line breaks the summary cut depends on. So the wider pass is the cross-check
+rather than the source: a summary line that scrubbing the whole text would have changed
+is one the sink refuses, and stores the code for.
+
 The live case this closes (#1947): a bounded catalog wait expired as SQLSTATE `57014`,
 which is not a lock conflict, so a bare `DBAPIError` propagated and its rendering was
 stored. That rendering carries the statement and its bound parameters, and it reached

--- a/.github/ADR-002.md
+++ b/.github/ADR-002.md
@@ -103,9 +103,21 @@ up the difference. `IngestionError` is defined under `app.` and is built from GD
 stderr, which echoes the `PG:` destination it was handed, and that DSN carries a
 `password=` field that is neither a URL nor a registered request credential, beside the
 host and database it names. So every reason runs four scrubbers: URL credentials,
-registered secrets by exact value, libpq keyword values, and absolute paths, which is
-what carries the GDAL command line clause and the `/vsi` handles with it. A URL keeps
-its own path, since there the slash follows a host rather than a space.
+registered secrets by exact value, libpq keyword values, and absolute paths, taking the
+`/vsi` handles with them. A URL keeps its own path, since there the slash follows a host
+rather than a space.
+
+Scrubbing operands is not how the GDAL command line clause is met, because the flags and
+the target table are operands too. The reason ends at the invocation instead: a utility
+name followed by a flag or an operand is a command line and everything from there is
+dropped, while the same name followed by a word is a mention and survives. GDAL's own
+`ERROR n:` diagnostic sits before the invocation, so a refused service import still says
+what the origin answered. A reason left with nothing in front of the invocation is
+stored as the code.
+
+`ValueError` is admitted as itself and not as a base class, for the same reason a
+wrapper's provenance is not a promise: `UnicodeDecodeError` is a library's, and it
+renders the byte a decoder choked on.
 
 Choosing the summary line and scrubbing it are also not independent. A credential broken
 across a line break reaches the scrubbers as half of itself, and half a URL still carries

--- a/.github/ADR-002.md
+++ b/.github/ADR-002.md
@@ -80,10 +80,28 @@ no `last_verified_at`: v1 has no verification layer, and a column named for one 
 be a lie in the schema. See invariant 9.
 
 **A stored reason string carries no raw exception, no URL with query-string
-credentials, and no GDAL command line.** This clause covers `source_health_detail` and
-`dataset_refresh_runs.error_message`. It is why the PostGIS strategy composes its
-messages from a SQLSTATE lookup rather than from driver text, and why the STAC strategy
-composes them rather than passing through anything the origin sent.
+credentials, and no GDAL command line.** The clause covers `source_health_detail`,
+`dataset_refresh_runs.error_message` and, since #1953, `ingest_jobs.error_message`,
+which is the one a user reads: the re-upload dialog renders it. It is why the PostGIS
+strategy composes its messages from a SQLSTATE lookup rather than from driver text, and
+why the STAC strategy composes them rather than passing through anything the origin
+sent.
+
+**The clause is enforced at the sink.** `redact_failure_reason` in
+`backend/app/core/failure_reason.py` is the one door every sink writes through, because
+a rule applied at the caller only holds until the next careless one. It decides by
+provenance: an exception class defined outside `app.` carries text a library wrote, not
+text this codebase composed, so it stores the code `internal_error` instead. Free text
+keeps its first line only, which is where an exception's own summary ends and its
+payload dump begins, and both paths still run the credential redaction. A rollback that
+wants to say what broke uses `coded_failure_reason`, which names the exception's class
+and never its message, the durable form of the argument #1755 made for
+`DeferFailed.cause_class`.
+
+The live case this closes (#1947): a bounded catalog wait expired as SQLSTATE `57014`,
+which is not a lock conflict, so a bare `DBAPIError` propagated and its rendering was
+stored. That rendering carries the statement and its bound parameters, and it reached
+both a run row and an ingest job the user was watching.
 
 **A service credential is request-scoped.** It is supplied per request, is never stored,
 and a run that outlives its credential must ask a person for a new one rather than
@@ -130,11 +148,19 @@ A retry is a NEW row, never an edit of the old one.
 so the state is unreachable and shipping it would invite dead handling code. Widening a
 VARCHAR CHECK is a two-line migration for whoever adds an enforced policy.
 
-`cancelled` is a bookkeeping correction, not a stop signal. The sweep may write it only
-once the work is provably not happening: no Procrastinate job in a live state references
-the bound ingest job, and that job is absent, `failed`, or `pending` with no live task.
-(#1677 later added a second writer of this status for an explicit user cancel. See
-"Where the code and this record disagree".)
+`cancelled` has two writers, told apart by `error_code`, and only the first carries a
+proof obligation (#1954).
+
+The stale-run sweep writes `abandoned`. That one is a bookkeeping correction and never a
+stop signal, so it may be written only once the work is provably not happening: no
+Procrastinate job in a live state references the bound ingest job, and that job is
+absent, `failed`, or `pending` with no live task.
+
+`cancel_active_run_for_job` writes `user_cancelled` (#1677). That one IS a stop signal,
+and it needs no proof because the request is the proof: a person asked in-flight work to
+stop, and the run row should say so rather than invent a failure. It commits beside the
+fenced `ingest_jobs` cancel, and the worker's finalize fence is what actually stops the
+work. Reading either writer's rows means reading `error_code`, not `status` alone.
 
 #### 4e: Field redaction on the read path
 
@@ -392,34 +418,6 @@ Each item below is a live divergence between what a citation claims and what the
 annotates does. They are written down rather than smoothed over, because a reader who
 takes this document as a description of the running system needs to know which clauses
 the code only partly honours.
-
-**Decision 3's reason-string clause is two-thirds enforced.** `redact_run_error` in
-`backend/app/platform/refresh/service.py` carries the three-part prohibition in its own
-docstring, and does two of them: it calls `redact_url_credentials`, which handles URLs and
-URL-shaped substrings inside free text, and it truncates at 2000 characters. It does not
-strip a raw exception, and it removes a GDAL command line only to the extent that the
-command line contains a URL. A driver or database exception reaching that helper is stored
-in full, up to the truncation limit.
-
-**One site inside the refresh machinery composes exactly what Decision 3 forbids.**
-`make_refresh_run_failed_rollback` builds `f"Failed to queue refresh task: {defer_exc}"`
-and hands it to `record_refresh_failure`, which redacts credentials and stores the rest.
-
-**`ingest_jobs.error_message` carries the same class of text and no ADR-002 citation.**
-It is written by `_fail_job` in `backend/app/processing/ingest/tasks_common.py` as
-`redact_url_credentials(str(exc))`, which is the same two-of-three shape, and it is the
-field `frontend/src/components/dataset/ReuploadDialog.tsx` renders to the user. The
-Decision 3 citations only ever name `source_health_detail` and
-`dataset_refresh_runs.error_message`, so this surface was never inside the policy as
-cited, even though it is the same failure text from the same handlers.
-
-**`cancelled` now has two writers, and one of them is a stop signal.** Decision 4d, as
-cited at `service.py`, is explicit that the status is a bookkeeping correction and never a
-stop signal. #1677 added `cancel_run_for_job`, which writes `cancelled` with
-`error_code="user_cancelled"` when a person asks in-flight work to stop, and a
-`refresh.cancelled` audit action described as exactly that. The two writers are
-distinguishable by `error_code`, and the sweep's proof obligations are unchanged, but the
-decision as cited no longer describes the whole of the status.
 
 **Migration 0036's backfill predicate is deliberately wider than ADR-002's.** The
 migration says so in a comment: "ADR-002's predicate names the common case rather than an

--- a/backend/app/core/failure_reason.py
+++ b/backend/app/core/failure_reason.py
@@ -1,0 +1,61 @@
+"""ADR-002 Decision 3 (#1953): what may become a stored failure reason.
+
+The single enforcement point for the clause "a stored reason string carries
+no raw exception, no URL with query-string credentials, and no GDAL command
+line". Every sink that persists or returns failure text routes through this
+module, so the clause holds whichever caller composed the text.
+"""
+
+from __future__ import annotations
+
+from app.core.url_redaction import redact_url_credentials, scrub_registered_credentials
+
+# Cap on stored failure text. GDAL stderr runs to kilobytes and the useful
+# part is at the front.
+MAX_REASON_CHARS = 2000
+
+# fix(#1953): what a sink stores instead of an exception it did not compose.
+# A code rather than prose, so a reader (`ReuploadDialog.tsx`) can localize
+# it and no driver text can hide behind it.
+INTERNAL_FAILURE_REASON = "internal_error"
+
+_OWN_EXCEPTION_ROOT = "app."
+
+
+def is_composed_exception(exc: BaseException) -> bool:
+    """Whether this codebase, rather than a library, wrote the message.
+
+    fix(#1953): provenance, not shape. A class defined under ``app.``
+    carries text we chose; anything else renders library internals, which
+    for SQLAlchemy means the statement and its bound parameters.
+    """
+    return type(exc).__module__.startswith(_OWN_EXCEPTION_ROOT)
+
+
+def redact_failure_reason(reason: str | BaseException) -> str:
+    """Failure text safe to store in a reason column or return in a response.
+
+    fix(#1953): a sink is reached both with an exception and with text a
+    caller already flattened, so the raw-exception clause is enforced for
+    both. A library exception becomes ``INTERNAL_FAILURE_REASON``; text
+    keeps only its first line, which is where an exception's own summary
+    ends and its payload dump begins.
+    """
+    if isinstance(reason, BaseException):
+        if not is_composed_exception(reason):
+            return INTERNAL_FAILURE_REASON
+        reason = str(reason)
+    lines = reason.splitlines()
+    summary = lines[0] if lines else ""
+    redacted = scrub_registered_credentials(redact_url_credentials(summary))
+    return redacted[:MAX_REASON_CHARS]
+
+
+def coded_failure_reason(prefix: str, exc: BaseException) -> str:
+    """A composed reason naming the exception's TYPE, never its message.
+
+    fix(#1953): the durable half of #1755's ``DeferFailed.cause_class``
+    argument. A class name is a Python identifier and can carry no
+    credential, so it survives Decision 3 where ``str(exc)`` does not.
+    """
+    return f"{prefix} ({type(exc).__name__})"

--- a/backend/app/core/failure_reason.py
+++ b/backend/app/core/failure_reason.py
@@ -8,7 +8,11 @@ module, so the clause holds whichever caller composed the text.
 
 from __future__ import annotations
 
-from app.core.url_redaction import redact_url_credentials, scrub_registered_credentials
+from app.core.url_redaction import (
+    redact_libpq_credentials,
+    redact_url_credentials,
+    scrub_registered_credentials,
+)
 
 # Cap on stored failure text. GDAL stderr runs to kilobytes and the useful
 # part is at the front.
@@ -25,11 +29,15 @@ _OWN_EXCEPTION_ROOT = "app."
 def is_composed_exception(exc: BaseException) -> bool:
     """Whether this codebase, rather than a library, wrote the message.
 
-    fix(#1953): provenance, not shape. A class defined under ``app.``
-    carries text we chose; anything else renders library internals, which
-    for SQLAlchemy means the statement and its bound parameters.
+    fix(#1953): provenance, not shape. A class defined under ``app.``, or a
+    ``ValueError``, which is this tree's spelling for a refusal the user is
+    meant to read. The exceptions that render internals are none of those:
+    SQLAlchemy appends the statement and its parameters, GDAL and
+    subprocesses raise ``RuntimeError``, HTTP clients embed the request URL.
     """
-    return type(exc).__module__.startswith(_OWN_EXCEPTION_ROOT)
+    return isinstance(exc, ValueError) or type(exc).__module__.startswith(
+        _OWN_EXCEPTION_ROOT
+    )
 
 
 def redact_failure_reason(reason: str | BaseException) -> str:
@@ -47,7 +55,11 @@ def redact_failure_reason(reason: str | BaseException) -> str:
         reason = str(reason)
     lines = reason.splitlines()
     summary = lines[0] if lines else ""
-    redacted = scrub_registered_credentials(redact_url_credentials(summary))
+    # fix(#1953): an exception this codebase raised can still embed a
+    # subprocess's output, so all three scrubbers run on the summary line.
+    redacted = redact_libpq_credentials(
+        scrub_registered_credentials(redact_url_credentials(summary))
+    )
     return redacted[:MAX_REASON_CHARS]
 
 

--- a/backend/app/core/failure_reason.py
+++ b/backend/app/core/failure_reason.py
@@ -9,6 +9,7 @@ module, so the clause holds whichever caller composed the text.
 from __future__ import annotations
 
 from app.core.url_redaction import (
+    redact_filesystem_paths,
     redact_libpq_credentials,
     redact_url_credentials,
     scrub_registered_credentials,
@@ -66,9 +67,16 @@ def redact_failure_reason(reason: str | BaseException) -> str:
 
 
 def _scrub(text: str) -> str:
-    """Every credential shape a reason can carry, masked."""
-    return redact_libpq_credentials(
-        scrub_registered_credentials(redact_url_credentials(text))
+    """Every shape Decision 3 keeps out of a reason, masked.
+
+    fix(#1953): the last two are what a GDAL wrapper drags in. Being defined
+    under ``app.`` says who raised the exception, never that its message is
+    free of the subprocess output it was built from.
+    """
+    return redact_filesystem_paths(
+        redact_libpq_credentials(
+            scrub_registered_credentials(redact_url_credentials(text))
+        )
     )
 
 

--- a/backend/app/core/failure_reason.py
+++ b/backend/app/core/failure_reason.py
@@ -8,6 +8,8 @@ module, so the clause holds whichever caller composed the text.
 
 from __future__ import annotations
 
+import re
+
 from app.core.url_redaction import (
     redact_filesystem_paths,
     redact_libpq_credentials,
@@ -30,13 +32,13 @@ _OWN_EXCEPTION_ROOT = "app."
 def is_composed_exception(exc: BaseException) -> bool:
     """Whether this codebase, rather than a library, wrote the message.
 
-    fix(#1953): provenance, not shape. A class defined under ``app.``, or a
-    ``ValueError``, which is this tree's spelling for a refusal the user is
-    meant to read. The exceptions that render internals are none of those:
-    SQLAlchemy appends the statement and its parameters, GDAL and
-    subprocesses raise ``RuntimeError``, HTTP clients embed the request URL.
+    fix(#1953): provenance, not shape. A class defined under ``app.``, or
+    ``ValueError`` itself, which is this tree's spelling for a refusal the
+    user is meant to read. Its subclasses are NOT admitted by that half: a
+    library's own is still a library's text, and ``UnicodeDecodeError``
+    renders the byte a decoder choked on.
     """
-    return isinstance(exc, ValueError) or type(exc).__module__.startswith(
+    return type(exc) is ValueError or type(exc).__module__.startswith(
         _OWN_EXCEPTION_ROOT
     )
 
@@ -55,15 +57,34 @@ def redact_failure_reason(reason: str | BaseException) -> str:
             return INTERNAL_FAILURE_REASON
         reason = str(reason)
     lines = reason.splitlines()
-    summary = _scrub(lines[0] if lines else "")
+    summary = _drop_subprocess_output(_scrub(lines[0] if lines else ""))
     # fix(#1953): the scrubbers must see a credential whole, and choosing the
     # summary line first can hand them half of one. Scrubbing the whole text
     # cannot replace that (urlsplit deletes the line breaks the payload cut
     # needs), so it is the cross-check: a line the wider pass would have
     # changed is not one to keep.
-    if _scrub_stable(summary) not in _scrub_stable(_scrub(reason)):
+    if not summary or _scrub_stable(summary) not in _scrub_stable(_scrub(reason)):
         return INTERNAL_FAILURE_REASON
     return summary[:MAX_REASON_CHARS]
+
+
+# fix(#1953): a GDAL invocation, which is the clause's "command line". The
+# lookahead is what tells one from a mention: an invocation is followed by a
+# flag or an operand, never by "failed" or by prose. Scrubbing the operands
+# cannot meet the clause, since the flags and the target table are operands.
+_GDAL_INVOCATION_RE = re.compile(
+    r"(?i)\b(?:ogr2ogr|ogrinfo|ogrtindex|gdal[a-z_]{0,24})\s+(?=-|/|PG:|<redacted>)"
+)
+
+
+def _drop_subprocess_output(summary: str) -> str:
+    """Everything from a GDAL invocation onward, removed.
+
+    What comes before it is this tree's own prefix and GDAL's diagnostic,
+    which is the part a reader needs.
+    """
+    match = _GDAL_INVOCATION_RE.search(summary)
+    return summary[: match.start()].rstrip(" :-") if match else summary
 
 
 def _scrub(text: str) -> str:
@@ -87,6 +108,19 @@ _URLSPLIT_STRIPS = str.maketrans("", "", "\t\r\n")
 
 def _scrub_stable(text: str) -> str:
     return text.translate(_URLSPLIT_STRIPS)
+
+
+def prefixed_failure_reason(prefix: str, reason: str | BaseException) -> str:
+    """``prefix: reason``, or the bare code when there is no reason to give.
+
+    fix(#1953): a prefix wrapped around ``INTERNAL_FAILURE_REASON`` hides the
+    code inside a sentence, and the readers that localize it match the code
+    exactly.
+    """
+    redacted = redact_failure_reason(reason)
+    if redacted == INTERNAL_FAILURE_REASON:
+        return INTERNAL_FAILURE_REASON
+    return f"{prefix}: {redacted}"[:MAX_REASON_CHARS]
 
 
 def coded_failure_reason(prefix: str, exc: BaseException) -> str:

--- a/backend/app/core/failure_reason.py
+++ b/backend/app/core/failure_reason.py
@@ -54,13 +54,31 @@ def redact_failure_reason(reason: str | BaseException) -> str:
             return INTERNAL_FAILURE_REASON
         reason = str(reason)
     lines = reason.splitlines()
-    summary = lines[0] if lines else ""
-    # fix(#1953): an exception this codebase raised can still embed a
-    # subprocess's output, so all three scrubbers run on the summary line.
-    redacted = redact_libpq_credentials(
-        scrub_registered_credentials(redact_url_credentials(summary))
+    summary = _scrub(lines[0] if lines else "")
+    # fix(#1953): the scrubbers must see a credential whole, and choosing the
+    # summary line first can hand them half of one. Scrubbing the whole text
+    # cannot replace that (urlsplit deletes the line breaks the payload cut
+    # needs), so it is the cross-check: a line the wider pass would have
+    # changed is not one to keep.
+    if _scrub_stable(summary) not in _scrub_stable(_scrub(reason)):
+        return INTERNAL_FAILURE_REASON
+    return summary[:MAX_REASON_CHARS]
+
+
+def _scrub(text: str) -> str:
+    """Every credential shape a reason can carry, masked."""
+    return redact_libpq_credentials(
+        scrub_registered_credentials(redact_url_credentials(text))
     )
-    return redacted[:MAX_REASON_CHARS]
+
+
+# The characters `urlsplit` deletes, so the cross-check above compares what
+# the scrubbers changed rather than where they were handed a line break.
+_URLSPLIT_STRIPS = str.maketrans("", "", "\t\r\n")
+
+
+def _scrub_stable(text: str) -> str:
+    return text.translate(_URLSPLIT_STRIPS)
 
 
 def coded_failure_reason(prefix: str, exc: BaseException) -> str:

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -281,6 +281,23 @@ def scrub_registered_credentials(text: str) -> str:
     return text
 
 
+# fix(#1953): libpq keyword/value credentials. GDAL echoes the `PG:` destination
+# it was handed on a connection failure, and that DSN carries `password=`, which
+# is neither a URL nor a registered request credential.
+_LIBPQ_SECRET_RE = re.compile(
+    r"(?i)\b(password|sslpassword)\s*=\s*(?:'(?:[^'\\]|\\.)*'|\S*)"
+)
+
+
+def redact_libpq_credentials(text: str) -> str:
+    """Mask the secret values in a libpq keyword/value connection string.
+
+    Handles both spellings ``libpq_value`` emits: a bare token, and a
+    single-quoted value with backslash escapes.
+    """
+    return _LIBPQ_SECRET_RE.sub(rf"\1={REDACTED_QUERY_VALUE}", text)
+
+
 def redact_exception_text(exc: BaseException) -> str:
     """``str(exc)``, with any URL-shaped substring redacted.
 

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -281,21 +281,33 @@ def scrub_registered_credentials(text: str) -> str:
     return text
 
 
-# fix(#1953): libpq keyword/value credentials. GDAL echoes the `PG:` destination
-# it was handed on a connection failure, and that DSN carries `password=`, which
-# is neither a URL nor a registered request credential.
-_LIBPQ_SECRET_RE = re.compile(
-    r"(?i)\b(password|sslpassword)\s*=\s*(?:'(?:[^'\\]|\\.)*'|\S*)"
+# fix(#1953): libpq keyword/value connection detail. GDAL echoes the `PG:`
+# destination it was handed on a connection failure, and that DSN carries the
+# password, which is no URL and no registered request credential, beside the
+# database topology fix(#1953) keeps out of a stored reason with it.
+_LIBPQ_VALUE_RE = re.compile(
+    r"(?i)\b(password|sslpassword|host|hostaddr|port|dbname|user|sslrootcert)"
+    r"\s*=\s*(?:'(?:[^'\\]|\\.)*'|\S*)"
 )
+
+# fix(#1953): a path GDAL echoes back names the server's layout, `/vsi` handles
+# included. The lookbehind keeps a URL's own path out of it: there the slash
+# follows the host, never a space or a quote.
+_ABSOLUTE_PATH_RE = re.compile(r"(?<![\w/:])(?:/[\w.+-]+){2,}/?")
 
 
 def redact_libpq_credentials(text: str) -> str:
-    """Mask the secret values in a libpq keyword/value connection string.
+    """Mask the values in a libpq keyword/value connection string.
 
     Handles both spellings ``libpq_value`` emits: a bare token, and a
     single-quoted value with backslash escapes.
     """
-    return _LIBPQ_SECRET_RE.sub(rf"\1={REDACTED_QUERY_VALUE}", text)
+    return _LIBPQ_VALUE_RE.sub(rf"\1={REDACTED_QUERY_VALUE}", text)
+
+
+def redact_filesystem_paths(text: str) -> str:
+    """Mask absolute paths and ``/vsi`` handles, keeping the text around them."""
+    return _ABSOLUTE_PATH_RE.sub(REDACTED_QUERY_VALUE, text)
 
 
 def redact_exception_text(exc: BaseException) -> str:

--- a/backend/app/modules/admin/backfill_jobs.py
+++ b/backend/app/modules/admin/backfill_jobs.py
@@ -21,6 +21,7 @@ import structlog
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.failure_reason import redact_failure_reason
 from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.platform.jobs.heartbeat import (
     claim_job_attempt_and_start_heartbeat,
@@ -116,7 +117,10 @@ async def _finalize(
     values: dict[str, object] = {
         "status": status,
         "completed_at": datetime.now(timezone.utc),
-        "error_message": error_message,
+        # fix(#1953): ADR-002 Decision 3 at the sink, not at each caller.
+        "error_message": redact_failure_reason(error_message)
+        if error_message
+        else None,
     }
     backfill_meta = dict((metadata or {}).get(EMBEDDING_BACKFILL_METADATA_KEY) or {})
     extra_metadata: dict[str, Any] = {}
@@ -249,7 +253,7 @@ class _TerminalState:
         self.status = "failed"
         self.outcome = "failed"
         self.error_code = error_code
-        self.error_message = message
+        self.error_message = redact_failure_reason(message)
         self.result = result
 
     def audit_extra(self) -> dict[str, Any]:

--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -19,6 +19,7 @@ from fastapi import (
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.failure_reason import redact_failure_reason
 from app.core.upload_errors import UnsafeUploadError
 from app.core.identity import Identity
 from app.core.async_io import (
@@ -376,7 +377,7 @@ async def reupload_dataset(
             await db.execute(
                 _pending_reupload_update(job.id, dataset_id).values(
                     status="failed",
-                    error_message=str(exc),
+                    error_message=redact_failure_reason(exc),
                     completed_at=datetime.now(timezone.utc),
                 )
             )
@@ -1407,7 +1408,7 @@ async def complete_presigned_reupload(
         # leave the job retryable exactly as they do on the upload door.
         if exc.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT:
             job.status = "failed"
-            job.error_message = str(exc.detail)
+            job.error_message = redact_failure_reason(str(exc.detail))
             await db.commit()
         raise
 

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -28,6 +28,7 @@ from sqlalchemy import inspect as sa_inspect, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_object_session
 from sqlalchemy.orm.attributes import set_committed_value
 
+from app.core.failure_reason import coded_failure_reason
 from app.core.logging_config import redact_nested
 from app.platform.jobs.models import (
     COMMIT_ATTEMPTED_METADATA_KEY,
@@ -50,10 +51,11 @@ DeferCallable = Callable[[], Awaitable[Any]]
 RollbackCallable = Callable[[BaseException], Awaitable[None]]
 """Async callable that reverts committed DB state after a defer failure.
 
-Receives the defer exception so the rollback can embed its details in
-error messages (matches the ``f"Failed to queue ...: {exc}"`` format the
-pre-existing regression tests assert on). Must *not* commit the session
-— ``defer_with_orphan_guard`` commits after invoking the rollback.
+Receives the defer exception so the rollback can name its type in the
+stored reason (fix(#1953): ``coded_failure_reason``, never ``str(exc)``,
+which ADR-002 Decision 3 keeps out of a stored reason). Must *not* commit
+the session — ``defer_with_orphan_guard`` commits after invoking the
+rollback.
 """
 
 
@@ -302,12 +304,13 @@ async def settle_ingest_job_failed(
     and a lazy reload outside a greenlet raises ``MissingGreenlet``.
     """
     completed_at = datetime.now(timezone.utc)
+    error_message = coded_failure_reason(message_prefix, defer_exc)
     session = async_object_session(job)
     if session is None:
         # No session to fence through (detached instance). Still act — an
         # orphaned pending row is the failure this guard exists to prevent.
         job.status = "failed"
-        job.error_message = f"{message_prefix}: {defer_exc}"
+        job.error_message = error_message
         job.completed_at = datetime.now(timezone.utc)
         return True
 
@@ -324,14 +327,14 @@ async def settle_ingest_job_failed(
         )
         .values(
             status="failed",
-            error_message=f"{message_prefix}: {defer_exc}",
+            error_message=error_message,
             completed_at=completed_at,
         )
     )
     landed = bool(result.rowcount)
     if landed:
         job.status = "failed"
-        job.error_message = f"{message_prefix}: {defer_exc}"
+        job.error_message = error_message
         job.completed_at = completed_at
     else:
         logger.info(
@@ -393,6 +396,8 @@ def make_vrt_regeneration_failed_rollback(
         vrt_asset.current_generation_id = previous_generation_id
         generation.status = "failed"
         generation.completed_at = datetime.now(timezone.utc)
-        generation.error_message = f"Failed to queue VRT regeneration: {defer_exc}"
+        generation.error_message = coded_failure_reason(
+            "Failed to queue VRT regeneration", defer_exc
+        )
 
     return _rollback

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -17,6 +17,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.failure_reason import redact_failure_reason
 from app.core.db.sqlstate import is_lock_conflict
 from app.core.dependencies import get_client_ip, get_db
 from app.core.identity import Identity
@@ -401,7 +402,11 @@ async def get_job_status(
             # writes `failed` outright — same split the background sweep and
             # the worker's startup recovery apply.
             values = (
-                {"status": "failed", "error_message": message, "completed_at": now}
+                {
+                    "status": "failed",
+                    "error_message": redact_failure_reason(message),
+                    "completed_at": now,
+                }
                 if completion_bound
                 else stale_pending_unbound_values(now, message=message)
             )

--- a/backend/app/platform/refresh/service.py
+++ b/backend/app/platform/refresh/service.py
@@ -25,7 +25,7 @@ from sqlalchemy import select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.url_redaction import redact_url_credentials
+from app.core.failure_reason import coded_failure_reason, redact_failure_reason
 from app.platform.refresh.models import DatasetRefreshRun
 
 logger = structlog.get_logger(__name__)
@@ -58,10 +58,6 @@ RUN_ORIGIN_KINDS: tuple[str, ...] = (
 # cutoff only has to be longer than the gap between dispatch and claim.
 ABANDONED_RUN_CUTOFF_SECONDS = 3600
 
-# Cap on the stored failure text. GDAL stderr can run to kilobytes and the
-# useful part is at the front.
-_MAX_ERROR_MESSAGE_CHARS = 2000
-
 ABANDONED_ERROR_CODE = "abandoned"
 ABANDONED_ERROR_MESSAGE = (
     "The refresh task was never picked up by a worker, or the worker "
@@ -76,14 +72,13 @@ USER_CANCELLED_ERROR_CODE = "user_cancelled"
 USER_CANCELLED_ERROR_MESSAGE = "Cancelled by user."
 
 
-def redact_run_error(message: str) -> str:
-    """Short, credential-free failure text for a run row.
+def redact_run_error(message: str | BaseException) -> str:
+    """ADR-002 Decision 3 applied to a run row's ``error_message``.
 
-    Never store a raw exception, a URL with query-string credentials, or a
-    GDAL command line. ``redact_url_credentials`` also scans free text (not
-    just URLs) for URL-shaped substrings, which is what GDAL stderr is.
+    fix(#1953): the clause is enforced in ``core/failure_reason.py``, shared
+    with the ``ingest_jobs`` sink, rather than restated per caller.
     """
-    return redact_url_credentials(message)[:_MAX_ERROR_MESSAGE_CHARS]
+    return redact_failure_reason(message)
 
 
 def drift_status_from_diff(schema_diff: dict[str, Any] | None) -> str | None:
@@ -596,7 +591,7 @@ async def record_refresh_failure(
     *,
     ingest_job_id: uuid.UUID,
     error_code: str,
-    error_message: str,
+    error_message: str | BaseException,
     contacted_origin: bool,
     origin_binding: tuple[str | None, dict[str, Any] | None, str | None] | None = None,
 ) -> uuid.UUID | None:
@@ -741,7 +736,9 @@ def make_refresh_run_failed_rollback(
             db,
             ingest_job_id=ingest_job_id,
             error_code="dispatch_failed",
-            error_message=f"Failed to queue refresh task: {defer_exc}",
+            error_message=coded_failure_reason(
+                "Failed to queue refresh task", defer_exc
+            ),
             contacted_origin=False,
         )
 
@@ -783,8 +780,11 @@ _NO_OTHER_LIVE_LEGACY_TASK = """
 # in one visibility scope. No table has RLS enabled today (#998), so this is
 # currently a no-op — written now rather than remembered later.
 #
-# The two proofs the sweep needs before writing `cancelled` (a bookkeeping
-# correction, never a stop signal, per ADR-002 4d):
+# fix(#1954): the two proofs THIS sweep needs before writing `cancelled`.
+# ADR-002 4d gives the status two writers told apart by `error_code`:
+# `abandoned` here, a bookkeeping correction provable only when the work is
+# not happening, and `cancel_active_run_for_job`'s `user_cancelled` stop
+# signal, which is a person's decision and needs no proof.
 #
 # 1. No live Procrastinate job references the bound ingest job (correlated
 #    on args->>'job_id', inlined rather than importing

--- a/backend/app/processing/ingest/manifest_reservation.py
+++ b/backend/app/processing/ingest/manifest_reservation.py
@@ -15,6 +15,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import set_committed_value
 
+from app.core.failure_reason import redact_failure_reason
 from app.platform.jobs.models import IngestJob
 from app.platform.jobs.sweep import JOB_TIMEOUT_SECONDS
 
@@ -185,8 +186,12 @@ async def release_manifest_reservation(
 
     fix(#1814): the shared settlement fences on ``pending``, so the lease needs
     its own exit. The trap: ``user_metadata`` is not mirrored, reading queries.
+
+    fix(#1953): ``message`` is redacted HERE, not at the caller. This is the
+    sink, and the manifest door composes it from an exception.
     """
     now = now or datetime.now(timezone.utc)
+    message = redact_failure_reason(message)
     result = await db.execute(
         update(IngestJob)
         .where(

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -872,7 +872,7 @@ async def _settle_staged_entry(
         nonlocal referenced, failed
         referenced = await staged_source_is_referenced(db, job_id, file_path=file_path)
         if not await release_manifest_reservation(
-            db, job, f"Failed to stage manifest source: {exc}"
+            db, job, f"Failed to stage manifest source: {redact_failure_reason(exc)}"
         ):
             await settle_ingest_job_failed(
                 job, exc, message_prefix="Failed to queue manifest job"

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -23,7 +23,7 @@ from app.core.async_io import (
     run_in_thread_draining_capture_cancel,
 )
 from app.core.config import settings
-from app.core.failure_reason import redact_failure_reason
+from app.core.failure_reason import prefixed_failure_reason
 from app.core.db.tenant_session import defer_async_with_tenant
 from app.core.identity import Identity
 from app.core.persistent_config import UPLOAD_MAX_SIZE_MB, get_allowed_extensions_list
@@ -835,7 +835,7 @@ async def _fail_reservation(
 
     async def _release() -> None:
         await release_manifest_reservation(
-            db, job, f"Failed to stage manifest source: {redact_failure_reason(exc)}"
+            db, job, prefixed_failure_reason("Failed to stage manifest source", exc)
         )
 
     await _settle_under_reset(db, job, _release, job_id=job_id)
@@ -872,7 +872,7 @@ async def _settle_staged_entry(
         nonlocal referenced, failed
         referenced = await staged_source_is_referenced(db, job_id, file_path=file_path)
         if not await release_manifest_reservation(
-            db, job, f"Failed to stage manifest source: {redact_failure_reason(exc)}"
+            db, job, prefixed_failure_reason("Failed to stage manifest source", exc)
         ):
             await settle_ingest_job_failed(
                 job, exc, message_prefix="Failed to queue manifest job"

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -23,6 +23,7 @@ from app.core.async_io import (
     run_in_thread_draining_capture_cancel,
 )
 from app.core.config import settings
+from app.core.failure_reason import redact_failure_reason
 from app.core.db.tenant_session import defer_async_with_tenant
 from app.core.identity import Identity
 from app.core.persistent_config import UPLOAD_MAX_SIZE_MB, get_allowed_extensions_list
@@ -834,7 +835,7 @@ async def _fail_reservation(
 
     async def _release() -> None:
         await release_manifest_reservation(
-            db, job, f"Failed to stage manifest source: {exc}"
+            db, job, f"Failed to stage manifest source: {redact_failure_reason(exc)}"
         )
 
     await _settle_under_reset(db, job, _release, job_id=job_id)

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.failure_reason import redact_failure_reason
 from app.core.identity import Identity
 from app.core.async_io import (
     run_in_thread_draining,
@@ -665,7 +666,7 @@ async def upload_file(
                 await db.execute(
                     _pending_upload_update(job_id).values(
                         status="failed",
-                        error_message=str(exc),
+                        error_message=redact_failure_reason(exc),
                         completed_at=datetime.now(timezone.utc),
                     )
                 )

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -27,7 +27,8 @@ from app.platform.cache.tiles import invalidate_catalog_cache
 from app.platform.dataset_origin import classify_origin, set_dataset_origin
 from app.core.config import settings
 from app.core.service_tokens import reset_registered_credential_secrets
-from app.core.url_redaction import redact_exception_text, redact_url_credentials
+from app.core.failure_reason import redact_failure_reason
+from app.core.url_redaction import redact_exception_text
 from app.processing.embeddings.helpers import defer_embedding
 from app.processing.ingest.source_format import derive_source_format
 from app.platform.storage import get_storage
@@ -1179,7 +1180,7 @@ async def _cleanup_staging_on_failure(
     """Mark the job failed, then drop the staging table, in that order.
 
     The single terminal-write site for ``reupload_file``/``reupload_service``
-    and the import tasks: applies the ``redact_url_credentials`` backstop,
+    and the import tasks: applies the ``redact_failure_reason`` backstop,
     the ``pending``-inclusive attempt fence (fix(#1274): a worker-time refusal
     that raises before the claim must still finalize the job it owns rather
     than leave it for the stale sweep), and the ``ingest_failed`` notification.
@@ -1215,10 +1216,11 @@ async def _cleanup_staging_on_failure(
     completed_at = datetime.now(timezone.utc)
     # fix(#1277): last boundary before this text becomes durable — feeds the
     # persisted error_message, the log record, and the notification reason,
-    # so redacting once here covers all three for every caller. Pattern-based
-    # (also scrubs the reupload commit door's token, never held as a distinct
-    # value). The exception object itself is left unmodified.
-    error_message = redact_url_credentials(str(exc))
+    # so redacting once here covers all three for every caller.
+    # fix(#1953): ADR-002 Decision 3 now covers this sink, and it is the
+    # exception rather than its text that crosses, so a library exception
+    # becomes a code instead of its statement-and-parameters dump.
+    error_message = redact_failure_reason(exc)
     await session.rollback()
 
     failure_update = sa_update(type(job)).where(type(job).id == job_id)

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -29,6 +29,7 @@ import structlog
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import DBAPIError
 
+from app.core.failure_reason import redact_failure_reason
 from app.core.db.sqlstate import sqlstate
 from app.core.db.tenant_session import tenant_task
 from app.platform.cache.tiles import invalidate_catalog_cache
@@ -949,7 +950,7 @@ async def refresh_postgis(
                 attempt_uuid,
                 values={
                     "status": "failed",
-                    "error_message": str(exc),
+                    "error_message": redact_failure_reason(exc),
                     "completed_at": datetime.now(timezone.utc),
                 },
                 task_name="refresh_postgis",
@@ -968,7 +969,7 @@ async def refresh_postgis(
                 err_session,
                 ingest_job_id=job_uuid,
                 error_code=error_code,
-                error_message=str(exc),
+                error_message=exc,
                 contacted_origin=False,
             )
             await err_session.commit()

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import structlog
 from sqlalchemy.exc import DBAPIError
 
+from app.core.failure_reason import redact_failure_reason
 from app.core.db.tenant_session import current_tenant_var, tenant_task
 from app.core.tenancy import is_multi_tenant
 from app.platform.cache.tiles import invalidate_catalog_cache
@@ -193,7 +194,7 @@ async def ingest_raster(
                     attempt_uuid,
                     values={
                         "status": "failed",
-                        "error_message": str(exc),
+                        "error_message": redact_failure_reason(exc),
                         "completed_at": datetime.now(timezone.utc),
                     },
                 )
@@ -783,7 +784,7 @@ async def ingest_raster(
                     )
                     .values(
                         status="failed",
-                        error_message=str(exc),
+                        error_message=redact_failure_reason(exc),
                         completed_at=datetime.now(timezone.utc),
                     )
                 )

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -35,6 +35,7 @@ from pathlib import Path
 import structlog
 from sqlalchemy import select, text
 
+from app.core.failure_reason import redact_failure_reason
 from app.core.db.tenant_session import tenant_task
 from app.platform.catalog_locks import (
     CATALOG_LOCK_CONFLICT_CODE,
@@ -406,7 +407,7 @@ async def reupload_raster(
                     attempt_uuid,
                     values={
                         "status": "failed",
-                        "error_message": str(exc),
+                        "error_message": redact_failure_reason(exc),
                         "completed_at": datetime.now(timezone.utc),
                     },
                 )
@@ -417,7 +418,7 @@ async def reupload_raster(
                     session,
                     ingest_job_id=job_uuid,
                     error_code="validation_failed",
-                    error_message=str(exc),
+                    error_message=exc,
                     contacted_origin=False,
                 )
                 await session.commit()
@@ -908,7 +909,7 @@ async def reupload_raster(
                 attempt_uuid,
                 values={
                     "status": "failed",
-                    "error_message": str(exc),
+                    "error_message": redact_failure_reason(exc),
                     "completed_at": datetime.now(timezone.utc),
                 },
             )
@@ -921,7 +922,7 @@ async def reupload_raster(
                 err_session,
                 ingest_job_id=job_uuid,
                 error_code=_raster_refresh_error_code(exc),
-                error_message=str(exc),
+                error_message=exc,
                 contacted_origin=False,
             )
             await err_session.commit()

--- a/backend/app/processing/ingest/tasks_reupload.py
+++ b/backend/app/processing/ingest/tasks_reupload.py
@@ -9,6 +9,7 @@ import structlog
 from sqlalchemy import select, update
 
 from app.core.db.tenant_session import tenant_task
+from app.core.failure_reason import redact_failure_reason
 from app.core.url_redaction import scrub_secret_from_exception
 from app.platform.cache.tiles import invalidate_catalog_cache
 from app.platform.catalog_locks import (
@@ -260,7 +261,7 @@ async def reupload_file(
                     attempt_uuid,
                     values={
                         "status": "failed",
-                        "error_message": str(exc),
+                        "error_message": redact_failure_reason(exc),
                         "completed_at": datetime.now(timezone.utc),
                     },
                 )
@@ -272,7 +273,7 @@ async def reupload_file(
                     session,
                     ingest_job_id=job_uuid,
                     error_code="validation_failed",
-                    error_message=str(exc),
+                    error_message=exc,
                     contacted_origin=False,
                 )
                 await session.commit()
@@ -550,7 +551,7 @@ async def reupload_file(
                     err_session,
                     ingest_job_id=job_uuid,
                     error_code=_file_refresh_error_code(exc),
-                    error_message=str(exc),
+                    error_message=exc,
                     contacted_origin=False,
                 )
                 await err_session.commit()
@@ -1230,7 +1231,7 @@ async def reupload_service(
                 err_session,
                 ingest_job_id=job_uuid,
                 error_code=_service_refresh_error_code(exc),
-                error_message=str(exc),
+                error_message=exc,
                 contacted_origin=False,
             )
             await err_session.commit()

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -30,6 +30,7 @@ from typing import Any
 import structlog
 from sqlalchemy import func, select, update
 
+from app.core.failure_reason import redact_failure_reason
 from app.core.geo import bbox_to_extent_wkt
 
 from app.core.db.tenant_session import tenant_task
@@ -669,7 +670,7 @@ async def refresh_stac(
                 attempt_uuid,
                 values={
                     "status": "failed",
-                    "error_message": str(exc),
+                    "error_message": redact_failure_reason(exc),
                     "completed_at": datetime.now(timezone.utc),
                 },
                 task_name="refresh_stac",
@@ -700,7 +701,7 @@ async def refresh_stac(
                 err_session,
                 ingest_job_id=job_uuid,
                 error_code=error_code,
-                error_message=str(exc),
+                error_message=exc,
                 contacted_origin=dates_contact,
                 origin_binding=bound if dates_contact else None,
             )

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -11,6 +11,7 @@ from sqlalchemy import or_, text, update
 from sqlalchemy.exc import DBAPIError
 
 from app.core.db.tenant_session import tenant_task
+from app.core.failure_reason import redact_failure_reason
 from app.core.url_redaction import scrub_secret_from_exception
 from app.platform.dataset_origin import service_layer_identity
 from app.platform.jobs.heartbeat import (
@@ -486,7 +487,7 @@ async def ingest_file(
                     attempt_uuid,
                     values={
                         "status": "failed",
-                        "error_message": str(exc),
+                        "error_message": redact_failure_reason(exc),
                         "completed_at": datetime.now(timezone.utc),
                     },
                 )

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -33,6 +33,7 @@ from app.platform.jobs.heartbeat import (
     stop_ingest_job_heartbeat,
     update_ingest_job_for_attempt,
 )
+from app.core.failure_reason import redact_failure_reason
 from app.core.db import tenant_task
 from app.processing.embeddings.helpers import defer_embedding
 from app.processing.raster.cog import extract_raster_metadata, sha256_file
@@ -1607,7 +1608,7 @@ async def regenerate_vrt(
                     attempt_uuid,
                     values={
                         "status": "failed",
-                        "error_message": str(exc),
+                        "error_message": redact_failure_reason(exc),
                         "completed_at": datetime.now(timezone.utc),
                     },
                 )
@@ -1629,7 +1630,7 @@ async def regenerate_vrt(
                             gen.duration_seconds = (
                                 gen.completed_at - gen.started_at
                             ).total_seconds()
-                        gen.error_message = str(exc)
+                        gen.error_message = redact_failure_reason(exc)
 
                 await err_session.commit()
         except DBAPIError as write_failure:

--- a/backend/app/processing/ingest/url_import_staging.py
+++ b/backend/app/processing/ingest/url_import_staging.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.async_io import run_in_thread_draining
+from app.core.failure_reason import redact_failure_reason
 from app.modules.quota.service import get_user_quota_usage
 from app.platform.storage import get_storage
 from app.platform.storage.titiler_url import resolve_current_storage_key
@@ -355,7 +356,7 @@ async def _settle_failed_url_import(
             .values(
                 status="failed",
                 error_message=(
-                    str(exc.detail)
+                    redact_failure_reason(str(exc.detail))
                     if isinstance(exc, HTTPException)
                     else "URL import failed"
                 ),

--- a/backend/tests/finding_markers.py
+++ b/backend/tests/finding_markers.py
@@ -335,7 +335,6 @@ UNANCHORED_MARKER_DEBT: dict[str, int] = {
     "platform/notifications/webhook_channel.py": 7,
     "platform/refresh/credentials.py": 1,
     "platform/refresh/models.py": 1,
-    "platform/refresh/service.py": 1,
     "platform/security.py": 8,
     "platform/service_auth.py": 1,
     "platform/storage/azure.py": 2,

--- a/backend/tests/test_cancelled_run_writers_1954.py
+++ b/backend/tests/test_cancelled_run_writers_1954.py
@@ -1,0 +1,131 @@
+"""The two writers of the `cancelled` run status (#1954, ADR-002 4d).
+
+The sweep's guard comment claimed the status is never a stop signal while
+the module beside it wrote one for an explicit user cancel. The resolution
+is that `cancelled` carries both meanings and `error_code` tells them apart,
+so the sweep's proof obligation binds only its own writer.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.platform.jobs.models import IngestJob
+from app.platform.refresh.models import DatasetRefreshRun
+from app.platform.refresh.service import (
+    ABANDONED_ERROR_CODE,
+    ABANDONED_RUN_CUTOFF_SECONDS,
+    USER_CANCELLED_ERROR_CODE,
+    cancel_active_run_for_job,
+    create_pending_run,
+    sweep_abandoned_refresh_runs,
+)
+from tests.factories import create_dataset, get_user_id
+
+pytestmark = pytest.mark.anyio
+
+
+async def _seed(session):
+    user_id = await get_user_id(session, "admin")
+    dataset = await create_dataset(
+        session, created_by=user_id, name=f"cancel-{uuid.uuid4().hex[:8]}"
+    )
+    job = IngestJob(
+        dataset_id=dataset.id,
+        status="pending",
+        source_filename="parcels.gpkg",
+        created_by=user_id,
+        user_metadata={"reupload": True, "dataset_id": str(dataset.id)},
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    run = await create_pending_run(
+        session,
+        dataset_id=dataset.id,
+        origin_kind="upload",
+        trigger="manual",
+        triggered_by=user_id,
+        ingest_job_id=job.id,
+        feature_count_before=dataset.feature_count,
+    )
+    await session.commit()
+    return dataset, job, run
+
+
+class TestBothWritersAreDistinguishableByErrorCode:
+    async def test_a_user_cancel_is_a_stop_signal_and_says_so(
+        self, test_db_session
+    ) -> None:
+        _, job, run = await _seed(test_db_session)
+
+        assert await cancel_active_run_for_job(test_db_session, job.id) == run.id
+        await test_db_session.commit()
+        await test_db_session.refresh(run)
+
+        assert run.status == "cancelled"
+        assert run.error_code == USER_CANCELLED_ERROR_CODE
+        assert run.finished_at is not None
+
+    async def test_the_sweep_writes_only_its_own_bookkeeping_code(
+        self, test_db_session
+    ) -> None:
+        """The sweep's proofs hold: no live task, and the job is `pending`."""
+        _, job, run = await _seed(test_db_session)
+        run.started_at = datetime.now(timezone.utc) - timedelta(
+            seconds=ABANDONED_RUN_CUTOFF_SECONDS + 60
+        )
+        await test_db_session.commit()
+
+        assert await sweep_abandoned_refresh_runs(test_db_session) == 1
+        await test_db_session.commit()
+        await test_db_session.refresh(run)
+
+        assert run.status == "cancelled"
+        assert run.error_code == ABANDONED_ERROR_CODE
+        assert run.error_code != USER_CANCELLED_ERROR_CODE
+
+    async def test_the_sweep_leaves_a_users_cancel_alone(self, test_db_session) -> None:
+        """`cancelled` is terminal for both, so neither writer overwrites the
+        other's row and `error_code` stays the way to read them apart."""
+        _, job, run = await _seed(test_db_session)
+        await cancel_active_run_for_job(test_db_session, job.id)
+        run.started_at = datetime.now(timezone.utc) - timedelta(
+            seconds=ABANDONED_RUN_CUTOFF_SECONDS + 60
+        )
+        await test_db_session.commit()
+
+        assert await sweep_abandoned_refresh_runs(test_db_session) == 0
+        await test_db_session.commit()
+
+        stored = (
+            await test_db_session.execute(
+                select(DatasetRefreshRun).where(DatasetRefreshRun.id == run.id)
+            )
+        ).scalar_one()
+        assert stored.error_code == USER_CANCELLED_ERROR_CODE
+
+
+class TestTheGuardCommentMatchesTheModule:
+    """The comment is load-bearing: it is the argument for the sweep's two
+    proofs, and a reader who finds it contradicted has no rule at all."""
+
+    def test_the_sweep_no_longer_claims_the_status_is_never_a_stop_signal(
+        self,
+    ) -> None:
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "app"
+            / "platform"
+            / "refresh"
+            / "service.py"
+        ).read_text()
+
+        assert "never a stop signal" not in source
+        assert "told apart by `error_code`" in source

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -523,7 +523,9 @@ class TestDeferWithOrphanGuard:
 
             assert job.status == "failed"
             assert "Failed to queue custom task" in job.error_message
-            assert "queue dead" in job.error_message
+            # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+            assert "(RuntimeError)" in job.error_message
+            assert "queue dead" not in job.error_message
             assert job.completed_at is not None
 
         asyncio.run(_check())
@@ -575,10 +577,14 @@ class TestDeferWithOrphanGuard:
             assert vrt_asset.current_generation_id == previous_generation_id
             assert generation.status == "failed"
             assert generation.completed_at is not None
-            assert "procrastinate unreachable" in generation.error_message
+            # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+            assert "(RuntimeError)" in generation.error_message
+            assert "procrastinate unreachable" not in generation.error_message
             assert job.status == "failed"
             assert job.completed_at is not None
-            assert "procrastinate unreachable" in job.error_message
+            # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+            assert "(RuntimeError)" in job.error_message
+            assert "procrastinate unreachable" not in job.error_message
 
         asyncio.run(_check())
 
@@ -700,7 +706,9 @@ class TestReuploadOrphanGuard:
 
             assert exc_info.value.status_code == 503
             assert job.status == "failed"
-            assert "reupload_service queue down" in job.error_message
+            # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+            assert "(RuntimeError)" in job.error_message
+            assert "reupload_service queue down" not in job.error_message
             assert job.completed_at is not None
 
         asyncio.run(_check())
@@ -758,7 +766,9 @@ class TestReuploadOrphanGuard:
 
             assert exc_info.value.status_code == 503
             assert job.status == "failed"
-            assert "priority queue dead" in job.error_message
+            # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+            assert "(RuntimeError)" in job.error_message
+            assert "priority queue dead" not in job.error_message
 
         asyncio.run(_check())
 
@@ -810,7 +820,9 @@ class TestReuploadOrphanGuard:
 
             assert exc_info.value.status_code == 503
             assert job.status == "failed"
-            assert "default queue dead" in job.error_message
+            # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+            assert "(RuntimeError)" in job.error_message
+            assert "default queue dead" not in job.error_message
 
         asyncio.run(_check())
 
@@ -959,7 +971,9 @@ class TestVrtSourceOrphanGuard:
             assert vrt_asset.current_generation_id == original_generation_id
             # IngestJob marked failed
             assert mock_job.status == "failed"
-            assert "vrt add_source queue dead" in mock_job.error_message
+            # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+            assert "(RuntimeError)" in mock_job.error_message
+            assert "vrt add_source queue dead" not in mock_job.error_message
             # fix(#1327): the link table was only READ. No INSERT to undo, so
             # no DELETE to issue — the compensation the rollback used to owe.
             statements = "\n".join(
@@ -1054,7 +1068,9 @@ class TestVrtSourceOrphanGuard:
             assert vrt_asset.current_generation_id == original_generation_id
             # IngestJob marked failed
             assert mock_job.status == "failed"
-            assert "vrt remove_source queue dead" in mock_job.error_message
+            # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+            assert "(RuntimeError)" in mock_job.error_message
+            assert "vrt remove_source queue dead" not in mock_job.error_message
             # fix(#1327): the member set was only READ — the removal lived on
             # the generation and died with it.
             statements = "\n".join(
@@ -1189,10 +1205,14 @@ class TestDatasetsVrtOrphanGuard:
             assert vrt_asset.current_generation_id == original_generation_id
             # VrtGeneration marked failed
             assert generation.status == "failed"
-            assert "regenerate_vrt queue dead" in (generation.error_message or "")
+            # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+            assert "(RuntimeError)" in (generation.error_message or "")
+            assert "regenerate_vrt queue dead" not in (generation.error_message or "")
             assert generation.completed_at is not None
             # IngestJob marked failed
             assert mock_job.status == "failed"
-            assert "regenerate_vrt queue dead" in mock_job.error_message
+            # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+            assert "(RuntimeError)" in mock_job.error_message
+            assert "regenerate_vrt queue dead" not in mock_job.error_message
 
         asyncio.run(_check())

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -1343,7 +1343,9 @@ async def test_queue_ingest_job_file_defer_failure_marks_job_failed(tmp_path):
     assert exc_info.value.status_code == 503
     assert job.status == "failed"
     assert job.error_message is not None
-    assert "procrastinate unreachable" in job.error_message
+    # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+    assert "(RuntimeError)" in job.error_message
+    assert "procrastinate unreachable" not in job.error_message
     assert job.completed_at is not None
     mock_db.commit.assert_awaited()
 
@@ -1382,7 +1384,9 @@ async def test_queue_ingest_job_service_defer_failure_marks_job_failed():
 
     assert exc_info.value.status_code == 503
     assert job.status == "failed"
-    assert "queue down" in job.error_message
+    # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+    assert "(RuntimeError)" in job.error_message
+    assert "queue down" not in job.error_message
 
 
 @pytest.mark.anyio
@@ -1421,7 +1425,9 @@ async def test_queue_ingest_job_raster_defer_failure_marks_job_failed(tmp_path):
 
     assert exc_info.value.status_code == 503
     assert job.status == "failed"
-    assert "raster queue dead" in job.error_message
+    # fix(#1953): the type, never the message ADR-002 Decision 3 excludes.
+    assert "(RuntimeError)" in job.error_message
+    assert "raster queue dead" not in job.error_message
 
 
 class TestCommitImportDispatch:

--- a/backend/tests/test_ingest_vector_failure_tails.py
+++ b/backend/tests/test_ingest_vector_failure_tails.py
@@ -22,6 +22,7 @@ from sqlalchemy import delete, select
 
 from app.modules.auth.models import User
 from app.platform.jobs.models import IngestJob
+from app.processing.ingest.ogr import IngestionError
 from app.processing.ingest.tasks_vector import ingest_file
 
 pytestmark = pytest.mark.anyio
@@ -136,8 +137,11 @@ class TestVectorFailureEmitsTheOperatorNotification:
 
     @staticmethod
     def _break_ogrinfo(monkeypatch, message: str) -> None:
+        # fix(#1953): the type production raises here. A library exception
+        # stores `internal_error` under ADR-002 Decision 3, so a stand-in
+        # would assert the operator reads text no real failure produces.
         async def _raise(*args, **kwargs):
-            raise RuntimeError(message)
+            raise IngestionError(message)
 
         monkeypatch.setattr(
             "app.processing.ingest.ogr.run_ogrinfo", _raise, raising=True
@@ -149,7 +153,7 @@ class TestVectorFailureEmitsTheOperatorNotification:
         admin_id = await _admin_id(session)
         job = await _queue_upload(session, file_path=str(source), user_id=admin_id)
         self._break_ogrinfo(monkeypatch, message)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(IngestionError):
             await ingest_file.func(
                 job_id=str(job.id),
                 file_path=str(source),
@@ -293,7 +297,7 @@ class TestACleanupFailureCannotSwallowTheFailureWrite:
                     err_session,
                     staging_table="roads_staging_deadbeef",
                     job=err_job,
-                    exc=RuntimeError("ogr2ogr could not read the layer"),
+                    exc=IngestionError("ogr2ogr could not read the layer"),
                     task_name="ingest_file",
                     attempt_id=attempt_id,
                 )

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2552,9 +2552,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1888): +16. The staged-entry settlement reads the row's status on
     # its own transaction and reaps the staged copy once a committed attempt
     # left the row failed, best effort. Cap 1130 -> 1146, exact.
-    # fix(#2017): +15. Bounds the admit-plus-bind step under its own deadline
-    # so a heartbeat-less running row can't be reaped mid-admit. Cap 1136 -> 1151.
-    "backend/app/processing/ingest/manifest_service.py": 1151,
+    # fix(#2017): +15. Bounds the admit-plus-bind step under its own deadline and fix(#1953): +1 merged; re-measured after both landed. Cap 1152, exact.
+    "backend/app/processing/ingest/manifest_service.py": 1152,
     # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
     # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
     # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3641,10 +3641,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950 codex r2-r5): +55 — `load_job_for_error_write`, the guarded job
     # load the two re-upload tails share, which also ends the transaction on a
     # miss so the run row they write next is unbudgeted. Cap 2668 -> 2723, exact.
-    # fix(#1755 item 12): -8 — the by-id purge statement moved to
-    # `platform/jobs/sweep.py`, which the stalled sweep also calls.
-    # Cap 2421 -> 2413, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2413,
+    # fix(#1755 item 12): -8 and fix(#1953): +2 merged; re-measured after both landed. Cap 2415, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2415,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3392,14 +3392,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # refactor(#1711): -459. The URL-import staging cluster — budget, bounded
     # put, settlement — lives in url_import_staging.py; the route handler and
     # its filename/metadata helpers stay. Cap 2639 -> 2180, exact.
-    # fix(#1955): +15 — both VRT source doors admit through the shared
-    # per-dataset lock instead of reading the status, and refuse with the
-    # coded `dataset_busy` body. Cap 1969 -> 1984, exact.
-    # fix(#2016): +10. The fan-out door reports a lost undo: it reads the
-    # restore's CAS result and logs the job and attempt when it matched no row,
-    # so a parent stranded terminal stops hiding behind a 202. Measured on the
-    # file rebased across #1955, not added up. Cap 1984 -> 1994, exact.
-    "backend/app/processing/ingest/router.py": 1994,
+    # fix(#1955): +15 and fix(#1955): +15 and fix(#1953): +1 merged; re-measured after both landed. Cap 1985, exact. merged; re-measured after both landed. Cap 1995, exact.
+    "backend/app/processing/ingest/router.py": 1995,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
@@ -3752,7 +3746,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950 codex r2): -12 — each tail's pre-helper job load moved to
     # `tasks_common.load_job_for_error_write`, which arms the budget and
     # swallows an expiry there. Cap 1329 -> 1317, exact.
-    "backend/app/processing/ingest/tasks_reupload.py": 1245,
+    # fix(#1953): +1 — the import of the one redactor every failure writer
+    # in this module now goes through. Cap 1245 -> 1246, exact.
+    "backend/app/processing/ingest/tasks_reupload.py": 1246,
     # --- entered by the inclusion rule, feat(#1266) -----------------------
     # The refresh door crossed 1000 when it gained its third execution
     # strategy. Two thirds of the addition is the STAC dispatcher, which is
@@ -4532,7 +4528,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # bind are helpers the direct door now shares. Cap 1455 -> 1506, exact.
     # chore(#1812): -18, the reupload door and _dispatch_reupload_task lose the
     # service_queue verdict, its parameter and the configure() branch. Cap 1506 -> 1488, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1427,
+    # fix(#1953): +1 — the import of the one redactor every failure writer
+    # in this module now goes through. Cap 1427 -> 1428, exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1428,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python
@@ -4662,12 +4660,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950 codex r4): -4 — `ingest_vrt`'s failure tail loads its job row
     # through `tasks_common.load_job_for_error_write` instead of an inline
     # unbounded SELECT. Cap 1709 -> 1705, exact.
-    # fix(#1962): +63 — `_settle_failed_vrt_asset` commits the asset write
-    # before the job row is touched, releases the asset unless a live
-    # generation owns it, bounds its own pool checkout, and reports
-    # whether it landed so the generation stays sweepable when it did
-    # not. Cap 1626 -> 1689, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1689,
+    # fix(#1962): +63 and fix(#1953): +1 merged; re-measured after both landed. Cap 1690, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1690,
     # --- entered by the inclusion rule, fix(#1937) ------------------------
     # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
     # The budget alone is six lines; the rest is what a newly failable wait
@@ -4677,9 +4671,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # unbounded. The reporter is a context manager so the acquisition stays a
     # direct call the #1847 gates can see, and the failure write carries a bound
     # of its own so phase 2's contention cannot move onto it. Cap 1056, exact.
-    # fix(#1957): -4 — the failure write reads the shared budget constant
-    # instead of a second definition of it. Cap 997 -> 993, exact.
-    "backend/app/processing/ingest/tasks_raster_replace.py": 993,
+    # fix(#1957): -4 and fix(#1953): +1 merged; re-measured after both landed. Cap 994, exact.
+    "backend/app/processing/ingest/tasks_raster_replace.py": 994,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.
@@ -4815,7 +4808,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950 codex r2): +17 — the budget also bounds the job load
     # `_job_phase_session` runs before the helper, so both tails grew the
     # DBAPIError handler that swallows an expiry. Cap 1380 -> 1397, exact.
-    "backend/app/processing/ingest/tasks_vector.py": 1277,
+    # fix(#1953): +1 — the import of the one redactor every failure writer
+    # in this module now goes through. Cap 1277 -> 1278, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1278,
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern
@@ -5271,9 +5266,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): phase 3 takes the job row before the datasets row. Cap
     # 1134 -> 1141, exact.
     # fix(#1902): the atomic bump comment states its contract. Cap 1141 -> 1137.
-    # fix(#1957): +3 — the failure write is budgeted, and states what an
-    # expiry leaves behind. Cap 975 -> 978, exact.
-    "backend/app/processing/ingest/tasks_postgis_refresh.py": 978,
+    # fix(#1957): +3 and fix(#1953): +1 merged; re-measured after both landed. Cap 979, exact.
+    "backend/app/processing/ingest/tasks_postgis_refresh.py": 979,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.

--- a/backend/tests/test_stored_failure_reason_1953.py
+++ b/backend/tests/test_stored_failure_reason_1953.py
@@ -94,7 +94,41 @@ class TestTheHelperRefusesWhatDecision3Forbids:
             assert "hunter2" not in reason
             assert "hunt er2" not in reason
             assert "password=<redacted>" in reason
-            assert "dbname=geolens" in reason, "only the secret is masked"
+            assert "geolens" not in reason, "the topology goes with the secret"
+
+    def test_a_one_line_gdal_echo_keeps_no_path_and_no_topology(self) -> None:
+        """The whole leak fits on one line, so the summary cut removes none of
+        it. Being defined under ``app.`` says who raised the exception, never
+        that its message is free of the subprocess output it was built from."""
+        reason = redact_failure_reason(
+            IngestionError(
+                "ogr2ogr -f PostgreSQL PG:host=db port=5432 dbname=geolens "
+                "user=gl password=hunter2 /app/staging/9f2_roads.gpkg"
+            )
+        )
+
+        assert "hunter2" not in reason
+        for keyword in ("host", "port", "dbname", "user", "password"):
+            assert f"{keyword}=<redacted>" in reason
+        assert "geolens" not in reason
+        assert "/app/staging" not in reason
+        assert "9f2_roads.gpkg" not in reason
+
+    def test_a_vsi_handle_is_a_path_too(self) -> None:
+        reason = redact_failure_reason(
+            IngestionError("ERROR 1: Cannot open /vsis3/geolens-data/r/abc.tif")
+        )
+
+        assert reason == "ERROR 1: Cannot open <redacted>"
+
+    def test_a_url_in_a_composed_message_keeps_its_path(self) -> None:
+        """The path masking's negative control: a manifest download names its
+        source, and a URL's slashes follow a host rather than a space."""
+        assert redact_failure_reason(
+            "Failed to download manifest source: https://example.com/a/b.gpkg timed out"
+        ) == (
+            "Failed to download manifest source: https://example.com/a/b.gpkg timed out"
+        )
 
     def test_a_credential_broken_across_a_line_is_still_masked(self) -> None:
         """Choosing the summary line first would hand the scrubbers a URL cut

--- a/backend/tests/test_stored_failure_reason_1953.py
+++ b/backend/tests/test_stored_failure_reason_1953.py
@@ -96,6 +96,23 @@ class TestTheHelperRefusesWhatDecision3Forbids:
             assert "password=<redacted>" in reason
             assert "dbname=geolens" in reason, "only the secret is masked"
 
+    def test_a_credential_broken_across_a_line_is_still_masked(self) -> None:
+        """Choosing the summary line first would hand the scrubbers a URL cut
+        in half, and half a URL keeps its password."""
+        assert "hunter2" not in redact_failure_reason("https://user:hunter2\n@[::1")
+        assert "hunt er2" not in redact_failure_reason(
+            "ERROR 1: PG:host=db password='hunt\ner2' dbname=x"
+        )
+
+    def test_a_tab_in_the_summary_is_not_read_as_a_straddling_credential(
+        self,
+    ) -> None:
+        """The cross-check's negative control. ``urlsplit`` deletes tabs as
+        well as line breaks, so comparing raw text would refuse this line."""
+        assert redact_failure_reason("ERROR 1:\tCannot open\n[SQL: SELECT 1]") == (
+            "ERROR 1:Cannot open"
+        )
+
     def test_credentials_are_still_stripped(self) -> None:
         assert "hunter2" not in redact_failure_reason(
             IngestionError(

--- a/backend/tests/test_stored_failure_reason_1953.py
+++ b/backend/tests/test_stored_failure_reason_1953.py
@@ -164,13 +164,23 @@ _SANCTIONED_REDACTORS = frozenset(
 )
 
 
-# The sinks that redact what they are handed, so a caller may pass the
-# exception itself. `release_manifest_reservation` joined them in round 2.
-_REDACTING_SINKS = frozenset({"record_refresh_failure", "release_manifest_reservation"})
+# The sinks that redact what they are handed, and where each keeps its
+# message. A caller may pass the exception, never a rendering of it: once it
+# has been interpolated the sink can no longer tell whose text it is.
+_REDACTING_SINKS: dict[str, str | int] = {
+    "record_refresh_failure": "error_message",
+    "release_manifest_reservation": 2,
+}
+
+
+def _sink_message(node: ast.Call, where: str | int) -> ast.expr | None:
+    if isinstance(where, int):
+        return node.args[where] if len(node.args) > where else None
+    return next((kw.value for kw in node.keywords if kw.arg == where), None)
 
 
 def _reason_values(tree: ast.AST) -> list[tuple[ast.expr, str | None]]:
-    """Every expression assigned to an ``error_message``, with its callee."""
+    """Every expression that becomes an ``error_message``, with its callee."""
     values: list[tuple[ast.expr, str | None]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Call):
@@ -178,6 +188,11 @@ def _reason_values(tree: ast.AST) -> list[tuple[ast.expr, str | None]]:
             values += [
                 (kw.value, callee) for kw in node.keywords if kw.arg == "error_message"
             ]
+            where = _REDACTING_SINKS.get(callee or "")
+            if where is not None and where != "error_message":
+                message = _sink_message(node, where)
+                if message is not None:
+                    values.append((message, callee))
         elif isinstance(node, ast.Dict):
             values += [
                 (value, None)
@@ -294,12 +309,14 @@ class TestEverySinkGoesThroughTheOneDoor:
             }
             safe_locals = _redacted_locals(tree)
             for value, callee in _reason_values(tree):
-                if callee in _REDACTING_SINKS:
-                    continue
                 if _call_names(value) & _SANCTIONED_REDACTORS:
                     continue
                 if isinstance(value, ast.Name):
-                    if value.id in safe_locals or value.id.isupper():
+                    if (
+                        callee in _REDACTING_SINKS
+                        or value.id in safe_locals
+                        or value.id.isupper()
+                    ):
                         continue
                 elif (
                     not {

--- a/backend/tests/test_stored_failure_reason_1953.py
+++ b/backend/tests/test_stored_failure_reason_1953.py
@@ -1,0 +1,259 @@
+"""ADR-002 Decision 3's raw-exception clause, at the sinks (#1953).
+
+The clause was two-thirds enforced: credentials and length were handled, a
+raw exception was not. #1947 stored a `DBAPIError` rendering carrying a
+statement and its bound parameters into both a run row and the ingest job
+the re-upload dialog renders.
+"""
+
+from __future__ import annotations
+
+import ast
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy.exc import DBAPIError
+
+from app.core.failure_reason import (
+    INTERNAL_FAILURE_REASON,
+    MAX_REASON_CHARS,
+    coded_failure_reason,
+    is_composed_exception,
+    redact_failure_reason,
+)
+from app.processing.ingest.ogr import IngestionError
+
+_APP = Path(__file__).resolve().parents[1] / "app"
+_STATEMENT = "SELECT id FROM catalog.datasets WHERE id = %(dataset_id)s FOR UPDATE"
+
+
+def _driver_error() -> DBAPIError:
+    """The #1947 shape: SQLAlchemy renders the statement and the parameters."""
+
+    class _QueryCanceled(Exception):
+        pass
+
+    return DBAPIError.instance(
+        _STATEMENT,
+        {"dataset_id": "b0a1f2e3-0000-4000-8000-000000000000"},
+        _QueryCanceled("canceling statement due to statement timeout"),
+        Exception,
+    )
+
+
+class TestTheHelperRefusesWhatDecision3Forbids:
+    def test_a_library_exception_becomes_a_code(self) -> None:
+        exc = _driver_error()
+        assert _STATEMENT in str(exc), "precondition: the payload is in the rendering"
+
+        reason = redact_failure_reason(exc)
+
+        assert reason == INTERNAL_FAILURE_REASON
+        assert "SELECT" not in reason
+        assert "parameters" not in reason
+
+    def test_flattened_exception_text_loses_its_payload(self) -> None:
+        """The door a caller reaches with ``str(exc)`` already applied."""
+        reason = redact_failure_reason(str(_driver_error()))
+
+        assert reason.endswith("canceling statement due to statement timeout")
+        assert "[SQL:" not in reason
+        assert "[parameters:" not in reason
+        assert "sqlalche.me" not in reason
+
+    def test_a_message_this_codebase_composed_survives(self) -> None:
+        """The refusal half needs its admission, or a redactor that eats
+        everything passes every assertion above."""
+        message = "Layer 'parcels' has no geometry column"
+        assert redact_failure_reason(IngestionError(message)) == message
+        assert redact_failure_reason(message) == message
+
+    def test_gdal_stderr_keeps_only_its_summary_line(self) -> None:
+        exc = IngestionError(
+            "ogr2ogr failed (exit 1): ERROR 1: Cannot open datasource\n"
+            "ogr2ogr -f PostgreSQL PG:dbname=geolens /app/staging/abc_roads.gpkg"
+        )
+        reason = redact_failure_reason(exc)
+
+        assert reason.endswith("Cannot open datasource")
+        assert "/app/staging" not in reason
+
+    def test_credentials_are_still_stripped(self) -> None:
+        assert "hunter2" not in redact_failure_reason(
+            IngestionError(
+                "ogr2ogr failed on https://svc.example/FeatureServer/0?token=hunter2"
+            )
+        )
+        assert "s3cret" not in redact_failure_reason(
+            "GDAL error: https://bob:s3cret@svc.example/wfs"
+        )
+
+    def test_the_reason_is_capped(self) -> None:
+        assert len(redact_failure_reason("x" * 10_000)) == MAX_REASON_CHARS
+
+    def test_provenance_is_the_test_not_the_shape(self) -> None:
+        assert is_composed_exception(IngestionError("composed here"))
+        assert not is_composed_exception(_driver_error())
+        assert not is_composed_exception(ValueError("composed by nobody in particular"))
+
+    def test_a_coded_reason_names_the_class_and_not_the_message(self) -> None:
+        reason = coded_failure_reason("Failed to queue refresh task", _driver_error())
+
+        assert reason == "Failed to queue refresh task (DBAPIError)"
+        assert _STATEMENT not in reason
+
+
+def _function(module_path: Path, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    tree = ast.parse(module_path.read_text())
+    found = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == name
+    ]
+    assert len(found) == 1, f"{name} not found once in {module_path}"
+    return found[0]
+
+
+def _call_names(node: ast.AST) -> set[str]:
+    return {
+        call.func.id
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+
+
+class TestEverySinkGoesThroughTheOneDoor:
+    """Structural, because the failure mode is a NEW caller, not this one.
+
+    Each assertion carries its own positive control: a refactor that moves
+    the write out of the function named here fails the lookup rather than
+    passing vacuously.
+    """
+
+    def test_the_ingest_job_sink_passes_the_exception_not_its_text(self) -> None:
+        fn = _function(
+            _APP / "processing" / "ingest" / "tasks_common.py",
+            "_cleanup_staging_on_failure",
+        )
+        assigned = [
+            node
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "error_message"
+                for t in node.targets
+            )
+        ]
+        assert len(assigned) == 1, (
+            "the terminal write's reason is composed elsewhere now"
+        )
+        value = assigned[0].value
+        assert isinstance(value, ast.Call)
+        assert isinstance(value.func, ast.Name)
+        assert value.func.id == "redact_failure_reason"
+        assert [a.id for a in value.args if isinstance(a, ast.Name)] == ["exc"]
+
+    def test_every_run_row_reason_goes_through_redact_run_error(self) -> None:
+        source = (_APP / "platform" / "refresh" / "service.py").read_text()
+        tree = ast.parse(source)
+        values = [
+            item
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Dict)
+            for key, item in zip(node.keys, node.values)
+            if isinstance(key, ast.Constant) and key.value == "error_message"
+        ]
+        assert len(values) == 3, "the run row's error_message writers moved"
+        for value in values:
+            if isinstance(value, ast.Name):
+                # The sweep's own constant: composed here, nothing to redact.
+                assert value.id.endswith("_ERROR_MESSAGE")
+                continue
+            assert isinstance(value, ast.Call)
+            assert isinstance(value.func, ast.Name)
+            assert value.func.id == "redact_run_error"
+
+    def test_the_dispatch_rollback_no_longer_interpolates_the_exception(self) -> None:
+        fn = _function(
+            _APP / "platform" / "refresh" / "service.py",
+            "make_refresh_run_failed_rollback",
+        )
+        assert "coded_failure_reason" in _call_names(fn)
+        assert not [node for node in ast.walk(fn) if isinstance(node, ast.JoinedStr)], (
+            "an f-string here is how #1947's payload reached the run row"
+        )
+
+    def test_the_defer_guard_rollbacks_name_the_type_only(self) -> None:
+        source = (_APP / "platform" / "jobs" / "defer_guard.py").read_text()
+        tree = ast.parse(source)
+        writes = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Attribute) and t.attr == "error_message"
+                for t in node.targets
+            )
+        ]
+        assert len(writes) == 3, "the job/generation reason writers moved"
+        for write in writes:
+            assert isinstance(write.value, (ast.Name, ast.Call))
+            if isinstance(write.value, ast.Call):
+                assert isinstance(write.value.func, ast.Name)
+                assert write.value.func.id == "coded_failure_reason"
+
+
+@pytest.mark.anyio
+class TestTheRunRowStoresTheCodeRatherThanTheStatement:
+    async def test_a_driver_failure_stores_no_sql(self, test_db_session) -> None:
+        from app.platform.jobs.models import IngestJob
+        from app.platform.refresh.service import (
+            create_pending_run,
+            record_refresh_failure,
+        )
+        from tests.factories import create_dataset, get_user_id
+
+        user_id = await get_user_id(test_db_session, "admin")
+        dataset = await create_dataset(
+            test_db_session,
+            created_by=user_id,
+            name=f"reason-{uuid.uuid4().hex[:8]}",
+        )
+        job = IngestJob(
+            dataset_id=dataset.id,
+            status="running",
+            source_filename="parcels.gpkg",
+            created_by=user_id,
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+        run = await create_pending_run(
+            test_db_session,
+            dataset_id=dataset.id,
+            origin_kind="postgis",
+            trigger="manual",
+            triggered_by=user_id,
+            ingest_job_id=job.id,
+            feature_count_before=dataset.feature_count,
+        )
+        await test_db_session.commit()
+
+        assert (
+            await record_refresh_failure(
+                test_db_session,
+                ingest_job_id=job.id,
+                error_code="postgis_refresh_failed",
+                error_message=_driver_error(),
+                contacted_origin=False,
+            )
+            == run.id
+        )
+        await test_db_session.commit()
+        await test_db_session.refresh(run)
+
+        assert run.status == "failed"
+        assert run.error_message == INTERNAL_FAILURE_REASON
+        assert "SELECT" not in (run.error_message or "")

--- a/backend/tests/test_stored_failure_reason_1953.py
+++ b/backend/tests/test_stored_failure_reason_1953.py
@@ -147,15 +147,23 @@ _SANCTIONED_REDACTORS = frozenset(
 )
 
 
-def _reason_values(tree: ast.AST) -> list[ast.expr]:
-    """Every expression assigned to an ``error_message``, however spelled."""
-    values: list[ast.expr] = []
+# The sinks that redact what they are handed, so a caller may pass the
+# exception itself. `release_manifest_reservation` joined them in round 2.
+_REDACTING_SINKS = frozenset({"record_refresh_failure", "release_manifest_reservation"})
+
+
+def _reason_values(tree: ast.AST) -> list[tuple[ast.expr, str | None]]:
+    """Every expression assigned to an ``error_message``, with its callee."""
+    values: list[tuple[ast.expr, str | None]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Call):
-            values += [kw.value for kw in node.keywords if kw.arg == "error_message"]
+            callee = node.func.id if isinstance(node.func, ast.Name) else None
+            values += [
+                (kw.value, callee) for kw in node.keywords if kw.arg == "error_message"
+            ]
         elif isinstance(node, ast.Dict):
             values += [
-                value
+                (value, None)
                 for key, value in zip(node.keys, node.values)
                 if isinstance(key, ast.Constant) and key.value == "error_message"
             ]
@@ -166,8 +174,20 @@ def _reason_values(tree: ast.AST) -> list[ast.expr]:
                     isinstance(target, ast.Attribute) and target.attr == "error_message"
                 )
                 if named or attr:
-                    values.append(node.value)
+                    values.append((node.value, None))
     return values
+
+
+def _redacted_locals(tree: ast.AST) -> set[str]:
+    """Names a module binds from a sanctioned redactor."""
+    return {
+        target.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and _call_names(node.value) & _SANCTIONED_REDACTORS
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
 
 
 def _call_names(node: ast.AST) -> set[str]:
@@ -242,9 +262,10 @@ class TestEverySinkGoesThroughTheOneDoor:
     def test_no_writer_anywhere_puts_an_exception_into_a_reason(self) -> None:
         """The gate codex round 1 asked for: enumerate, do not list.
 
-        Every `error_message` value in `backend/app/` that mentions a name an
-        `except ... as` bound must reach a sanctioned redactor first. Bare
-        names are the sink's own argument and are redacted there.
+        Every `error_message` value in `backend/app/` must reach a sanctioned
+        redactor, be a name this module already redacted, or be a fixed
+        constant. Round 2 removed the bare-name exemption: the manifest
+        reservation was handed one composed from an exception.
         """
         offenders: list[str] = []
         for module in sorted(_APP.rglob("*.py")):
@@ -254,15 +275,23 @@ class TestEverySinkGoesThroughTheOneDoor:
                 for handler in ast.walk(tree)
                 if isinstance(handler, ast.ExceptHandler) and handler.name
             }
-            if not caught:
-                continue
-            for value in _reason_values(tree):
-                if isinstance(value, ast.Name):
-                    continue
-                names = {n.id for n in ast.walk(value) if isinstance(n, ast.Name)}
-                if not names & caught:
+            safe_locals = _redacted_locals(tree)
+            for value, callee in _reason_values(tree):
+                if callee in _REDACTING_SINKS:
                     continue
                 if _call_names(value) & _SANCTIONED_REDACTORS:
+                    continue
+                if isinstance(value, ast.Name):
+                    if value.id in safe_locals or value.id.isupper():
+                        continue
+                elif (
+                    not {
+                        node.id
+                        for node in ast.walk(value)
+                        if isinstance(node, ast.Name)
+                    }
+                    & caught
+                ):
                     continue
                 offenders.append(
                     f"{module.relative_to(_APP)}:{value.lineno} "
@@ -284,9 +313,11 @@ class TestEverySinkGoesThroughTheOneDoor:
         }
         values = _reason_values(tree)
         assert len(values) == 1
-        names = {n.id for n in ast.walk(values[0]) if isinstance(n, ast.Name)}
-        assert names & caught
-        assert not _call_names(values[0]) & _SANCTIONED_REDACTORS
+        value, callee = values[0]
+        assert callee not in _REDACTING_SINKS
+        assert {n.id for n in ast.walk(value) if isinstance(n, ast.Name)} & caught
+        assert not _call_names(value) & _SANCTIONED_REDACTORS
+        assert not _redacted_locals(tree)
 
     def test_the_defer_guard_rollbacks_name_the_type_only(self) -> None:
         source = (_APP / "platform" / "jobs" / "defer_guard.py").read_text()

--- a/backend/tests/test_stored_failure_reason_1953.py
+++ b/backend/tests/test_stored_failure_reason_1953.py
@@ -79,6 +79,23 @@ class TestTheHelperRefusesWhatDecision3Forbids:
         assert reason.endswith("Cannot open datasource")
         assert "/app/staging" not in reason
 
+    def test_a_wrapper_around_gdal_stderr_loses_the_libpq_password(self) -> None:
+        """Being defined under ``app.`` does not make the text ours: ogr.py
+        builds ``IngestionError`` from stderr, and GDAL echoes the ``PG:``
+        destination it was handed on a connection failure."""
+        for rendered in ("password=hunter2", "password='hunt er2'"):
+            reason = redact_failure_reason(
+                IngestionError(
+                    "ogr2ogr failed (exit 1): ERROR 1: Unable to connect: "
+                    f"PG:host=db port=5432 dbname=geolens user=gl {rendered} "
+                    "sslmode=require"
+                )
+            )
+            assert "hunter2" not in reason
+            assert "hunt er2" not in reason
+            assert "password=<redacted>" in reason
+            assert "dbname=geolens" in reason, "only the secret is masked"
+
     def test_credentials_are_still_stripped(self) -> None:
         assert "hunter2" not in redact_failure_reason(
             IngestionError(
@@ -94,8 +111,10 @@ class TestTheHelperRefusesWhatDecision3Forbids:
 
     def test_provenance_is_the_test_not_the_shape(self) -> None:
         assert is_composed_exception(IngestionError("composed here"))
+        # The upload size refusal, which reaches the user through the dialog.
+        assert is_composed_exception(ValueError("File size (9.0 MB) exceeds"))
         assert not is_composed_exception(_driver_error())
-        assert not is_composed_exception(ValueError("composed by nobody in particular"))
+        assert not is_composed_exception(RuntimeError("osgeo raises these"))
 
     def test_a_coded_reason_names_the_class_and_not_the_message(self) -> None:
         reason = coded_failure_reason("Failed to queue refresh task", _driver_error())
@@ -114,6 +133,41 @@ def _function(module_path: Path, name: str) -> ast.FunctionDef | ast.AsyncFuncti
     ]
     assert len(found) == 1, f"{name} not found once in {module_path}"
     return found[0]
+
+
+_SANCTIONED_REDACTORS = frozenset(
+    {
+        "redact_failure_reason",
+        "redact_run_error",
+        "coded_failure_reason",
+        # analysis/tasks.py's SQLSTATE-to-sentence mapper, the same argument
+        # made for the PostGIS strategy in ADR-002 Decision 3.
+        "_user_error_message",
+    }
+)
+
+
+def _reason_values(tree: ast.AST) -> list[ast.expr]:
+    """Every expression assigned to an ``error_message``, however spelled."""
+    values: list[ast.expr] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            values += [kw.value for kw in node.keywords if kw.arg == "error_message"]
+        elif isinstance(node, ast.Dict):
+            values += [
+                value
+                for key, value in zip(node.keys, node.values)
+                if isinstance(key, ast.Constant) and key.value == "error_message"
+            ]
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                named = isinstance(target, ast.Name) and target.id == "error_message"
+                attr = (
+                    isinstance(target, ast.Attribute) and target.attr == "error_message"
+                )
+                if named or attr:
+                    values.append(node.value)
+    return values
 
 
 def _call_names(node: ast.AST) -> set[str]:
@@ -184,6 +238,55 @@ class TestEverySinkGoesThroughTheOneDoor:
         assert not [node for node in ast.walk(fn) if isinstance(node, ast.JoinedStr)], (
             "an f-string here is how #1947's payload reached the run row"
         )
+
+    def test_no_writer_anywhere_puts_an_exception_into_a_reason(self) -> None:
+        """The gate codex round 1 asked for: enumerate, do not list.
+
+        Every `error_message` value in `backend/app/` that mentions a name an
+        `except ... as` bound must reach a sanctioned redactor first. Bare
+        names are the sink's own argument and are redacted there.
+        """
+        offenders: list[str] = []
+        for module in sorted(_APP.rglob("*.py")):
+            tree = ast.parse(module.read_text())
+            caught = {
+                handler.name
+                for handler in ast.walk(tree)
+                if isinstance(handler, ast.ExceptHandler) and handler.name
+            }
+            if not caught:
+                continue
+            for value in _reason_values(tree):
+                if isinstance(value, ast.Name):
+                    continue
+                names = {n.id for n in ast.walk(value) if isinstance(n, ast.Name)}
+                if not names & caught:
+                    continue
+                if _call_names(value) & _SANCTIONED_REDACTORS:
+                    continue
+                offenders.append(
+                    f"{module.relative_to(_APP)}:{value.lineno} "
+                    f"{ast.unparse(value)[:60]}"
+                )
+        assert not offenders, offenders
+
+    def test_the_gate_above_can_see_a_violation(self) -> None:
+        """Its positive control: the shape it hunts, parsed the same way."""
+        tree = ast.parse(
+            "try:\n    pass\n"
+            "except Exception as exc:\n"
+            "    job.error_message = str(exc)\n"
+        )
+        caught = {
+            handler.name
+            for handler in ast.walk(tree)
+            if isinstance(handler, ast.ExceptHandler) and handler.name
+        }
+        values = _reason_values(tree)
+        assert len(values) == 1
+        names = {n.id for n in ast.walk(values[0]) if isinstance(n, ast.Name)}
+        assert names & caught
+        assert not _call_names(values[0]) & _SANCTIONED_REDACTORS
 
     def test_the_defer_guard_rollbacks_name_the_type_only(self) -> None:
         source = (_APP / "platform" / "jobs" / "defer_guard.py").read_text()

--- a/backend/tests/test_stored_failure_reason_1953.py
+++ b/backend/tests/test_stored_failure_reason_1953.py
@@ -20,6 +20,7 @@ from app.core.failure_reason import (
     MAX_REASON_CHARS,
     coded_failure_reason,
     is_composed_exception,
+    prefixed_failure_reason,
     redact_failure_reason,
 )
 from app.processing.ingest.ogr import IngestionError
@@ -71,12 +72,12 @@ class TestTheHelperRefusesWhatDecision3Forbids:
 
     def test_gdal_stderr_keeps_only_its_summary_line(self) -> None:
         exc = IngestionError(
-            "ogr2ogr failed (exit 1): ERROR 1: Cannot open datasource\n"
+            "ERROR 1: Cannot open datasource\n"
             "ogr2ogr -f PostgreSQL PG:dbname=geolens /app/staging/abc_roads.gpkg"
         )
         reason = redact_failure_reason(exc)
 
-        assert reason.endswith("Cannot open datasource")
+        assert reason == "ERROR 1: Cannot open datasource"
         assert "/app/staging" not in reason
 
     def test_a_wrapper_around_gdal_stderr_loses_the_libpq_password(self) -> None:
@@ -86,7 +87,7 @@ class TestTheHelperRefusesWhatDecision3Forbids:
         for rendered in ("password=hunter2", "password='hunt er2'"):
             reason = redact_failure_reason(
                 IngestionError(
-                    "ogr2ogr failed (exit 1): ERROR 1: Unable to connect: "
+                    "ERROR 1: Unable to connect: "
                     f"PG:host=db port=5432 dbname=geolens user=gl {rendered} "
                     "sslmode=require"
                 )
@@ -95,6 +96,69 @@ class TestTheHelperRefusesWhatDecision3Forbids:
             assert "hunt er2" not in reason
             assert "password=<redacted>" in reason
             assert "geolens" not in reason, "the topology goes with the secret"
+
+    def test_a_subprocess_diagnostic_ends_at_the_prefix_this_tree_composed(
+        self,
+    ) -> None:
+        """Scrubbing operands out of a command line cannot terminate: the
+        flags and the target table are operands too."""
+        reason = redact_failure_reason(
+            IngestionError(
+                "ogr2ogr failed (exit 1): ogr2ogr -f PostgreSQL PG:host=db "
+                "-nln tenant_private.roads /app/staging/file.gpkg"
+            )
+        )
+
+        assert reason == "ogr2ogr failed (exit 1)"
+        assert "tenant_private" not in reason
+        assert "-nln" not in reason
+
+        # The same command line with nothing composed in front of it leaves
+        # nothing worth storing.
+        assert (
+            redact_failure_reason(
+                IngestionError("ogr2ogr -f PostgreSQL PG:host=db /app/staging/f.gpkg")
+            )
+            == INTERNAL_FAILURE_REASON
+        )
+
+    def test_the_diagnostic_survives_what_the_command_line_does_not(self) -> None:
+        """The refusal half needs its admission. A remote service import that
+        is refused has the origin's status code as its only useful signal."""
+        assert redact_failure_reason(
+            IngestionError(
+                "ogr2ogr failed (exit 1): ERROR 1: HTTP error code : 400\n"
+                "ERROR 1: Unable to open datasource"
+            )
+        ) == ("ogr2ogr failed (exit 1): ERROR 1: HTTP error code : 400")
+
+    def test_naming_gdal_in_prose_is_not_a_command_line(self) -> None:
+        """The cut's negative control: an invocation is followed by a flag or
+        an operand, a mention by a word."""
+        message = "GDAL error: the layer has no geometry column"
+        assert redact_failure_reason(IngestionError(message)) == message
+
+    def test_a_prefix_never_wraps_the_code(self) -> None:
+        """A reader localizes the code by matching it exactly, so a sentence
+        around it is a sentence nobody can translate."""
+        assert (
+            prefixed_failure_reason("Failed to stage manifest source", _driver_error())
+            == INTERNAL_FAILURE_REASON
+        )
+        assert prefixed_failure_reason(
+            "Failed to stage manifest source", ValueError("the archive is empty")
+        ) == ("Failed to stage manifest source: the archive is empty")
+
+    def test_a_decoder_complaint_is_not_this_tree_s_text(self) -> None:
+        """`UnicodeDecodeError` is a `ValueError` a library raises, and its
+        message renders the byte the decoder choked on."""
+        try:
+            b"\xff\xfe".decode()
+        except UnicodeDecodeError as exc:
+            assert not is_composed_exception(exc)
+            assert redact_failure_reason(exc) == INTERNAL_FAILURE_REASON
+        else:  # pragma: no cover
+            raise AssertionError("precondition: the decode must fail")
 
     def test_a_one_line_gdal_echo_keeps_no_path_and_no_topology(self) -> None:
         """The whole leak fits on one line, so the summary cut removes none of
@@ -107,12 +171,9 @@ class TestTheHelperRefusesWhatDecision3Forbids:
             )
         )
 
-        assert "hunter2" not in reason
-        for keyword in ("host", "port", "dbname", "user", "password"):
-            assert f"{keyword}=<redacted>" in reason
-        assert "geolens" not in reason
-        assert "/app/staging" not in reason
-        assert "9f2_roads.gpkg" not in reason
+        assert reason == INTERNAL_FAILURE_REASON
+        for leaked in ("hunter2", "geolens", "/app/staging", "9f2_roads.gpkg"):
+            assert leaked not in reason
 
     def test_a_vsi_handle_is_a_path_too(self) -> None:
         reason = redact_failure_reason(
@@ -189,6 +250,7 @@ def _function(module_path: Path, name: str) -> ast.FunctionDef | ast.AsyncFuncti
 _SANCTIONED_REDACTORS = frozenset(
     {
         "redact_failure_reason",
+        "prefixed_failure_reason",
         "redact_run_error",
         "coded_failure_reason",
         # analysis/tasks.py's SQLSTATE-to-sentence mapper, the same argument

--- a/backend/tests/test_vrt_creation_173.py
+++ b/backend/tests/test_vrt_creation_173.py
@@ -658,7 +658,9 @@ class TestCreateVrtJob:
             # Job was marked failed before the exception propagated.
             assert stub_job.status == "failed"
             assert stub_job.error_message is not None
-            assert "procrastinate unreachable" in stub_job.error_message
+            # fix(#1953): the stored reason names the class, never the raw text.
+            assert "procrastinate unreachable" not in stub_job.error_message
+            assert "RuntimeError" in stub_job.error_message
             assert stub_job.completed_at is not None
             # Three commits: one after create_ingest_job, one for the #1744
             # dispatch stamp the orphan guard writes before it defers, and one

--- a/frontend/src/components/admin/JobList.tsx
+++ b/frontend/src/components/admin/JobList.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useCallback, useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { describeFailureReason } from '@/lib/failure-reason';
 import { useLocation, useSearchParams } from 'react-router';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useAdminJobs, useCancelAdminJob, useRetryAdminJob, useUserNames } from '@/hooks/use-admin';
@@ -437,7 +438,10 @@ export function JobList() {
                                     {t('jobs.detail.errorMessage')}
                                   </p>
                                   <pre className="whitespace-pre-wrap overflow-x-auto text-xs">
-                                    {job.error_message}
+                                    {describeFailureReason(
+                                      job.error_message,
+                                      t('common:errors.unexpected'),
+                                    )}
                                   </pre>
                                 </div>
                               )}

--- a/frontend/src/components/analysis/AnalysisJobWatcher.tsx
+++ b/frontend/src/components/analysis/AnalysisJobWatcher.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { INTERNAL_FAILURE_REASON } from '@/lib/failure-reason';
 import { useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -210,7 +211,9 @@ export function AnalysisJobWatcher() {
             { id: toastId },
           );
         } else {
-          const message = data?.error_message;
+          // fix(#1953): the coded reason is not a detail worth showing.
+          const reason = data?.error_message;
+          const message = reason === INTERNAL_FAILURE_REASON ? null : reason;
           // Interpolate the detail through i18n rather than concatenating onto
           // t(): check:i18n:toast-strings flags any toast call whose first
           // argument opens with a quote or backtick, template literals included.

--- a/frontend/src/components/builder/AnalysisPanel.tsx
+++ b/frontend/src/components/builder/AnalysisPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { INTERNAL_FAILURE_REASON } from '@/lib/failure-reason';
 import { useMutation } from '@tanstack/react-query';
 import { TerraDraw, TerraDrawPolygonMode } from 'terra-draw';
 import { TerraDrawMapLibreGLAdapter } from 'terra-draw-maplibre-gl-adapter';
@@ -1917,7 +1918,10 @@ export function AnalysisPanel({
                     // rather than concatenating the raw server error onto a
                     // translated prefix, which left half the sentence untranslated.
                     job.status === 'failed'
-                    ? job.error_message
+                    ? // fix(#1953): the coded reason is not a detail worth
+                      // showing; the plain line below already says it failed.
+                      job.error_message &&
+                      job.error_message !== INTERNAL_FAILURE_REASON
                       ? t('analysisTools.jobFailedDetail', {
                           defaultValue: 'Analysis job failed: {{message}}',
                           message: job.error_message,

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -66,6 +66,11 @@ type ReuploadStep =
   | 'error';
 
 
+// fix(#1953): the code ADR-002 Decision 3 stores in place of a failure the
+// server did not compose (backend/app/core/failure_reason.py). Rendering it
+// raw would put an untranslated identifier in front of the user.
+const INTERNAL_FAILURE_REASON = 'internal_error';
+
 const AUTH_ERROR_HINTS = [
   '401',
   '403',
@@ -263,7 +268,11 @@ export function ReuploadDialog({
         cancelled = true;
       };
     } else if (jobData.status === 'failed') {
-      const message = jobData.error_message ?? t('reupload.jobFailed');
+      const reason = jobData.error_message;
+      const message =
+        !reason || reason === INTERNAL_FAILURE_REASON
+          ? t('reupload.jobFailed')
+          : reason;
       setError(
         sourceType === 'service_url'
           ? appendRetryGuidance(message)

--- a/frontend/src/components/dataset/ReuploadDialog.tsx
+++ b/frontend/src/components/dataset/ReuploadDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { useJobStatus, useUploadConfig } from '@/components/import/hooks/use-ingest';
 import { queryKeys } from '@/lib/query-keys';
 import { buildAcceptMap, deriveFormatBadges } from '@/lib/file-utils';
+import { describeFailureReason } from '@/lib/failure-reason';
 import { SchemaDiffView } from './SchemaDiffView';
 import {
   Dialog,
@@ -65,11 +66,6 @@ type ReuploadStep =
   | 'complete'
   | 'error';
 
-
-// fix(#1953): the code ADR-002 Decision 3 stores in place of a failure the
-// server did not compose (backend/app/core/failure_reason.py). Rendering it
-// raw would put an untranslated identifier in front of the user.
-const INTERNAL_FAILURE_REASON = 'internal_error';
 
 const AUTH_ERROR_HINTS = [
   '401',
@@ -269,10 +265,9 @@ export function ReuploadDialog({
       };
     } else if (jobData.status === 'failed') {
       const reason = jobData.error_message;
-      const message =
-        !reason || reason === INTERNAL_FAILURE_REASON
-          ? t('reupload.jobFailed')
-          : reason;
+      const message = reason
+        ? describeFailureReason(reason, t('reupload.jobFailed'))
+        : t('reupload.jobFailed');
       setError(
         sourceType === 'service_url'
           ? appendRetryGuidance(message)

--- a/frontend/src/components/dataset/SourcePanel.tsx
+++ b/frontend/src/components/dataset/SourcePanel.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { describeFailureReason } from '@/lib/failure-reason';
 import { Link } from 'react-router';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
@@ -372,7 +373,12 @@ function RefreshRunHistory({ dataset, canEdit }: { dataset: DatasetResponse; can
                   : ''}
               </p>
               {run.status === 'failed' && run.error_message && (
-                <p className="mt-1 text-xs text-destructive">{run.error_message}</p>
+                <p className="mt-1 text-xs text-destructive">
+                  {describeFailureReason(
+                    run.error_message,
+                    t('common:errors.unexpected'),
+                  )}
+                </p>
               )}
             </li>
           ))}

--- a/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
+++ b/frontend/src/components/dataset/__tests__/ReuploadDialog.test.tsx
@@ -1561,4 +1561,43 @@ describe('ReuploadDialog raster reupload', () => {
     // Reset really did win: still on the reset source-selector screen.
     expect(screen.getByTestId('reupload-source-selector')).toBeInTheDocument();
   });
+
+  // fix(#1953): ADR-002 Decision 3 stores `internal_error` in place of a
+  // failure the server did not compose, so the dialog is the surface that
+  // has to turn that code into something a reader understands.
+  it('renders the localized line for the coded internal failure', async () => {
+    const user = userEvent.setup();
+    mockUseJobStatus.mockReturnValue({
+      data: { status: 'failed', error_message: 'internal_error' },
+    } as unknown as ReturnType<typeof useJobStatus>);
+    renderRasterDialog();
+
+    await openFileSource(user);
+    await dropFile('ortho.tif');
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    expect(await screen.findByText('Re-upload job failed.')).toBeInTheDocument();
+    expect(screen.queryByText('internal_error')).not.toBeInTheDocument();
+  });
+
+  it('still shows a composed failure message verbatim', async () => {
+    const user = userEvent.setup();
+    mockUseJobStatus.mockReturnValue({
+      data: {
+        status: 'failed',
+        error_message: "Layer 'parcels' has no geometry column",
+      },
+    } as unknown as ReturnType<typeof useJobStatus>);
+    renderRasterDialog();
+
+    await openFileSource(user);
+    await dropFile('ortho.tif');
+    await screen.findByRole('button', { name: 'Confirm Re-Upload' });
+    await user.click(screen.getByRole('button', { name: 'Confirm Re-Upload' }));
+
+    expect(
+      await screen.findByText("Layer 'parcels' has no geometry column"),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/import/JobProgress.tsx
+++ b/frontend/src/components/import/JobProgress.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
+import { describeFailureReason } from '@/lib/failure-reason';
 import {
   useJobStatus,
   useRetryJob,
@@ -316,7 +317,9 @@ export function JobProgress({ jobId, onReset, isRasterEntry = false }: JobProgre
         {job.status === 'failed' && (
           <div className="space-y-3">
             {job.error_message && (
-              <p className="text-sm text-destructive">{job.error_message}</p>
+              <p className="text-sm text-destructive">
+                {describeFailureReason(job.error_message, t('common:errors.unexpected'))}
+              </p>
             )}
             {job.retry_reason && (
               <p className="text-sm text-muted-foreground">{job.retry_reason}</p>

--- a/frontend/src/lib/__tests__/failure-reason.test.ts
+++ b/frontend/src/lib/__tests__/failure-reason.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { INTERNAL_FAILURE_REASON, describeFailureReason } from '@/lib/failure-reason';
+
+describe('describeFailureReason', () => {
+  it('replaces the coded reason with the localized line', () => {
+    expect(describeFailureReason(INTERNAL_FAILURE_REASON, 'Something went wrong')).toBe(
+      'Something went wrong',
+    );
+  });
+
+  it('leaves a message the server composed alone', () => {
+    const composed = "Layer 'parcels' has no geometry column";
+    expect(describeFailureReason(composed, 'Something went wrong')).toBe(composed);
+  });
+
+  it('pins the code the backend stores', () => {
+    // Mirrors INTERNAL_FAILURE_REASON in backend/app/core/failure_reason.py.
+    expect(INTERNAL_FAILURE_REASON).toBe('internal_error');
+  });
+});

--- a/frontend/src/lib/failure-reason.ts
+++ b/frontend/src/lib/failure-reason.ts
@@ -1,0 +1,12 @@
+/**
+ * fix(#1953): the code ADR-002 Decision 3 stores in place of a failure the
+ * server did not compose (`backend/app/core/failure_reason.py`). Every surface
+ * that renders a job or run reason maps it here, or the reader gets an
+ * untranslated identifier where a sentence belongs.
+ */
+export const INTERNAL_FAILURE_REASON = 'internal_error';
+
+/** The stored reason, or a localized line when the reason is only a code. */
+export function describeFailureReason(reason: string, localizedFallback: string): string {
+  return reason === INTERNAL_FAILURE_REASON ? localizedFallback : reason;
+}


### PR DESCRIPTION
## Summary

ADR-002 Decision 3 says a stored reason string carries no raw exception, no
credentialed URL and no GDAL command line. Two of the three were enforced. #1947 is
the live case for the third: a bounded catalog wait expired as SQLSTATE `57014`, a
bare `DBAPIError` propagated, and its rendering was stored with the SQL statement and
its bound parameters in it. Measured on `main`, that path stores 262 characters
carrying both. It reaches a run row and the ingest job the re-upload dialog renders.

The fix is at the sink rather than at each caller, because the next careless caller is
the failure mode. `backend/app/core/failure_reason.py` is the one door. It decides by
provenance: an exception class defined outside `app.` carries a library's text, not a
message this codebase composed, so the sink stores the code `internal_error` instead
of it. Text a caller already flattened keeps its first line only, which is where an
exception's own summary ends and its payload dump begins. Both paths still run the
credential redaction, and the ingest sink gains the exact-value secret scrub it did
not have.

ADR-002 4d had a second contradiction (#1954): the sweep's guard comment says
`cancelled` is never a stop signal while the module next to it writes one for a user
cancel. The issue's reading holds up against #1677: the status has two writers,
`error_code` tells them apart, and the sweep's proof obligation binds only its own.
The decision text and the guard comment now say that, and the code is unchanged.

## Changes

- `core/failure_reason.py`: `redact_failure_reason` (provenance plus first line plus
  redaction plus the 2000-character cap) and `coded_failure_reason`, which names an
  exception's class and never its message.
- Run rows: `redact_run_error` delegates to the helper and accepts the exception
  itself; `make_refresh_run_failed_rollback` stops interpolating `defer_exc`.
- `ingest_jobs.error_message`: the shared terminal-write site hands the exception to
  the helper instead of `redact_url_credentials(str(exc))`.
- `defer_guard.py`: the three job writers and the VRT generation writer name the
  exception's class, extending #1755's `cause_class` argument to the durable row.
- Every other terminal writer, after codex round 1: the six `record_refresh_failure`
  callers pass the exception rather than `str(exc)`, and the writes that go straight to
  a row wrap it. That covers `tasks_raster.py`, `tasks_vrt.py`, `tasks_vector.py`,
  `tasks_reupload.py`, `tasks_raster_replace.py`, `tasks_postgis_refresh.py`,
  `tasks_stac_refresh.py`, `url_import_staging.py`, `processing/ingest/router.py` and
  `router_reupload.py`.
- `redact_libpq_credentials`: GDAL echoes the `PG:` destination it was handed, and that
  DSN carries a `password=` field that neither the URL nor the registered-secret
  scrubber recognizes. Provenance says whose rendering the text is, never what an
  app-owned wrapper embedded in it, so all three scrubbers run on every reason.
- After codex round 2: `release_manifest_reservation` redacts the reason it is handed,
  because it is a sink and its caller composes one from a `ManifestSourceError`. The
  gate's bare-name exemption went with it, which took three more pass-through writers in
  `backfill_jobs.py` and the stale-pending sweep.
- `frontend/src/lib/failure-reason.ts` holds the code-to-line mapping, read by the
  dialog, `JobProgress.tsx` and `SourcePanel.tsx`, so no surface renders the code.
- After codex round 3: the scrubbers run on the summary line, and the whole-text pass is
  the cross-check rather than the source. Scrubbing the whole text first would take the
  payload cut with it, because `urlsplit` deletes the line breaks it depends on, so a
  summary that pass would have changed is refused and stored as the code.
- After codex round 4: the gate knows where each redacting sink keeps its message, so a
  positional argument is checked too, and the second manifest caller keeps provenance.
  `JobList.tsx`, `AnalysisPanel.tsx` and `AnalysisJobWatcher.tsx` also map the code; an
  analysis job is an `ingest_jobs` row, so it can carry one.
- After codex round 5: the third clause, no GDAL command line. The libpq pass masks
  every keyword value rather than the secret ones, since the host and database are the
  topology, and a new pass masks absolute paths, covering staging paths and `/vsi`
  handles alike. A URL keeps its own path.
- After codex round 6: the reason ends at a GDAL invocation rather than at its operands,
  since the flags and the target table are operands too. GDAL's own `ERROR n:`
  diagnostic sits before the invocation and survives, which is what keeps a refused
  service import readable. `prefixed_failure_reason` stops a prefix wrapping the code.
- `ValueError` is admitted as itself and not as a base class. It is this tree's spelling
  for a refusal the user is meant to read, `validate_file_size` raises one the dialog
  shows, and a library's subclass is still a library's text.
- `ReuploadDialog.tsx` renders the localized failure line for the code. No new
  strings: it reuses `reupload.jobFailed`, which exists in all four locales.
- ADR-002: Decision 3 gains the sink rule and `ingest_jobs.error_message`; 4d gains
  the two-writer resolution; the four divergences these close are removed.

## Area

- [x] Backend (API, services, models)
- [x] Frontend (UI, components, hooks)
- [x] Import / Ingestion
- [x] Docs / Config

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)

New: `backend/tests/test_stored_failure_reason_1953.py` and
`backend/tests/test_cancelled_run_writers_1954.py`. The first holds the helper's
behaviour, a database-backed run-row assertion, and a tree-wide AST gate:
any `error_message` value in `backend/app/` that mentions a name an `except ... as`
bound must reach a sanctioned redactor. The gate enumerates rather than lists, so a new
writer is caught by construction, and it carries a positive control that parses the
shape it hunts.

Counterfactuals actually run, with the fix reverted: 3 of the 1953 tests fail,
including the database-backed one; 8 of `test_defer_orphan_guard.py` fail; the
dialog's new vitest fails; the 4d comment test fails.

Backend, on the host at migration heads: `test_stored_failure_reason_1953.py`,
`test_cancelled_run_writers_1954.py`, `test_defer_orphan_guard.py`, `test_ingest.py`,
`test_dataset_refresh_runs.py`, `test_job_cancel_*.py`, `test_reupload*.py`,
`test_ingest_vector_failure_tails.py`, `test_service_auth_transport_1746.py`,
`test_url_redaction_sec.py`, `test_service_token_redaction_1277.py`,
`test_layering.py`, `test_rule1_structural.py`. `ruff check` and `ruff format
--check` clean; `python3 backend/tests/finding_markers.py` clean, and
`platform/refresh/service.py` leaves `UNANCHORED_MARKER_DEBT`.

Frontend: `npm run typecheck`, `npm run lint`, `npm run test:i18n`, and the vitest files
for the dialog, `JobProgress`, `SourcePanel` and the new `failure-reason` helper.

Behaviour change worth flagging: a library exception reaching a sink now stores
`internal_error` rather than its own text. `IngestionError` and `ValueError` are both
admitted, so the messages a user reads are unaffected; three test fixtures that stood in
with `RuntimeError` where production raises `IngestionError` were moved to that type.

Eight `_MODULE_LOC_CAPS` entries move by one line each, the import of the redactor, and
each is re-measured to the file's exact size.

## Deferred

Two consumers outside this PR's surface print `internal_error` verbatim rather than
mapping it: the CLI's job and run views, and the ingest-failure notification's reason.
The fix is a mapping they share, the way `lib/failure-reason.ts` is shared by the four
React readers. Both print a stable code today instead of a database exception's
statement and parameters, so nothing regresses by leaving it.

GDAL's own diagnostic can name a source inside its own sentence, which neither the
scrubbers nor the invocation cut reach. Closing that means composing a message per failure class in `ogr.py`, the
way `_friendly_open_failure_message` already does for the open-failure class, and it is
a different change with its own regression surface. `main` stores the whole multi-line
stderr today, so this PR is strictly narrower than what ships.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: no new user-facing strings
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [x] No migration needed
- [x] No secrets or credentials in the diff

Closes #1953
Closes #1954
