### PR TITLE
fix: host psql -X gaps and Azure managed identity docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -653,10 +653,12 @@ FRONTEND_PORT=8080
 
 # --- Azure Blob Storage (cloud-dev or production) ---
 # [OPTIONAL] Required when STORAGE_PROVIDER=azure.
-# Use either AZURE_STORAGE_CONNECTION_STRING (for Azurite or a full connection string)
-# OR AZURE_STORAGE_ACCOUNT_URL + AZURE_STORAGE_ACCOUNT_KEY (for production key-auth).
-# Managed identity / Entra ID auth: set AZURE_STORAGE_ACCOUNT_URL and leave
-# AZURE_STORAGE_CONNECTION_STRING and AZURE_STORAGE_ACCOUNT_KEY unset.
+# Two supported forms only:
+#   1. AZURE_STORAGE_CONNECTION_STRING (Azurite dev or a full connection string)
+#   2. AZURE_STORAGE_ACCOUNT_URL + AZURE_STORAGE_ACCOUNT_KEY (production key auth)
+# Managed identity / Entra ID auth is not supported. The backend does not
+# ship azure-identity, so AZURE_STORAGE_ACCOUNT_URL alone authenticates
+# anonymously and fails at the first object read, not at boot.
 #
 # Type: string | No default
 # AZURE_STORAGE_CONTAINER=geolens-prod
@@ -664,14 +666,14 @@ FRONTEND_PORT=8080
 # Full connection string (Azurite dev or Azure Storage emulator):
 # AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...
 #
-# Account URL for production (Entra ID / managed identity or key auth):
+# Account URL for production key auth (used with AZURE_STORAGE_ACCOUNT_KEY below):
 # AZURE_STORAGE_ACCOUNT_URL=https://<account>.blob.core.windows.net
 #
 # Storage account name used by GDAL/Titiler when no connection string is set.
 # This is the <account> segment from AZURE_STORAGE_ACCOUNT_URL.
 # AZURE_STORAGE_ACCOUNT=<account-name>
 #
-# Storage account access key (when using account_url + key auth, not connection_string):
+# Storage account access key, required when using ACCOUNT_URL instead of CONNECTION_STRING:
 # AZURE_STORAGE_ACCOUNT_KEY=<base64-encoded-key>
 
 # [OPTIONAL] Threshold for multipart presigned S3 uploads in megabytes

--- a/backend/tests/test_runtime_db_role.py
+++ b/backend/tests/test_runtime_db_role.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import json
 import os
+import re
 import shutil
 import subprocess
 from types import SimpleNamespace
@@ -17,6 +18,7 @@ from tests.repo_paths import repo_root
 ROOT = repo_root(__file__)
 ROLE_SCRIPT = ROOT / "scripts" / "lib" / "configure-runtime-db-role.sh"
 ROUNDTRIP_SCRIPT = ROOT / "scripts" / "tests" / "test-backup-restore-roundtrip.sh"
