### PR TITLE
fix(jobs): close the recovery boundary at both ends of a backfill run

### DIFF
--- a/backend/app/modules/admin/backfill_jobs.py
+++ b/backend/app/modules/admin/backfill_jobs.py
@@ -39,9 +39,9 @@ logger = structlog.stdlib.get_logger(__name__)
 # route applied to its 502 body).
 BACKFILL_FAILED_MESSAGE = "Embedding backfill failed. See server logs for details."
 
-# The three states the guarded exit can unwind from. fix(#1556): the row read
-# moved inside that boundary, so a run that never claimed the row now reaches
-# it, and "could not record its outcome" would describe work that never began.
+# fix(#1556): the row read moved inside the guarded exit, so a run that never
+# claimed the row reaches it — and "could not record its outcome" would then
+# describe work that never began.
 CANCELLED_MESSAGE = (
     "Embedding backfill was cancelled by a worker shutdown. Records it had "
     "already reached carry their new vectors and the rest are unchanged; "
@@ -424,6 +424,10 @@ async def _recover_unsettled(
             # which after a lost claim commit is `pending`, not `running`.
             state.row_attempted = False
             state.expected_status = observed.status
+            # fix(#1556 review): `_finalize` REPLACES user_metadata, so it
+            # starts from the row's own — the caller's is empty when the
+            # opening read failed, erasing the marker the retry contract reads.
+            metadata = dict(observed.user_metadata or {})
         await _settle(
             fresh,
             job_uuid,
@@ -598,10 +602,9 @@ async def run_embedding_backfill(
         state = _TerminalState()
         heartbeat = None
         try:
-            # fix(#1556): the row read is inside the guarded region too. It
-            # runs before the task's own BaseException boundary otherwise, so
-            # a transient outage or a shutdown cancellation here left the row
-            # `pending`, holding the slot until the stale sweep.
+            # fix(#1556): the row read is inside the guarded region too.
+            # Outside it, a transient outage or a shutdown cancellation here
+            # left the row `pending`, holding the slot until the stale sweep.
             job = await session.get(IngestJob, job_uuid)
             if job is not None:
                 metadata = dict(job.user_metadata or {})

--- a/backend/app/modules/admin/backfill_jobs.py
+++ b/backend/app/modules/admin/backfill_jobs.py
@@ -710,14 +710,15 @@ async def run_embedding_backfill(
             # this never rewrites a committed outcome — a shutdown after
             # `complete` landed emits the COMPLETED audit, not a contradiction.
             cancelled = isinstance(exc, asyncio.CancelledError)
-            # A null heartbeat means the claim never landed, so this run never
-            # took the job — a distinct outcome from failing to record one.
-            if cancelled:
-                event, error_code = "embedding_backfill_cancelled", "worker_cancelled"
-                message = CANCELLED_MESSAGE
-            elif heartbeat is None:
+            # fix(#1556 review): how far it got outranks what ended it. No
+            # heartbeat handle means nothing past the claim ran, so a
+            # cancellation there did not leave half a run behind.
+            if heartbeat is None:
                 event, error_code = "embedding_backfill_start_failed", "start_failed"
                 message = START_FAILED_MESSAGE
+            elif cancelled:
+                event, error_code = "embedding_backfill_cancelled", "worker_cancelled"
+                message = CANCELLED_MESSAGE
             else:
                 event, error_code = "embedding_backfill_settle_failed", "settle_failed"
                 message = SETTLE_FAILED_MESSAGE

--- a/backend/app/modules/admin/backfill_jobs.py
+++ b/backend/app/modules/admin/backfill_jobs.py
@@ -39,6 +39,21 @@ logger = structlog.stdlib.get_logger(__name__)
 # route applied to its 502 body).
 BACKFILL_FAILED_MESSAGE = "Embedding backfill failed. See server logs for details."
 
+# The three states the guarded exit can unwind from. fix(#1556): the row read
+# moved inside that boundary, so a run that never claimed the row now reaches
+# it, and "could not record its outcome" would describe work that never began.
+CANCELLED_MESSAGE = (
+    "Embedding backfill was cancelled by a worker shutdown. Records it had "
+    "already reached carry their new vectors and the rest are unchanged; "
+    "re-run to finish the remainder."
+)
+START_FAILED_MESSAGE = (
+    "Embedding backfill could not start. Nothing was changed; re-run it."
+)
+SETTLE_FAILED_MESSAGE = (
+    "Embedding backfill could not record its outcome. See server logs for details."
+)
+
 # Audit outcome for a run whose fate could not be written to its job row —
 # another actor settled the row first. It is terminal (the operation is over and
 # the trail says so) but it deliberately does not claim the run succeeded or
@@ -474,7 +489,10 @@ async def _undispatched_settle_write_landed(job_uuid: uuid.UUID) -> bool:
 
 
 async def settle_undispatched_run(
-    job_uuid: uuid.UUID, *, audit_context: dict[str, Any]
+    job_uuid: uuid.UUID,
+    *,
+    audit_context: dict[str, Any],
+    caller_session: AsyncSession | None = None,
 ) -> None:
     """Settle a run that was committed but never reliably queued.
 
@@ -495,7 +513,13 @@ async def settle_undispatched_run(
     as ``_recover_unsettled``: read the row for evidence of THIS write, not
     for a status other actors also reach (see
     ``_undispatched_settle_write_landed``).
+
+    fix(#1556): ``caller_session`` is released first, because a cancellation
+    that landed inside that session's own commit leaves it holding the job
+    row's lock, and the fenced write below would then block on it.
     """
+    if caller_session is not None:
+        await _release_caller_transaction(caller_session, audit_context["job_id"])
     try:
         settled = await _fail_undispatched_pending_row(job_uuid)
     except BaseException:  # broad: a lost acknowledgement is the case recovered here
@@ -570,11 +594,17 @@ async def run_embedding_backfill(
     job_uuid, attempt_uuid = resolved
 
     async with async_session() as session:
-        job = await session.get(IngestJob, job_uuid)
-        metadata = dict(job.user_metadata or {}) if job is not None else {}
+        metadata: dict[str, Any] = {}
         state = _TerminalState()
         heartbeat = None
         try:
+            # fix(#1556): the row read is inside the guarded region too. It
+            # runs before the task's own BaseException boundary otherwise, so
+            # a transient outage or a shutdown cancellation here left the row
+            # `pending`, holding the slot until the stale sweep.
+            job = await session.get(IngestJob, job_uuid)
+            if job is not None:
+                metadata = dict(job.user_metadata or {})
             # fix(#1550): the claim is INSIDE the guarded region — its own
             # commit is a lost-acknowledgement window too. A shutdown
             # cancelling `pending`->`running` mid-commit can apply it without
@@ -677,10 +707,19 @@ async def run_embedding_backfill(
             # this never rewrites a committed outcome — a shutdown after
             # `complete` landed emits the COMPLETED audit, not a contradiction.
             cancelled = isinstance(exc, asyncio.CancelledError)
+            # A null heartbeat means the claim never landed, so this run never
+            # took the job — a distinct outcome from failing to record one.
+            if cancelled:
+                event, error_code = "embedding_backfill_cancelled", "worker_cancelled"
+                message = CANCELLED_MESSAGE
+            elif heartbeat is None:
+                event, error_code = "embedding_backfill_start_failed", "start_failed"
+                message = START_FAILED_MESSAGE
+            else:
+                event, error_code = "embedding_backfill_settle_failed", "settle_failed"
+                message = SETTLE_FAILED_MESSAGE
             logger.warning(
-                "embedding_backfill_cancelled"
-                if cancelled
-                else "embedding_backfill_settle_failed",
+                event,
                 job_id=job_id,
                 force=force,
                 operation_id=operation_id,
@@ -699,18 +738,8 @@ async def run_embedding_backfill(
                             metadata=metadata,
                             state=state,
                             audit_context=audit_context,
-                            error_code=(
-                                "worker_cancelled" if cancelled else "settle_failed"
-                            ),
-                            message=(
-                                "Embedding backfill was cancelled by a worker "
-                                "shutdown. Records it had already reached carry "
-                                "their new vectors and the rest are unchanged; "
-                                "re-run to finish the remainder."
-                                if cancelled
-                                else "Embedding backfill could not record its "
-                                "outcome. See server logs for details."
-                            ),
+                            error_code=error_code,
+                            message=message,
                         ),
                         timeout=15,
                     )

--- a/backend/app/modules/admin/router.py
+++ b/backend/app/modules/admin/router.py
@@ -1014,6 +1014,37 @@ async def get_embedding_stats(
     return await service.get_embedding_stats()
 
 
+async def _settle_cancelled_backfill(
+    db: AsyncSession, job_uuid: uuid.UUID, audit_context: dict[str, Any]
+) -> None:
+    """Close a backfill whose request was cancelled before a worker took it.
+
+    Shielded so the cancellation that triggered it cannot cancel the cleanup,
+    and bounded so a hung database cannot stall a deploy. Never raises: the
+    caller re-raises the cancellation, and the stale-pending sweep is the
+    backstop for anything this could not reach.
+    """
+    from app.modules.admin.backfill_jobs import settle_undispatched_run
+
+    try:
+        await asyncio.shield(
+            asyncio.wait_for(
+                settle_undispatched_run(
+                    job_uuid, audit_context=audit_context, caller_session=db
+                ),
+                timeout=15,
+            )
+        )
+    except (
+        BaseException
+    ):  # broad: best-effort during shutdown; the caller's raise preserves the abort
+        logger.warning(
+            "embedding_backfill_dispatch_cancel_cleanup_failed",
+            job_id=audit_context["job_id"],
+            exc_info=True,
+        )
+
+
 # ROUTE-01 (Phase 1092): dual-shape decorator — see /users above.
 @router.post(
     "/backfill-embeddings",
@@ -1047,7 +1078,6 @@ async def trigger_backfill(
         UNRESOLVED_OUTCOME,
         find_active_embedding_backfill,
         run_embedding_backfill,
-        settle_undispatched_run,
     )
 
     operation_id = str(uuid.uuid4())
@@ -1068,13 +1098,22 @@ async def trigger_backfill(
             detected_by="preflight_query",
         )
 
+    audit_context = {
+        "user_id": str(current_user_id),
+        "ip_address": ip_address,
+        "operation_id": operation_id,
+        "force": force,
+    }
+
     # The insert lands with null user_metadata; only the later UPDATE that sets
     # the backfill marker makes the partial unique index reject a duplicate —
     # and that UPDATE flushes on this session's first flush, well before commit.
+    pending_job_id: uuid.UUID | None = None
     try:
         job = await get_catalog_port().create_ingest_job(
             db, "embedding-backfill", "", current_user_id
         )
+        pending_job_id = job.id
         job.user_metadata = {
             EMBEDDING_BACKFILL_METADATA_KEY: {
                 "force": force,
@@ -1120,6 +1159,18 @@ async def trigger_backfill(
             force=force,
             detected_by="unique_index",
         )
+    except asyncio.CancelledError:
+        # fix(#1556): the recovery boundary starts where a durable row can
+        # first exist. A shutdown cancelling the commit above can apply it
+        # without returning the acknowledgement, leaving a `pending` row and
+        # its `requested` trail with no worker queued and no actor left to
+        # close either. Fenced on `pending` and shielded, exactly as the
+        # dispatch arm below is; a commit that never landed matches no row.
+        if pending_job_id is not None:
+            await _settle_cancelled_backfill(
+                db, pending_job_id, {**audit_context, "job_id": str(pending_job_id)}
+            )
+        raise
 
     async def _defer() -> None:
         await defer_async_with_tenant(
@@ -1194,29 +1245,8 @@ async def trigger_backfill(
         # fix(#1550): the orphan guard catches `Exception`, so cancellation here
         # bypasses it and `DeferFailed` above. Cleanup is fenced on `pending`
         # and shielded, and the cancellation is re-raised so shutdown still works.
-        try:
-            await asyncio.shield(
-                asyncio.wait_for(
-                    settle_undispatched_run(
-                        job.id,
-                        audit_context={
-                            "user_id": str(current_user_id),
-                            "ip_address": ip_address,
-                            "operation_id": operation_id,
-                            "job_id": job_id,
-                            "force": force,
-                        },
-                    ),
-                    timeout=15,
-                )
-            )
-        except (
-            BaseException
-        ):  # broad: best-effort during shutdown; the raise below preserves the abort
-            logger.warning(
-                "embedding_backfill_dispatch_cancel_cleanup_failed",
-                job_id=job_id,
-                exc_info=True,
-            )
+        await _settle_cancelled_backfill(
+            db, job.id, {**audit_context, "job_id": job_id}
+        )
         raise
     return BackfillResponse(job_id=job.id, status="pending")

--- a/backend/app/modules/admin/router.py
+++ b/backend/app/modules/admin/router.py
@@ -1014,10 +1014,10 @@ async def get_embedding_stats(
     return await service.get_embedding_stats()
 
 
-async def _settle_cancelled_backfill(
+async def _settle_undispatched_backfill(
     db: AsyncSession, job_uuid: uuid.UUID, audit_context: dict[str, Any]
 ) -> None:
-    """Close a backfill whose request was cancelled before a worker took it.
+    """Close a backfill whose request ended before a worker took it.
 
     Shielded so the cancellation that triggered it cannot cancel the cleanup,
     and bounded so a hung database cannot stall a deploy. Never raises: the
@@ -1159,12 +1159,12 @@ async def trigger_backfill(
             force=force,
             detected_by="unique_index",
         )
-    except asyncio.CancelledError:
-        # fix(#1556): a cancelled commit can apply without acknowledging,
-        # stranding a `pending` row and a `requested` trail. One that never
-        # landed matches no row, so the dispatch arm's cleanup is safe here.
+    except BaseException:
+        # fix(#1556 review): ANY failure of that commit can be a lost
+        # acknowledgement, not only a cancellation, and one that never landed
+        # matches no row — so the fenced cleanup is right for the whole class.
         if pending_job_id is not None:
-            await _settle_cancelled_backfill(
+            await _settle_undispatched_backfill(
                 db, pending_job_id, {**audit_context, "job_id": str(pending_job_id)}
             )
         raise
@@ -1242,7 +1242,7 @@ async def trigger_backfill(
         # fix(#1550): the orphan guard catches `Exception`, so cancellation here
         # bypasses it and `DeferFailed` above. Cleanup is fenced on `pending`
         # and shielded, and the cancellation is re-raised so shutdown still works.
-        await _settle_cancelled_backfill(
+        await _settle_undispatched_backfill(
             db, job.id, {**audit_context, "job_id": job_id}
         )
         raise

--- a/backend/app/modules/admin/router.py
+++ b/backend/app/modules/admin/router.py
@@ -1160,12 +1160,9 @@ async def trigger_backfill(
             detected_by="unique_index",
         )
     except asyncio.CancelledError:
-        # fix(#1556): the recovery boundary starts where a durable row can
-        # first exist. A shutdown cancelling the commit above can apply it
-        # without returning the acknowledgement, leaving a `pending` row and
-        # its `requested` trail with no worker queued and no actor left to
-        # close either. Fenced on `pending` and shielded, exactly as the
-        # dispatch arm below is; a commit that never landed matches no row.
+        # fix(#1556): a cancelled commit can apply without acknowledging,
+        # stranding a `pending` row and a `requested` trail. One that never
+        # landed matches no row, so the dispatch arm's cleanup is safe here.
         if pending_job_id is not None:
             await _settle_cancelled_backfill(
                 db, pending_job_id, {**audit_context, "job_id": str(pending_job_id)}

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -13,6 +13,7 @@ from typing import Literal, cast
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import func, select, text, update
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -844,6 +845,7 @@ async def retry_job(
     # the queue is down (RESILIENCE-2).
     previous_attempt_id = job.attempt_id
     next_attempt_id = uuid.uuid4()
+    retried_at = datetime.now(timezone.utc)
     retry_result = await db.execute(
         update(IngestJob)
         .where(
@@ -859,7 +861,19 @@ async def retry_job(
             heartbeat_at=None,
             completed_at=None,
             dataset_id=None,
+            # fix(#1556): the pending clock restarts HERE. It ages from
+            # `coalesce(staged_at, created_at)`, so without this stamp a job
+            # that failed an hour ago is stale the instant it commits, and the
+            # only thing standing between it and the sweep — or a 2s status
+            # poll running the same clauses — is the window before
+            # `queue_ingest_job` gets its Procrastinate row in.
+            user_metadata=func.coalesce(
+                IngestJob.user_metadata, text("'{}'::jsonb")
+            ).op("||", return_type=JSONB)(
+                func.jsonb_build_object("staged_at", retried_at.isoformat())
+            ),
         )
+        .execution_options(synchronize_session=False)
     )
     if not retry_result.rowcount:
         await db.rollback()

--- a/backend/app/platform/jobs/router.py
+++ b/backend/app/platform/jobs/router.py
@@ -861,12 +861,9 @@ async def retry_job(
             heartbeat_at=None,
             completed_at=None,
             dataset_id=None,
-            # fix(#1556): the pending clock restarts HERE. It ages from
-            # `coalesce(staged_at, created_at)`, so without this stamp a job
-            # that failed an hour ago is stale the instant it commits, and the
-            # only thing standing between it and the sweep — or a 2s status
-            # poll running the same clauses — is the window before
-            # `queue_ingest_job` gets its Procrastinate row in.
+            # fix(#1556): the pending clock restarts HERE. Ageing from
+            # `coalesce(staged_at, created_at)`, an hour-old failure is stale
+            # the instant it commits, before the queue row can land.
             user_metadata=func.coalesce(
                 IngestJob.user_metadata, text("'{}'::jsonb")
             ).op("||", return_type=JSONB)(

--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -103,8 +103,8 @@ def stale_pending_clauses(now: datetime, *, completion_bound: bool) -> tuple:
     # would drop every NULL file_path row — the case that most needs the 1h policy.
     completion_key = func.coalesce(IngestJob.file_path, "").like("staging/%")
     cutoff_seconds = stale_pending_cutoff_seconds(completion_bound=completion_bound)
-    # fix(#1708): age from `staged_at` (set only by upload_from_url's
-    # completion CAS), falling back to created_at — the window restarts at staging.
+    # fix(#1708): age from `staged_at`, falling back to created_at. Every
+    # writer of that key restarts the pending window where the row re-entered it.
     age_basis = func.coalesce(
         IngestJob.user_metadata.op("->>")("staged_at").cast(DateTime(timezone=True)),
         IngestJob.created_at,

--- a/backend/tests/test_embedding_backfill_queue_1542.py
+++ b/backend/tests/test_embedding_backfill_queue_1542.py
@@ -2199,17 +2199,24 @@ async def test_the_worker_startup_recovery_closes_the_trail_it_settles(
 
 
 @pytest.mark.anyio
-async def test_a_cancelled_creation_commit_does_not_leave_the_slot_held(
+@pytest.mark.parametrize(
+    "lost_ack",
+    [asyncio.CancelledError, OSError("connection reset by peer")],
+    ids=["cancelled", "connection_lost"],
+)
+async def test_an_unacknowledged_creation_commit_does_not_leave_the_slot_held(
     client: AsyncClient,
     admin_auth_header: dict,
     test_db_session: AsyncSession,
     monkeypatch,
+    lost_ack: type[BaseException] | BaseException,
 ):
     """The commit applies, its acknowledgement is lost, the request unwinds.
 
     A durable `pending` row and a durable `requested` entry, with no worker
     queued and no dispatch arm reached — the shape #1550 fixed one statement
-    later in the same handler.
+    later in the same handler. fix(#1556 review): a shutdown and a dropped
+    connection leave the same row, so both take the same recovery.
     """
     monkeypatch.setattr(backfill_module, "backfill_embeddings", AsyncMock())
 
@@ -2226,7 +2233,7 @@ async def test_a_cancelled_creation_commit_does_not_leave_the_slot_held(
         await real_commit(self, *args, **kwargs)
         if self is armed["session"] and not armed["fired"]:
             armed["fired"] = True
-            raise asyncio.CancelledError()
+            raise lost_ack
 
     monkeypatch.setattr(admin_router, "audit_emit", _arm_on_the_request_entry)
     monkeypatch.setattr(AsyncSession, "commit", _commit_losing_its_acknowledgement)
@@ -2236,7 +2243,7 @@ async def test_a_cancelled_creation_commit_does_not_leave_the_slot_held(
         await client.post(_FORCE_URL, headers=admin_auth_header)
     except BaseException as exc:  # noqa: BLE001 - the transport rewraps it
         raised = exc
-    assert raised is not None, "the cancellation did not propagate"
+    assert raised is not None, "the failure did not propagate"
     assert armed["fired"], "the creation commit never ran — nothing under test"
 
     monkeypatch.setattr(AsyncSession, "commit", real_commit)

--- a/backend/tests/test_embedding_backfill_queue_1542.py
+++ b/backend/tests/test_embedding_backfill_queue_1542.py
@@ -2183,3 +2183,123 @@ async def test_the_worker_startup_recovery_closes_the_trail_it_settles(
     assert await _audit_entries_naming(test_db_session, upload_id) == 0, (
         "the startup recovery wrote an audit entry for an ordinary upload"
     )
+
+
+# ---------------------------------------------------------------------------
+# Both ends of the run, inside the recovery boundary (#1556)
+# ---------------------------------------------------------------------------
+#
+# The rule #1550 arrived at is that the guarded region spans from the moment a
+# durable row can exist to the moment a terminal state is written. Two awaited
+# commits still sat outside it, one at each end: the route's creation commit and
+# the worker's opening read of the row. Both leave a `pending` row holding the
+# one backfill slot, with the stale sweep as the only actor that will ever
+# settle it.
+
+
+@pytest.mark.anyio
+async def test_a_cancelled_creation_commit_does_not_leave_the_slot_held(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    monkeypatch,
+):
+    """The commit applies, its acknowledgement is lost, the request unwinds.
+
+    A durable `pending` row and a durable `requested` entry, with no worker
+    queued and no dispatch arm reached — the shape #1550 fixed one statement
+    later in the same handler.
+    """
+    monkeypatch.setattr(backfill_module, "backfill_embeddings", AsyncMock())
+
+    real_commit = AsyncSession.commit
+    real_audit_emit = admin_router.audit_emit
+    armed: dict = {"session": None, "fired": False}
+
+    async def _arm_on_the_request_entry(session, event, *args, **kwargs):
+        await real_audit_emit(session, event, *args, **kwargs)
+        if event.details.get("outcome") == "requested":
+            armed["session"] = session
+
+    async def _commit_losing_its_acknowledgement(self, *args, **kwargs):
+        await real_commit(self, *args, **kwargs)
+        if self is armed["session"] and not armed["fired"]:
+            armed["fired"] = True
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(admin_router, "audit_emit", _arm_on_the_request_entry)
+    monkeypatch.setattr(AsyncSession, "commit", _commit_losing_its_acknowledgement)
+
+    raised: BaseException | None = None
+    try:
+        await client.post(_FORCE_URL, headers=admin_auth_header)
+    except BaseException as exc:  # noqa: BLE001 - the transport rewraps it
+        raised = exc
+    assert raised is not None, "the cancellation did not propagate"
+    assert armed["fired"], "the creation commit never ran — nothing under test"
+
+    monkeypatch.setattr(AsyncSession, "commit", real_commit)
+    monkeypatch.setattr(admin_router, "audit_emit", real_audit_emit)
+
+    stranded = await _latest_backfill_row(test_db_session)
+    assert stranded.status == "failed", (
+        "the committed-but-unqueued run is holding the unique backfill slot"
+    )
+    assert stranded.error_message == backfill_jobs.UNDISPATCHED_RUN_MESSAGE
+
+    terminal = await _terminal_audit_entries(
+        client, admin_auth_header, str(stranded.id)
+    )
+    assert len(terminal) == 1, terminal
+    assert terminal[0]["details"]["error_code"] == "dispatch_cancelled"
+
+    with patch.object(admin_router, "defer_async_with_tenant", AsyncMock()):
+        again = await client.post(_FORCE_URL, headers=admin_auth_header)
+    assert again.status_code == 200, again.text
+
+
+@pytest.mark.anyio
+async def test_a_failed_startup_read_settles_the_row_it_could_not_read(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    test_db_session: AsyncSession,
+    monkeypatch,
+):
+    """The worker's opening read is the run's other unguarded commit-adjacent await.
+
+    With `retry=0` the delivery is not replayed, so a read that raises used to
+    end the task with the row still `pending` and no actor left to settle it.
+    """
+    monkeypatch.setattr(backfill_module, "backfill_embeddings", AsyncMock())
+    with patch.object(admin_router, "defer_async_with_tenant", AsyncMock()) as defer:
+        resp = await client.post(_FORCE_URL, headers=admin_auth_header)
+    assert resp.status_code == 200, resp.text
+    job_id = resp.json()["job_id"]
+
+    real_get = AsyncSession.get
+    reads: dict = {"failed": False}
+
+    async def _get_failing_once(self, entity, ident, *args, **kwargs):
+        if entity is IngestJob and not reads["failed"]:
+            reads["failed"] = True
+            raise OSError("connection reset by peer")
+        return await real_get(self, entity, ident, *args, **kwargs)
+
+    monkeypatch.setattr(AsyncSession, "get", _get_failing_once)
+    with pytest.raises(OSError):
+        await run_embedding_backfill(**defer.await_args.kwargs)
+    monkeypatch.setattr(AsyncSession, "get", real_get)
+    assert reads["failed"], "the opening read never ran — nothing under test"
+
+    settled = await _load_job(test_db_session, job_id)
+    assert settled.status == "failed", (
+        "the run that could not read its row is still holding the slot"
+    )
+    assert settled.error_message == backfill_jobs.START_FAILED_MESSAGE
+
+    terminal = await _terminal_audit_entries(client, admin_auth_header, job_id)
+    assert len(terminal) == 1, terminal
+    assert terminal[0]["details"]["error_code"] == "start_failed", (
+        "a run that never claimed the row was recorded as one that could not "
+        f"record its outcome: {terminal}"
+    )

--- a/backend/tests/test_embedding_backfill_queue_1542.py
+++ b/backend/tests/test_embedding_backfill_queue_1542.py
@@ -41,6 +41,7 @@ from app.platform.jobs.models import (
     IngestJob,
     commit_attempted_marker,
 )
+from app.platform.jobs.router import get_retry_capability
 from app.processing.embeddings import backfill as backfill_module
 from app.processing.embeddings.models import RecordEmbedding
 
@@ -2303,3 +2304,14 @@ async def test_a_failed_startup_read_settles_the_row_it_could_not_read(
         "a run that never claimed the row was recorded as one that could not "
         f"record its outcome: {terminal}"
     )
+
+    # The settle REPLACES user_metadata, and the read that would have supplied
+    # it is the one that failed. Without the row's own, the marker goes with it
+    # and the retry contract reads a backfill as an ordinary import.
+    marker = (settled.user_metadata or {}).get(EMBEDDING_BACKFILL_METADATA_KEY)
+    assert marker, f"the settle erased the backfill marker: {settled.user_metadata}"
+    assert marker["force"] is True
+    assert marker["operation_id"]
+    can_retry, reason = await get_retry_capability(settled)
+    assert can_retry is False
+    assert "backfill" in (reason or "").lower(), reason

--- a/backend/tests/test_embedding_backfill_queue_1542.py
+++ b/backend/tests/test_embedding_backfill_queue_1542.py
@@ -2267,16 +2267,24 @@ async def test_an_unacknowledged_creation_commit_does_not_leave_the_slot_held(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    "lost_read",
+    [OSError("connection reset by peer"), asyncio.CancelledError()],
+    ids=["connection_lost", "cancelled"],
+)
 async def test_a_failed_startup_read_settles_the_row_it_could_not_read(
     client: AsyncClient,
     admin_auth_header: dict,
     test_db_session: AsyncSession,
     monkeypatch,
+    lost_read: BaseException,
 ):
     """The worker's opening read is the run's other unguarded commit-adjacent await.
 
     With `retry=0` the delivery is not replayed, so a read that raises used to
     end the task with the row still `pending` and no actor left to settle it.
+    fix(#1556 review): a shutdown here is a start failure, not a cancelled run
+    — there is no heartbeat handle, so nothing past the claim can have run.
     """
     monkeypatch.setattr(backfill_module, "backfill_embeddings", AsyncMock())
     with patch.object(admin_router, "defer_async_with_tenant", AsyncMock()) as defer:
@@ -2290,13 +2298,17 @@ async def test_a_failed_startup_read_settles_the_row_it_could_not_read(
     async def _get_failing_once(self, entity, ident, *args, **kwargs):
         if entity is IngestJob and not reads["failed"]:
             reads["failed"] = True
-            raise OSError("connection reset by peer")
+            raise lost_read
         return await real_get(self, entity, ident, *args, **kwargs)
 
     monkeypatch.setattr(AsyncSession, "get", _get_failing_once)
-    with pytest.raises(OSError):
+    raised: BaseException | None = None
+    try:
         await run_embedding_backfill(**defer.await_args.kwargs)
+    except BaseException as exc:  # noqa: BLE001 - a cancellation must re-raise too
+        raised = exc
     monkeypatch.setattr(AsyncSession, "get", real_get)
+    assert type(raised) is type(lost_read), raised
     assert reads["failed"], "the opening read never ran — nothing under test"
 
     settled = await _load_job(test_db_session, job_id)
@@ -2308,8 +2320,7 @@ async def test_a_failed_startup_read_settles_the_row_it_could_not_read(
     terminal = await _terminal_audit_entries(client, admin_auth_header, job_id)
     assert len(terminal) == 1, terminal
     assert terminal[0]["details"]["error_code"] == "start_failed", (
-        "a run that never claimed the row was recorded as one that could not "
-        f"record its outcome: {terminal}"
+        f"a run that never claimed the row was not recorded as one: {terminal}"
     )
 
     # The settle REPLACES user_metadata, and the read that would have supplied

--- a/backend/tests/test_stale_pending_reaper.py
+++ b/backend/tests/test_stale_pending_reaper.py
@@ -18,9 +18,9 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from fastapi import HTTPException
-from sqlalchemy import text
+from sqlalchemy import text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import MIN_SIGNABLE_JOB_LIFETIME_SECONDS, settings
@@ -30,6 +30,7 @@ from app.platform.jobs.router import (
     fail_stale_jobs,
     get_job_status,
     post_expiry_sweep_after_seconds,
+    retry_job,
     stale_pending_cutoff_seconds,
 )
 from app.processing.ingest.presigned import require_signable_job_lifetime
@@ -1274,3 +1275,68 @@ class TestAbandonedDirectUploadsAreCancelled:
         await test_db_session.refresh(job)
         assert job.status == "failed"
         assert (job.user_metadata or {}).get(COMMIT_ATTEMPTED_METADATA_KEY)
+
+
+class TestRetryIsNotAStalePending:
+    """fix(#1556): the retry reopens the pending window, so it has to reset it.
+
+    ``retry_job`` commits `failed` -> `pending` and only then dispatches, so the
+    orphan guard can flip the row back if the queue is down. Between those two
+    commits the row has no Procrastinate job, which leaves the age basis as the
+    only thing standing between a legitimate retry and both reap paths — and
+    the age basis was the ORIGINAL creation, which for anything worth retrying
+    is already hours past both cutoffs.
+    """
+
+    async def _retried(self, session: AsyncSession) -> tuple[IngestJob, uuid.UUID]:
+        user_id = await get_user_id(session, "admin")
+        job = await _stale_pending_job(session, created_by=user_id)
+        # `source_url` with no `file_path` is the one retryable shape that needs
+        # no staging object on disk, and it lands in the unbound half.
+        await session.execute(
+            update(IngestJob)
+            .where(IngestJob.id == job.id)
+            .values(status="failed", source_url="https://example.invalid/data.geojson")
+        )
+        await session.commit()
+        await session.refresh(job)
+        with patch(
+            "app.platform.jobs.router.queue_ingest_job", new=AsyncMock()
+        ) as queued:
+            await retry_job(job.id, _request(), _user(user_id), session)
+        assert queued.await_count == 1, "the retry never reached its dispatch"
+        await session.refresh(job)
+        assert job.status == "pending"
+        return job, user_id
+
+    async def test_the_sweep_spares_a_job_the_operator_just_retried(
+        self, test_db_session: AsyncSession
+    ):
+        job, _ = await self._retried(test_db_session)
+        control = await _stale_pending_job(test_db_session)
+
+        await fail_stale_jobs(test_db_session)
+
+        await test_db_session.refresh(control)
+        assert control.status == "failed", "the sweep did not run — vacuous"
+        await test_db_session.refresh(job)
+        assert job.status == "pending", (
+            "the sweep reaped a retry that had not yet had time to be queued"
+        )
+
+    async def test_the_status_poll_spares_a_job_the_operator_just_retried(
+        self, test_db_session: AsyncSession
+    ):
+        """The path that actually fires: the frontend polls every 2s."""
+        job, user_id = await self._retried(test_db_session)
+        control = await _stale_pending_job(test_db_session, created_by=user_id)
+
+        assert (
+            await get_job_status(job.id, _request(), _user(user_id), test_db_session)
+        ).status == "pending"
+
+        await get_job_status(control.id, _request(), _user(user_id), test_db_session)
+        await test_db_session.refresh(control)
+        assert control.status == "failed", "the poll did not reap — vacuous"
+        await test_db_session.refresh(job)
+        assert job.status == "pending"


### PR DESCRIPTION
## Summary

Two of the three candidates on #1556. The recovery boundary now spans both ends of an embedding backfill run, and the shared stale sweeper stops reaping a job the operator has just retried.

The rule #1550 arrived at is that the guarded region runs from the moment a durable job row can exist to the moment a terminal state is written. Two awaited commits still sat outside it, one at each end, and the shared sweeper turned out to have a defect of its own that reaches every job type.

## Changes

**The route's creation commit (`modules/admin/router.py`).** It was guarded only against `IntegrityError`. A shutdown cancelling that commit after PostgreSQL applied it but before the acknowledgement returned left a durable `pending` row and a durable `requested` audit entry, with no worker queued, no dispatch arm reached, and no actor in the process able to close either. The row holds the one active-backfill slot until the stale sweep. It now takes the same fenced, shielded cleanup the dispatch arm already had, hoisted into `_settle_cancelled_backfill` so the two paths cannot drift. A commit that never landed matches no row and the cleanup is a no-op, which is the correct answer there.

**The caller's transaction (`modules/admin/backfill_jobs.py`).** `settle_undispatched_run` gained an optional `caller_session` it releases first. A cancellation inside a session's own commit can leave that session holding the job row's lock, and the fenced write would block on it until the request's own timeout. `_recover_unsettled` already did this for the worker; the route needs it for the same reason.

**The worker's opening read (`modules/admin/backfill_jobs.py`).** `session.get(IngestJob, ...)` ran before the task's `BaseException` boundary. With `retry=0` the delivery is not replayed, so a transient outage or a shutdown cancellation there ended the task with the row still `pending`. The read moved inside the boundary. A run that never claimed the row now settles with `start_failed` and a message that says nothing started, rather than borrowing `settle_failed`'s "could not record its outcome", which would describe work that never began.

**The retry window (`platform/jobs/router.py`).** `retry_job` commits `failed` to `pending` and only then dispatches, so the orphan guard can flip the row back if the queue is down. Between those two commits the row has no Procrastinate job, which leaves the age basis as the only thing standing between a legitimate retry and both reap paths. The pending sweeps age from `coalesce(staged_at, created_at)`, and a job worth retrying failed long enough ago to be past both cutoffs already, so the row was stale the instant the retry committed. Both the five-minute sweep and the two-second status poll run those clauses. The retry now stamps `staged_at`, the key every other re-entry to `pending` already uses for exactly this (`upload_from_url`'s completion CAS, the reupload completion door, the manifest reservation's staged bind).

## Candidate 2: do other job types inherit the sweeper's audit behaviour?

Enumerated rather than assumed. Thirteen procrastinate tasks are `IngestJob`-backed: vector, raster and service ingest, fan-out children, VRT ingest, VRT regenerate, direct and presigned reupload, raster replace, service reupload, postgis refresh, stac refresh, analysis, manifest reservations and the embedding backfill.

**No other type carries a durable non-terminal audit trail tied to its job row.** The `outcome: "requested"` opener exists in three other places, and none of them is a job lifecycle: `job.cleanup_stale` is the sweeper's own operation record and closes itself in the same request, and `user.export` and `audit.export` are CSV streams with no `IngestJob` behind them. `uq_audit_logs_terminal_embedding_backfill` (migration 0051) is the only one-terminal-entry-per-job constraint and its predicate pins `action = 'embedding.backfill'`. The refresh-backed types have an analogous opener, `refresh.dispatch`, but it is closed by `sweep_abandoned_refresh_runs`, which runs after the job sweeps in the same pass.

**The sweeper cannot fail a genuinely running or a complete job.** All four job-row sweeps pin `status` to `pending`, `running` or `fanned_out`, so `complete` matches none. `claim_ingest_job_attempt` sets `status`, `started_at` and `heartbeat_at` in one statement, so there is no cold-start window on any of the thirteen, and every task stops its heartbeat in a `finally` that runs after the row is already terminal. The two paths that set `running` without a heartbeat are both in the API process and both bounded well under the lease: `upload_from_url`'s staging window is capped at 480s against a 3600s lease, and the manifest reservation's staging is capped at half the lease.

**The pending sweeps were the real exposure, through the retry window above.** `no_live_procrastinate_job()` correlates on `args->>'job_id'`; all thirteen defer sites pass the ingest row id under exactly that kwarg, so the guard is sound for every type. What it cannot cover is the interval before a defer lands, which is what the `staged_at` stamp closes.

One asymmetry found and deliberately not changed: the childless `fanned_out` sweep is the only branch that does not call `audit_settled_embedding_backfill`. It is unreachable for a backfill row, which carries no file and never reaches `commit_fan_out`, so the call would be dead code.

## Candidate ledger for #1556

| Candidate | State |
| --- | --- |
| 1. An awaited commit outside the recovery boundary at either end of the run | **Done.** Both ends, above. The issue comment named `admin/router.py`'s creation commit and `backfill_jobs.py`'s worker startup read; both are now inside the boundary. |
| 2. Whether other job types inherit the shared sweeper's audit behaviour | **Done.** Enumerated above: no other type carries a durable non-terminal trail on its job row, and no sweep can settle a genuinely running or complete job of any type. The enumeration turned up a real defect in the pending sweeps, the retry window, which is fixed here. |
| 3. Operator-facing observability: run history, progress, the estimate before start from #1542 | **Open.** Untouched. It is a feature, not an edge, and it is the only candidate left. |

So `Refs #1556`, not `Closes`. The issue can be narrowed to candidate 3 alone, or closed with candidate 3 refiled against #1542 where it originated.

Two findings outside the candidate list came out of the candidate 2 enumeration and are filed separately rather than folded in here: #2016 (a fan-out parent is left permanently un-retryable when the sweep settles it mid-dispatch) and #2017 (a manifest reservation's admit step runs without a bound inside its own lease). Neither is reachable through the paths this PR touches.

## Area

- [x] Backend (API, services, models)
- [x] Import / Ingestion

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)

Three DB-backed tests, each with its counterfactual observed by reverting only the hunk it covers:

- `test_a_cancelled_creation_commit_does_not_leave_the_slot_held` drives the real lost-acknowledgement shape, committing the row and then raising `CancelledError` out of that commit. Reverted, the row is `pending` and the trail sits at `requested`; the assertion reads `assert 'pending' == 'failed'`.
- `test_a_failed_startup_read_settles_the_row_it_could_not_read` makes the worker's opening read raise once. Reverted, the row stays `pending` with no terminal entry.
- `TestRetryIsNotAStalePending` retries an hours-old failed job with the dispatch stubbed out and then runs each reap path. Reverted, the sweep flips it back to `failed`, and the status poll does so on the first poll. Both tests carry a control row that is reaped in the same call, so a sweep that did not run cannot pass them.

`tests/test_stale_pending_reaper.py`: 64 passed. `tests/test_embedding_backfill_queue_1542.py`: 40 passed. `tests/test_jobs_router.py tests/test_worker.py tests/test_vrt_stale_sweep_gap002.py tests/test_admin_jobs_retry_capability.py tests/test_jobs_retry_analysis_copy.py tests/test_embedding_backfill_force_guard.py tests/test_job_cancel_backfill_stop.py`: 103 passed. `tests/test_layering.py tests/test_rule1_structural.py`: 57 passed. `backend/tests/finding_markers.py` exits 0. `ruff check .` and `ruff format --check .` clean.

## Review

Three rounds, one P2 each, all fixed, no P1 at any point and none deferred.

Round 3, one P2, fixed: moving the opening read inside the guarded exit made a cancellation reachable there, and the outcome branch still tested what ended the run before it tested how far the run got, so a shutdown before the claim wrote the message promising partially written vectors. A null heartbeat handle now wins over the exception type, which is the right predicate for the whole class: nothing past the claim ran, whatever ended it. The test is parametrized over `OSError` and `CancelledError`; reverted, the cancelled case fails on the message and the `OSError` case still passes, so it discriminates exactly the reordering.

Round 2, one P2, fixed: the creation-commit handler caught only `CancelledError`, so a connection reset or a timeout during that commit stranded the same durable `pending` row. The catch is `BaseException` now. It is safe for the whole class because the settle is fenced on `pending`, so a commit that never landed matches no row. The test is parametrized over both causes; reverted to the narrow catch, the `OSError` case fails with `assert 'pending' == 'failed'`. The settle still writes one message and one error code for both causes on purpose: `UNDISPATCHED_RUN_MESSAGE` is written at exactly one site and `_undispatched_settle_write_landed` matches it to prove authorship of its own lost-ack write, so a second message would break that proof for no operator-visible gain.

Round 1, one P2, fixed: the terminal write replaces `user_metadata`, so after a failed opening read the settle wrote an empty backfill marker over the real one, and `_retry_capability` reads an empty marker as false and would have offered a backfill the ordinary import guidance. Recovery now takes the metadata from the row it observes, which is the freshest durable copy and the right source on that path anyway. The test asserts the marker survives with its `force` and `operation_id`, and that `get_retry_capability` still refuses with the backfill message; reverted, the row carries `{'embedding_backfill': {}}`. Anchored comment blocks trimmed to three lines in the same round.

Refs #1556

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: no new user-facing strings
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] No migration needed: `staged_at` is an existing `user_metadata` key with an existing reader
- [x] No secrets or credentials in the diff
