### PR TITLE
fix(ingest): refuse strict_cog alongside options that force a rewrite (#1961)

### DIFF
--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -199,6 +199,37 @@ class VectorCommitRequest(BaseCommitRequest):
     )
 
 
+# fix(#1961): each of these reaches a conversion argument, which is the
+# rewrite strict mode exists to refuse. Mirrors ``check_and_prepare_cog``'s
+# own predicate, case-sensitive DEFLATE default included.
+def reject_strict_cog_conflict(model: Any) -> Any:
+    """Refuse a strict-COG commit that also asks for a rewrite.
+
+    An ``@model_validator(mode="after")`` on both models carrying
+    ``strict_cog``: passing the strict gate and then converting anyway
+    would break the flag's contract, so the combination is a 422.
+    """
+    if not model.strict_cog:
+        return model
+    offenders = [
+        name
+        for name, conflicts in (
+            ("compression", (model.compression or "DEFLATE") != "DEFLATE"),
+            ("resampling", bool(model.resampling)),
+            ("nodata_override", model.nodata_override is not None),
+            ("srid_override", model.srid_override is not None),
+        )
+        if conflicts
+    ]
+    if offenders:
+        raise ValueError(
+            "strict_cog cannot be combined with options that require a "
+            f"rewrite: {', '.join(offenders)}. Drop the option or set "
+            "strict_cog to false."
+        )
+    return model
+
+
 class RasterCommitRequest(BaseCommitRequest):
     """Commit request for raster file uploads (GeoTIFF, VRT)."""
 
@@ -226,10 +257,14 @@ class RasterCommitRequest(BaseCommitRequest):
             "Raster only: reject a non-COG TIFF instead of converting it. "
             "False (the default) converts the source to a COG during ingest. "
             "True fails the job when the source is not already a compliant "
-            "COG. Setting compression, resampling, nodata_override or "
-            "srid_override still rewrites the file even when the strict "
-            "check passes, because each of those is applied by a conversion."
+            "COG, and cannot be combined with resampling, nodata_override, "
+            "srid_override or a compression other than the default DEFLATE: "
+            "each of those is applied by a conversion, so the commit is "
+            "refused with a 422 naming the fields that clash."
         ),
+    )
+    _reject_strict_cog_conflict = model_validator(mode="after")(
+        reject_strict_cog_conflict
     )
 
 
@@ -354,12 +389,16 @@ class CommitRequest(BaseModel):
             "Raster only: reject a non-COG TIFF instead of converting it. "
             "False (the default) converts the source to a COG during ingest. "
             "True fails the job when the source is not already a compliant "
-            "COG. Setting compression, resampling, nodata_override or "
-            "srid_override still rewrites the file even when the strict "
-            "check passes, because each of those is applied by a conversion."
+            "COG, and cannot be combined with resampling, nodata_override, "
+            "srid_override or a compression other than the default DEFLATE: "
+            "each of those is applied by a conversion, so the commit is "
+            "refused with a 422 naming the fields that clash."
         ),
     )
     _reject_auth_conflict = model_validator(mode="after")(reject_service_auth_conflict)
+    _reject_strict_cog_conflict = model_validator(mode="after")(
+        reject_strict_cog_conflict
+    )
 
 
 class CommitResponse(BaseModel):

--- a/backend/app/processing/ingest/schemas.py
+++ b/backend/app/processing/ingest/schemas.py
@@ -205,9 +205,11 @@ class VectorCommitRequest(BaseCommitRequest):
 def reject_strict_cog_conflict(model: Any) -> Any:
     """Refuse a strict-COG commit that also asks for a rewrite.
 
-    An ``@model_validator(mode="after")`` on both models carrying
-    ``strict_cog``: passing the strict gate and then converting anyway
-    would break the flag's contract, so the combination is a 422.
+    An ``@model_validator(mode="after")`` on ``RasterCommitRequest``, which
+    the handler re-validates the body against, so a vector or service job
+    sending a kitchen-sink body still commits. Passing the strict gate and
+    then converting anyway would break the flag's contract, so for a raster
+    job the combination is a 422.
     """
     if not model.strict_cog:
         return model