+INIT_TEST_DB_SCRIPT = ROOT / "scripts" / "init-test-db.sh"
 
 requires_docker_cli = pytest.mark.skipif(
     shutil.which("docker") is None,
@@ -259,6 +261,33 @@ def test_role_script_disables_host_psqlrc() -> None:
     assert source.index(args_line, args_block_start) < source.index(
         "ON_ERROR_STOP=1", args_block_start
     )
+
+
+def test_init_test_db_disables_host_psqlrc() -> None:
+    """fix(#1992): init-test-db.sh also runs directly against a host
+    Postgres, so it needs the same -X guard as init-db.sh."""
+    source = INIT_TEST_DB_SCRIPT.read_text(encoding="utf-8")
+
+    args_block_start = source.index("psql_base=(")
+    args_block_end = source.index(")", args_block_start)
+    args_block = source[args_block_start:args_block_end]
+    assert "-X" in args_block
+    assert args_block.index("-X") < args_block.index("ON_ERROR_STOP=1")
+
+
+def test_roundtrip_every_host_psql_call_disables_host_psqlrc() -> None:
+    """fix(#1992): every psql call the round-trip script makes straight to
+    the host Postgres (the psql_admin helper included) must carry -X, like
+    the role-authenticated calls beside it already did."""
+    source = ROUNDTRIP_SCRIPT.read_text(encoding="utf-8")
+
+    missing = [
+        line
+        for line in source.splitlines()
+        if re.search(r"\bpsql\b", line) and '-h "$PGHOST"' in line and "-X" not in line
+    ]
+    assert not missing, f"psql call(s) missing -X: {missing}"
+    assert 'psql_admin() { psql -X -h "$PGHOST"' in source
 
 
 def test_role_script_keeps_password_out_of_argv_and_catalog_ownership() -> None:

--- a/scripts/init-test-db.sh
+++ b/scripts/init-test-db.sh
@@ -6,7 +6,11 @@ db_port="${POSTGRES_PORT:-5432}"
 db_user="${POSTGRES_USER:-geolens}"
 test_db="${POSTGRES_DB_TEST:-geolens_test}"
 
+# fix(#1992): -X skips a host .psqlrc that could `\set ON_ERROR_STOP off`
+# and let a failed statement fall through, matching init-db.sh and the
+# runtime-role reconciler's host-invoked psql calls.
 psql_base=(
+  -X
   -v ON_ERROR_STOP=1
   --username "$db_user"
   --host "$db_host"

--- a/scripts/tests/test-backup-restore-roundtrip.sh
+++ b/scripts/tests/test-backup-restore-roundtrip.sh
@@ -60,7 +60,7 @@ for bin in pg_dump pg_dumpall pg_restore psql createdb dropdb; do
 done
 
 # Verify the test Postgres is reachable before creating throwaway DBs.
-if ! psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$ADMIN_DB" -tAc "SELECT 1" >/dev/null 2>&1; then
+if ! psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$ADMIN_DB" -tAc "SELECT 1" >/dev/null 2>&1; then
     echo "SKIP: test Postgres not reachable at ${PGHOST}:${PGPORT} (is the test DB up?)"
     exit 0
 fi
@@ -68,7 +68,7 @@ fi
 # The generic CI service is postgis/postgis and intentionally has no pgvector.
 # Keep the backup/restore and role-isolation proof portable there, while the
 # project DB image/local stack must exercise the complete embedding DDL path.
-PGVECTOR_AVAILABLE="$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" \
+PGVECTOR_AVAILABLE="$(psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" \
     -d "$ADMIN_DB" -tAc \
     "SELECT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector');" \
     | tr -d '[:space:]')"
@@ -77,7 +77,7 @@ if [ "$PGVECTOR_AVAILABLE" = "t" ]; then
 else
     echo "SKIP [pgvector]: extension unavailable; vector-specific embedding-definer DDL subproof disabled (function ownership and ACL checks still run)."
 fi
-READER_EXISTED_AT_START="$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" \
+READER_EXISTED_AT_START="$(psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" \
     -d "$ADMIN_DB" -tAc \
     "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'geolens_reader');" \
     | tr -d '[:space:]')"
@@ -131,7 +131,10 @@ OLD_SESSION_PID=""
 WORKDIR="$(mktemp -d)"
 DUMP_FILE="${WORKDIR}/roundtrip.dump"
 
-psql_admin() { psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$ADMIN_DB" "$@"; }
+# fix(#1992): -X skips a host .psqlrc, matching every role-authenticated
+# psql call below (already -X) so a `\set ON_ERROR_STOP off` there can't
+# mask a failed statement.
+psql_admin() { psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$ADMIN_DB" "$@"; }
 
 cleanup() {
     set +e
@@ -175,7 +178,7 @@ echo "[1/5] Creating source DB and seeding known rows (bundled mode)..."
 createdb -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" "$SRC_DB"
 
 # Mirror the app's catalog schema shape just enough to be representative.
-psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" -v ON_ERROR_STOP=1 >/dev/null <<'EOSQL'
+psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" -v ON_ERROR_STOP=1 >/dev/null <<'EOSQL'
 CREATE SCHEMA IF NOT EXISTS catalog;
 CREATE TABLE catalog.records  (id serial PRIMARY KEY, name text NOT NULL);
 CREATE TABLE catalog.datasets (id serial PRIMARY KEY, slug text NOT NULL);
@@ -206,7 +209,7 @@ INSERT INTO catalog.datasets (slug)
 INSERT INTO data.ci_probe (name) VALUES ('runtime-ownership-probe');
 EOSQL
 if [ "$PGVECTOR_AVAILABLE" = "t" ]; then
-    psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" \
+    psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" \
         -v ON_ERROR_STOP=1 >/dev/null <<'EOSQL'
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE TABLE catalog.record_embeddings (
@@ -303,8 +306,8 @@ SOURCE_DATA_ROUTINE_STATE="$(psql_admin -d "$SRC_DB" -tAc \
 [ "$SOURCE_DATA_ROUTINE_STATE" = "${FRESH_RUNTIME_ROLE}|false" ] \
     || fail "source runtime routine fixture is unsafe: ${SOURCE_DATA_ROUTINE_STATE}"
 
-SRC_RECORDS="$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" -tAc "SELECT COUNT(*) FROM catalog.records;")"
-SRC_DATASETS="$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" -tAc "SELECT COUNT(*) FROM catalog.datasets;")"
+SRC_RECORDS="$(psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" -tAc "SELECT COUNT(*) FROM catalog.records;")"
+SRC_DATASETS="$(psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SRC_DB" -tAc "SELECT COUNT(*) FROM catalog.datasets;")"
 echo "      source counts: records=${SRC_RECORDS} datasets=${SRC_DATASETS}"
 
 echo "[2/5] pg_dump -Fc, then pg_restore into a fresh DB (restore.sh flags)..."
