### PR TITLE
perf(builder): fit the export credit line to its budget

### DIFF
--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -1705,10 +1705,8 @@ describe('export canvas ceiling', () => {
 });
 
 /* feat(#1553): the layout fits only what the budget can hold. The bound is
- * sound only if it cannot change an answer, which is what these assert — and
- * over the null-fallback path too, since an entry wider than the line picks a
- * different wrapper, and a bound that skipped a later over-wide entry would
- * pick the wrong one. */
+ * sound only if it cannot change an answer, which these assert — including on
+ * the word-wrapper path, where a misplaced bound would pick the wrong one. */
 describe('bounded layout (#1553)', () => {
   const shapes: Array<{ name: string; credits: string[] }> = [
     { name: 'the real five-provider load', credits: [
@@ -1770,10 +1768,9 @@ describe('bounded layout (#1553)', () => {
   });
 
   it('measures a bounded multiple of the budget, not of the input', () => {
-    // 200 credits of 5,000 characters, the contract's maximum on both axes.
-    // Against this stub the band took 71,552 measureText calls unbounded and
-    // 5,024 bounded; the card 81,336 and 3,129. The threshold is loose because
-    // the exact figure moves with the wrap.
+    // The contract's maximum on both axes. Against this stub the band took
+    // 71,552 measureText calls unbounded and 5,024 bounded, the card 81,336
+    // and 3,129; the threshold is loose because the figure moves with the wrap.
     const credits = Array.from({ length: 200 }, (_, i) => `© P${i} ` + 'x'.repeat(4990));
 
     const bandCtx = makeCtx();

--- a/frontend/src/lib/__tests__/map-image-attribution.test.ts
+++ b/frontend/src/lib/__tests__/map-image-attribution.test.ts
@@ -1703,3 +1703,89 @@ describe('export canvas ceiling', () => {
     expectTotal(measured.lines, credits);
   });
 });
+
+/* feat(#1553): the layout fits only what the budget can hold. The bound is
+ * sound only if it cannot change an answer, which is what these assert — and
+ * over the null-fallback path too, since an entry wider than the line picks a
+ * different wrapper, and a bound that skipped a later over-wide entry would
+ * pick the wrong one. */
+describe('bounded layout (#1553)', () => {
+  const shapes: Array<{ name: string; credits: string[] }> = [
+    { name: 'the real five-provider load', credits: [
+      '© OpenStreetMap contributors',
+      '© OpenMapTiles',
+      'Swisstopo',
+      'NOAA National Centers for Environmental Information',
+      'US Census Bureau TIGER/Line',
+    ] },
+    { name: 'many short credits', credits: Array.from({ length: 40 }, (_, i) => `© P${i}`) },
+    { name: 'one credit wider than the line', credits: ['© A', 'B'.repeat(400), '© C'] },
+    { name: 'every credit wider than the line', credits: Array.from(
+      { length: 6 }, (_, i) => `© P${i} ` + 'x'.repeat(300)) },
+    { name: 'a single unbreakable run', credits: ['x'.repeat(900)] },
+  ];
+
+  for (const { name, credits } of shapes) {
+    for (const maxLines of [1, 2, 3, 7, 40]) {
+      it(`agrees with the full layout for ${name} at ${maxLines} lines`, () => {
+        const ctx = makeCtx();
+        const opts = { maxWidth: 300, fontPx: 12 };
+        const full = fitAttributionText(ctx as never, credits, opts);
+        const bounded = fitAttributionText(ctx as never, credits, { ...opts, maxLines });
+        if (full.lines.length <= maxLines) {
+          expect(bounded.lines).toEqual(full.lines);
+        } else {
+          // Over budget the lines are a prefix, and the only thing the callers
+          // read is that it exceeded — which it must still say.
+          expect(bounded.lines.length).toBeGreaterThan(maxLines);
+          expect(full.lines.slice(0, bounded.lines.length - 1)).toEqual(
+            bounded.lines.slice(0, bounded.lines.length - 1),
+          );
+        }
+      });
+    }
+  }
+
+  it('draws the same overlay it drew before the bound', () => {
+    // The end-to-end statement of the same property: identical pixels, at a
+    // load that crosses the capacity and produces the counted marker.
+    const credits = Array.from({ length: 30 }, (_, i) => `© Provider ${i} and licensors`);
+    const ctx = makeCtx();
+    expect(
+      drawAttributionOverlay(makeCanvas(400, 250, ctx), credits, THUMBNAIL_ATTRIBUTION),
+    ).toBe(true);
+    const drawn = ctx.fillText.mock.calls.map((call) => String(call[0]));
+    expect(drawn.length).toBeGreaterThan(1);
+    expect(drawn.length).toBeLessThanOrEqual(
+      overlayLineCapacity(THUMBNAIL_ATTRIBUTION, 250),
+    );
+    expect(drawn[0]).toBe('© Provider 0 and licensors | © Provider 1 and licensors');
+    // Nothing is lost without being counted: the marker names exactly the
+    // credits the visible lines do not carry.
+    const marker = drawn[drawn.length - 1];
+    const rendered = drawn.slice(0, -1).join(' ');
+    const shown = credits.filter((credit) => rendered.includes(credit)).length;
+    expect(marker).toContain(String(credits.length - shown));
+    expect(shown + (credits.length - shown)).toBe(credits.length);
+  });
+
+  it('measures a bounded multiple of the budget, not of the input', () => {
+    // 200 credits of 5,000 characters, the contract's maximum on both axes.
+    // Against this stub the band took 71,552 measureText calls unbounded and
+    // 5,024 bounded; the card 81,336 and 3,129. The threshold is loose because
+    // the exact figure moves with the wrap.
+    const credits = Array.from({ length: 200 }, (_, i) => `© P${i} ` + 'x'.repeat(4990));
+
+    const bandCtx = makeCtx();
+    measureAttributionBand(bandCtx as never, credits, {
+      maxWidth: 1016,
+      dpr: 1,
+      maxHeight: 600,
+    });
+    expect(bandCtx.measureText.mock.calls.length).toBeLessThan(20_000);
+
+    const cardCtx = makeCtx();
+    drawAttributionOverlay(makeCanvas(1200, 630, cardCtx), credits, OG_ATTRIBUTION);
+    expect(cardCtx.measureText.mock.calls.length).toBeLessThan(20_000);
+  });
+});

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -866,11 +866,9 @@ export interface FittedAttribution {
  * every entry. There is no code path that drops one, which is the property the
  * whole module exists to hold. Leaves `ctx.font` set.
  *
- * feat(#1553): `maxLines` makes it a BOUNDED PROBE — wrapping stops once the
- * budget is known to be exceeded, and the lines are then a PREFIX. Sound only
- * for a caller that discards them in that case, which both do. Under the
- * budget the result is unchanged: both wrappers are greedy and left to right,
- * so an emitted line is one a longer run would emit identically.
+ * feat(#1553): `maxLines` makes it a BOUNDED PROBE whose lines are a PREFIX
+ * once the budget is exceeded, so only a caller that discards them there may
+ * pass it. Both wrappers are greedy, so the under-budget result is unchanged.
  */
 export function fitAttributionText(
   ctx: CanvasRenderingContext2D,

--- a/frontend/src/lib/map-image-attribution.ts
+++ b/frontend/src/lib/map-image-attribution.ts
@@ -724,16 +724,23 @@ export function readRenderedAttribution(map: AttributionMapLike): string[] {
 
 /** Greedy wrap on entry boundaries, so a provider's name stays on one line.
  *  Returns null when a single entry is wider than `maxWidth`, which is the one
- *  case entry-boundary wrapping cannot resolve on its own. */
+ *  case entry-boundary wrapping cannot resolve on its own.
+ *
+ *  fix(#1553): the width scan is its own first pass so `maxLines` cannot
+ *  change the answer — it short-circuits at the same entry the interleaved
+ *  check did, and only the LAYOUT stops early. */
 function wrapEntries(
   ctx: CanvasRenderingContext2D,
   entries: string[],
   maxWidth: number,
+  maxLines = Infinity,
 ): string[] | null {
+  for (const entry of entries) {
+    if (ctx.measureText(entry).width > maxWidth) return null;
+  }
   const lines: string[] = [];
   let current = '';
   for (const entry of entries) {
-    if (ctx.measureText(entry).width > maxWidth) return null;
     if (!current) {
       current = entry;
       continue;
@@ -744,6 +751,7 @@ function wrapEntries(
     } else {
       lines.push(current);
       current = entry;
+      if (lines.length > maxLines) return lines;
     }
   }
   if (current) lines.push(current);
@@ -813,6 +821,7 @@ function wrapWords(
   ctx: CanvasRenderingContext2D,
   text: string,
   maxWidth: number,
+  maxLines = Infinity,
 ): string[] {
   const lines: string[] = [];
   let current = '';
@@ -829,6 +838,10 @@ function wrapWords(
       lines.push(...pieces.slice(0, -1));
       current = pieces[pieces.length - 1] ?? '';
     }
+    // fix(#1553): greedy and left to right, so every line already emitted is
+    // final. Past the budget the caller re-fits a counted prefix and throws
+    // these away, and finishing the wrap only to discard it is the whole cost.
+    if (lines.length > maxLines) return lines;
   }
   if (current) lines.push(current);
   return lines;
@@ -837,6 +850,8 @@ function wrapWords(
 export interface FitAttributionOptions {
   maxWidth: number;
   fontPx: number;
+  /** feat(#1553): stop once the result is known to exceed this many lines. */
+  maxLines?: number;
 }
 
 export interface FittedAttribution {
@@ -850,6 +865,12 @@ export interface FittedAttribution {
  * Total by construction: the returned lines always contain every character of
  * every entry. There is no code path that drops one, which is the property the
  * whole module exists to hold. Leaves `ctx.font` set.
+ *
+ * feat(#1553): `maxLines` makes it a BOUNDED PROBE — wrapping stops once the
+ * budget is known to be exceeded, and the lines are then a PREFIX. Sound only
+ * for a caller that discards them in that case, which both do. Under the
+ * budget the result is unchanged: both wrappers are greedy and left to right,
+ * so an emitted line is one a longer run would emit identically.
  */
 export function fitAttributionText(
   ctx: CanvasRenderingContext2D,
@@ -861,10 +882,10 @@ export function fitAttributionText(
     return { lines: [], fontPx: opts.fontPx };
   }
   ctx.font = attributionFont(opts.fontPx);
-  const byEntry = wrapEntries(ctx, clean, opts.maxWidth);
+  const byEntry = wrapEntries(ctx, clean, opts.maxWidth, opts.maxLines);
   if (byEntry) return { lines: byEntry, fontPx: opts.fontPx };
   return {
-    lines: wrapWords(ctx, clean.join(SEPARATOR), opts.maxWidth),
+    lines: wrapWords(ctx, clean.join(SEPARATOR), opts.maxWidth, opts.maxLines),
     fontPx: opts.fontPx,
   };
 }
@@ -936,10 +957,16 @@ function fitEntryPrefix(
   maxLines: number,
 ): { lines: string[]; count: number } {
   if (maxLines <= 0) return { lines: [], count: 0 };
+  // fix(#1553): each probe only has to answer "more than maxLines?", so it
+  // stops there. A probe over 200 credits of 5,000 characters otherwise laid
+  // out every line it was about to reject, once per step of the search.
   const wrapFirst = (count: number): string[] => {
     if (count === 0) return [];
     const slice = entries.slice(0, count);
-    return wrapEntries(ctx, slice, maxWidth) ?? wrapWords(ctx, slice.join(SEPARATOR), maxWidth);
+    return (
+      wrapEntries(ctx, slice, maxWidth, maxLines) ??
+      wrapWords(ctx, slice.join(SEPARATOR), maxWidth, maxLines)
+    );
   };
   let best: { lines: string[]; count: number } = { lines: [], count: 0 };
   let lo = 0;
@@ -1016,7 +1043,11 @@ export function drawAttributionOverlay(
   // Deduped here as well as inside the fitter, because the overflow marker
   // counts CREDITS and must not count the same one twice.
   const credits = dedupe(entries);
-  const fitted = fitAttributionText(ctx, credits, { maxWidth, fontPx: spec.fontPx });
+  const fitted = fitAttributionText(ctx, credits, {
+    maxWidth,
+    fontPx: spec.fontPx,
+    maxLines: capacity,
+  });
   if (fitted.lines.length === 0) return false;
 
   // fix(#1541 codex P1 round 2): removing the fitter's elision left one way to
@@ -1206,9 +1237,11 @@ export function measureAttributionBand(
   // Deduped here as well as inside the fitter, because the overflow marker
   // counts CREDITS and must not count the same one twice.
   const credits = dedupe(entries);
+  const capacity = attributionBandLineCapacity(opts.maxHeight, dpr);
   const fitted = fitAttributionText(ctx, credits, {
     maxWidth: opts.maxWidth,
     fontPx: BAND_FONT_PX * dpr,
+    maxLines: capacity,
   });
   if (fitted.lines.length === 0) return fallback;
 
@@ -1216,7 +1249,6 @@ export function measureAttributionBand(
   // every ordinary export, by three orders of magnitude — nothing changes and
   // the band still grows a line at a time.
   let lines = fitted.lines;
-  const capacity = attributionBandLineCapacity(opts.maxHeight, dpr);
   if (lines.length > capacity) {
     // No room for even a marker: a band here could only make an already
     // unencodable canvas taller. See `attributionBandHeightBudget`.


### PR DESCRIPTION
## Summary

Closes the last open candidate on #1553 and re-triages the rest against the current code, so the issue can close rather than stay a rolling home.

The attribution layout fit everything before checking whether any of it would fit. `drawAttributionOverlay` and `measureAttributionBand` wrapped the entire credit set to learn whether it exceeded the line budget, and when it did, `fitEntryPrefix` binary-searched the prefix that does, laying out and rejecting a full set once per step of the search. At the supported maximum, 200 layers with a 5,000-character credit each, that is nine full layouts of about a million characters, and one save performs three of them (export band, thumbnail, OG card) on the main thread before nearly all of it becomes a single `+N more credits` marker.

Both wrappers now take a line budget and stop once it is exceeded.

## Changes

- `wrapEntries` and `wrapWords` take an optional `maxLines` and return as soon as the result is known to exceed it. Both are greedy and left to right, so a line already emitted is one a longer run emits identically: under the budget the result is unchanged, and over it the lines are a prefix.
- `fitAttributionText` threads `maxLines` through and documents that only a caller which discards the lines in the over-budget case may pass it. Both callers do, since past the budget they re-fit a counted prefix.
- `wrapEntries` keeps its null contract exactly. The over-wide scan moved into its own first pass, which short-circuits at the same entry the interleaved check did. Without that split, a bound could stop the layout before reaching a later over-wide entry, and the wrap would take the entry-boundary path where the unbounded one takes the word path.
- `fitEntryPrefix` bounds each probe, which is where most of the waste was.
- No behaviour change and no new strings. Nothing about which credits are rendered, in which order, or how the marker counts them moves.

## The rest of the candidate list, and why it is not here

**Layer `filter` expressions that exclude every feature (issue candidate 1).** Settled by parity in #1702 and re-verified against the installed maplibre-gl 6.5.0. In `src/ui/control/attribution_control.ts`, `_updateAttributions` credits a source on `tileManager.used || tileManager.usedForTerrain` and reads nothing else, and `used` is set from `!layer.isHidden(zoom)`, which is zoom range plus `layout.visibility`. Filters play no part, so the on-screen control credits a fully filtered source and parity means counting it shown here too. Evaluating filters ourselves would open a divergence rather than close one. Pinned by an existing test.

**The priority set as a proxy for the live `used` state.** Done in #1702. `liveUsedSourceIds` reads `map.style.tileManagers[id].used || .usedForTerrain`, the control's own input, and the modeled approximation is the fallback for a map that does not expose it. Verified still matching the installed version's internal name.

**Divergence from the control's dedupe and suppression rules (issue candidate 2).** Re-read `_updateAttributions` in the installed 6.5.0 line by line: exact-duplicate skip at collection, whitespace-only filter, length sort, drop any entry a later one `includes`, join with ` | `. Unchanged from what #1702 recorded, and the module mirrors the suppression and the join. One collection input it does not mirror is `options.customAttribution`; the builder passes none, because it has no explicit `<AttributionControl>` to hand one to and credits through MapLibre's native per-source mechanism instead (`components/builder/map-sync.ts`). The builder map is the only map these three exports are captured from.

**Other embedded markup forms (issue candidate 3).** Done in #1702. `<object>`, `<embed>`, `<iframe>` and `<video>` take the same derivation as an unnamed `<img>`.

**Two residuals, both stated rather than fixed.** `Style.tileManagers` is internal and was renamed once already (`sourceCaches` until 5.24), so the live read degrades to the modeled tier on the next rename and nothing here can detect that beyond falling back. Re-verifying on each maplibre-gl major is a standing task, not work. And the control compares raw HTML while this module compares derived text, which is deliberate and documented: text is what the image renders, and the difference only ever removes a line whose text another line carries whole.

## Area

- [x] Frontend (UI, components, hooks)

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)

Counterfactuals, each observed with the change reverted:

- The cost test asserts under 20,000 text measurements at the contract maximum for both outputs. Without the bound the band takes 71,552 and the card 81,336 against the same stub; with it, 5,024 and 3,129.
- The equivalence tests compare a bounded probe against the full layout over five credit shapes at five budgets, including the two that reach the word wrapper. They pass before and after, which is the point: they are the guard on the bound being unable to change an answer, and they fail if the over-wide scan is folded back into the layout loop.
- The overlay test asserts the marker still counts exactly the credits the visible lines do not carry.

From `frontend/`: `npm run build`, `npm run lint`, `npm run typecheck` clean. `npx vitest run src/lib/__tests__/map-image-attribution.test.ts src/components/builder/hooks/__tests__/use-builder-save.test.ts`: 243 passed. `npm run test:coverage`: 456 files, 6048 tests, all passing.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: no new user-facing strings
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [x] No migration needed
- [x] No secrets or credentials in the diff