@@ -396,9 +398,6 @@ class CommitRequest(BaseModel):
         ),
     )
     _reject_auth_conflict = model_validator(mode="after")(reject_service_auth_conflict)
-    _reject_strict_cog_conflict = model_validator(mode="after")(
-        reject_strict_cog_conflict
-    )
 
 
 class CommitResponse(BaseModel):

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3933,7 +3933,7 @@
           },
           "strict_cog": {
             "default": false,
-            "description": "Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG. Setting compression, resampling, nodata_override or srid_override still rewrites the file even when the strict check passes, because each of those is applied by a conversion.",
+            "description": "Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG, and cannot be combined with resampling, nodata_override, srid_override or a compression other than the default DEFLATE: each of those is applied by a conversion, so the commit is refused with a 422 naming the fields that clash.",
             "title": "Strict Cog",
             "type": "boolean"
           }

--- a/backend/tests/test_commit_request_schemas.py
+++ b/backend/tests/test_commit_request_schemas.py
@@ -146,13 +146,8 @@ _CONVERTER_ARGUMENT_TO_FIELD = {
 }
 
 
-@pytest.mark.parametrize(
-    "model",
-    [CommitRequest, RasterCommitRequest],
-    ids=lambda model: model.__name__,
-)
 class TestStrictCogRefusesOptionsThatForceARewrite:
-    """Both the published body and the subclass the handler re-validates."""
+    """The subclass the handler re-validates a raster job's body against."""
 
     @pytest.mark.parametrize(
         "field, value",
@@ -165,32 +160,48 @@ class TestStrictCogRefusesOptionsThatForceARewrite:
         ],
     )
     def test_one_rewriting_option_is_refused_by_name(
-        self, model: type, field: str, value: object
+        self, field: str, value: object
     ) -> None:
         with pytest.raises(ValidationError) as exc:
-            model(title="DEM", strict_cog=True, **{field: value})
+            RasterCommitRequest(title="DEM", strict_cog=True, **{field: value})
         message = str(exc.value)
         assert "strict_cog" in message
         assert field in message
 
-    def test_every_offending_field_is_named_at_once(self, model: type) -> None:
+    def test_every_offending_field_is_named_at_once(self) -> None:
         with pytest.raises(ValidationError) as exc:
-            model(title="DEM", strict_cog=True, **_REWRITING_OPTIONS)
+            RasterCommitRequest(title="DEM", strict_cog=True, **_REWRITING_OPTIONS)
         message = str(exc.value)
         for field in _REWRITING_OPTIONS:
             assert field in message, field
 