@@ -356,8 +359,8 @@ if [ "$RC" -ne 0 ]; then
     echo "      pg_restore exit ${RC} (warnings only — expected on fresh DB)"
 fi
 
-DST_RECORDS="$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$DST_DB" -tAc "SELECT COUNT(*) FROM catalog.records;")"
-DST_DATASETS="$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$DST_DB" -tAc "SELECT COUNT(*) FROM catalog.datasets;")"
+DST_RECORDS="$(psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$DST_DB" -tAc "SELECT COUNT(*) FROM catalog.records;")"
+DST_DATASETS="$(psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$DST_DB" -tAc "SELECT COUNT(*) FROM catalog.datasets;")"
 echo "      restored counts: records=${DST_RECORDS} datasets=${DST_DATASETS}"
 
 [ "$SRC_RECORDS" = "$DST_RECORDS" ]   || fail "records count mismatch: ${SRC_RECORDS} != ${DST_RECORDS}"
@@ -1500,8 +1503,8 @@ if [ "$SNAP_RC" -ne 0 ]; then
     echo "      snapshot pg_restore exit ${SNAP_RC} (warnings only — expected on fresh DB)"
 fi
 
-SNAP_RECORDS="$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SNAP_DB" -tAc "SELECT COUNT(*) FROM catalog.records;")"
-SNAP_DATASETS="$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SNAP_DB" -tAc "SELECT COUNT(*) FROM catalog.datasets;")"
+SNAP_RECORDS="$(psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SNAP_DB" -tAc "SELECT COUNT(*) FROM catalog.records;")"
+SNAP_DATASETS="$(psql -X -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$SNAP_DB" -tAc "SELECT COUNT(*) FROM catalog.datasets;")"
 echo "      snapshot DB counts: records=${SNAP_RECORDS} datasets=${SNAP_DATASETS}"
 
 [ "$SRC_RECORDS" = "$SNAP_RECORDS" ]   || fail "managed-mode: snapshot records count mismatch: ${SRC_RECORDS} != ${SNAP_RECORDS}"


### PR DESCRIPTION
## Summary

Two small wave leftovers: a host `.psqlrc` gap left over from #1995, and an
`.env.example` claim that Azure managed identity works when it does not.

## Changes

- `scripts/init-test-db.sh` and the admin/direct `psql` calls in
  `scripts/tests/test-backup-restore-roundtrip.sh` now pass `-X`, matching
  `init-db.sh` and the runtime-role reconciler. Without it, a host
  `.psqlrc` that sets `\set ON_ERROR_STOP off` can let a failed statement
  in either script pass silently.
- `.env.example`'s Azure Blob Storage block claimed setting
  `AZURE_STORAGE_ACCOUNT_URL` alone enables managed identity / Entra ID
  auth. It does not: `azure-identity` is deliberately not a backend
  dependency (`backend/app/platform/storage/azure.py`, fix(#836)), so that
  configuration authenticates anonymously and fails at the first object
  read instead of at boot. The block now documents the two forms the
  backend actually supports: a connection string, or an account URL paired
  with an account key. Checked `RUNBOOK.md`, `README.md` and
  `backend/app/core/config.py` for the same claim; none carried it.

## Area

- [x] Docs / Config
- [x] Infrastructure (Docker, nginx)

## Testing

- [x] Unit tests pass (`pytest`)
- [x] No tests needed (docs, config, etc.), for the `.env.example` change

Added `test_init_test_db_disables_host_psqlrc` and
`test_roundtrip_every_host_psql_call_disables_host_psqlrc` to
`backend/tests/test_runtime_db_role.py`, extending the pattern
`test_role_script_disables_host_psqlrc` already uses. Both fail against the
pre-fix scripts and pass after.

```
cd backend && uv run pytest tests/test_runtime_db_role.py -q
44 passed
```

Also ran `uv run ruff check . && uv run ruff format --check .`,
`pytest tests/test_layering.py -q`, `python3 backend/tests/finding_markers.py`,
`git diff --check`, and `make openapi-check` (clean, since `.env.example`
is not published API surface), plus `shellcheck` on both changed scripts
(no new findings).

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing

Refs #1992, Refs #836
