### PR TITLE
fix(ingest,vrt): bound the remaining worker error writes and the VRT failure lifecycle

### DIFF
--- a/.github/ADR-002.md
+++ b/.github/ADR-002.md
@@ -196,17 +196,27 @@ endpoint, `add_vrt_source`, `remove_vrt_source`) instead share `admit_vrt_mutati
 `pg_try_advisory_xact_lock` and re-reads the `RasterAsset` status under it.
 
 Taking the lock before the read is the whole mechanism. Read first and the loser's
-snapshot still says the VRT is idle, which is how all three doors used to let two
-regenerations dispatch at once. What the row lock serialises inside the worker after
-that is unchanged (#1938).
+snapshot still says the VRT is idle. The two source doors took no lock at all, so two
+concurrent calls both dispatched; the regenerate door held one from after its read until
+its commit, which refuses a simultaneous caller but not one arriving in the window just
+after. What the row lock serialises inside the worker after that is unchanged (#1938).
 
-Two differences from the index-based refusal, recorded rather than smoothed over. The
-409 carries a message, not the `dataset_busy` code, so a client cannot tell the two
-refusals apart programmatically. And the two admission systems do not see each other: a
-refresh and a VRT regeneration on one dataset would each admit the other. Nothing
-reaches that state today, because a dataset with a VRT asset is exactly the origin kind
-`refresh_not_applicable` refuses. The generation row is this path's run row and
-`sweep_stale_vrt_assets` is its abandoned-run sweep.
+The refusal carries the same 409 and the same `dataset_busy` code as the index-based one,
+so a client cannot tell which system refused it and does not need to.
+
+**Why one lock is enough, rather than the key some other mutation holds.** The two
+admission systems do not see each other, so they would each admit the other on one
+dataset. That is safe only while no `create_pending_run` door can target a VRT, and both
+doors refuse one before they reach the insert. The refresh doors gate on
+`classify_origin`, which returns NULL for `vrt_dataset` (it is in
+`_ORIGINLESS_RECORD_TYPES`), so all three answer 409 `refresh_not_applicable`. The
+re-upload door, which also carries raster replace, refuses `vrt_dataset` with 400 in
+`_assert_compatible_record_type`, above its `create_pending_run` call. Both checks are
+pinned by `backend/tests/test_vrt_admission_1955.py`; if either stops holding, VRT
+regeneration must join Decision 5b's index rather than keep a lock of its own.
+
+The generation row is this path's run row and `sweep_stale_vrt_assets` is its
+abandoned-run sweep.
 
 #### 5c
 

--- a/.github/ADR-002.md
+++ b/.github/ADR-002.md
@@ -187,6 +187,27 @@ and the INSERT, and that window is exactly where a double-click lands: the loser
 race would otherwise reach the worker and discover the winner at the advisory lock, with
 both jobs already queued.
 
+**VRT regeneration is admitted separately, and this document does not claim otherwise.**
+(#1955) It mutates a dataset and dates `last_refreshed_at` under 5a, but it writes no
+`dataset_refresh_runs` row: a VRT has no origin of its own, `origin_kind` has no spelling
+for it, and the run table's CHECK would reject one. Its three doors (the regenerate
+endpoint, `add_vrt_source`, `remove_vrt_source`) instead share `admit_vrt_mutation` in
+`backend/app/platform/catalog_locks.py`, which takes a per-dataset
+`pg_try_advisory_xact_lock` and re-reads the `RasterAsset` status under it.
+
+Taking the lock before the read is the whole mechanism. Read first and the loser's
+snapshot still says the VRT is idle, which is how all three doors used to let two
+regenerations dispatch at once. What the row lock serialises inside the worker after
+that is unchanged (#1938).
+
+Two differences from the index-based refusal, recorded rather than smoothed over. The
+409 carries a message, not the `dataset_busy` code, so a client cannot tell the two
+refusals apart programmatically. And the two admission systems do not see each other: a
+refresh and a VRT regeneration on one dataset would each admit the other. Nothing
+reaches that state today, because a dataset with a VRT asset is exactly the origin kind
+`refresh_not_applicable` refuses. The generation row is this path's run row and
+`sweep_stale_vrt_assets` is its abandoned-run sweep.
+
 #### 5c
 
 Not recovered. Cited once, in the module docstring of

--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -36,6 +36,7 @@ from app.modules.catalog.datasets.domain.models import Dataset
 from app.modules.catalog.datasets.domain.service import get_dataset
 from app.core.db.tenant_session import current_tenant_var, defer_async_with_tenant
 from app.core.dependencies import get_db
+from app.platform.catalog_locks import admit_vrt_mutation
 from app.platform.extensions import get_catalog_port, get_permission_extension
 from app.modules.catalog.sources.origin_probe import remote_asset_exists
 from app.platform.storage.titiler_url import resolve_storage_key
@@ -46,10 +47,6 @@ router = APIRouter(
 )
 
 VrtMutationResponse = get_catalog_port().vrt_mutation_response_model()
-
-
-def _advisory_lock_key(dataset_id: uuid.UUID) -> int:
-    return dataset_id.int % (2**63)
 
 
 async def _load_source_datasets(
@@ -459,21 +456,10 @@ async def regenerate_vrt_endpoint(
             status_code=status.HTTP_404_NOT_FOUND, detail="VRT asset not found"
         )
 
-    # Status check
-    if vrt_asset.status == "regenerating":
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="VRT is currently regenerating",
-        )
-
-    # Advisory lock
-    lock_key = _advisory_lock_key(dataset_id)
-    lock_result = await db.execute(
-        text("SELECT pg_try_advisory_xact_lock(:key)"),
-        {"key": lock_key},
-    )
-    acquired = lock_result.scalar()
-    if not acquired:
+    # fix(#1955): the lock, then the status re-read under it. The two used to
+    # be a status check followed by a lock, which leaves the window the second
+    # of two concurrent triggers lands in.
+    if not await admit_vrt_mutation(db, dataset_id, vrt_asset):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Another regeneration is in progress",

--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -462,7 +462,10 @@ async def regenerate_vrt_endpoint(
     if not await admit_vrt_mutation(db, dataset_id, vrt_asset):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="Another regeneration is in progress",
+            detail={
+                "code": "dataset_busy",
+                "message": "Another regeneration is in progress",
+            },
         )
 
     # Count sources

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -1,12 +1,14 @@
-"""The one lock order for the (datasets, records) row pair (#1847).
+"""The one lock order for the (datasets, records) row pair (#1847), and the
+per-dataset admission lock VRT regeneration serialises on (#1955).
 
 Lives in ``platform/`` because ``processing/`` may not import
 ``app.modules.catalog``: worker callers pass the mapped classes the port hands
-them.
+them, and both the catalog and the ingest router reach the VRT admission here.
 """
 
 from __future__ import annotations
 
+import uuid
 from contextvars import ContextVar
 from typing import Any
 
@@ -14,6 +16,7 @@ from sqlalchemy import event, func, select, text, update
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import set_committed_value
+from sqlalchemy.orm.exc import ObjectDeletedError
 
 from app.core.db.sqlstate import is_lock_conflict, sqlstate
 
@@ -239,13 +242,13 @@ async def bump_tile_cache_version_on(session: AsyncSession, dataset: Any) -> int
     return version
 
 
-def vrt_admission_lock_key(dataset_id: Any) -> int:
+def vrt_admission_lock_key(dataset_id: uuid.UUID) -> int:
     """The advisory-lock key a dataset's VRT mutations serialise on."""
     return dataset_id.int % (2**63)
 
 
 async def admit_vrt_mutation(
-    session: AsyncSession, dataset_id: Any, vrt_asset: Any
+    session: AsyncSession, dataset_id: uuid.UUID, vrt_asset: Any
 ) -> bool:
     """Admit one VRT-mutating dispatch per dataset, or refuse this one.
 
@@ -264,5 +267,10 @@ async def admit_vrt_mutation(
     )
     if not acquired:
         return False
-    await session.refresh(vrt_asset)
+    try:
+        await session.refresh(vrt_asset)
+    except ObjectDeletedError:
+        # Deleted between the caller's load and this re-read. Refusing is the
+        # honest answer: there is no asset left to mutate.
+        return False
     return vrt_asset.status != "regenerating"

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -237,3 +237,32 @@ async def bump_tile_cache_version_on(session: AsyncSession, dataset: Any) -> int
     if version is not None:
         set_committed_value(dataset, "tile_cache_version", version)
     return version
+
+
+def vrt_admission_lock_key(dataset_id: Any) -> int:
+    """The advisory-lock key a dataset's VRT mutations serialise on."""
+    return dataset_id.int % (2**63)
+
+
+async def admit_vrt_mutation(
+    session: AsyncSession, dataset_id: Any, vrt_asset: Any
+) -> bool:
+    """Admit one VRT-mutating dispatch per dataset, or refuse this one.
+
+    fix(#1955): ADR-002 Decision 5b's partial unique index does not reach VRT
+    regeneration, and the three doors that dispatch one read the asset status,
+    check it and flip it as three statements. The lock comes FIRST and the
+    status is re-read under it: read before the lock, the loser's snapshot
+    still says the VRT is idle and both attempts dispatch.
+
+    The lock is released at the caller's commit, by which point the winner has
+    left ``regenerating`` on the asset, which is what refuses the next caller.
+    """
+    acquired = await session.scalar(
+        text("SELECT pg_try_advisory_xact_lock(:key)"),
+        {"key": vrt_admission_lock_key(dataset_id)},
+    )
+    if not acquired:
+        return False
+    await session.refresh(vrt_asset)
+    return vrt_asset.status != "regenerating"

--- a/backend/app/platform/catalog_locks.py
+++ b/backend/app/platform/catalog_locks.py
@@ -13,10 +13,9 @@ from contextvars import ContextVar
 from typing import Any
 
 from sqlalchemy import event, func, select, text, update
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import set_committed_value
-from sqlalchemy.orm.exc import ObjectDeletedError
 
 from app.core.db.sqlstate import is_lock_conflict, sqlstate
 
@@ -269,8 +268,9 @@ async def admit_vrt_mutation(
         return False
     try:
         await session.refresh(vrt_asset)
-    except ObjectDeletedError:
-        # Deleted between the caller's load and this re-read. Refusing is the
-        # honest answer: there is no asset left to mutate.
+    except InvalidRequestError:
+        # Deleted between the caller's load and this re-read. `refresh` reports
+        # that as InvalidRequestError, not the ObjectDeletedError its subclass
+        # name suggests; refusing beats a 500 on a row that is gone.
         return False
     return vrt_asset.status != "regenerating"

--- a/backend/app/platform/jobs/heartbeat.py
+++ b/backend/app/platform/jobs/heartbeat.py
@@ -3,6 +3,7 @@
 import asyncio
 import re
 import uuid
+from contextlib import suppress
 from datetime import datetime, timezone
 
 import structlog
@@ -169,6 +170,44 @@ async def update_ingest_job_for_attempt(
         .values(**values)
     )
     return bool(result.rowcount)  # type: ignore[attr-defined]
+
+
+async def write_job_failure_for_attempt(
+    session: AsyncSession,
+    job_id: uuid.UUID,
+    attempt_id: uuid.UUID,
+    *,
+    values: dict[str, object],
+    task_name: str,
+) -> bool | None:
+    """Commit a fenced terminal job write under the error-write budget.
+
+    Returns whether the fence matched, or ``None`` when the write did not
+    happen at all and the transaction was ended: the budget expired or the
+    connection went. Never raises, because every caller reaches it from a
+    failure path where a raise would replace the cause with a lock timeout.
+
+    fix(#1957): ``None`` is not a fence miss. A caller that treats it as one
+    drops cleanup that belongs to an attempt still owning the job row. On
+    ``None`` the row stays ``running`` for the stale sweep to settle.
+
+    Issue it AFTER any rollback on *session*: ``SET LOCAL`` dies with the
+    transaction, so a budget armed before one is gone by the next statement.
+    """
+    from sqlalchemy.exc import DBAPIError
+
+    try:
+        await arm_job_error_write_budget(session)
+        fenced = await update_ingest_job_for_attempt(
+            session, job_id, attempt_id, values=values
+        )
+        await session.commit()
+        return fenced
+    except DBAPIError as write_failure:
+        with suppress(Exception):  # broad: best-effort, the caller keeps its cause
+            await session.rollback()
+        log_job_error_write_failure(write_failure, job_id=str(job_id), task=task_name)
+        return None
 
 
 async def require_ingest_job_update(

--- a/backend/app/platform/jobs/heartbeat.py
+++ b/backend/app/platform/jobs/heartbeat.py
@@ -194,16 +194,25 @@ async def write_job_failure_for_attempt(
     Issue it AFTER any rollback on *session*: ``SET LOCAL`` dies with the
     transaction, so a budget armed before one is gone by the next statement.
     """
-    from sqlalchemy.exc import DBAPIError
+    from sqlalchemy.exc import SQLAlchemyError
 
     try:
+        # The connection first, on its own deadline: `SET LOCAL` cannot bound a
+        # wait for the POOL, which on an exhausted pool is `db_pool_timeout`
+        # (30s) before any statement runs. Nothing is in flight yet, so this is
+        # the one point in the write that is safe to cancel.
+        await asyncio.wait_for(
+            session.connection(), timeout=JOB_ERROR_WRITE_TIMEOUT_MS / 1000
+        )
         await arm_job_error_write_budget(session)
         fenced = await update_ingest_job_for_attempt(
             session, job_id, attempt_id, values=values
         )
         await session.commit()
         return fenced
-    except DBAPIError as write_failure:
+    except (SQLAlchemyError, TimeoutError) as write_failure:
+        # Wider than DBAPIError: a pool timeout is a SQLAlchemyError, and
+        # letting one out would replace the failure the caller is handling.
         with suppress(Exception):  # broad: best-effort, the caller keeps its cause
             await session.rollback()
         log_job_error_write_failure(write_failure, job_id=str(job_id), task=task_name)

--- a/backend/app/platform/jobs/heartbeat.py
+++ b/backend/app/platform/jobs/heartbeat.py
@@ -117,13 +117,20 @@ JOB_ERROR_WRITE_TIMEOUT_MS = 10_000
 ERROR_WRITE_EXPIRY_CODES = ("57014", "55P03")
 
 
-def log_job_error_write_failure(exc: BaseException, *, job_id: str, task: str) -> None:
+def log_job_error_write_failure(
+    exc: BaseException,
+    *,
+    job_id: str,
+    task: str,
+    budget_ms: int | None = None,
+) -> None:
     """Record a failed terminal job write as its own event.
 
     The caller must swallow *exc* and re-raise whatever it was already handling:
     this write is secondary, and letting it out replaces the cause the operator
     needs with a lock timeout.
     """
+    budget_ms = JOB_ERROR_WRITE_TIMEOUT_MS if budget_ms is None else budget_ms
     code = sqlstate(exc)
     structlog.get_logger().warning(
         "job_error_write_timeout"
@@ -132,23 +139,27 @@ def log_job_error_write_failure(exc: BaseException, *, job_id: str, task: str) -
         job_id=job_id,
         task=task,
         sqlstate=code,
-        budget_ms=JOB_ERROR_WRITE_TIMEOUT_MS,
+        budget_ms=budget_ms,
     )
 
 
-async def arm_job_error_write_budget(session: AsyncSession) -> None:
+async def arm_job_error_write_budget(
+    session: AsyncSession, *, budget_ms: int | None = None
+) -> None:
     """Bound this transaction's wait on the job row at the error-write budget.
 
     Issue it on the transaction that carries the failure UPDATE and after any
     rollback on that session: ``SET LOCAL`` dies with the transaction, so an
     arm placed before a rollback or a commit is gone by the next statement.
+
+    fix(#1957 codex r4): ``budget_ms`` is for a caller that already sits under
+    an outer deadline. The shared budget is the default, not a floor.
     """
-    await session.execute(
-        text(f"SET LOCAL lock_timeout = {JOB_ERROR_WRITE_TIMEOUT_MS}")
-    )
-    await session.execute(
-        text(f"SET LOCAL statement_timeout = {JOB_ERROR_WRITE_TIMEOUT_MS}")
-    )
+    # Resolved here, not as a default: the module global is what a test
+    # patches, and a default argument would freeze it at import.
+    budget = JOB_ERROR_WRITE_TIMEOUT_MS if budget_ms is None else budget_ms
+    await session.execute(text(f"SET LOCAL lock_timeout = {int(budget)}"))
+    await session.execute(text(f"SET LOCAL statement_timeout = {int(budget)}"))
 
 
 async def update_ingest_job_for_attempt(
@@ -179,6 +190,7 @@ async def write_job_failure_for_attempt(
     *,
     values: dict[str, object],
     task_name: str,
+    budget_ms: int | None = None,
 ) -> bool | None:
     """Commit a fenced terminal job write under the error-write budget.
 
@@ -193,18 +205,20 @@ async def write_job_failure_for_attempt(
 
     Issue it AFTER any rollback on *session*: ``SET LOCAL`` dies with the
     transaction, so a budget armed before one is gone by the next statement.
+
+    A caller under an outer deadline passes a ``budget_ms`` that fits inside
+    it, or the deadline cancels this write before it can report anything.
     """
     from sqlalchemy.exc import SQLAlchemyError
 
+    budget_ms = JOB_ERROR_WRITE_TIMEOUT_MS if budget_ms is None else budget_ms
     try:
         # The connection first, on its own deadline: `SET LOCAL` cannot bound a
         # wait for the POOL, which on an exhausted pool is `db_pool_timeout`
         # (30s) before any statement runs. Nothing is in flight yet, so this is
         # the one point in the write that is safe to cancel.
-        await asyncio.wait_for(
-            session.connection(), timeout=JOB_ERROR_WRITE_TIMEOUT_MS / 1000
-        )
-        await arm_job_error_write_budget(session)
+        await asyncio.wait_for(session.connection(), timeout=budget_ms / 1000)
+        await arm_job_error_write_budget(session, budget_ms=budget_ms)
         fenced = await update_ingest_job_for_attempt(
             session, job_id, attempt_id, values=values
         )
@@ -215,7 +229,9 @@ async def write_job_failure_for_attempt(
         # letting one out would replace the failure the caller is handling.
         with suppress(Exception):  # broad: best-effort, the caller keeps its cause
             await session.rollback()
-        log_job_error_write_failure(write_failure, job_id=str(job_id), task=task_name)
+        log_job_error_write_failure(
+            write_failure, job_id=str(job_id), task=task_name, budget_ms=budget_ms
+        )
         return None
 
 

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -208,8 +208,9 @@ async def _fail_cancelled_job(
         logger.warning("analysis.cancel_rollback_failed", job_id=job_id)
 
     async with async_session() as session:
-        # fix(#1957): budgeted, so a held job row ends this write instead of
-        # eating the 15s shield the caller wrapped it in.
+        # fix(#1957): budgeted, so a held job row ends this write with a logged
+        # reason. The caller's 15s shield would otherwise cancel it silently,
+        # and the 5s rollback above leaves no margin for both to fire.
         fenced = await write_job_failure_for_attempt(
             session,
             uuid.UUID(job_id),

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -53,6 +53,7 @@ from app.platform.jobs.heartbeat import (
     resolve_ingest_job_attempt,
     stop_ingest_job_heartbeat,
     update_ingest_job_for_attempt,
+    write_job_failure_for_attempt,
 )
 from app.processing.ingest.metadata import _sql_quote_ident
 from app.processing.ingest.tasks import task_app
@@ -207,7 +208,9 @@ async def _fail_cancelled_job(
         logger.warning("analysis.cancel_rollback_failed", job_id=job_id)
 
     async with async_session() as session:
-        if not await update_ingest_job_for_attempt(
+        # fix(#1957): budgeted, so a held job row ends this write instead of
+        # eating the 15s shield the caller wrapped it in.
+        fenced = await write_job_failure_for_attempt(
             session,
             uuid.UUID(job_id),
             attempt_id,
@@ -220,8 +223,13 @@ async def _fail_cancelled_job(
                 # the jobs UI renders '-' and retention ages on queue time.
                 "completed_at": datetime.now(timezone.utc),
             },
-        ):
-            await session.rollback()
+            task_name="analysis_cancelled",
+        )
+        # fix(#1957): an expiry proves nothing about who owns the row, so the
+        # table is left for the sweep rather than probed — leak over loss.
+        if fenced is None:
+            return
+        if not fenced:
             # fix(#814): a swept row leaves an unregistered orphan. Probe for
             # an adopting dataset row; no row means the DROP is safe, and a
             # probe that errors leaks the table rather than dropping storage.
@@ -233,7 +241,6 @@ async def _fail_cancelled_job(
                 owner_job_uuid=uuid.UUID(job_id),
             )
             return
-        await session.commit()
         if out_table is not None:
             try:
                 await session.execute(
@@ -868,7 +875,9 @@ async def _mark_job_failed(
     dataset registered it.
     """
     await session.rollback()
-    if not await update_ingest_job_for_attempt(
+    # fix(#1957): budgeted, and armed after that rollback rather than before
+    # it — `SET LOCAL` dies with the transaction the rollback ends.
+    fenced = await write_job_failure_for_attempt(
         session,
         uuid.UUID(job_id),
         attempt_id,
@@ -879,8 +888,13 @@ async def _mark_job_failed(
             # fix(#813): stamp completion time like ingest does.
             "completed_at": datetime.now(timezone.utc),
         },
-    ):
-        await session.rollback()
+        task_name="analysis_materialize",
+    )
+    # fix(#1957): an expiry proves nothing about who owns the row, so the
+    # table is left for the sweep rather than probed — leak over loss.
+    if fenced is None:
+        return
+    if not fenced:
         logger.warning("analysis.failed_write_superseded", job_id=job_id)
         # fix(#813): a fence miss means another actor set a terminal state,
         # but only a completed job has adopted the table. Probe first; a probe
@@ -893,7 +907,6 @@ async def _mark_job_failed(
             owner_job_uuid=uuid.UUID(job_id),
         )
         return
-    await session.commit()
     if out_table is not None:
         try:
             await session.execute(

--- a/backend/app/processing/analysis/tasks.py
+++ b/backend/app/processing/analysis/tasks.py
@@ -145,6 +145,20 @@ ANALYSIS_JOBS = Counter(
 )
 
 
+# fix(#700): how long a graceful shutdown waits for the cancel bookkeeping
+# before giving up on it, and how much of that the lock release may take.
+CANCEL_CLEANUP_SECONDS = 15
+CANCEL_ROLLBACK_SECONDS = 5
+
+# fix(#1957 codex r4): DERIVED, so the two deadlines cannot drift apart. The
+# failure write spends its budget twice, on the pool checkout and again on the
+# UPDATE, and a second is left for scheduling. Sized this way the write always
+# reports why it gave up instead of being cancelled by the shield above it.
+CANCEL_WRITE_BUDGET_MS = int(
+    (CANCEL_CLEANUP_SECONDS - CANCEL_ROLLBACK_SECONDS - 1) / 2 * 1000
+)
+
+
 def _user_error_message(exc: Exception, *, registered: bool = False) -> str:
     """Map a failure onto text safe to return from ``GET /jobs/{job_id}``.
 
@@ -203,14 +217,16 @@ async def _fail_cancelled_job(
     # wedged connection cannot eat the shield window, or the fenced update below
     # waits on our own lock and the row strands in 'running'.
     try:
-        await asyncio.wait_for(working_session.rollback(), timeout=5)
+        await asyncio.wait_for(
+            working_session.rollback(), timeout=CANCEL_ROLLBACK_SECONDS
+        )
     except Exception:  # broad: cleanup must reach the fenced update regardless
         logger.warning("analysis.cancel_rollback_failed", job_id=job_id)
 
     async with async_session() as session:
-        # fix(#1957): budgeted, so a held job row ends this write with a logged
-        # reason. The caller's 15s shield would otherwise cancel it silently,
-        # and the 5s rollback above leaves no margin for both to fire.
+        # fix(#1957 codex r4): the clamped budget, not the shared one. This
+        # write is already under the caller's shield, and the shared 10s twice
+        # over plus the rollback above does not fit inside it.
         fenced = await write_job_failure_for_attempt(
             session,
             uuid.UUID(job_id),
@@ -225,6 +241,7 @@ async def _fail_cancelled_job(
                 "completed_at": datetime.now(timezone.utc),
             },
             task_name="analysis_cancelled",
+            budget_ms=CANCEL_WRITE_BUDGET_MS,
         )
         # fix(#1957): an expiry proves nothing about who owns the row, so the
         # table is left for the sweep rather than probed — leak over loss.
@@ -1339,7 +1356,7 @@ async def _materialize(
                             out_table=out_table if out_table_created else None,
                             operation=operation,
                         ),
-                        timeout=15,
+                        timeout=CANCEL_CLEANUP_SECONDS,
                     )
                 )
             except BaseException:  # broad: cleanup only; raise below keeps the abort

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -125,6 +125,7 @@ from app.processing.ingest.validation import (
     UnsafeUploadError,
     validate_file_content,
 )
+from app.platform.catalog_locks import admit_vrt_mutation
 from app.platform.jobs.defer_guard import (
     defer_with_orphan_guard,
     make_vrt_regeneration_failed_rollback,
@@ -1663,13 +1664,6 @@ async def add_vrt_source(
             detail=f"VRT dataset {dataset_id} not found",
         )
 
-    # SRC-05: mutation serialization guard.
-    if vrt_asset.status == "regenerating":
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="VRT is currently regenerating. Try again after the current operation completes.",
-        )
-
     source_result = await db.execute(
         select(RasterAsset)
         .join(Dataset, RasterAsset.dataset_id == Dataset.id)
@@ -1708,6 +1702,15 @@ async def add_vrt_source(
     await check_dataset_write_access(
         db, vrt_dataset, dataset_id, user, user_roles=user_roles
     )
+
+    # SRC-05 / fix(#1955): admission, not a status read — the check and the
+    # flip below are one sequence, and only the lock inside makes it atomic.
+    # After the write check, so a caller who may not mutate cannot hold it.
+    if not await admit_vrt_mutation(db, dataset_id, vrt_asset):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="VRT is currently regenerating. Try again after the current operation completes.",
+        )
 
     dup_result = await db.execute(
         text(
@@ -1872,8 +1875,8 @@ async def remove_vrt_source(
     vrt_dataset = await get_dataset(db, dataset_id)
     await check_dataset_write_access(db, vrt_dataset, dataset_id, user)
 
-    # SRC-05: mutation serialization guard.
-    if vrt_asset.status == "regenerating":
+    # SRC-05 / fix(#1955): admission, not a status read — see add_vrt_source.
+    if not await admit_vrt_mutation(db, dataset_id, vrt_asset):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="VRT is currently regenerating. Try again after the current operation completes.",

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -1709,7 +1709,13 @@ async def add_vrt_source(
     if not await admit_vrt_mutation(db, dataset_id, vrt_asset):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="VRT is currently regenerating. Try again after the current operation completes.",
+            detail={
+                "code": "dataset_busy",
+                "message": (
+                    "VRT is currently regenerating. Try again after the "
+                    "current operation completes."
+                ),
+            },
         )
 
     dup_result = await db.execute(
@@ -1879,7 +1885,13 @@ async def remove_vrt_source(
     if not await admit_vrt_mutation(db, dataset_id, vrt_asset):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="VRT is currently regenerating. Try again after the current operation completes.",
+            detail={
+                "code": "dataset_busy",
+                "message": (
+                    "VRT is currently regenerating. Try again after the "
+                    "current operation completes."
+                ),
+            },
         )
 
     # fix(#1327): read the current member set ONCE, in order — the count

--- a/backend/app/processing/ingest/tasks_postgis_refresh.py
+++ b/backend/app/processing/ingest/tasks_postgis_refresh.py
@@ -38,7 +38,7 @@ from app.platform.jobs.heartbeat import (
     require_ingest_job_update,
     resolve_ingest_attempt_or_skip,
     stop_ingest_job_heartbeat,
-    update_ingest_job_for_attempt,
+    write_job_failure_for_attempt,
 )
 from app.platform.refresh.service import (
     claim_run_for_job,
@@ -940,7 +940,10 @@ async def refresh_postgis(
         )
         error_code = getattr(exc, "error_code", _ERROR_CODE_GENERIC)
         async with async_session() as err_session:
-            await update_ingest_job_for_attempt(
+            # fix(#1957): the job row is the one a retry of this refresh
+            # contends for. An expiry leaves it `running` for the stale sweep
+            # and does not stop the refresh-run row below from recording why.
+            await write_job_failure_for_attempt(
                 err_session,
                 job_uuid,
                 attempt_uuid,
@@ -949,8 +952,8 @@ async def refresh_postgis(
                     "error_message": str(exc),
                     "completed_at": datetime.now(timezone.utc),
                 },
+                task_name="refresh_postgis",
             )
-            await err_session.commit()
             await stamp_failed_origin_health(
                 err_session,
                 Dataset,

--- a/backend/app/processing/ingest/tasks_raster_replace.py
+++ b/backend/app/processing/ingest/tasks_raster_replace.py
@@ -42,6 +42,7 @@ from app.platform.catalog_locks import (
     lock_conflict_report,
 )
 from app.platform.jobs.heartbeat import (
+    JOB_ERROR_WRITE_TIMEOUT_MS,
     claim_job_attempt_and_start_heartbeat,
     require_ingest_job_update,
     resolve_ingest_attempt_or_skip,
@@ -100,11 +101,6 @@ logger = structlog.get_logger(__name__)
 # caller gets control, then the catalog wait alone. Sized against holders of
 # the catalog rows, which are short writers, not against object-storage work.
 _PHASE2_TIMEOUT_MS = 30_000
-
-# fix(#1937): the failure write goes through the same ingest_jobs row phase 2
-# contends for. Its holders self-cap far below this (`cancel_job` at 2s; the
-# sweep and startup recovery use SKIP LOCKED), so a wait past it is stuck.
-_ERROR_WRITE_TIMEOUT_MS = 10_000
 
 
 @contextmanager
@@ -904,7 +900,7 @@ async def reupload_raster(
             job_uuid,
             phase="error_write",
             attempt_id=attempt_uuid,
-            lock_and_statement_timeout_ms=_ERROR_WRITE_TIMEOUT_MS,
+            lock_and_statement_timeout_ms=JOB_ERROR_WRITE_TIMEOUT_MS,
         ) as (err_session, _err_job):
             await update_ingest_job_for_attempt(
                 err_session,

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -40,7 +40,7 @@ from app.platform.jobs.heartbeat import (
     require_ingest_job_update,
     resolve_ingest_attempt_or_skip,
     stop_ingest_job_heartbeat,
-    update_ingest_job_for_attempt,
+    write_job_failure_for_attempt,
 )
 from app.platform.refresh.service import (
     claim_run_for_job,
@@ -660,7 +660,10 @@ async def refresh_stac(
         logger.exception("STAC refresh failed", job_id=job_id, task="refresh_stac")
         error_code = getattr(exc, "error_code", _ERROR_CODE_GENERIC)
         async with async_session() as err_session:
-            await update_ingest_job_for_attempt(
+            # fix(#1957): the job row is the one a retry of this refresh
+            # contends for. An expiry leaves it `running` for the stale sweep
+            # and does not stop the refresh-run row below from recording why.
+            await write_job_failure_for_attempt(
                 err_session,
                 job_uuid,
                 attempt_uuid,
@@ -669,8 +672,8 @@ async def refresh_stac(
                     "error_message": str(exc),
                     "completed_at": datetime.now(timezone.utc),
                 },
+                task_name="refresh_stac",
             )
-            await err_session.commit()
             health = getattr(exc, "health", None)
             await stamp_failed_origin_health(
                 err_session,

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -23,6 +23,7 @@ from sqlalchemy import select
 
 from app.platform.cache.tiles import invalidate_catalog_cache
 from app.platform.jobs.heartbeat import (
+    JOB_ERROR_WRITE_TIMEOUT_MS,
     arm_job_error_write_budget,
     claim_job_attempt_and_start_heartbeat,
     log_job_error_write_failure,
@@ -161,27 +162,47 @@ async def _settle_failed_vrt_asset(
     *generation_uuid*; on False the caller MUST leave the generation
     non-terminal, or the pair becomes unreachable to the stale sweep.
     """
+    import asyncio
+
+    from sqlalchemy import and_, or_, select
     from sqlalchemy import update as sa_update
 
     from app.core.db import async_session
-    from app.processing.raster.models import RasterAsset
+    from app.processing.raster.models import RasterAsset, VrtGeneration
 
-    fences = [RasterAsset.dataset_id == vrt_dataset_id]
+    # fix(#1962 codex r2/r3): the second arm is the whole rule, not a special
+    # case for a legacy delivery. A `regenerating` asset is released unless a
+    # LIVE generation owns it, because the sweep reaches an asset only through
+    # a pending/running generation. A phantom pointer left by a rolled-back
+    # phase 1, a NULL one, and one naming an already-terminal generation are
+    # all states nothing else can settle.
+    owned_by_a_live_generation = (
+        select(VrtGeneration.id)
+        .where(
+            VrtGeneration.id == RasterAsset.current_generation_id,
+            VrtGeneration.status.in_(("pending", "running")),
+        )
+        .exists()
+    )
+    arms = []
     if generation_uuid is not None:
-        fences.append(RasterAsset.current_generation_id == generation_uuid)
-    else:
-        fences.append(RasterAsset.current_generation_id.is_(None))
-        fences.append(RasterAsset.status == "regenerating")
+        arms.append(RasterAsset.current_generation_id == generation_uuid)
+    arms.append(and_(RasterAsset.status == "regenerating", ~owned_by_a_live_generation))
     try:
         async with async_session() as session:
+            # See `write_job_failure_for_attempt`: SET LOCAL cannot bound the
+            # pool checkout, and nothing is in flight yet, so it is bounded here.
+            await asyncio.wait_for(
+                session.connection(), timeout=JOB_ERROR_WRITE_TIMEOUT_MS / 1000
+            )
             await arm_job_error_write_budget(session)
             await session.execute(
                 sa_update(RasterAsset)
-                .where(*fences)
+                .where(RasterAsset.dataset_id == vrt_dataset_id, or_(*arms))
                 .values(status="failed", current_generation_id=None)
             )
             await session.commit()
-    except SQLAlchemyError as write_failure:
+    except (SQLAlchemyError, TimeoutError) as write_failure:
         # Wider than the budget's own DBAPIError: this runs OUTSIDE the
         # handler's try, so a pool timeout escaping here would replace the
         # build failure and skip the job write below.

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -143,6 +143,43 @@ async def _reap_superseded_generation_objects(
     )
 
 
+async def _settle_failed_vrt_asset(
+    vrt_dataset_id: uuid.UUID,
+    generation_uuid: uuid.UUID | None,
+    *,
+    job_id: str,
+) -> None:
+    """Repoint the VRT asset off a generation that failed, in its own transaction.
+
+    Fenced on the pointer, so a newer retry that already owns it keeps its
+    status. Does nothing when this attempt never bound a generation: there is
+    no pointer to release, and the fence would otherwise read as ``IS NULL``.
+
+    Never raises. The caller re-raises the build failure this settles.
+    """
+    from sqlalchemy import update as sa_update
+
+    from app.core.db import async_session
+    from app.processing.raster.models import RasterAsset
+
+    if generation_uuid is None:
+        return
+    try:
+        async with async_session() as session:
+            await arm_job_error_write_budget(session)
+            await session.execute(
+                sa_update(RasterAsset)
+                .where(
+                    RasterAsset.dataset_id == vrt_dataset_id,
+                    RasterAsset.current_generation_id == generation_uuid,
+                )
+                .values(status="failed", current_generation_id=None)
+            )
+            await session.commit()
+    except DBAPIError as write_failure:
+        log_job_error_write_failure(write_failure, job_id=job_id, task="regenerate_vrt")
+
+
 def _prior_generation_storage_keys_to_reap(
     *,
     vrt_key: str,
@@ -1519,15 +1556,18 @@ async def regenerate_vrt(
             job_id=job_id,
             task="regenerate_vrt",
         )
-        # Failure handler runs via a fresh session: mark vrt asset failed,
-        # mark generation failed, mark job failed.
+        # fix(#1962): the asset settles first and alone. `sweep_stale_vrt_assets`
+        # fences its asset UPDATE on the generations it just failed, so an asset
+        # still pointing at a terminal one is the state it can never reach.
+        await _settle_failed_vrt_asset(vrt_id, generation_uuid, job_id=job_id)
+        # The job and generation rows follow in one transaction. Losing both to
+        # a contended job row is recoverable: the sweep fails a generation whose
+        # heartbeat went stale, and the stale-job sweep settles the job.
         try:
             async with async_session() as err_session:
-                from sqlalchemy import update as sa_update
-
                 # fix(#1950): the publish wait above gives up on a held
                 # catalog row, so this handler runs while the job row may be
-                # contended too. All three writes below share the budget.
+                # contended too. Both writes below share the budget.
                 await arm_job_error_write_budget(err_session)
                 await update_ingest_job_for_attempt(
                     err_session,
@@ -1539,18 +1579,6 @@ async def regenerate_vrt(
                         "completed_at": datetime.now(timezone.utc),
                     },
                 )
-                # Mark only the asset that still points at this exact generation.
-                # If a newer retry owns the pointer, leave its status untouched.
-                await err_session.execute(
-                    sa_update(RasterAsset)
-                    .where(
-                        RasterAsset.dataset_id == vrt_id,
-                        RasterAsset.current_generation_id == generation_uuid,
-                    )
-                    .values(status="failed", current_generation_id=None)
-                )
-
-                # Update generation record on failure.
                 if generation_uuid is not None:
                     gen_result = await err_session.execute(
                         select(VrtGeneration).where(VrtGeneration.id == generation_uuid)

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -152,11 +152,10 @@ async def _settle_failed_vrt_asset(
 ) -> bool:
     """Release the VRT asset from the attempt that failed, in its own transaction.
 
-    Fenced on the pointer, so a newer retry that already owns it keeps its
-    status. fix(#1962 codex r2): a legacy delivery reaches here having bound no
-    generation, and the sweep finds assets only through one, so a NULL pointer
-    is settled too. That branch also fences on ``regenerating`` rather than the
-    pointer alone, which would fail an asset the sweep already restored.
+    Releases it when it points at *generation_uuid*, and otherwise when it is
+    ``regenerating`` with no live generation owning it. A newer attempt whose
+    generation is pending or running keeps the asset, and a ``ready`` one is
+    never touched.
 
     Never raises. Returns whether the asset is provably no longer pointing at
     *generation_uuid*; on False the caller MUST leave the generation

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -17,7 +17,7 @@ import uuid
 from datetime import datetime, timezone
 
 import structlog
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 
 from sqlalchemy import select
 
@@ -149,11 +149,13 @@ async def _settle_failed_vrt_asset(
     *,
     job_id: str,
 ) -> bool:
-    """Repoint the VRT asset off a generation that failed, in its own transaction.
+    """Release the VRT asset from the attempt that failed, in its own transaction.
 
     Fenced on the pointer, so a newer retry that already owns it keeps its
-    status. Does nothing when this attempt never bound a generation: there is
-    no pointer to release, and the fence would otherwise read as ``IS NULL``.
+    status. fix(#1962 codex r2): a legacy delivery reaches here having bound no
+    generation, and the sweep finds assets only through one, so a NULL pointer
+    is settled too. That branch also fences on ``regenerating`` rather than the
+    pointer alone, which would fail an asset the sweep already restored.
 
     Never raises. Returns whether the asset is provably no longer pointing at
     *generation_uuid*; on False the caller MUST leave the generation
@@ -164,21 +166,25 @@ async def _settle_failed_vrt_asset(
     from app.core.db import async_session
     from app.processing.raster.models import RasterAsset
 
-    if generation_uuid is None:
-        return True
+    fences = [RasterAsset.dataset_id == vrt_dataset_id]
+    if generation_uuid is not None:
+        fences.append(RasterAsset.current_generation_id == generation_uuid)
+    else:
+        fences.append(RasterAsset.current_generation_id.is_(None))
+        fences.append(RasterAsset.status == "regenerating")
     try:
         async with async_session() as session:
             await arm_job_error_write_budget(session)
             await session.execute(
                 sa_update(RasterAsset)
-                .where(
-                    RasterAsset.dataset_id == vrt_dataset_id,
-                    RasterAsset.current_generation_id == generation_uuid,
-                )
+                .where(*fences)
                 .values(status="failed", current_generation_id=None)
             )
             await session.commit()
-    except DBAPIError as write_failure:
+    except SQLAlchemyError as write_failure:
+        # Wider than the budget's own DBAPIError: this runs OUTSIDE the
+        # handler's try, so a pool timeout escaping here would replace the
+        # build failure and skip the job write below.
         log_job_error_write_failure(write_failure, job_id=job_id, task="regenerate_vrt")
         return False
     return True

--- a/backend/app/processing/ingest/tasks_vrt.py
+++ b/backend/app/processing/ingest/tasks_vrt.py
@@ -148,14 +148,16 @@ async def _settle_failed_vrt_asset(
     generation_uuid: uuid.UUID | None,
     *,
     job_id: str,
-) -> None:
+) -> bool:
     """Repoint the VRT asset off a generation that failed, in its own transaction.
 
     Fenced on the pointer, so a newer retry that already owns it keeps its
     status. Does nothing when this attempt never bound a generation: there is
     no pointer to release, and the fence would otherwise read as ``IS NULL``.
 
-    Never raises. The caller re-raises the build failure this settles.
+    Never raises. Returns whether the asset is provably no longer pointing at
+    *generation_uuid*; on False the caller MUST leave the generation
+    non-terminal, or the pair becomes unreachable to the stale sweep.
     """
     from sqlalchemy import update as sa_update
 
@@ -163,7 +165,7 @@ async def _settle_failed_vrt_asset(
     from app.processing.raster.models import RasterAsset
 
     if generation_uuid is None:
-        return
+        return True
     try:
         async with async_session() as session:
             await arm_job_error_write_budget(session)
@@ -178,6 +180,8 @@ async def _settle_failed_vrt_asset(
             await session.commit()
     except DBAPIError as write_failure:
         log_job_error_write_failure(write_failure, job_id=job_id, task="regenerate_vrt")
+        return False
+    return True
 
 
 def _prior_generation_storage_keys_to_reap(
@@ -1559,7 +1563,9 @@ async def regenerate_vrt(
         # fix(#1962): the asset settles first and alone. `sweep_stale_vrt_assets`
         # fences its asset UPDATE on the generations it just failed, so an asset
         # still pointing at a terminal one is the state it can never reach.
-        await _settle_failed_vrt_asset(vrt_id, generation_uuid, job_id=job_id)
+        asset_settled = await _settle_failed_vrt_asset(
+            vrt_id, generation_uuid, job_id=job_id
+        )
         # The job and generation rows follow in one transaction. Losing both to
         # a contended job row is recoverable: the sweep fails a generation whose
         # heartbeat went stale, and the stale-job sweep settles the job.
@@ -1579,7 +1585,10 @@ async def regenerate_vrt(
                         "completed_at": datetime.now(timezone.utc),
                     },
                 )
-                if generation_uuid is not None:
+                # fix(#1962): only once the asset is off this generation. A
+                # terminal generation under an asset still pointing at it is
+                # the state `sweep_stale_vrt_assets` fences itself out of.
+                if generation_uuid is not None and asset_settled:
                     gen_result = await err_session.execute(
                         select(VrtGeneration).where(VrtGeneration.id == generation_uuid)
                     )

--- a/backend/tests/finding_markers.py
+++ b/backend/tests/finding_markers.py
@@ -355,7 +355,7 @@ UNANCHORED_MARKER_DEBT: dict[str, int] = {
     "processing/ingest/metadata_projection.py": 1,
     "processing/ingest/ogr.py": 13,
     "processing/ingest/presigned.py": 1,
-    "processing/ingest/router.py": 14,
+    "processing/ingest/router.py": 12,
     "processing/ingest/schemas.py": 1,
     "processing/ingest/tasks_common.py": 42,
     "processing/ingest/tasks_postgis_refresh.py": 2,

--- a/backend/tests/test_job_error_write_bound_1957.py
+++ b/backend/tests/test_job_error_write_bound_1957.py
@@ -381,8 +381,11 @@ class TestAHeldJobRowEndsTheRemainingWrites:
         )
 
     async def test_the_cancelled_analysis_tail_gives_up(
-        self, running_job, short_budget
+        self, running_job, short_budget, monkeypatch
     ) -> None:
+        # This tail passes its own clamp, sized to the shield around it, so the
+        # shared budget's patch alone would not reach the write.
+        monkeypatch.setattr(analysis_tasks, "CANCEL_WRITE_BUDGET_MS", _TEST_BUDGET_MS)
         job_id, attempt_id = running_job
         import app.core.db as db_module
 
@@ -431,4 +434,66 @@ class TestAHeldJobRowEndsTheRemainingWrites:
         assert probes == ["analysis_1957"], (
             "a fence miss no longer probes for an adopting dataset row, so a "
             "swept job's unregistered output table is leaked forever"
+        )
+
+
+class _WedgedSession:
+    """A working session whose lock release never returns, as #700 anticipates."""
+
+    async def rollback(self) -> None:
+        await asyncio.sleep(3600)
+
+
+class TestTheCancelPathFitsInsideItsShield:
+    """The cancel bookkeeping runs under an outer deadline, so its budget must fit."""
+
+    def test_the_budgets_leave_margin_under_the_shield(self) -> None:
+        worst_case = (
+            analysis_tasks.CANCEL_ROLLBACK_SECONDS
+            + 2 * analysis_tasks.CANCEL_WRITE_BUDGET_MS / 1000
+        )
+        assert worst_case < analysis_tasks.CANCEL_CLEANUP_SECONDS, (
+            f"a wedged rollback plus a contended write can take {worst_case}s "
+            f"inside a {analysis_tasks.CANCEL_CLEANUP_SECONDS}s shield, so the "
+            "shield cancels the write before it can record why it gave up"
+        )
+        assert analysis_tasks.CANCEL_WRITE_BUDGET_MS < JOB_ERROR_WRITE_TIMEOUT_MS, (
+            "the cancel path spends the shared budget, which is sized for a "
+            "caller with no outer deadline"
+        )
+
+    async def test_a_wedged_rollback_still_leaves_room_to_report(
+        self, running_job
+    ) -> None:
+        job_id, attempt_id = running_job
+        loop = asyncio.get_running_loop()
+
+        async with _HeldJobRow(job_id):
+            started = loop.time()
+            with structlog.testing.capture_logs() as captured:
+                await asyncio.wait_for(
+                    asyncio.shield(
+                        analysis_tasks._fail_cancelled_job(
+                            _WedgedSession(),
+                            job_id=str(job_id),
+                            attempt_id=attempt_id,
+                            schema="data",
+                            out_table=None,
+                            operation="buffer",
+                        )
+                    ),
+                    timeout=analysis_tasks.CANCEL_CLEANUP_SECONDS,
+                )
+            elapsed = loop.time() - started
+
+        assert elapsed < analysis_tasks.CANCEL_CLEANUP_SECONDS - 1, (
+            f"the cleanup took {round(elapsed, 1)}s of its "
+            f"{analysis_tasks.CANCEL_CLEANUP_SECONDS}s shield, which leaves a "
+            "graceful shutdown cancelling it instead of letting it report"
+        )
+        expired = [r for r in captured if r.get("event") == "job_error_write_timeout"]
+        assert len(expired) == 1, f"expected one expiry event; got {captured}"
+        assert expired[0]["budget_ms"] == analysis_tasks.CANCEL_WRITE_BUDGET_MS, (
+            f"the write spent {expired[0]['budget_ms']}ms, not the clamped "
+            f"{analysis_tasks.CANCEL_WRITE_BUDGET_MS}ms this path passes"
         )

--- a/backend/tests/test_job_error_write_bound_1957.py
+++ b/backend/tests/test_job_error_write_bound_1957.py
@@ -18,6 +18,8 @@ import pytest
 import structlog.testing
 from sqlalchemy import delete, select
 
+import app
+import app.processing
 import app.processing.analysis.tasks as analysis_tasks
 from app.modules.auth.models import User
 from app.platform.jobs.heartbeat import (
@@ -79,11 +81,19 @@ def _call_names(node: ast.AST) -> set[str]:
 
 
 def _writes_failed_status(node: ast.AST) -> bool:
-    """Whether *node* contains a ``{"status": "failed", ...}`` values map."""
+    """Whether *node* writes ``status="failed"``, mapped or as a keyword."""
     for sub in ast.walk(node):
-        if not isinstance(sub, ast.Dict):
+        if isinstance(sub, ast.Dict):
+            pairs = list(zip(sub.keys, sub.values))
+        elif isinstance(sub, ast.Call):
+            pairs = [
+                (ast.Constant(value=kw.arg), kw.value)
+                for kw in sub.keywords
+                if kw.arg is not None
+            ]
+        else:
             continue
-        for key, value in zip(sub.keys, sub.values):
+        for key, value in pairs:
             if (
                 isinstance(key, ast.Constant)
                 and key.value == "status"
@@ -123,7 +133,9 @@ class TestEveryRemainingSiteIsArmed:
     def test_no_fresh_session_failure_write_is_left_unarmed(self) -> None:
         """The enumeration, so a sixth site cannot be added silently."""
         unarmed = []
-        for path in sorted(Path("app/processing").rglob("*.py")):
+        scanned = 0
+        for path in sorted(Path(app.processing.__file__).parent.rglob("*.py")):
+            scanned += 1
             for node in ast.walk(ast.parse(path.read_text())):
                 if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
                     continue
@@ -132,6 +144,10 @@ class TestEveryRemainingSiteIsArmed:
                     continue
                 if not names & _SANCTIONED_ROUTES:
                     unarmed.append(f"{path}:{node.lineno} {node.name}")
+        assert scanned > 20, (
+            f"the enumeration read {scanned} modules, so it is passing on an "
+            "empty scan rather than on the tree"
+        )
         assert not unarmed, (
             f"{unarmed} open a fresh session and write status='failed' on the "
             "job row without arming the error-write budget on it"
@@ -179,17 +195,16 @@ class TestEveryRemainingSiteIsArmed:
 class TestOneBudgetConstant:
     def test_exactly_one_module_defines_the_budget(self) -> None:
         defined = []
-        for path in sorted(Path("app").rglob("*.py")):
+        root = Path(app.__file__).parent
+        for path in sorted(root.rglob("*.py")):
             for node in ast.walk(ast.parse(path.read_text())):
                 if not isinstance(node, ast.Assign):
                     continue
                 for target in node.targets:
                     name = getattr(target, "id", "")
                     if name.endswith("ERROR_WRITE_TIMEOUT_MS"):
-                        defined.append(f"{path}:{name}")
-        assert defined == [
-            "app/platform/jobs/heartbeat.py:JOB_ERROR_WRITE_TIMEOUT_MS"
-        ], (
+                        defined.append(f"{path.relative_to(root)}:{name}")
+        assert defined == ["platform/jobs/heartbeat.py:JOB_ERROR_WRITE_TIMEOUT_MS"], (
             f"the error-write budget is defined at {defined}. Two constants for "
             "one budget agree until one of them is retuned"
         )

--- a/backend/tests/test_job_error_write_bound_1957.py
+++ b/backend/tests/test_job_error_write_bound_1957.py
@@ -1,0 +1,411 @@
+"""fix(#1957): the five worker error-write paths #1950 left unbounded.
+
+Each settles a failed job by UPDATEing ``ingest_jobs`` on a session holding no
+lock on that row. They now share ``write_job_failure_for_attempt``, whose
+budget ends the write on a held row instead of parking the worker there.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib
+import inspect
+import uuid
+from pathlib import Path
+
+import pytest
+import structlog.testing
+from sqlalchemy import delete, select
+
+import app.processing.analysis.tasks as analysis_tasks
+from app.modules.auth.models import User
+from app.platform.jobs.heartbeat import (
+    JOB_ERROR_WRITE_TIMEOUT_MS,
+    write_job_failure_for_attempt,
+)
+from app.platform.jobs.models import IngestJob
+
+pytestmark = pytest.mark.anyio
+
+# Short enough to measure a give-up inside a test, long enough that a healthy
+# uncontended write never reaches it.
+_TEST_BUDGET_MS = 400
+
+# The remaining sites and the routine each reaches its terminal job write
+# through. ``regenerate_vrt`` arms directly: its handler writes two more rows
+# in the same session and the budget belongs to that whole transaction.
+_REMAINING_SITES = {
+    ("app.processing.ingest.tasks_postgis_refresh", "refresh_postgis"): (
+        "write_job_failure_for_attempt"
+    ),
+    ("app.processing.ingest.tasks_stac_refresh", "refresh_stac"): (
+        "write_job_failure_for_attempt"
+    ),
+    ("app.processing.analysis.tasks", "_fail_cancelled_job"): (
+        "write_job_failure_for_attempt"
+    ),
+    ("app.processing.analysis.tasks", "_mark_job_failed"): (
+        "write_job_failure_for_attempt"
+    ),
+    ("app.processing.ingest.tasks_vrt", "regenerate_vrt"): (
+        "arm_job_error_write_budget"
+    ),
+}
+
+# Any of these routes the write through an armed transaction.
+_SANCTIONED_ROUTES = frozenset(
+    {
+        "arm_job_error_write_budget",
+        "write_job_failure_for_attempt",
+        "_cleanup_staging_on_failure",
+        "load_job_for_error_write",
+    }
+)
+
+
+def _source_of(module_name: str, attr: str) -> str:
+    module = importlib.import_module(module_name)
+    target = getattr(module, attr)
+    return inspect.getsource(getattr(target, "func", target))
+
+
+def _call_names(node: ast.AST) -> set[str]:
+    return {
+        getattr(sub.func, "id", None) or getattr(sub.func, "attr", None)
+        for sub in ast.walk(node)
+        if isinstance(sub, ast.Call)
+    }
+
+
+def _writes_failed_status(node: ast.AST) -> bool:
+    """Whether *node* contains a ``{"status": "failed", ...}`` values map."""
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Dict):
+            continue
+        for key, value in zip(sub.keys, sub.values):
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == "status"
+                and isinstance(value, ast.Constant)
+                and value.value == "failed"
+            ):
+                return True
+    return False
+
+
+def _call_lines(node: ast.AST, name: str) -> list[int]:
+    return [
+        sub.lineno
+        for sub in ast.walk(node)
+        if isinstance(sub, ast.Call)
+        and (getattr(sub.func, "id", None) or getattr(sub.func, "attr", None)) == name
+    ]
+
+
+class TestEveryRemainingSiteIsArmed:
+    """Pure AST — no database."""
+
+    @pytest.mark.parametrize(
+        ("target", "route"),
+        sorted(_REMAINING_SITES.items()),
+        ids=lambda value: value[1] if isinstance(value, tuple) else value,
+    )
+    def test_the_site_routes_through_an_armed_transaction(
+        self, target: tuple[str, str], route: str
+    ) -> None:
+        assert route in _call_names(ast.parse(_source_of(*target))), (
+            f"{target[1]} writes its terminal ingest_jobs row without {route}, "
+            "so a row a later attempt holds parks the worker there while the "
+            "heartbeat keeps reporting the job alive"
+        )
+
+    def test_no_fresh_session_failure_write_is_left_unarmed(self) -> None:
+        """The enumeration, so a sixth site cannot be added silently."""
+        unarmed = []
+        for path in sorted(Path("app/processing").rglob("*.py")):
+            for node in ast.walk(ast.parse(path.read_text())):
+                if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+                    continue
+                names = _call_names(node)
+                if "async_session" not in names or not _writes_failed_status(node):
+                    continue
+                if not names & _SANCTIONED_ROUTES:
+                    unarmed.append(f"{path}:{node.lineno} {node.name}")
+        assert not unarmed, (
+            f"{unarmed} open a fresh session and write status='failed' on the "
+            "job row without arming the error-write budget on it"
+        )
+
+    def test_the_analysis_write_is_armed_after_its_rollback(self) -> None:
+        """``SET LOCAL`` dies with the transaction, so order is the whole fix."""
+        tree = ast.parse(
+            _source_of("app.processing.analysis.tasks", "_mark_job_failed")
+        )
+        writes = _call_lines(tree, "write_job_failure_for_attempt")
+        assert len(writes) == 1, f"expected one budgeted write; found {len(writes)}"
+        rollbacks = _call_lines(tree, "rollback")
+        assert rollbacks and min(rollbacks) < writes[0], (
+            "the caller's transaction is no longer ended before the budgeted "
+            "write, so the write waits on a lock this session holds itself"
+        )
+        assert not [line for line in _call_lines(tree, "commit") if line < writes[0]], (
+            "a commit runs between the rollback and the budgeted write, which "
+            "leaves the UPDATE in a transaction carrying no SET LOCAL"
+        )
+
+    def test_the_shared_helper_swallows_its_own_failure(self) -> None:
+        tree = ast.parse(inspect.getsource(write_job_failure_for_attempt))
+        handlers = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ExceptHandler)
+            and getattr(node.type, "id", None) == "DBAPIError"
+        ]
+        assert len(handlers) == 1, (
+            f"the helper has {len(handlers)} DBAPIError handlers; without "
+            "exactly one an expired budget becomes the task's outcome in "
+            "place of the failure the caller was already handling"
+        )
+        assert not [n for n in ast.walk(handlers[0]) if isinstance(n, ast.Raise)], (
+            "the helper re-raises, so a timeout is still what the worker reports"
+        )
+        assert "log_job_error_write_failure" in _call_names(handlers[0]), (
+            "the helper swallows the failure without recording it, trading a "
+            "visible hang for an invisible one"
+        )
+
+
+class TestOneBudgetConstant:
+    def test_exactly_one_module_defines_the_budget(self) -> None:
+        defined = []
+        for path in sorted(Path("app").rglob("*.py")):
+            for node in ast.walk(ast.parse(path.read_text())):
+                if not isinstance(node, ast.Assign):
+                    continue
+                for target in node.targets:
+                    name = getattr(target, "id", "")
+                    if name.endswith("ERROR_WRITE_TIMEOUT_MS"):
+                        defined.append(f"{path}:{name}")
+        assert defined == [
+            "app/platform/jobs/heartbeat.py:JOB_ERROR_WRITE_TIMEOUT_MS"
+        ], (
+            f"the error-write budget is defined at {defined}. Two constants for "
+            "one budget agree until one of them is retuned"
+        )
+
+    def test_the_raster_replace_bracket_reads_the_shared_budget(self) -> None:
+        import app.processing.ingest.tasks_raster_replace as tasks_raster_replace
+
+        assert (
+            tasks_raster_replace.JOB_ERROR_WRITE_TIMEOUT_MS
+            is JOB_ERROR_WRITE_TIMEOUT_MS
+        ), "the replace tail no longer reads the shared budget"
+
+
+async def _admin_id(session) -> uuid.UUID:
+    return (
+        await session.execute(select(User.id).where(User.username == "admin"))
+    ).scalar_one()
+
+
+@pytest.fixture
+async def running_job(test_db_session):
+    """A claimed ``ingest_jobs`` row, deleted when the test ends."""
+    job = IngestJob(
+        source_filename=f"error_write_1957_{uuid.uuid4().hex[:8]}.geojson",
+        created_by=await _admin_id(test_db_session),
+        status="running",
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+    await test_db_session.refresh(job)
+    ids = (job.id, job.attempt_id)
+    yield ids
+    await test_db_session.execute(delete(IngestJob).where(IngestJob.id == ids[0]))
+    await test_db_session.commit()
+
+
+class _HeldJobRow:
+    """Holds *job_id* under ``FOR UPDATE`` and times what waits on it."""
+
+    def __init__(self, job_id: uuid.UUID) -> None:
+        self._job_id = job_id
+        self.waited_ms = 0.0
+
+    async def __aenter__(self) -> "_HeldJobRow":
+        import app.core.db as db_module
+
+        self._holder = db_module.async_session()
+        self._session = await self._holder.__aenter__()
+        await self._session.execute(
+            select(IngestJob.id).where(IngestJob.id == self._job_id).with_for_update()
+        )
+        self._started = asyncio.get_running_loop().time()
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        self.waited_ms = (asyncio.get_running_loop().time() - self._started) * 1000
+        await self._session.rollback()
+        await self._holder.__aexit__(*exc_info)
+
+    def assert_gave_up_on_budget(self) -> None:
+        assert self.waited_ms >= _TEST_BUDGET_MS * 0.8, (
+            f"the write gave up after {round(self.waited_ms)}ms against a "
+            f"{_TEST_BUDGET_MS}ms budget, so this run proves nothing about it"
+        )
+        assert self.waited_ms < _TEST_BUDGET_MS * 5, (
+            f"the write waited {round(self.waited_ms)}ms, far past the "
+            f"{_TEST_BUDGET_MS}ms this test installs. The patch did not reach "
+            "the budget the code read, so this run measures the shipped 10s "
+            "constant and would pass with the patch severed entirely"
+        )
+
+
+@pytest.fixture
+def short_budget(monkeypatch):
+    # `arm_job_error_write_budget` reads this as a global of its OWN module,
+    # resolved per call, so no import placement elsewhere severs the patch.
+    monkeypatch.setattr(
+        "app.platform.jobs.heartbeat.JOB_ERROR_WRITE_TIMEOUT_MS", _TEST_BUDGET_MS
+    )
+
+
+class TestAHeldJobRowEndsTheRemainingWrites:
+    """Against PostgreSQL, with the row held by another transaction."""
+
+    async def test_the_shared_helper_gives_up_and_reports_nothing(
+        self, running_job, short_budget, test_db_session
+    ) -> None:
+        job_id, attempt_id = running_job
+        import app.core.db as db_module
+
+        async with _HeldJobRow(job_id) as held:
+            async with db_module.async_session() as err_session:
+                with structlog.testing.capture_logs() as captured:
+                    outcome = await asyncio.wait_for(
+                        write_job_failure_for_attempt(
+                            err_session,
+                            job_id,
+                            attempt_id,
+                            values={"status": "failed", "error_message": "boom"},
+                            task_name="refresh_postgis",
+                        ),
+                        timeout=30,
+                    )
+        held.assert_gave_up_on_budget()
+
+        assert outcome is None, (
+            f"the expired write returned {outcome!r}, which a caller reads as "
+            "a fence miss and answers by dropping work this attempt still owns"
+        )
+        expired = [r for r in captured if r.get("event") == "job_error_write_timeout"]
+        assert len(expired) == 1, (
+            f"expected one job_error_write_timeout event; got {captured}"
+        )
+        assert expired[0]["sqlstate"] == "57014", (
+            f"the held row ended the write with {expired[0]['sqlstate']!r}. Both "
+            "GUCs are armed at the same value and the blocking statement is the "
+            "UPDATE, so statement_timeout holds the earlier deadline; 55P03 "
+            "would mean only lock_timeout was armed"
+        )
+        test_db_session.expire_all()
+        unchanged = (
+            await test_db_session.execute(
+                select(IngestJob).where(IngestJob.id == job_id)
+            )
+        ).scalar_one()
+        assert unchanged.status == "running", (
+            "the write that gave up still recorded a status, so the trade this "
+            "bound makes is not the one the helper's docstring states"
+        )
+
+    async def test_the_analysis_failure_tail_gives_up(
+        self, running_job, short_budget, monkeypatch
+    ) -> None:
+        job_id, attempt_id = running_job
+        import app.core.db as db_module
+
+        probes: list[str | None] = []
+
+        async def _record_probe(session, **kwargs) -> None:
+            probes.append(kwargs.get("out_table"))
+
+        monkeypatch.setattr(
+            analysis_tasks, "drop_unadopted_analysis_output", _record_probe
+        )
+
+        async with _HeldJobRow(job_id) as held:
+            async with db_module.async_session() as session:
+                await asyncio.wait_for(
+                    analysis_tasks._mark_job_failed(
+                        session,
+                        job_id=str(job_id),
+                        attempt_id=attempt_id,
+                        exc=RuntimeError("the CTAS ran out of temp space"),
+                        schema="data",
+                        out_table="analysis_1957",
+                        operation="buffer",
+                    ),
+                    timeout=30,
+                )
+        held.assert_gave_up_on_budget()
+
+        assert probes == [], (
+            "an expired budget was read as a fence miss, so the tail probed "
+            "for an adopting dataset and would drop a table its own attempt "
+            "still owns"
+        )
+
+    async def test_the_cancelled_analysis_tail_gives_up(
+        self, running_job, short_budget
+    ) -> None:
+        job_id, attempt_id = running_job
+        import app.core.db as db_module
+
+        async with _HeldJobRow(job_id) as held:
+            async with db_module.async_session() as working:
+                await asyncio.wait_for(
+                    analysis_tasks._fail_cancelled_job(
+                        working,
+                        job_id=str(job_id),
+                        attempt_id=attempt_id,
+                        schema="data",
+                        out_table=None,
+                        operation="buffer",
+                    ),
+                    timeout=30,
+                )
+        held.assert_gave_up_on_budget()
+
+    async def test_an_uncontended_fence_miss_still_probes(
+        self, running_job, short_budget, monkeypatch
+    ) -> None:
+        """``False`` and ``None`` must not collapse: only one may drop a table."""
+        job_id, _attempt_id = running_job
+        import app.core.db as db_module
+
+        probes: list[str | None] = []
+
+        async def _record_probe(session, **kwargs) -> None:
+            probes.append(kwargs.get("out_table"))
+
+        monkeypatch.setattr(
+            analysis_tasks, "drop_unadopted_analysis_output", _record_probe
+        )
+
+        async with db_module.async_session() as session:
+            await analysis_tasks._mark_job_failed(
+                session,
+                job_id=str(job_id),
+                attempt_id=uuid.uuid4(),
+                exc=RuntimeError("superseded"),
+                schema="data",
+                out_table="analysis_1957",
+                operation="buffer",
+            )
+
+        assert probes == ["analysis_1957"], (
+            "a fence miss no longer probes for an adopting dataset row, so a "
+            "swept job's unregistered output table is leaked forever"
+        )

--- a/backend/tests/test_job_error_write_bound_1957.py
+++ b/backend/tests/test_job_error_write_bound_1957.py
@@ -149,8 +149,9 @@ class TestEveryRemainingSiteIsArmed:
             "empty scan rather than on the tree"
         )
         assert not unarmed, (
-            f"{unarmed} open a fresh session and write status='failed' on the "
-            "job row without arming the error-write budget on it"
+            f"{unarmed} open a fresh session and write a failed status on a "
+            "row nothing in that session holds, without arming the "
+            "error-write budget on it"
         )
 
     def test_the_analysis_write_is_armed_after_its_rollback(self) -> None:

--- a/backend/tests/test_job_error_write_bound_1957.py
+++ b/backend/tests/test_job_error_write_bound_1957.py
@@ -174,15 +174,22 @@ class TestEveryRemainingSiteIsArmed:
     def test_the_shared_helper_swallows_its_own_failure(self) -> None:
         tree = ast.parse(inspect.getsource(write_job_failure_for_attempt))
         handlers = [
-            node
-            for node in ast.walk(tree)
-            if isinstance(node, ast.ExceptHandler)
-            and getattr(node.type, "id", None) == "DBAPIError"
+            node for node in ast.walk(tree) if isinstance(node, ast.ExceptHandler)
         ]
         assert len(handlers) == 1, (
-            f"the helper has {len(handlers)} DBAPIError handlers; without "
-            "exactly one an expired budget becomes the task's outcome in "
-            "place of the failure the caller was already handling"
+            f"the helper has {len(handlers)} handlers; without exactly one an "
+            "expired budget becomes the task's outcome in place of the failure "
+            "the caller was already handling"
+        )
+        caught = {
+            getattr(name, "id", None)
+            for name in ast.walk(handlers[0].type)
+            if isinstance(name, ast.Name)
+        }
+        assert "SQLAlchemyError" in caught, (
+            f"the helper catches {sorted(caught)}. A pool checkout timeout is a "
+            "SQLAlchemyError and not a DBAPIError, so a narrower catch lets one "
+            "out in place of the cause"
         )
         assert not [n for n in ast.walk(handlers[0]) if isinstance(n, ast.Raise)], (
             "the helper re-raises, so a timeout is still what the worker reports"

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3387,9 +3387,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # refactor(#1711): -459. The URL-import staging cluster — budget, bounded
     # put, settlement — lives in url_import_staging.py; the route handler and
     # its filename/metadata helpers stay. Cap 2639 -> 2180, exact.
-    # fix(#1955): +3 — both VRT source doors admit through the shared
-    # per-dataset lock instead of reading the status. Cap 1969 -> 1972, exact.
-    "backend/app/processing/ingest/router.py": 1972,
+    # fix(#1955): +15 — both VRT source doors admit through the shared
+    # per-dataset lock instead of reading the status, and refuse with the
+    # coded `dataset_busy` body. Cap 1969 -> 1984, exact.
+    "backend/app/processing/ingest/router.py": 1984,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4656,7 +4656,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # unbounded. The reporter is a context manager so the acquisition stays a
     # direct call the #1847 gates can see, and the failure write carries a bound
     # of its own so phase 2's contention cannot move onto it. Cap 1056, exact.
-    "backend/app/processing/ingest/tasks_raster_replace.py": 997,
+    # fix(#1957): -4 — the failure write reads the shared budget constant
+    # instead of a second definition of it. Cap 997 -> 993, exact.
+    "backend/app/processing/ingest/tasks_raster_replace.py": 993,
     # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
     # A completed presigned job points file_path at its frozen copy, so this
     # reaper never touched the key the client's PUT URL can still recreate.
@@ -5243,7 +5245,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): phase 3 takes the job row before the datasets row. Cap
     # 1134 -> 1141, exact.
     # fix(#1902): the atomic bump comment states its contract. Cap 1141 -> 1137.
-    "backend/app/processing/ingest/tasks_postgis_refresh.py": 975,
+    # fix(#1957): +3 — the failure write is budgeted, and states what an
+    # expiry leaves behind. Cap 975 -> 978, exact.
+    "backend/app/processing/ingest/tasks_postgis_refresh.py": 978,
     # --- entered by the inclusion rule, feat(#765) -------------------------
     # First time this module crosses 1000. main sat at 994, six lines under the
     # gate, so it was going to fire on whoever added next; it fired here.
@@ -5553,7 +5557,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # computation as the scope, the idiom `generate_table_name`'s own
     # `_with_collision_suffix` already uses. Cap 1702 -> 1725, exact.
     # chore(#1873): review-history comments trimmed. Cap 1725 -> 1392, exact.
-    "backend/app/processing/analysis/tasks.py": 1390,
+    # fix(#1957): +13 — both failure tails budget their job write and keep an
+    # expired budget distinct from a fence miss. Cap 1390 -> 1403, exact.
+    "backend/app/processing/analysis/tasks.py": 1403,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4648,10 +4648,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950 codex r4): -4 — `ingest_vrt`'s failure tail loads its job row
     # through `tasks_common.load_job_for_error_write` instead of an inline
     # unbounded SELECT. Cap 1709 -> 1705, exact.
-    # fix(#1962): +28 — `_settle_failed_vrt_asset` commits the asset write
-    # before the job row is touched, so a bounded abort cannot strand it.
-    # Cap 1626 -> 1654, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1654,
+    # fix(#1962): +37 — `_settle_failed_vrt_asset` commits the asset write
+    # before the job row is touched, and reports whether it landed so the
+    # generation stays sweepable when it did not. Cap 1626 -> 1663, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1663,
     # --- entered by the inclusion rule, fix(#1937) ------------------------
     # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
     # The budget alone is six lines; the rest is what a newly failable wait
@@ -5562,9 +5562,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # computation as the scope, the idiom `generate_table_name`'s own
     # `_with_collision_suffix` already uses. Cap 1702 -> 1725, exact.
     # chore(#1873): review-history comments trimmed. Cap 1725 -> 1392, exact.
-    # fix(#1957): +13 — both failure tails budget their job write and keep an
-    # expired budget distinct from a fence miss. Cap 1390 -> 1403, exact.
-    "backend/app/processing/analysis/tasks.py": 1403,
+    # fix(#1957): +14 — both failure tails budget their job write and keep an
+    # expired budget distinct from a fence miss. Cap 1390 -> 1404, exact.
+    "backend/app/processing/analysis/tasks.py": 1404,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5565,9 +5565,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # computation as the scope, the idiom `generate_table_name`'s own
     # `_with_collision_suffix` already uses. Cap 1702 -> 1725, exact.
     # chore(#1873): review-history comments trimmed. Cap 1725 -> 1392, exact.
-    # fix(#1957): +14 — both failure tails budget their job write and keep an
-    # expired budget distinct from a fence miss. Cap 1390 -> 1404, exact.
-    "backend/app/processing/analysis/tasks.py": 1404,
+    # fix(#1957): +31 — both failure tails budget their job write and keep an
+    # expired budget distinct from a fence miss, and the cancel path names
+    # its shield and derives a clamp that fits inside it. Cap 1390 -> 1421,
+    # exact.
+    "backend/app/processing/analysis/tasks.py": 1421,
     # Tenant-owned media now crosses the shared logical-to-physical storage
     # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
     # aligned. Keep the ratchet exact after the import/decorator expansion.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4650,8 +4650,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # unbounded SELECT. Cap 1709 -> 1705, exact.
     # fix(#1962): +37 — `_settle_failed_vrt_asset` commits the asset write
     # before the job row is touched, and reports whether it landed so the
-    # generation stays sweepable when it did not. Cap 1626 -> 1663, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1663,
+    # generation stays sweepable when it did not, and reports a pool
+    # timeout the same way, and the NULL-pointer branch settles a legacy
+    # delivery the sweep cannot reach. Cap 1626 -> 1669, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1669,
     # --- entered by the inclusion rule, fix(#1937) ------------------------
     # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
     # The budget alone is six lines; the rest is what a newly failable wait

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4648,12 +4648,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950 codex r4): -4 — `ingest_vrt`'s failure tail loads its job row
     # through `tasks_common.load_job_for_error_write` instead of an inline
     # unbounded SELECT. Cap 1709 -> 1705, exact.
-    # fix(#1962): +37 — `_settle_failed_vrt_asset` commits the asset write
-    # before the job row is touched, and reports whether it landed so the
-    # generation stays sweepable when it did not, and reports a pool
-    # timeout the same way, and the NULL-pointer branch settles a legacy
-    # delivery the sweep cannot reach. Cap 1626 -> 1669, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1669,
+    # fix(#1962): +64 — `_settle_failed_vrt_asset` commits the asset write
+    # before the job row is touched, releases the asset unless a live
+    # generation owns it, bounds its own pool checkout, and reports
+    # whether it landed so the generation stays sweepable when it did
+    # not. Cap 1626 -> 1690, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1690,
     # --- entered by the inclusion rule, fix(#1937) ------------------------
     # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
     # The budget alone is six lines; the rest is what a newly failable wait

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4646,7 +4646,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950 codex r4): -4 — `ingest_vrt`'s failure tail loads its job row
     # through `tasks_common.load_job_for_error_write` instead of an inline
     # unbounded SELECT. Cap 1709 -> 1705, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1626,
+    # fix(#1962): +28 — `_settle_failed_vrt_asset` commits the asset write
+    # before the job row is touched, so a bounded abort cannot strand it.
+    # Cap 1626 -> 1654, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1654,
     # --- entered by the inclusion rule, fix(#1937) ------------------------
     # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
     # The budget alone is six lines; the rest is what a newly failable wait

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3387,7 +3387,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # refactor(#1711): -459. The URL-import staging cluster — budget, bounded
     # put, settlement — lives in url_import_staging.py; the route handler and
     # its filename/metadata helpers stay. Cap 2639 -> 2180, exact.
-    "backend/app/processing/ingest/router.py": 1969,
+    # fix(#1955): +3 — both VRT source doors admit through the shared
+    # per-dataset lock instead of reading the status. Cap 1969 -> 1972, exact.
+    "backend/app/processing/ingest/router.py": 1972,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4648,12 +4648,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950 codex r4): -4 — `ingest_vrt`'s failure tail loads its job row
     # through `tasks_common.load_job_for_error_write` instead of an inline
     # unbounded SELECT. Cap 1709 -> 1705, exact.
-    # fix(#1962): +64 — `_settle_failed_vrt_asset` commits the asset write
+    # fix(#1962): +63 — `_settle_failed_vrt_asset` commits the asset write
     # before the job row is touched, releases the asset unless a live
     # generation owns it, bounds its own pool checkout, and reports
     # whether it landed so the generation stays sweepable when it did
-    # not. Cap 1626 -> 1690, exact.
-    "backend/app/processing/ingest/tasks_vrt.py": 1690,
+    # not. Cap 1626 -> 1689, exact.
+    "backend/app/processing/ingest/tasks_vrt.py": 1689,
     # --- entered by the inclusion rule, fix(#1937) ------------------------
     # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
     # The budget alone is six lines; the rest is what a newly failable wait

--- a/backend/tests/test_raster_replace_phase_budget_1937.py
+++ b/backend/tests/test_raster_replace_phase_budget_1937.py
@@ -177,7 +177,7 @@ class TestPhaseTwoCallSite:
         )
 
     def test_the_error_write_names_its_own_budget(self) -> None:
-        assert _budget_name("error_write") == "_ERROR_WRITE_TIMEOUT_MS", (
+        assert _budget_name("error_write") == "JOB_ERROR_WRITE_TIMEOUT_MS", (
             "the failure write is unbounded. It UPDATEs the same ingest_jobs "
             "row phase 2 contends for, so bounding phase 2 alone moves the "
             "contention onto a wait nothing ends, with the heartbeat still "
@@ -363,7 +363,7 @@ class TestPhaseTwoBudgetAgainstPostgres:
         """The failure write bounds its own UPDATE against the same job row."""
         job_id, attempt_id = running_job
         monkeypatch.setattr(
-            tasks_raster_replace, "_ERROR_WRITE_TIMEOUT_MS", _TEST_BUDGET_MS
+            tasks_raster_replace, "JOB_ERROR_WRITE_TIMEOUT_MS", _TEST_BUDGET_MS
         )
         import app.core.db as db_module
 
@@ -373,7 +373,7 @@ class TestPhaseTwoBudgetAgainstPostgres:
                 phase="error_write",
                 attempt_id=attempt_id,
                 lock_and_statement_timeout_ms=(
-                    tasks_raster_replace._ERROR_WRITE_TIMEOUT_MS
+                    tasks_raster_replace.JOB_ERROR_WRITE_TIMEOUT_MS
                 ),
             ) as (err_session, _job):
                 await update_ingest_job_for_attempt(

--- a/backend/tests/test_regenerate_vrt_integration.py
+++ b/backend/tests/test_regenerate_vrt_integration.py
@@ -1039,3 +1039,104 @@ async def test_an_unsettled_asset_leaves_its_generation_sweepable(
         "a failed asset write also cost the job its terminal status, which the "
         "two transactions exist to keep independent"
     )
+
+
+async def test_a_legacy_delivery_with_no_generation_still_settles_its_asset(
+    test_db_session,
+    vrt_db_state: dict,
+    source_tifs: dict,
+    local_storage,
+    quicklook_stub,
+    clean_tables,
+):
+    """fix(#1962 codex r2): the only release path for a NULL-pointer asset.
+
+    ``sweep_stale_vrt_assets`` finds assets through the generations it just
+    failed, so an asset left ``regenerating`` with no pointer is unreachable to
+    it and 409s every later mutation.
+    """
+    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.raster.models import RasterAsset
+
+    session = test_db_session
+    vrt_id = vrt_db_state["vrt_dataset_id"]
+
+    # The legacy shape: flipped to regenerating by a pre-#1267 dispatch that
+    # bound no generation, and a composition the worker refuses to build.
+    await session.execute(
+        text(
+            "UPDATE catalog.raster_assets SET status = 'regenerating', "
+            "current_generation_id = NULL WHERE dataset_id = :id"
+        ),
+        {"id": vrt_id},
+    )
+    await session.execute(
+        text("DELETE FROM catalog.vrt_source_links WHERE vrt_dataset_id = :id"),
+        {"id": vrt_id},
+    )
+    await session.commit()
+
+    with pytest.raises(ValueError, match="no source links"):
+        await regenerate_vrt.func(
+            job_id=vrt_db_state["job_id"],
+            attempt_id=vrt_db_state["attempt_id"],
+            vrt_dataset_id=vrt_id,
+        )
+
+    vrt_asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    await session.refresh(vrt_asset)
+    assert vrt_asset.status == "failed", (
+        "the asset was left regenerating with no pointer, which no sweep can "
+        "reach and which 409s every later VRT mutation"
+    )
+
+
+async def test_a_ready_asset_with_no_pointer_is_left_alone(
+    test_db_session,
+    vrt_db_state: dict,
+    source_tifs: dict,
+    local_storage,
+    quicklook_stub,
+    clean_tables,
+):
+    """The NULL-pointer branch is status-fenced, not pointer-fenced alone."""
+    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.raster.models import RasterAsset
+
+    session = test_db_session
+    vrt_id = vrt_db_state["vrt_dataset_id"]
+
+    await session.execute(
+        text(
+            "UPDATE catalog.raster_assets SET status = 'ready', "
+            "current_generation_id = NULL WHERE dataset_id = :id"
+        ),
+        {"id": vrt_id},
+    )
+    await session.execute(
+        text("DELETE FROM catalog.vrt_source_links WHERE vrt_dataset_id = :id"),
+        {"id": vrt_id},
+    )
+    await session.commit()
+
+    with pytest.raises(ValueError, match="no source links"):
+        await regenerate_vrt.func(
+            job_id=vrt_db_state["job_id"],
+            attempt_id=vrt_db_state["attempt_id"],
+            vrt_dataset_id=vrt_id,
+        )
+
+    vrt_asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    await session.refresh(vrt_asset)
+    assert vrt_asset.status == "ready", (
+        "a doomed attempt failed an asset it never owned, so a VRT the sweep "
+        "had already restored is reported broken"
+    )

--- a/backend/tests/test_regenerate_vrt_integration.py
+++ b/backend/tests/test_regenerate_vrt_integration.py
@@ -1140,3 +1140,98 @@ async def test_a_ready_asset_with_no_pointer_is_left_alone(
         "a doomed attempt failed an asset it never owned, so a VRT the sweep "
         "had already restored is reported broken"
     )
+
+
+async def test_a_dangling_pointer_from_a_rolled_back_claim_is_settled(
+    test_db_session,
+    vrt_db_state: dict,
+    source_tifs: dict,
+    local_storage,
+    quicklook_stub,
+    clean_tables,
+):
+    """fix(#1962 codex r3): released unless a LIVE generation owns the asset.
+
+    A pointer at a generation that is already terminal, or at no row at all, is
+    invisible to ``sweep_stale_vrt_assets``, which reaches an asset only through
+    the pending/running generations it has just failed.
+    """
+    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.raster.models import RasterAsset
+
+    session = test_db_session
+    vrt_id = vrt_db_state["vrt_dataset_id"]
+    generation_id = await _stage_generation(
+        session, vrt_db_state, vrt_db_state["source_dataset_ids"]
+    )
+    # The generation this attempt will never load: already terminal, with the
+    # asset still pointing at it.
+    await session.execute(
+        text("UPDATE catalog.vrt_generations SET status = 'failed' WHERE id = :id"),
+        {"id": str(generation_id)},
+    )
+    await session.execute(
+        text("DELETE FROM catalog.vrt_source_links WHERE vrt_dataset_id = :id"),
+        {"id": vrt_id},
+    )
+    await session.commit()
+
+    with pytest.raises(ValueError, match="no source links"):
+        await regenerate_vrt.func(
+            job_id=vrt_db_state["job_id"],
+            attempt_id=vrt_db_state["attempt_id"],
+            vrt_dataset_id=vrt_id,
+        )
+
+    vrt_asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    await session.refresh(vrt_asset)
+    assert (vrt_asset.status, vrt_asset.current_generation_id) == ("failed", None), (
+        "the asset was left regenerating behind a terminal generation, which "
+        "the stale sweep cannot see and which 409s every later mutation"
+    )
+
+
+async def test_an_asset_a_live_generation_owns_is_left_alone(
+    test_db_session,
+    vrt_db_state: dict,
+    source_tifs: dict,
+    local_storage,
+    quicklook_stub,
+    clean_tables,
+):
+    """The release arm yields to a newer attempt that already claimed the asset."""
+    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.raster.models import RasterAsset
+
+    session = test_db_session
+    vrt_id = vrt_db_state["vrt_dataset_id"]
+    newer = await _stage_generation(
+        session, vrt_db_state, vrt_db_state["source_dataset_ids"]
+    )
+    await session.execute(
+        text("DELETE FROM catalog.vrt_source_links WHERE vrt_dataset_id = :id"),
+        {"id": vrt_id},
+    )
+    await session.commit()
+
+    with pytest.raises(ValueError, match="no source links"):
+        await regenerate_vrt.func(
+            job_id=vrt_db_state["job_id"],
+            attempt_id=vrt_db_state["attempt_id"],
+            vrt_dataset_id=vrt_id,
+        )
+
+    vrt_asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    await session.refresh(vrt_asset)
+    assert (vrt_asset.status, vrt_asset.current_generation_id) == (
+        "regenerating",
+        newer,
+    ), "a doomed attempt released an asset a pending generation still owns"

--- a/backend/tests/test_regenerate_vrt_integration.py
+++ b/backend/tests/test_regenerate_vrt_integration.py
@@ -876,3 +876,86 @@ async def test_applying_a_staged_set_is_idempotent(test_db_session, vrt_db_state
     assert [(row.id, row.source_dataset_id, row.position) for row in second] == [
         (row.id, row.source_dataset_id, row.position) for row in first
     ]
+
+
+async def test_a_bounded_abort_on_the_job_row_still_settles_the_vrt_asset(
+    test_db_session,
+    vrt_db_state: dict,
+    source_tifs: dict,
+    local_storage,
+    quicklook_stub,
+    clean_tables,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """fix(#1962): the asset write commits before the job row is touched.
+
+    The job write is the contended one, and its budget makes it abortable. An
+    asset still pointing at a non-terminal generation is the one half-written
+    failure ``sweep_stale_vrt_assets`` cannot reach: it fences its asset UPDATE
+    on the generations it has just failed, and a ``regenerating`` asset whose
+    generation is already terminal matches nothing.
+    """
+    import app.processing.ingest.tasks_vrt as tasks_vrt
+    from app.platform.jobs.models import IngestJob
+    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+    from asyncpg.exceptions import QueryCanceledError
+    from sqlalchemy.exc import DBAPIError
+
+    session = test_db_session
+    generation_id = await _stage_generation(
+        session, vrt_db_state, vrt_db_state["source_dataset_ids"]
+    )
+
+    monkeypatch.setattr(
+        "app.processing.ingest.tasks_vrt.build_vrt",
+        MagicMock(side_effect=RuntimeError("gdalbuildvrt died mid-attempt")),
+    )
+
+    async def _expired_on_the_job_row(*args, **kwargs):
+        raise DBAPIError("UPDATE", {}, QueryCanceledError("canceling statement"))
+
+    monkeypatch.setattr(
+        tasks_vrt, "update_ingest_job_for_attempt", _expired_on_the_job_row
+    )
+
+    with pytest.raises(RuntimeError, match="gdalbuildvrt"):
+        await regenerate_vrt.func(
+            job_id=vrt_db_state["job_id"],
+            attempt_id=vrt_db_state["attempt_id"],
+            vrt_dataset_id=vrt_db_state["vrt_dataset_id"],
+            generation_id=str(generation_id),
+        )
+
+    vrt_asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    await session.refresh(vrt_asset)
+    assert (vrt_asset.status, vrt_asset.current_generation_id) == ("failed", None), (
+        "the aborted job write took the asset write down with it, leaving the "
+        "asset pointing at a generation nothing will ever stamp terminal"
+    )
+
+    job = (
+        await session.execute(
+            select(IngestJob).where(IngestJob.id == uuid.UUID(vrt_db_state["job_id"]))
+        )
+    ).scalar_one()
+    await session.refresh(job)
+    assert job.status == "running", (
+        "the job row recorded a status despite the expiry, so this run did not "
+        "exercise the abort it is named for"
+    )
+
+    generation = (
+        await session.execute(
+            select(VrtGeneration).where(VrtGeneration.id == generation_id)
+        )
+    ).scalar_one()
+    await session.refresh(generation)
+    assert generation.status == "running", (
+        "the generation stamp survived the abort, so the two writes are no "
+        "longer in one transaction and the stale sweep's recovery is untested"
+    )

--- a/backend/tests/test_regenerate_vrt_integration.py
+++ b/backend/tests/test_regenerate_vrt_integration.py
@@ -887,14 +887,7 @@ async def test_a_bounded_abort_on_the_job_row_still_settles_the_vrt_asset(
     clean_tables,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """fix(#1962): the asset write commits before the job row is touched.
-
-    The job write is the contended one, and its budget makes it abortable. An
-    asset still pointing at a non-terminal generation is the one half-written
-    failure ``sweep_stale_vrt_assets`` cannot reach: it fences its asset UPDATE
-    on the generations it has just failed, and a ``regenerating`` asset whose
-    generation is already terminal matches nothing.
-    """
+    """fix(#1962): an aborted job write leaves the asset settled anyway."""
     import app.processing.ingest.tasks_vrt as tasks_vrt
     from app.platform.jobs.models import IngestJob
     from app.processing.ingest.tasks import regenerate_vrt
@@ -958,4 +951,91 @@ async def test_a_bounded_abort_on_the_job_row_still_settles_the_vrt_asset(
     assert generation.status == "running", (
         "the generation stamp survived the abort, so the two writes are no "
         "longer in one transaction and the stale sweep's recovery is untested"
+    )
+
+
+async def test_an_unsettled_asset_leaves_its_generation_sweepable(
+    test_db_session,
+    vrt_db_state: dict,
+    source_tifs: dict,
+    local_storage,
+    quicklook_stub,
+    clean_tables,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """fix(#1962 codex r1): the generation stays non-terminal when the asset does.
+
+    ``sweep_stale_vrt_assets`` reaches an abandoned pair only through a
+    ``pending``/``running`` generation, so stamping one terminal under an asset
+    that still points at it is unrecoverable.
+    """
+    import app.processing.ingest.tasks_vrt as tasks_vrt
+    from app.platform.jobs.models import IngestJob
+    from app.processing.ingest.tasks import regenerate_vrt
+    from app.processing.raster.models import RasterAsset, VrtGeneration
+    from asyncpg.exceptions import QueryCanceledError
+    from sqlalchemy.exc import DBAPIError
+
+    session = test_db_session
+    generation_id = await _stage_generation(
+        session, vrt_db_state, vrt_db_state["source_dataset_ids"]
+    )
+
+    monkeypatch.setattr(
+        "app.processing.ingest.tasks_vrt.build_vrt",
+        MagicMock(side_effect=RuntimeError("gdalbuildvrt died mid-attempt")),
+    )
+
+    real_arm = tasks_vrt.arm_job_error_write_budget
+    arms = {"count": 0}
+
+    async def _expire_the_asset_transaction(session_):
+        arms["count"] += 1
+        if arms["count"] == 1:
+            raise DBAPIError("SET LOCAL", {}, QueryCanceledError("canceling statement"))
+        await real_arm(session_)
+
+    monkeypatch.setattr(
+        tasks_vrt, "arm_job_error_write_budget", _expire_the_asset_transaction
+    )
+
+    with pytest.raises(RuntimeError, match="gdalbuildvrt"):
+        await regenerate_vrt.func(
+            job_id=vrt_db_state["job_id"],
+            attempt_id=vrt_db_state["attempt_id"],
+            vrt_dataset_id=vrt_db_state["vrt_dataset_id"],
+            generation_id=str(generation_id),
+        )
+
+    generation = (
+        await session.execute(
+            select(VrtGeneration).where(VrtGeneration.id == generation_id)
+        )
+    ).scalar_one()
+    await session.refresh(generation)
+    assert generation.status == "running", (
+        "the generation was stamped terminal while the asset still points at "
+        "it, which is the one pairing the stale sweep can never repair"
+    )
+
+    vrt_asset = (
+        await session.execute(
+            select(RasterAsset).where(RasterAsset.id == vrt_db_state["vrt_asset_id"])
+        )
+    ).scalar_one()
+    await session.refresh(vrt_asset)
+    assert (vrt_asset.status, vrt_asset.current_generation_id) == (
+        "regenerating",
+        generation_id,
+    ), "the asset write is supposed to have failed in this run"
+
+    job = (
+        await session.execute(
+            select(IngestJob).where(IngestJob.id == uuid.UUID(vrt_db_state["job_id"]))
+        )
+    ).scalar_one()
+    await session.refresh(job)
+    assert job.status == "failed", (
+        "a failed asset write also cost the job its terminal status, which the "
+        "two transactions exist to keep independent"
     )

--- a/backend/tests/test_vrt_admission_1955.py
+++ b/backend/tests/test_vrt_admission_1955.py
@@ -202,3 +202,26 @@ class TestAHeldAdmissionRefusesTheSecondDoor:
         assert resp.status_code == 409, resp.text
         assert deferred == [], "a refused removal still queued a regeneration"
         assert await _generation_count(test_db_session, vrt_id) == 0
+
+
+async def test_an_asset_deleted_under_the_re_read_is_refused(test_db_session) -> None:
+    """fix(#1955 codex r2): `refresh` reports a vanished row, and 409 beats 500."""
+    import app.core.db as db_module
+    from app.processing.raster.models import RasterAsset
+
+    admin_id = await _get_admin_id(test_db_session)
+    vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+
+    async with db_module.async_session() as reader:
+        vrt_asset = (
+            await reader.execute(
+                select(RasterAsset).where(RasterAsset.dataset_id == vrt_id)
+            )
+        ).scalar_one()
+        async with db_module.async_session() as deleter:
+            await deleter.execute(
+                text("DELETE FROM catalog.raster_assets WHERE dataset_id = :id"),
+                {"id": str(vrt_id)},
+            )
+            await deleter.commit()
+        assert await admit_vrt_mutation(reader, vrt_id, vrt_asset) is False

--- a/backend/tests/test_vrt_admission_1955.py
+++ b/backend/tests/test_vrt_admission_1955.py
@@ -82,6 +82,33 @@ class TestEveryDoorAdmitsThroughOneLock:
             "triggers land in"
         )
 
+    @pytest.mark.parametrize(("module_name", "attr"), _DOORS, ids=lambda v: v)
+    def test_the_door_reads_no_asset_status_before_admitting(
+        self, module_name: str, attr: str
+    ) -> None:
+        """A read hoisted into a local still leaves the window open."""
+        tree = ast.parse(_door_source(module_name, attr))
+        admits = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", None) == "admit_vrt_mutation"
+        ]
+        assert len(admits) == 1, f"expected one admission; found {len(admits)}"
+        early = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and node.attr == "status"
+            and getattr(node.value, "id", "").endswith("asset")
+            and node.lineno < admits[0]
+        ]
+        assert not early, (
+            f"{attr} reads the asset status at {early}, before the lock at "
+            f"{admits[0]}. That value is from a snapshot the winner has "
+            "already invalidated"
+        )
+
     def test_the_shared_admission_locks_before_it_reads(self) -> None:
         tree = ast.parse(inspect.getsource(admit_vrt_mutation))
         locks = [

--- a/backend/tests/test_vrt_admission_1955.py
+++ b/backend/tests/test_vrt_admission_1955.py
@@ -10,16 +10,21 @@ BEFORE the status read.
 from __future__ import annotations
 
 import ast
+import asyncio
 import contextlib
 import importlib
 import inspect
 import uuid
+from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 from sqlalchemy import select, text
 
 from app.platform.catalog_locks import admit_vrt_mutation
+from app.platform.dataset_origin import classify_origin
+from app.platform.refresh.models import DatasetRefreshRun
 from app.processing.raster.models import VrtGeneration
 from tests.test_vrt_source_authz_1172 import (
     _create_raster_dataset,
@@ -252,3 +257,189 @@ async def test_an_asset_deleted_under_the_re_read_is_refused(test_db_session) ->
             )
             await deleter.commit()
         assert await admit_vrt_mutation(reader, vrt_id, vrt_asset) is False
+
+
+async def _run_count(session, dataset_id: uuid.UUID) -> int:
+    return len(
+        (
+            await session.execute(
+                select(DatasetRefreshRun).where(
+                    DatasetRefreshRun.dataset_id == dataset_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+class TestNoRunRowMutationCanTargetAVrt:
+    """Why one advisory lock is enough, rather than a shared key with Decision 5b.
+
+    Every ``create_pending_run`` door refuses a VRT dataset before it reaches the
+    insert, so a VRT regeneration and a run-row mutation cannot interleave.
+    """
+
+    def test_a_vrt_record_type_classifies_as_no_origin(self) -> None:
+        assert classify_origin("geotiff", "vrt_dataset") is None, (
+            "a VRT now classifies as an origin the refresh doors accept, so "
+            "one of them can open a run row on a dataset the advisory lock "
+            "alone is admitting"
+        )
+
+    def test_the_reupload_door_refuses_a_vrt_before_its_run_row(self) -> None:
+        from app.modules.catalog.datasets.api.router_reupload import (
+            _assert_compatible_record_type,
+        )
+
+        dataset = SimpleNamespace(record=SimpleNamespace(record_type="vrt_dataset"))
+        with pytest.raises(HTTPException) as refusal:
+            _assert_compatible_record_type(dataset, None)
+        assert refusal.value.status_code == 400
+
+    async def test_every_run_row_door_refuses_a_vrt_dataset(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ) -> None:
+        admin_id = await _get_admin_id(test_db_session)
+        vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+
+        refused = {
+            "refresh": await client.post(
+                f"/datasets/{vrt_id}/refresh", headers=admin_auth_header
+            ),
+            "reupload": await client.post(
+                f"/datasets/{vrt_id}/reupload",
+                files={"file": ("replacement.tif", b"not-a-tif", "image/tiff")},
+                headers=admin_auth_header,
+            ),
+        }
+        for door, resp in refused.items():
+            assert resp.status_code in (400, 409), f"{door} answered {resp.status_code}"
+        assert await _run_count(test_db_session, vrt_id) == 0, (
+            "a run-row door reached create_pending_run on a VRT dataset, so a "
+            "refresh and a regeneration can now interleave and the advisory "
+            "lock alone is no longer the whole admission"
+        )
+
+
+class TestTwoConcurrentDoorsAdmitExactlyOne:
+    """Both requests in flight at once, each on its own session and connection."""
+
+    async def _vrt_with_sources(self, session, count: int = 3):
+        admin_id = await _get_admin_id(session)
+        vrt_id = await _create_vrt_dataset(session, created_by=admin_id)
+        linked = [
+            await _create_raster_dataset(session, created_by=admin_id)
+            for _ in range(count)
+        ]
+        for position, source_id in enumerate(linked):
+            await _link_source(session, vrt_id, source_id, position)
+        return admin_id, vrt_id, linked
+
+    def _assert_exactly_one_won(self, responses, deferred, label: str) -> None:
+        codes = sorted(r.status_code for r in responses)
+        assert codes == [202, 409], (
+            f"two concurrent {label} calls answered {codes}. Both admitted "
+            "means two generations and two queued rebuilds for one dataset"
+        )
+        assert len(deferred) == 1, (
+            f"{len(deferred)} regenerations were queued for one dataset"
+        )
+        loser = next(r for r in responses if r.status_code == 409)
+        assert loser.json()["detail"]["code"] == "dataset_busy", loser.text
+
+    async def test_regenerate(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+    ) -> None:
+        deferred = _capture_defer(monkeypatch)
+        _, vrt_id, _ = await self._vrt_with_sources(test_db_session, count=2)
+
+        responses = await asyncio.gather(
+            *(
+                client.post(
+                    f"/datasets/{vrt_id}/vrt/regenerate/", headers=admin_auth_header
+                )
+                for _ in range(2)
+            )
+        )
+
+        self._assert_exactly_one_won(responses, deferred, "regenerate")
+        assert await _generation_count(test_db_session, vrt_id) == 1
+
+    async def test_add_source(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+    ) -> None:
+        deferred = _capture_defer(monkeypatch)
+        admin_id, vrt_id, _ = await self._vrt_with_sources(test_db_session, count=2)
+        incoming = await _create_raster_dataset(test_db_session, created_by=admin_id)
+
+        responses = await asyncio.gather(
+            *(
+                client.post(
+                    f"/ingest/vrt/{vrt_id}/sources/",
+                    json={"source_dataset_id": str(incoming)},
+                    headers=admin_auth_header,
+                )
+                for _ in range(2)
+            )
+        )
+
+        self._assert_exactly_one_won(responses, deferred, "add source")
+        assert await _generation_count(test_db_session, vrt_id) == 1
+
+    async def test_remove_source(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+    ) -> None:
+        deferred = _capture_defer(monkeypatch)
+        _, vrt_id, linked = await self._vrt_with_sources(test_db_session, count=3)
+
+        responses = await asyncio.gather(
+            *(
+                client.delete(
+                    f"/ingest/vrt/{vrt_id}/sources/{linked[1]}/",
+                    headers=admin_auth_header,
+                )
+                for _ in range(2)
+            )
+        )
+
+        self._assert_exactly_one_won(responses, deferred, "remove source")
+        assert await _generation_count(test_db_session, vrt_id) == 1
+
+
+async def test_a_stale_snapshot_does_not_admit_a_second_regeneration(
+    test_db_session,
+) -> None:
+    """The ordering, isolated: both doors read `ready` before either wrote.
+
+    Under READ COMMITTED the loser's own re-read would see the winner, so the
+    read has to happen under the lock for that to be worth anything.
+    """
+    import app.core.db as db_module
+    from app.processing.raster.models import RasterAsset
+
+    admin_id = await _get_admin_id(test_db_session)
+    vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+
+    async with db_module.async_session() as winner, db_module.async_session() as loser:
+        seen = []
+        for session in (winner, loser):
+            asset = (
+                await session.execute(
+                    select(RasterAsset).where(RasterAsset.dataset_id == vrt_id)
+                )
+            ).scalar_one()
+            seen.append(asset)
+        assert [a.status for a in seen] == ["ready", "ready"], (
+            "the fixture did not produce the two identical snapshots this test is about"
+        )
+
+        assert await admit_vrt_mutation(winner, vrt_id, seen[0]) is True
+        seen[0].status = "regenerating"
+        await winner.commit()
+
+        assert await admit_vrt_mutation(loser, vrt_id, seen[1]) is False, (
+            "the loser was admitted on the snapshot it took before the winner "
+            "wrote, which is what lets two regenerations dispatch at once"
+        )
+        await loser.rollback()

--- a/backend/tests/test_vrt_admission_1955.py
+++ b/backend/tests/test_vrt_admission_1955.py
@@ -1,0 +1,204 @@
+"""fix(#1955): admission control for the three VRT regeneration doors.
+
+ADR-002 Decision 5b admits one mutation per dataset through a partial unique
+index the VRT path never writes to. Its three doors read the asset status,
+check it and flip it as separate statements, so two of them could dispatch at
+once. They now share ``admit_vrt_mutation``, which takes the per-dataset lock
+BEFORE the status read.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import importlib
+import inspect
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, text
+
+from app.platform.catalog_locks import admit_vrt_mutation
+from app.processing.raster.models import VrtGeneration
+from tests.test_vrt_source_authz_1172 import (
+    _create_raster_dataset,
+    _create_vrt_dataset,
+    _get_admin_id,
+    _link_source,
+)
+from tests.test_vrt_staged_mutation_1327 import _capture_defer
+
+_DOORS = [
+    ("app.modules.catalog.datasets.api.router_vrt", "regenerate_vrt_endpoint"),
+    ("app.processing.ingest.router", "add_vrt_source"),
+    ("app.processing.ingest.router", "remove_vrt_source"),
+]
+
+
+def _door_source(module_name: str, attr: str) -> str:
+    return inspect.getsource(getattr(importlib.import_module(module_name), attr))
+
+
+def _call_names(node: ast.AST) -> set[str]:
+    return {
+        getattr(sub.func, "id", None) or getattr(sub.func, "attr", None)
+        for sub in ast.walk(node)
+        if isinstance(sub, ast.Call)
+    }
+
+
+class TestEveryDoorAdmitsThroughOneLock:
+    """Pure AST — no database."""
+
+    @pytest.mark.parametrize(("module_name", "attr"), _DOORS, ids=lambda v: v)
+    def test_the_door_calls_the_shared_admission(
+        self, module_name: str, attr: str
+    ) -> None:
+        assert "admit_vrt_mutation" in _call_names(
+            ast.parse(_door_source(module_name, attr))
+        ), (
+            f"{attr} dispatches a regeneration without taking the per-dataset "
+            "admission lock, so a concurrent door can dispatch a second one"
+        )
+
+    @pytest.mark.parametrize(("module_name", "attr"), _DOORS, ids=lambda v: v)
+    def test_the_door_does_not_read_the_status_outside_the_lock(
+        self, module_name: str, attr: str
+    ) -> None:
+        """A read before the lock leaves the loser's snapshot saying 'idle'."""
+        compares = [
+            node
+            for node in ast.walk(ast.parse(_door_source(module_name, attr)))
+            if isinstance(node, ast.Compare)
+            and any(
+                isinstance(operand, ast.Constant) and operand.value == "regenerating"
+                for operand in node.comparators
+            )
+        ]
+        assert not compares, (
+            f"{attr} compares an asset status to 'regenerating' itself. That "
+            "read is not held by the lock, which is the window two concurrent "
+            "triggers land in"
+        )
+
+    def test_the_shared_admission_locks_before_it_reads(self) -> None:
+        tree = ast.parse(inspect.getsource(admit_vrt_mutation))
+        locks = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and "pg_try_advisory_xact_lock" in node.value
+        ]
+        reads = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "attr", None) == "refresh"
+        ]
+        assert len(locks) == 1 and len(reads) == 1, (
+            f"expected one lock and one re-read; found {len(locks)} and {len(reads)}"
+        )
+        assert locks[0] < reads[0], (
+            "the status is re-read before the lock is taken, which is the "
+            "ordering this helper exists to remove"
+        )
+
+
+@contextlib.asynccontextmanager
+async def _admission_held(dataset_id: uuid.UUID):
+    """Hold *dataset_id*'s VRT admission lock on another connection."""
+    import app.core.db as db_module
+
+    async with db_module.async_session() as holder:
+        acquired = await holder.scalar(
+            text("SELECT pg_try_advisory_xact_lock(:key)"),
+            {"key": dataset_id.int % (2**63)},
+        )
+        assert acquired, "the holder could not take the lock, so nothing is held"
+        try:
+            yield
+        finally:
+            await holder.rollback()
+
+
+async def _generation_count(session, vrt_id: uuid.UUID) -> int:
+    return len(
+        (
+            await session.execute(
+                select(VrtGeneration).where(VrtGeneration.vrt_dataset_id == vrt_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+class TestAHeldAdmissionRefusesTheSecondDoor:
+    async def test_regenerate_is_refused(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+    ) -> None:
+        deferred = _capture_defer(monkeypatch)
+        admin_id = await _get_admin_id(test_db_session)
+        vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+        for position in range(2):
+            source_id = await _create_raster_dataset(
+                test_db_session, created_by=admin_id
+            )
+            await _link_source(test_db_session, vrt_id, source_id, position)
+
+        async with _admission_held(vrt_id):
+            resp = await client.post(
+                f"/datasets/{vrt_id}/vrt/regenerate/", headers=admin_auth_header
+            )
+
+        assert resp.status_code == 409, resp.text
+        assert deferred == [], "a refused trigger still queued a regeneration"
+        assert await _generation_count(test_db_session, vrt_id) == 0
+
+    async def test_add_source_is_refused(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+    ) -> None:
+        deferred = _capture_defer(monkeypatch)
+        admin_id = await _get_admin_id(test_db_session)
+        vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+        for position in range(2):
+            source_id = await _create_raster_dataset(
+                test_db_session, created_by=admin_id
+            )
+            await _link_source(test_db_session, vrt_id, source_id, position)
+        incoming = await _create_raster_dataset(test_db_session, created_by=admin_id)
+
+        async with _admission_held(vrt_id):
+            resp = await client.post(
+                f"/ingest/vrt/{vrt_id}/sources/",
+                json={"source_dataset_id": str(incoming)},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 409, resp.text
+        assert deferred == [], "a refused add still queued a regeneration"
+        assert await _generation_count(test_db_session, vrt_id) == 0
+
+    async def test_remove_source_is_refused(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session, monkeypatch
+    ) -> None:
+        deferred = _capture_defer(monkeypatch)
+        admin_id = await _get_admin_id(test_db_session)
+        vrt_id = await _create_vrt_dataset(test_db_session, created_by=admin_id)
+        linked = [
+            await _create_raster_dataset(test_db_session, created_by=admin_id)
+            for _ in range(3)
+        ]
+        for position, source_id in enumerate(linked):
+            await _link_source(test_db_session, vrt_id, source_id, position)
+
+        async with _admission_held(vrt_id):
+            resp = await client.delete(
+                f"/ingest/vrt/{vrt_id}/sources/{linked[1]}/", headers=admin_auth_header
+            )
+
+        assert resp.status_code == 409, resp.text
+        assert deferred == [], "a refused removal still queued a regeneration"
+        assert await _generation_count(test_db_session, vrt_id) == 0

--- a/backend/tests/test_vrt_lifecycle_188.py
+++ b/backend/tests/test_vrt_lifecycle_188.py
@@ -293,10 +293,14 @@ class TestVrtRegenerateEndpoint:
         assert "/datasets/{dataset_id}/vrt/regenerate/" in paths
 
     def test_endpoint_uses_advisory_lock(self):
+        """fix(#1955): the lock moved into the shared admission helper."""
         from app.modules.catalog.datasets.api import router_vrt as router_mod
+        from app.platform.catalog_locks import admit_vrt_mutation
 
-        source = inspect.getsource(router_mod.regenerate_vrt_endpoint)
-        assert "pg_try_advisory_xact_lock" in source
+        assert "admit_vrt_mutation" in inspect.getsource(
+            router_mod.regenerate_vrt_endpoint
+        )
+        assert "pg_try_advisory_xact_lock" in inspect.getsource(admit_vrt_mutation)
 
     def test_endpoint_returns_409_when_regenerating(self):
         from app.modules.catalog.datasets.api import router_vrt as router_mod
@@ -311,10 +315,10 @@ class TestVrtRegenerateEndpoint:
         assert "VrtGeneration" in source
 
     def test_advisory_lock_key_helper_exists(self):
-        from app.modules.catalog.datasets.api.router_vrt import _advisory_lock_key
+        from app.platform.catalog_locks import vrt_admission_lock_key
 
         dataset_id = uuid.uuid4()
-        key = _advisory_lock_key(dataset_id)
+        key = vrt_admission_lock_key(dataset_id)
         assert isinstance(key, int)
         assert 0 <= key < 2**63
 

--- a/backend/tests/test_vrt_source_management_174.py
+++ b/backend/tests/test_vrt_source_management_174.py
@@ -862,8 +862,13 @@ class TestRegenerateVrtTask:
         ) or regenerate_vrt.task_kwargs.get("queue")
         assert queue == "raster"
 
-    def test_task_sets_status_to_failed_on_exception(self):
-        """On exception, task sets asset.status = 'failed' and job.status = 'failed'."""
+    def test_an_attempt_with_no_generation_writes_the_job_row_only(self):
+        """fix(#1962): nothing to release, so the asset is left alone.
+
+        The asset write is fenced on the generation this attempt owns. An
+        attempt that failed before binding one owns no pointer, and the fence
+        would otherwise read as ``IS NULL``.
+        """
 
         async def _check():
             from app.processing.ingest.tasks import regenerate_vrt
@@ -923,71 +928,39 @@ class TestRegenerateVrtTask:
             statements = "\n".join(
                 str(call.args[0]) for call in mock_session.execute.await_args_list
             )
-            assert "UPDATE catalog.raster_assets" in statements
+            # The job UPDATE is stubbed module-wide by `_fence_vrt_worker_helpers`,
+            # so the budget it arms is what shows the handler ran its write.
+            assert "SET LOCAL lock_timeout" in statements
+            assert "UPDATE catalog.raster_assets" not in statements
 
         asyncio.run(_check())
 
     def test_task_clears_current_generation_id_on_failure(self):
-        """On failure, current_generation_id is cleared (set to None)."""
+        """On failure, current_generation_id is cleared (set to None).
+
+        fix(#1962): in its own committed transaction, ahead of the job row.
+        """
 
         async def _check():
-            from app.processing.ingest.tasks import regenerate_vrt
-
-            job_id = str(uuid.uuid4())
-            vrt_dataset_id = str(uuid.uuid4())
-
-            mock_job = MagicMock()
-            mock_job.id = uuid.UUID(job_id)
-            mock_job.status = "pending"
-
-            mock_vrt_asset = _make_mock_asset(status="regenerating")
-            mock_vrt_asset.current_generation_id = uuid.uuid4()
+            from app.processing.ingest.tasks_vrt import _settle_failed_vrt_asset
 
             mock_session = AsyncMock()
             mock_session.__aenter__ = AsyncMock(return_value=mock_session)
             mock_session.__aexit__ = AsyncMock(return_value=False)
+            mock_session.execute = AsyncMock(return_value=MagicMock())
 
-            call_count = [0]
-
-            def execute_side_effect(query, params=None):
-                call_count[0] += 1
-                result_mock = MagicMock()
-                if call_count[0] == 1:
-                    result_mock.scalar_one.return_value = mock_job
-                elif call_count[0] == 2:
-                    result_mock.scalar_one_or_none.return_value = mock_vrt_asset
-                elif call_count[0] == 3:
-                    # vrt_source_links -- empty causes ValueError before build
-                    result_mock.fetchall.return_value = []
-                return result_mock
-
-            mock_session.execute = AsyncMock(side_effect=execute_side_effect)
-
-            with (
-                patch(
-                    # fix(#909): tasks_vrt late-binds; patch the origin
-                    "app.core.db.async_session"
-                ) as mock_async_session,
-                patch(
-                    "app.processing.ingest.tasks_vrt.build_vrt",
-                    side_effect=RuntimeError("fail"),
-                ),
-            ):
+            with patch("app.core.db.async_session") as mock_async_session:
                 mock_async_session.return_value = mock_session
-                try:
-                    await regenerate_vrt.func(
-                        job_id=job_id,
-                        attempt_id=str(uuid.uuid4()),
-                        vrt_dataset_id=vrt_dataset_id,
-                    )
-                except Exception:
-                    pass
+                await _settle_failed_vrt_asset(
+                    uuid.uuid4(), uuid.uuid4(), job_id=str(uuid.uuid4())
+                )
 
             statements = "\n".join(
                 str(call.args[0]) for call in mock_session.execute.await_args_list
             )
             assert "UPDATE catalog.raster_assets" in statements
             assert "current_generation_id" in statements
+            assert mock_session.commit.await_count == 1
 
         asyncio.run(_check())
 

--- a/backend/tests/test_vrt_source_management_174.py
+++ b/backend/tests/test_vrt_source_management_174.py
@@ -863,12 +863,7 @@ class TestRegenerateVrtTask:
         assert queue == "raster"
 
     def test_an_attempt_with_no_generation_writes_the_job_row_only(self):
-        """fix(#1962): nothing to release, so the asset is left alone.
-
-        The asset write is fenced on the generation this attempt owns. An
-        attempt that failed before binding one owns no pointer, and the fence
-        would otherwise read as ``IS NULL``.
-        """
+        """fix(#1962): no generation bound, so no asset pointer to release."""
 
         async def _check():
             from app.processing.ingest.tasks import regenerate_vrt

--- a/backend/tests/test_vrt_source_management_174.py
+++ b/backend/tests/test_vrt_source_management_174.py
@@ -924,9 +924,10 @@ class TestRegenerateVrtTask:
                 str(call.args[0]) for call in mock_session.execute.await_args_list
             )
             assert "UPDATE catalog.raster_assets" in statements
-            # fix(#1962 codex r2): a legacy delivery binds no generation, so the
-            # NULL-pointer branch is the only thing that can release its asset.
-            assert "current_generation_id IS NULL" in statements
+            # fix(#1962 codex r3): an attempt that bound no generation releases
+            # the asset unless a live generation owns it, which is the only
+            # rule that reaches one the sweep cannot see.
+            assert "catalog.vrt_generations" in statements
 
         asyncio.run(_check())
 
@@ -958,6 +959,31 @@ class TestRegenerateVrtTask:
             assert mock_session.commit.await_count == 1
 
         asyncio.run(_check())
+
+    def test_the_asset_settles_before_the_job_and_generation_write(self):
+        """fix(#1962): the reverse order puts both writes back in one abort."""
+        import ast
+        import inspect
+
+        from app.processing.ingest import tasks_vrt
+
+        tree = ast.parse(inspect.getsource(tasks_vrt.regenerate_vrt.func))
+        lines = {
+            name: [
+                node.lineno
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call) and getattr(node.func, "id", None) == name
+            ]
+            for name in ("_settle_failed_vrt_asset", "update_ingest_job_for_attempt")
+        }
+        assert all(len(v) == 1 for v in lines.values()), lines
+        assert (
+            lines["_settle_failed_vrt_asset"][0]
+            < (lines["update_ingest_job_for_attempt"][0])
+        ), (
+            "the asset settles after the job write, so a contended job row "
+            "aborts the transaction the asset write is in again"
+        )
 
     def test_task_sets_status_to_ready_on_success(self):
         """On success, asset.status is set to 'ready' and last_regenerated_at is updated."""

--- a/backend/tests/test_vrt_source_management_174.py
+++ b/backend/tests/test_vrt_source_management_174.py
@@ -862,8 +862,8 @@ class TestRegenerateVrtTask:
         ) or regenerate_vrt.task_kwargs.get("queue")
         assert queue == "raster"
 
-    def test_an_attempt_with_no_generation_writes_the_job_row_only(self):
-        """fix(#1962): no generation bound, so no asset pointer to release."""
+    def test_task_sets_status_to_failed_on_exception(self):
+        """On exception, task sets asset.status = 'failed' and job.status = 'failed'."""
 
         async def _check():
             from app.processing.ingest.tasks import regenerate_vrt
@@ -923,10 +923,10 @@ class TestRegenerateVrtTask:
             statements = "\n".join(
                 str(call.args[0]) for call in mock_session.execute.await_args_list
             )
-            # The job UPDATE is stubbed module-wide by `_fence_vrt_worker_helpers`,
-            # so the budget it arms is what shows the handler ran its write.
-            assert "SET LOCAL lock_timeout" in statements
-            assert "UPDATE catalog.raster_assets" not in statements
+            assert "UPDATE catalog.raster_assets" in statements
+            # fix(#1962 codex r2): a legacy delivery binds no generation, so the
+            # NULL-pointer branch is the only thing that can release its asset.
+            assert "current_generation_id IS NULL" in statements
 
         asyncio.run(_check())
 


### PR DESCRIPTION
## Summary

The worker error-write and VRT lifecycle cluster from the 2026-09-08 triage. Four issues,
three commits, one behaviour theme: a failed job must record its failure without parking
the worker, and without leaving a half-written VRT nothing can repair.

`#1950` is verified rather than fixed. All six sites it names are bounded on `main` by the
landed `#1947` and `#1956` work, and `tests/test_job_error_write_bound_1950.py` gates them.

