### PR TITLE
fix(jobs): log the cause of a failed task dispatch

### DIFF
--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -186,9 +186,15 @@ def _log_dispatch_failure(job: IngestJob, exc: BaseException, *, stage: str) -> 
     ``stage`` separates the two raise sites, which ``cause_class`` alone
     cannot when both fail with the same type.
     """
+    try:
+        job_id = str(job.id)
+    except Exception:  # broad: a diagnostic must not preempt the settlement below
+        # fix(#1755): an already-expired instance raises `MissingGreenlet` on
+        # the read; `reset_session_for_settlement` is what recovers it.
+        job_id = "unreadable"
     logger.warning(
         "ingest_dispatch_failed",
-        job_id=str(job.id),
+        job_id=job_id,
         stage=stage,
         cause_class=type(exc).__name__,
         error=redact_exception_text(exc),
@@ -232,8 +238,6 @@ async def defer_with_orphan_guard(
     try:
         await stamp_commit_attempted(job, db=db)
     except Exception as stamp_exc:  # broad: a failed marker write is a failed dispatch
-        # Logged before the reset below, which expires `job` and can leave its
-        # id unreadable.
         _log_dispatch_failure(job, stamp_exc, stage="commit_attempted_marker")
         # fix(#1774): reset discards nothing — every caller commits before dispatching.
         await reset_session_for_settlement(job, db=db)

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -179,6 +179,19 @@ async def _settle_after_failed_dispatch(
         return False
 
 
+def _render_or_unreadable(render: Callable[[], str]) -> str:
+    """One diagnostic field, or a placeholder when producing it raises.
+
+    fix(#1755): an already-expired ``job`` raises on the ``id`` read and an
+    exception with a failing ``__str__`` raises on render. Neither may
+    escape the log that runs in front of the settlement.
+    """
+    try:
+        return render()
+    except Exception:  # broad: a diagnostic must not replace the failure it reports
+        return "unreadable"
+
+
 def _log_dispatch_failure(job: IngestJob, exc: BaseException, *, stage: str) -> None:
     """Record what made a dispatch fail, because nothing downstream will.
 
@@ -186,18 +199,12 @@ def _log_dispatch_failure(job: IngestJob, exc: BaseException, *, stage: str) -> 
     ``stage`` separates the two raise sites, which ``cause_class`` alone
     cannot when both fail with the same type.
     """
-    try:
-        job_id = str(job.id)
-    except Exception:  # broad: a diagnostic must not preempt the settlement below
-        # fix(#1755): an already-expired instance raises `MissingGreenlet` on
-        # the read; `reset_session_for_settlement` is what recovers it.
-        job_id = "unreadable"
     logger.warning(
         "ingest_dispatch_failed",
-        job_id=job_id,
+        job_id=_render_or_unreadable(lambda: str(job.id)),
         stage=stage,
         cause_class=type(exc).__name__,
-        error=redact_exception_text(exc),
+        error=_render_or_unreadable(lambda: redact_exception_text(exc)),
     )
 
 

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -28,7 +28,7 @@ from sqlalchemy import inspect as sa_inspect, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_object_session
 from sqlalchemy.orm.attributes import set_committed_value
 
-from app.core.url_redaction import redact_exception_text
+from app.core.logging_config import redact_nested
 from app.platform.jobs.models import (
     COMMIT_ATTEMPTED_METADATA_KEY,
     IngestJob,
@@ -198,14 +198,24 @@ def _log_dispatch_failure(job: IngestJob, exc: BaseException, *, stage: str) -> 
     fix(#1755): FastAPI answers a ``DeferFailed`` without logging it.
     ``stage`` separates the two raise sites, which ``cause_class`` alone
     cannot when both fail with the same type.
+
+    fix(#1755): ``error`` is scrubbed HERE, through ``redact_nested``.
+    ``_redact_sensitive_fields`` scrubs free text only under ``event`` and
+    ``exception``, and a defer exception can quote Procrastinate's
+    ``call_string``, which renders a live ``token='...'`` kwarg.
     """
-    logger.warning(
-        "ingest_dispatch_failed",
-        job_id=_render_or_unreadable(lambda: str(job.id)),
-        stage=stage,
-        cause_class=type(exc).__name__,
-        error=_render_or_unreadable(lambda: redact_exception_text(exc)),
-    )
+    # The inner guards degrade one field; this one covers the emit itself, so
+    # a raising processor cannot skip the settlement that follows.
+    try:
+        logger.warning(
+            "ingest_dispatch_failed",
+            job_id=_render_or_unreadable(lambda: str(job.id)),
+            stage=stage,
+            cause_class=type(exc).__name__,
+            error=_render_or_unreadable(lambda: redact_nested(str(exc))),
+        )
+    except Exception:  # broad: a diagnostic must not preempt the settlement below
+        pass
 
 
 async def defer_with_orphan_guard(

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -28,6 +28,7 @@ from sqlalchemy import inspect as sa_inspect, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_object_session
 from sqlalchemy.orm.attributes import set_committed_value
 
+from app.core.url_redaction import redact_exception_text
 from app.platform.jobs.models import (
     COMMIT_ATTEMPTED_METADATA_KEY,
     IngestJob,
@@ -178,6 +179,22 @@ async def _settle_after_failed_dispatch(
         return False
 
 
+def _log_dispatch_failure(job: IngestJob, exc: BaseException, *, stage: str) -> None:
+    """Record what made a dispatch fail, because nothing downstream will.
+
+    fix(#1755): FastAPI answers a ``DeferFailed`` without logging it.
+    ``stage`` separates the two raise sites, which ``cause_class`` alone
+    cannot when both fail with the same type.
+    """
+    logger.warning(
+        "ingest_dispatch_failed",
+        job_id=str(job.id),
+        stage=stage,
+        cause_class=type(exc).__name__,
+        error=redact_exception_text(exc),
+    )
+
+
 async def defer_with_orphan_guard(
     defer_call: DeferCallable,
     *,
@@ -215,6 +232,9 @@ async def defer_with_orphan_guard(
     try:
         await stamp_commit_attempted(job, db=db)
     except Exception as stamp_exc:  # broad: a failed marker write is a failed dispatch
+        # Logged before the reset below, which expires `job` and can leave its
+        # id unreadable.
+        _log_dispatch_failure(job, stamp_exc, stage="commit_attempted_marker")
         # fix(#1774): reset discards nothing — every caller commits before dispatching.
         await reset_session_for_settlement(job, db=db)
         rolled_back = await _settle_after_failed_dispatch(rollback, stamp_exc, db)
@@ -225,6 +245,7 @@ async def defer_with_orphan_guard(
     except (
         Exception
     ) as defer_exc:  # broad: defer_async can throw various job-runner errors
+        _log_dispatch_failure(job, defer_exc, stage="defer_async")
         rolled_back = await _settle_after_failed_dispatch(rollback, defer_exc, db)
         raise DeferFailed(rolled_back=rolled_back, cause=defer_exc) from defer_exc
 

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -159,6 +159,19 @@ async def reset_session_for_settlement(job: IngestJob, *, db: AsyncSession) -> N
         logger.exception("Could not reload the job before settling it")
 
 
+def _render_or_unreadable(render: Callable[[], str]) -> str:
+    """One diagnostic field, or a placeholder when producing it raises.
+
+    fix(#1755): an already-expired ``job`` raises on the ``id`` read and an
+    exception with a failing ``__str__`` raises on render. Neither may
+    escape the log that runs in front of the settlement.
+    """
+    try:
+        return render()
+    except Exception:  # broad: a diagnostic must not replace the failure it reports
+        return "unreadable"
+
+
 async def _settle_after_failed_dispatch(
     rollback: RollbackCallable, exc: BaseException, db: AsyncSession
 ) -> bool:
@@ -174,22 +187,9 @@ async def _settle_after_failed_dispatch(
     except Exception:  # broad: rollback can itself fail with DB errors
         logger.exception(
             "Orphan-guard rollback failed after defer error",
-            defer_error=str(exc),
+            defer_error=_render_or_unreadable(lambda: redact_nested(str(exc))),
         )
         return False
-
-
-def _render_or_unreadable(render: Callable[[], str]) -> str:
-    """One diagnostic field, or a placeholder when producing it raises.
-
-    fix(#1755): an already-expired ``job`` raises on the ``id`` read and an
-    exception with a failing ``__str__`` raises on render. Neither may
-    escape the log that runs in front of the settlement.
-    """
-    try:
-        return render()
-    except Exception:  # broad: a diagnostic must not replace the failure it reports
-        return "unreadable"
 
 
 def _log_dispatch_failure(job: IngestJob, exc: BaseException, *, stage: str) -> None:
@@ -331,7 +331,7 @@ async def settle_ingest_job_failed(
         logger.info(
             "orphan_guard_rollback_skipped_job_already_settled",
             job_id=str(job.id),
-            defer_error=str(defer_exc),
+            defer_error=_render_or_unreadable(lambda: redact_nested(str(defer_exc))),
         )
     return landed
 

--- a/backend/app/platform/jobs/defer_guard.py
+++ b/backend/app/platform/jobs/defer_guard.py
@@ -203,6 +203,11 @@ def _log_dispatch_failure(job: IngestJob, exc: BaseException, *, stage: str) -> 
     ``_redact_sensitive_fields`` scrubs free text only under ``event`` and
     ``exception``, and a defer exception can quote Procrastinate's
     ``call_string``, which renders a live ``token='...'`` kwarg.
+
+    fix(#1755): ``exc_info`` carries the chain, because Procrastinate wraps
+    a connector failure as ``ConnectorException("Database error.")`` and the
+    top frame alone tells two outages apart from neither. ``format_exc_info``
+    renders it under ``exception``, which the processor does scrub.
     """
     # The inner guards degrade one field; this one covers the emit itself, so
     # a raising processor cannot skip the settlement that follows.
@@ -213,6 +218,7 @@ def _log_dispatch_failure(job: IngestJob, exc: BaseException, *, stage: str) -> 
             stage=stage,
             cause_class=type(exc).__name__,
             error=_render_or_unreadable(lambda: redact_nested(str(exc))),
+            exc_info=exc,
         )
     except Exception:  # broad: a diagnostic must not preempt the settlement below
         pass

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -378,6 +378,38 @@ class TestDeferWithOrphanGuard:
 
         asyncio.run(_check())
 
+    def test_the_rollback_failure_log_scrubs_the_same_text(self):
+        """fix(#1755 item 10): the rollback-failure log renders the same defer
+        exception under its own scalar field, so it needs the same scrub.
+        """
+
+        async def _check():
+            from app.platform.jobs import defer_guard
+
+            async def _rollback(exc: BaseException) -> None:
+                raise ValueError("rollback crashed")
+
+            async def _defer() -> None:
+                raise RuntimeError(
+                    "could not enqueue ingest_service[9]"
+                    "(token='PLACEHOLDERSECRET2', credential_ref=None)"
+                )
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+
+            with patch.object(defer_guard, "logger") as mock_logger:
+                with pytest.raises(defer_guard.DeferFailed):
+                    await defer_guard.defer_with_orphan_guard(
+                        _defer, rollback=_rollback, db=mock_db, job=_job()
+                    )
+
+            logged = mock_logger.exception.call_args.kwargs["defer_error"]
+            assert "PLACEHOLDERSECRET2" not in logged
+            assert "[REDACTED]" in logged
+
+        asyncio.run(_check())
+
     def test_a_logger_that_raises_does_not_preempt_the_settlement(self):
         """fix(#1755 item 10): a structlog processor can raise while emitting.
         The whole diagnostic is best-effort, so the rollback still runs and the

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -410,6 +410,42 @@ class TestDeferWithOrphanGuard:
 
         asyncio.run(_check())
 
+    def test_the_wrapped_cause_reaches_the_record_scrubbed(self):
+        """fix(#1755 item 10): Procrastinate wraps a connector failure as
+        `ConnectorException("Database error.")`, so the top frame alone tells
+        two outages apart from neither. The chain lands under `exception`.
+        """
+        import logging
+
+        from app.platform.jobs.defer_guard import _log_dispatch_failure
+        from tests._logging_state import configured_logging
+
+        records: list[str] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(self.format(record))
+
+        try:
+            raise ValueError(
+                "connect failed for https://db.example.com/?token=PLACEHOLDERSECRET3"
+            )
+        except ValueError as inner:
+            wrapped = RuntimeError("Database error.")
+            wrapped.__cause__ = inner
+
+        handler = _Capture()
+        with configured_logging():
+            logging.getLogger().addHandler(handler)
+            try:
+                _log_dispatch_failure(_job(), wrapped, stage="defer_async")
+            finally:
+                logging.getLogger().removeHandler(handler)
+
+        emitted = "\n".join(records)
+        assert "connect failed for" in emitted
+        assert "PLACEHOLDERSECRET3" not in emitted
+
     def test_a_logger_that_raises_does_not_preempt_the_settlement(self):
         """fix(#1755 item 10): a structlog processor can raise while emitting.
         The whole diagnostic is best-effort, so the rollback still runs and the

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -259,7 +259,49 @@ class TestDeferWithOrphanGuard:
             assert defer_call.kwargs["cause_class"] == "RuntimeError"
             assert marker_call.kwargs["cause_class"] == "ValueError"
             assert "SECRETVALUE1" not in defer_call.kwargs["error"]
-            assert "queue.example.com" in defer_call.kwargs["error"]
+            assert defer_call.kwargs["error"].startswith("queue down: ")
+
+        asyncio.run(_check())
+
+    def test_an_unreadable_job_id_does_not_preempt_the_settlement(self):
+        """fix(#1755 item 10): reading `job.id` off an already-expired instance
+        raises, and `reset_session_for_settlement` is what recovers it. The log
+        runs first, so it has to absorb that read rather than skip the rollback.
+        """
+
+        async def _check():
+            from app.platform.jobs import defer_guard
+
+            class _Expired:
+                """A job whose identifier read raises, as an expired ORM instance does."""
+
+                user_metadata = None
+
+                @property
+                def id(self):
+                    raise RuntimeError("greenlet_spawn has not been called")
+
+            settled: list[BaseException] = []
+
+            async def _rollback(exc: BaseException) -> None:
+                settled.append(exc)
+
+            async def _defer() -> None:  # pragma: no cover - never reached
+                raise AssertionError("defer_call must not run")
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+            mock_db.rollback = AsyncMock()
+            mock_db.refresh = AsyncMock()
+
+            with pytest.raises(defer_guard.DeferFailed) as exc_info:
+                await defer_guard.defer_with_orphan_guard(
+                    _defer, rollback=_rollback, db=mock_db, job=_Expired()
+                )
+
+            assert exc_info.value.status_code == 503
+            assert exc_info.value.rolled_back is True
+            assert len(settled) == 1
 
         asyncio.run(_check())
 

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -214,6 +214,55 @@ class TestDeferWithOrphanGuard:
 
         asyncio.run(_check())
 
+    def test_each_stage_logs_its_cause_with_the_url_redacted(self):
+        """fix(#1755 item 10): FastAPI answers a `DeferFailed` without logging
+        it, so the guard logs the cause itself, under a `stage` that separates
+        the marker write from the defer call, with any URL redacted first.
+        """
+
+        async def _check():
+            from app.platform.jobs import defer_guard
+
+            async def _rollback(exc: BaseException) -> None:
+                return None
+
+            async def _defer() -> None:
+                raise RuntimeError(
+                    "queue down: https://queue.example.com/d?token=SECRETVALUE1"
+                )
+
+            defer_db = AsyncMock()
+            defer_db.commit = AsyncMock()
+            with patch.object(defer_guard, "logger") as defer_logger:
+                with pytest.raises(defer_guard.DeferFailed):
+                    await defer_guard.defer_with_orphan_guard(
+                        _defer, rollback=_rollback, db=defer_db, job=_job()
+                    )
+
+            marker_db = AsyncMock()
+            marker_db.commit = AsyncMock()
+            marker_db.rollback = AsyncMock()
+            marker_db.refresh = AsyncMock()
+            marker_db.execute = AsyncMock(side_effect=ValueError("bad shape"))
+            with patch.object(defer_guard, "logger") as marker_logger:
+                with pytest.raises(defer_guard.DeferFailed):
+                    await defer_guard.defer_with_orphan_guard(
+                        _defer, rollback=_rollback, db=marker_db, job=_job()
+                    )
+
+            defer_call = defer_logger.warning.call_args
+            marker_call = marker_logger.warning.call_args
+            assert defer_call.args[0] == "ingest_dispatch_failed"
+            assert marker_call.args[0] == "ingest_dispatch_failed"
+            assert defer_call.kwargs["stage"] == "defer_async"
+            assert marker_call.kwargs["stage"] == "commit_attempted_marker"
+            assert defer_call.kwargs["cause_class"] == "RuntimeError"
+            assert marker_call.kwargs["cause_class"] == "ValueError"
+            assert "SECRETVALUE1" not in defer_call.kwargs["error"]
+            assert "queue.example.com" in defer_call.kwargs["error"]
+
+        asyncio.run(_check())
+
     def test_rollback_failure_still_raises_503(self):
         """If rollback itself raises, helper still surfaces the 503 to the client."""
 

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -305,6 +305,45 @@ class TestDeferWithOrphanGuard:
 
         asyncio.run(_check())
 
+    def test_an_unrenderable_exception_does_not_preempt_the_settlement(self):
+        """fix(#1755 item 10): the dispatch log renders the exception, so an
+        exception whose `__str__` raises must degrade to a placeholder. The
+        readable field beside it keeps its real value.
+        """
+
+        async def _check():
+            from app.platform.jobs import defer_guard
+
+            class _Unrenderable(RuntimeError):
+                def __str__(self) -> str:
+                    raise ValueError("this exception cannot render itself")
+
+            settled: list[BaseException] = []
+
+            async def _rollback(exc: BaseException) -> None:
+                settled.append(exc)
+
+            async def _defer() -> None:
+                raise _Unrenderable()
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+
+            with patch.object(defer_guard, "logger") as mock_logger:
+                with pytest.raises(defer_guard.DeferFailed) as exc_info:
+                    await defer_guard.defer_with_orphan_guard(
+                        _defer, rollback=_rollback, db=mock_db, job=_job()
+                    )
+
+            assert exc_info.value.cause_class == "_Unrenderable"
+            assert exc_info.value.rolled_back is True
+            assert len(settled) == 1
+            logged = mock_logger.warning.call_args.kwargs
+            assert logged["error"] == "unreadable"
+            assert logged["job_id"] != "unreadable"
+
+        asyncio.run(_check())
+
     def test_rollback_failure_still_raises_503(self):
         """If rollback itself raises, helper still surfaces the 503 to the client."""
 

--- a/backend/tests/test_defer_orphan_guard.py
+++ b/backend/tests/test_defer_orphan_guard.py
@@ -344,6 +344,73 @@ class TestDeferWithOrphanGuard:
 
         asyncio.run(_check())
 
+    def test_a_rendered_task_kwarg_is_scrubbed_before_it_reaches_the_record(self):
+        """fix(#1755 item 10): `error` is a plain scalar field, and the log
+        processor scrubs free text only under `event` and `exception`. A defer
+        error quoting Procrastinate's `call_string` must be scrubbed here.
+        """
+
+        async def _check():
+            from app.platform.jobs import defer_guard
+
+            async def _rollback(exc: BaseException) -> None:
+                return None
+
+            async def _defer() -> None:
+                raise RuntimeError(
+                    "could not enqueue ingest_service[9]"
+                    "(token='PLACEHOLDERSECRET1', credential_ref=None)"
+                )
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+
+            with patch.object(defer_guard, "logger") as mock_logger:
+                with pytest.raises(defer_guard.DeferFailed):
+                    await defer_guard.defer_with_orphan_guard(
+                        _defer, rollback=_rollback, db=mock_db, job=_job()
+                    )
+
+            logged_error = mock_logger.warning.call_args.kwargs["error"]
+            assert "PLACEHOLDERSECRET1" not in logged_error
+            assert "[REDACTED]" in logged_error
+            assert logged_error.startswith("could not enqueue ingest_service[9]")
+
+        asyncio.run(_check())
+
+    def test_a_logger_that_raises_does_not_preempt_the_settlement(self):
+        """fix(#1755 item 10): a structlog processor can raise while emitting.
+        The whole diagnostic is best-effort, so the rollback still runs and the
+        caller still sees the 503.
+        """
+
+        async def _check():
+            from app.platform.jobs import defer_guard
+
+            settled: list[BaseException] = []
+
+            async def _rollback(exc: BaseException) -> None:
+                settled.append(exc)
+
+            async def _defer() -> None:
+                raise RuntimeError("queue down")
+
+            mock_db = AsyncMock()
+            mock_db.commit = AsyncMock()
+
+            with patch.object(defer_guard, "logger") as mock_logger:
+                mock_logger.warning.side_effect = OSError("log sink is gone")
+                with pytest.raises(defer_guard.DeferFailed) as exc_info:
+                    await defer_guard.defer_with_orphan_guard(
+                        _defer, rollback=_rollback, db=mock_db, job=_job()
+                    )
+
+            assert exc_info.value.status_code == 503
+            assert exc_info.value.rolled_back is True
+            assert len(settled) == 1
+
+        asyncio.run(_check())
+
     def test_rollback_failure_still_raises_503(self):
         """If rollback itself raises, helper still surfaces the 503 to the client."""
 


### PR DESCRIPTION
## Summary

Backend follow-ups from #1755, audited against `6077eddfb`. Six of the seven
backend items in scope (7, 8, 9, 11, 14, 15) were already on main and are
verified below rather than re-fixed. One half of item 10 was not: the cause of
a failed task dispatch reached the client but never reached the logs.

`defer_with_orphan_guard` raises `DeferFailed`, which subclasses
`HTTPException`. FastAPI answers those through `http_exception_handler`, which
logs nothing, and no middleware in this app logs a 5xx either. #1833 put a
`cause_class` field in the 503 body, which is what a test failure sees, but an
operator reading server logs after a 503 had no record of what broke. Both
raise sites now emit one `ingest_dispatch_failed` record.

## Changes

- `platform/jobs/defer_guard.py`: one `_log_dispatch_failure` helper, called
  from both raise sites in `defer_with_orphan_guard`. Fields are `job_id`,
  `stage`, `cause_class` and a redacted `error`.
- `stage` is `commit_attempted_marker` or `defer_async`, so the two failure
  shapes stay apart even when both raise the same exception type, which
  `cause_class` alone cannot do.
- The message goes through `redact_exception_text` before it reaches the
  record, so a defer error that quotes a credentialed URL is redacted at the
  call site as well as by the structlog processor.
- In the marker branch the log runs before `reset_session_for_settlement`,
  which rolls back and expires `job`.
- Response bodies are unchanged, so no OpenAPI or SDK regeneration.
- Every field is produced through `_render_or_unreadable` and the emit itself
  is wrapped, so an expired job, an exception that cannot render, or a raising
  log processor degrades the record instead of skipping the settlement.
- `error` is scrubbed at the call site through `redact_nested`. The log
  processor scrubs free text only under `event` and `exception`, and a defer
  error can quote Procrastinate's `call_string`, which renders a live
  `token='...'` kwarg. The guard's two other rendered-exception fields
  (`defer_error`, in the rollback-failure and already-settled logs) were
  unscrubbed for the same reason and now share the one call.

## Deferred

`settle_ingest_job_failed` writes `f"{message_prefix}: {defer_exc}"` into
`IngestJob.error_message`, which is stored and served on job reads. It has the
same exposure the log fields had, and it predates this PR. Changing it is a
behaviour change to a user-visible field, and the ingest-wide convention for
that column is `redact_url_credentials` (`tasks_common.py`), which does not
catch the kwarg-repr shape. Worth its own issue rather than a side effect
here.

### Items verified as already fixed, not re-done

| Item | Landed in | Evidence on `6077eddfb` |
| --- | --- | --- |
| 7 `origin_probe.py` docstring | #1830 | module docstring covers the ArcGIS provider-body branch and the 498/499 mapping |
| 8 `fileConfig` keeps existing loggers | #1883 | `disable_existing_loggers=False`; `test_1755_alembic_logger_flag.py` pins the flag and that an `httpx` logger stays enabled after a migration run; the reset fixture is gone from `test_1746_stdlib_log_redaction.py` |
| 9 `preview_service_layer` refusals | #1833 | `_run_service_preview_or_refuse` re-raises `HTTPException`, `_preview_refusal_response` maps each typed refusal, `TestPreviewEndpoint` covers each class |
| 11 cleanup in `finally` | #1883 | `cleanup_step` at 36 sites across seven task modules, both service tasks included; `test_1755_cleanup_step.py` |
| 14 `enrich_arcgis_feature_counts` | #1840 | calls `build_arcgis_count_query_url`, which builds the token with `urlencode`; `test_arcgis_header_transport_c2.py` covers the shared URL, reserved-character encoding and the absence of the token from the httpx log |
| 15 `_require_service_token_if_marked` docstring | #1830 | names `<layer>/query` and the 499/498 codes |

Items 1, 2, 3, 12 and 13 are product decisions or separate refactors and are
untouched. Items 4, 5 and 6 are the frontend lane's.

## Area

- [x] Backend (API, services, models)
- [x] Import / Ingestion

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)

Counterfactual for the new test: with the two `_log_dispatch_failure` calls
removed, `test_each_stage_logs_its_cause_with_the_url_redacted` fails on
`defer_logger.warning.call_args` being `None`; restored, it passes.

Host pytest at `localhost:5434`, all green:

```
tests/test_defer_orphan_guard.py                                    14 passed
tests/test_layering.py tests/test_rule1_structural.py
  tests/test_rule2_structural.py                                   168 passed
tests/test_commit_attempted_marker_doors.py + 7 defer-guard callers 173 passed
tests/test_services_endpoints.py + 5 refresh/auth files             566 passed
tests/test_1755_alembic_logger_flag.py + 6 item-verification files  303 passed
tests/test_origin_ref_indexes.py + 4 refresh files                  179 passed
```

`ruff check`, `ruff format --check` and `backend/tests/finding_markers.py`
pass.

## Checklist

- [x] Code follows existing project conventions
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] No secrets or credentials in the diff

Refs #1755