-    def test_the_default_compression_stated_explicitly_is_accepted(
+    def test_the_default_compression_stated_explicitly_is_accepted(self) -> None:
+        assert RasterCommitRequest(
+            title="DEM", strict_cog=True, compression="DEFLATE"
+        ).strict_cog
+
+    def test_strict_alone_is_accepted(self) -> None:
+        assert RasterCommitRequest(title="DEM", strict_cog=True).strict_cog
+
+    def test_the_same_options_are_accepted_without_strict(self) -> None:
+        assert (
+            RasterCommitRequest(title="DEM", **_REWRITING_OPTIONS).strict_cog is False
+        )
+
+    @pytest.mark.parametrize(
+        "model",
+        [CommitRequest, VectorCommitRequest, ServiceCommitRequest],
+        ids=lambda model: model.__name__,
+    )
+    def test_a_body_for_another_subclass_keeps_ignoring_the_flag(
         self, model: type
     ) -> None:
-        assert model(title="DEM", strict_cog=True, compression="DEFLATE").strict_cog
-
-    def test_strict_alone_is_accepted(self, model: type) -> None:
-        assert model(title="DEM", strict_cog=True).strict_cog
-
-    def test_the_same_options_are_accepted_without_strict(self, model: type) -> None:
-        accepted = model(title="DEM", **_REWRITING_OPTIONS)
-        assert accepted.strict_cog is False
+        """The flat wire model and the other subclasses drop what does not
+        apply to them, so a kitchen-sink body still commits."""
+        accepted = model.model_validate(
+            {"title": "Roads", "strict_cog": True, **_REWRITING_OPTIONS}
+        )
+        assert accepted.title == "Roads"
 
 
 def test_the_refused_set_is_the_converters_own_predicate() -> None:

--- a/backend/tests/test_commit_request_schemas.py
+++ b/backend/tests/test_commit_request_schemas.py
@@ -9,6 +9,7 @@ FastAPI, no fixtures. Fast (< 1 second total). They prove:
 
 import inspect
 import re
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -127,6 +128,82 @@ class TestRasterCommitRequest:
     def test_raster_strict_cog_omitted_validates(self) -> None:
         r = RasterCommitRequest.model_validate({"title": "DEM"})
         assert r.strict_cog is False
+
+
+# fix(#1961): the four options `check_and_prepare_cog` treats as custom, in the
+# spelling a commit body uses for each.
+_REWRITING_OPTIONS = {
+    "compression": "LZW",
+    "resampling": "bilinear",
+    "nodata_override": -9999,
+    "srid_override": 3857,
+}
+_CONVERTER_ARGUMENT_TO_FIELD = {
+    "compression": "compression",
+    "resampling": "resampling",
+    "nodata": "nodata_override",
+    "assign_crs": "srid_override",
+}
+
+
+@pytest.mark.parametrize(
+    "model",
+    [CommitRequest, RasterCommitRequest],
+    ids=lambda model: model.__name__,
+)
+class TestStrictCogRefusesOptionsThatForceARewrite:
+    """Both the published body and the subclass the handler re-validates."""
+
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            *_REWRITING_OPTIONS.items(),
+            # The converter compares the string, so a lowercase spelling of
+            # the default is a custom option to it and rewrites.
+            ("compression", "deflate"),
+            ("nodata_override", 0.0),
+        ],
+    )
+    def test_one_rewriting_option_is_refused_by_name(
+        self, model: type, field: str, value: object
+    ) -> None:
+        with pytest.raises(ValidationError) as exc:
+            model(title="DEM", strict_cog=True, **{field: value})
+        message = str(exc.value)
+        assert "strict_cog" in message
+        assert field in message
+
+    def test_every_offending_field_is_named_at_once(self, model: type) -> None:
+        with pytest.raises(ValidationError) as exc:
+            model(title="DEM", strict_cog=True, **_REWRITING_OPTIONS)
+        message = str(exc.value)
+        for field in _REWRITING_OPTIONS:
+            assert field in message, field
+
+    def test_the_default_compression_stated_explicitly_is_accepted(
+        self, model: type
+    ) -> None:
+        assert model(title="DEM", strict_cog=True, compression="DEFLATE").strict_cog
+
+    def test_strict_alone_is_accepted(self, model: type) -> None:
+        assert model(title="DEM", strict_cog=True).strict_cog
+
+    def test_the_same_options_are_accepted_without_strict(self, model: type) -> None:
+        accepted = model(title="DEM", **_REWRITING_OPTIONS)
+        assert accepted.strict_cog is False
+
+
+def test_the_refused_set_is_the_converters_own_predicate() -> None:
+    """A fifth argument added to `has_custom_opts` would otherwise pass the
+    validator and be converted behind a caller's back."""
+    cog = Path(inspect.getfile(CommitRequest)).parents[1] / "raster" / "cog.py"
+    predicate = re.search(r"has_custom_opts = \((.*?)\n    \)", cog.read_text(), re.S)
+    assert predicate, "check_and_prepare_cog's predicate is no longer readable"
+    arguments = set(re.findall(r"^\s*(?:or )?(\w+)", predicate.group(1), re.M))
+    assert arguments <= set(_CONVERTER_ARGUMENT_TO_FIELD), arguments
+    assert {_CONVERTER_ARGUMENT_TO_FIELD[name] for name in arguments} == set(
+        _REWRITING_OPTIONS
+    )
 
 
 class TestServiceCommitRequest:

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -1568,6 +1568,41 @@ class TestCommitImportDispatch:
         assert job.status == "pending"
         assert "strict_cog" not in (job.user_metadata or {})
 