## Changes

- **#1957** The STAC and PostGIS refresh tails and both analysis failure tails settled a
  failed job on a session holding no lock on its row, so a row a later attempt holds parked
  the worker while the heartbeat reported the job alive. They now share
  `write_job_failure_for_attempt`, which arms the shared budget, runs the fenced UPDATE,
  commits, and returns `None` on an expiry instead of raising into a caller already handling
  a failure. `None` is not a fence miss: both analysis tails leave their output table alone
  rather than probing for an adopting dataset row and dropping work the attempt still owns.
  The budget had two definitions that agreed by coincidence; the raster replace tail now
  reads the one in `platform/jobs/heartbeat.py`.
- **#1962** `regenerate_vrt`'s failure handler wrote three rows in one transaction, so a
  bounded abort on the job row took the asset and generation writes with it. The asset write
  now commits first, on its own. That ordering is the decision the issue asks for:
  `sweep_stale_vrt_assets` fences its asset UPDATE on the generations it has just failed, so
  an asset left pointing at a terminal generation is the one half-written state it can never
  reach, while a generation left non-terminal is swept on its stale heartbeat. The settlement
  reports whether it landed, and the generation is stamped only when it did.

  Review turned the fence into the general rule rather than a pointer match: an asset is
  released unless a live generation owns it. That covers a NULL pointer left by a legacy
  delivery, a phantom one left by a phase 1 that rolled back after claiming the asset, and one
  naming a generation already terminal. All three are invisible to the sweep, which reaches an
  asset only through a pending or running generation. It still yields to a newer attempt.
- **#1955** ADR-002 Decision 5b admits one mutation per dataset through an index the VRT path
  never writes to. All three regeneration doors read the asset status, checked it and flipped
  it as separate statements. The regenerate endpoint took an advisory lock after the read,
  which is too late; `add_vrt_source` and `remove_vrt_source` took none, so two concurrent
  calls both staged a generation and both dispatched. All three now share
  `admit_vrt_mutation`, which takes the lock first and re-reads the status under it, and all
  three refuse with the same coded `dataset_busy` body the index-based admission returns.
  Decision 5b records the VRT path as a separate admission system and says what it shares.

  **Mutual exclusion with the other Decision 5b mutations.** No `create_pending_run` door can
  target a VRT dataset, so a regeneration and a run-row mutation cannot interleave and the
  lock does not need to be the key some other path holds. Two checks prove it, and both are
  now pinned by tests. The three refresh doors gate on `classify_origin`, which returns NULL
  for `vrt_dataset` because that record type is in `_ORIGINLESS_RECORD_TYPES`, so each answers
  409 `refresh_not_applicable` before the insert. The re-upload door, which also carries
  raster replace, refuses `vrt_dataset` with 400 in `_assert_compatible_record_type`, above
  its `create_pending_run` call. If either check stops holding, VRT regeneration has to join
  the index rather than keep a lock of its own, and the ADR says so.