+    async def test_a_vector_job_still_commits_the_same_body(
+        self, client, admin_auth_header, test_db_session, mock_ingest_task
+    ) -> None:
+        """fix(#1961): the refusal is the raster subclass's, so a vector job
+        keeps dropping the raster fields it was always sent."""
+        result = await test_db_session.execute(
+            select(User).where(User.username == "admin")
+        )
+        admin = result.scalar_one()
+
+        job = IngestJob(
+            source_filename="roads.geojson",
+            file_path="/tmp/fake.geojson",
+            created_by=admin.id,
+            status="pending",
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+
+        resp = await client.post(
+            f"/ingest/commit/{job.id}",
+            json={
+                "title": "Roads",
+                "strict_cog": True,
+                "compression": "LZW",
+                "srid_override": 3857,
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 202, resp.text
+        await test_db_session.refresh(job)
+        assert job.user_metadata["srid_override"] == 3857
+        assert "strict_cog" not in job.user_metadata
+
     async def test_service_job_commits_with_service_body(
         self, client, admin_auth_header, test_db_session, mock_ingest_task
     ) -> None:

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -1535,6 +1535,39 @@ class TestCommitImportDispatch:
         await test_db_session.refresh(job)
         assert job.user_metadata["strict_cog"] is sent
 
+    async def test_strict_cog_with_a_rewriting_option_is_refused(
+        self, client, admin_auth_header, test_db_session, mock_ingest_task
+    ) -> None:
+        """fix(#1961): the four options are applied by a conversion, so the
+        combination is refused instead of converting behind the flag."""
+        result = await test_db_session.execute(
+            select(User).where(User.username == "admin")
+        )
+        admin = result.scalar_one()
+
+        job = IngestJob(
+            source_filename="dem.tif",
+            file_path="/tmp/fake.tif",
+            created_by=admin.id,
+            status="pending",
+            user_metadata={"file_type": "raster"},
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+        await test_db_session.refresh(job)
+
+        resp = await client.post(
+            f"/ingest/commit/{job.id}",
+            json={"title": "Elevation", "strict_cog": True, "compression": "LZW"},
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 422, resp.text
+        assert "compression" in resp.text
+        assert mock_ingest_task.await_count == 0
+        await test_db_session.refresh(job)
+        assert job.status == "pending"
+        assert "strict_cog" not in (job.user_metadata or {})
+
     async def test_service_job_commits_with_service_body(
         self, client, admin_auth_header, test_db_session, mock_ingest_task
     ) -> None:

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -7110,7 +7110,7 @@ export interface components {
             auth?: components["schemas"]["ServiceAuthRequest"] | null;
             /**
              * Strict Cog
-             * @description Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG. Setting compression, resampling, nodata_override or srid_override still rewrites the file even when the strict check passes, because each of those is applied by a conversion.
+             * @description Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG, and cannot be combined with resampling, nodata_override, srid_override or a compression other than the default DEFLATE: each of those is applied by a conversion, so the commit is refused with a 422 naming the fields that clash.
              * @default false
              */
             strict_cog: boolean;

--- a/sdks/python/geolens/models/commit_request.py
+++ b/sdks/python/geolens/models/commit_request.py
@@ -65,9 +65,10 @@ class CommitRequest:
             auth (None | ServiceAuthRequest | Unset): Structured credential for a protected service. Mutually exclusive with
                 the token field.
             strict_cog (bool | Unset): Raster only: reject a non-COG TIFF instead of converting it. False (the default)
-                converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG.
-                Setting compression, resampling, nodata_override or srid_override still rewrites the file even when the strict
-                check passes, because each of those is applied by a conversion. Default: False.
+                converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG,
+                and cannot be combined with resampling, nodata_override, srid_override or a compression other than the default
+                DEFLATE: each of those is applied by a conversion, so the commit is refused with a 422 naming the fields that
+                clash. Default: False.
     """
 
     title: str

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -2334,7 +2334,7 @@ export type CommitRequest = {
     /**
      * Strict Cog
      *
-     * Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG. Setting compression, resampling, nodata_override or srid_override still rewrites the file even when the strict check passes, because each of those is applied by a conversion.
+     * Raster only: reject a non-COG TIFF instead of converting it. False (the default) converts the source to a COG during ingest. True fails the job when the source is not already a compliant COG, and cannot be combined with resampling, nodata_override, srid_override or a compression other than the default DEFLATE: each of those is applied by a conversion, so the commit is refused with a 422 naming the fields that clash.
      */
     strict_cog?: boolean;
 };


### PR DESCRIPTION
## Summary

`strict_cog=true` asks ingest to refuse a non-COG TIFF rather than convert it. Combined with `compression`, `resampling`, `nodata_override` or `srid_override` it passed the strict gate in `_enforce_strict_cog` and was then converted anyway, because `check_and_prepare_cog` skips the compliance branch whenever any of those four is set. The flag was unsettable before #1949, so no caller can be relying on the current outcome.

Option 2 from the issue: the combination is refused at validation with a 422 that names the offending fields, rather than honouring the flag and silently ignoring options the caller sent.

## Changes

- `reject_strict_cog_conflict` in `backend/app/processing/ingest/schemas.py`, attached as a model validator to both models carrying `strict_cog`: the published flat `CommitRequest`, so the door answers 422, and `RasterCommitRequest`, so the handler's subclass re-validation answers the same way.
- The refused set mirrors `check_and_prepare_cog`'s own predicate, including its case-sensitive `DEFLATE` default: an explicit `compression="DEFLATE"` is the default and is accepted, while `"deflate"` is a custom option to the converter and is refused with the rest.
- The published `strict_cog` description now states the rule. Regenerated with `make sdks` and `npm run types:generate`: `backend/openapi.json`, both SDKs, `frontend/src/types/api.generated.ts`.
- The worker's `_enforce_strict_cog` is unchanged. The rule has one definition, and a new test reads `has_custom_opts` out of `cog.py` so a fifth conversion argument added there fails rather than quietly widening the gap again.

## Area

- [x] Backend (API, services, models)
- [x] Import / Ingestion

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)
- [x] No tests needed (docs, config, etc.) — n/a, tests added

`tests/test_commit_request_schemas.py`: a parametrised class over both models covers each option refused by name, all four named at once, explicit `DEFLATE` accepted, `strict_cog` alone accepted, and the same options accepted without the flag. `tests/test_ingest.py`: the commit route answers 422, queues nothing and leaves the job `pending`. Counterfactual with the validator detached: 15 failures across both files, all of them the conflict cases.

Gates run: `pytest tests/test_ingest.py tests/test_commit_request_schemas.py tests/test_strict_cog_enforcement.py` (101 passed), `test_layering.py`, `test_rule2_structural.py`, `test_openapi_finding_markers.py` (179 passed), `test_sdks_round_trip.py` and the contract suites (`test_fe_sdk_type_drift.py`, `test_api_contract_openapi.py`, `test_secondary_contract_bounds.py`, `test_openapi_overlay_boundary.py`, `test_phase_275_api_style.py`), `ruff check` and `ruff format --check`, `finding_markers.py`, `make openapi-check`, `make sdks-check`, `npm run types:check`.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: no new user-facing strings
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [x] Migration included (if DB schema changed) — no schema change
- [x] No secrets or credentials in the diff

API impact: `POST /ingest/commit/{job_id}` now answers 422 for a body that sets `strict_cog` together with any of the four rewrite-forcing options. The request schema itself is unchanged; only the `strict_cog` description moved, so the generated artifacts carry prose changes alone.

Closes #1961