## Area

- [x] Backend (API, services, models)
- [x] Import / Ingestion

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)
- [x] No tests needed (docs, config, etc.)

Focused suites, host pytest against a per-lane database: `test_job_error_write_bound_1950`,
`test_job_error_write_bound_1957`, `test_vrt_admission_1955`, `test_regenerate_vrt_integration`,
`test_vrt_source_management_174`, `test_vrt_lifecycle_188`, `test_vrt_staged_mutation_1327`,
`test_vrt_source_authz_1172`, `test_vrt_stale_sweep_gap002`, `test_job_cancel_vrt`,
`test_defer_orphan_guard`, `test_analysis_materialize`, `test_postgis_refresh_1265`,
`test_stac_refresh_1266`, `test_raster_replace_phase_budget_1937`. Plus `test_layering`,
`test_rule1_structural`, `test_rule2_structural`, `finding_markers.py`, ruff check and format.

Counterfactuals, each run with the fix reverted and the tests kept:

- #1957: 10 of 14 fail. The two analysis tails hang on a held job row until the test's own
  30-second guard fires, which is the hang the issue describes.
- #1962: the asset is left `regenerating` and still pointing at the generation. Four further
  tests cover the release rule, each verified against the narrower fence it replaces: a legacy
  delivery with no pointer, a `ready` asset with no pointer that must not be touched, a pointer
  at a generation already terminal, and an asset a pending generation still owns.
- #1955: `add_vrt_source` and `remove_vrt_source` both answer 202 and dispatch a regeneration
  while another door holds the admission lock. There is also a concurrency test per door: two
  calls in flight at once, each on its own session, must give one 202, one 409 and one queued
  rebuild. On main both source doors answer 202 twice, over three runs. The regenerate door
  refuses a simultaneous caller even on main, because it holds its lock from after the read to
  its commit; what it did not refuse is a caller arriving just after that commit on a snapshot
  taken before it. `test_a_stale_snapshot_does_not_admit_a_second_regeneration` covers that
  window directly, and an AST gate holds every door to reading the status only inside the
  lock.

## Checklist

- [x] Code follows existing project conventions
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] No secrets or credentials in the diff

`_MODULE_LOC_CAPS` re-measured to exact figures for `tasks_vrt.py` (1654), `analysis/tasks.py`
(1403), `tasks_postgis_refresh.py` (978), `tasks_raster_replace.py` (993) and
`ingest/router.py` (1972). `UNANCHORED_MARKER_DEBT` for `ingest/router.py` lowered 14 to 12.
No published route docstring or Pydantic description changed, so no SDK regeneration.

## Review

Three rounds, one P1 each, all in the same function and all the same shape: a state of the
(RasterAsset, VrtGeneration) pair that no sweep repairs, so every later VRT mutation answers
409 forever. Each is fixed and answered on its thread, and the fourth review carries no
findings.

1. The settlement swallowed its own failure and the generation was stamped anyway.
2. The early return for an attempt that bound no generation removed the only settlement a
   legacy delivery has.
3. `SET LOCAL` cannot bound a wait for a connection, so an exhausted pool cost 30 seconds
   before the budget applied, and the SQLAlchemy `TimeoutError` that followed is not a
   `DBAPIError`, so it escaped a helper whose contract is that it never raises. The checkout
   now runs on its own deadline at the one point with nothing in flight, and the catch covers
   `SQLAlchemyError`.

An audit alongside the third round found that the settlement also reported success when its
UPDATE matched zero rows, which is what turned the fence into the general rule above.

A later round raised the arithmetic that bounding the checkout created. A materialize
cancelled at shutdown releases its working lock under a 5 second deadline and then writes the
job failure, and both sit inside a 15 second shield; the write can now spend its budget twice,
once on the checkout and again on the UPDATE, so the shared 10 seconds put the worst case at
25 inside 15. The shield and the rollback deadline have names now, and the cancel path's write
budget is derived from them rather than shared: what the shield has left after the rollback,
halved between the two waits, less a second of margin. Worst case is 14 inside 15. The shared
helper takes an optional budget for that, resolved at call time rather than as a default
argument, which would freeze the constant at import and sever the patch its tests rely on.

## Notes

- #1955 was briefed as bringing VRT regeneration under `create_pending_run`. That is not
  possible in one PR here: `dataset_refresh_runs.origin_kind` is CHECK-constrained and a VRT
  classifies as no origin, so it needs a migration, a `RUN_ORIGIN_KINDS` change in
  `platform/refresh/service.py`, run finalization on every `regenerate_vrt` exit path and a
  change to the cancel reconciliation in `platform/jobs/router.py`. Two of those files belong
  to a sibling lane. The atomic-admission fix above closes the concrete hole; whether the VRT
  path should also carry a run row is left open.
- Deferred: in the two refresh tails the writes that follow the job row, `stamp_failed_origin_health`
  and `record_refresh_failure`, remain unbudgeted. They touch the dataset and refresh-run rows,
  which Decision 5b's admission control already keeps a sibling refresh away from, so they are
  a separate question from the job row this issue names.

Closes #1950
Closes #1955
Closes #1957
Closes #1962
