### PR TITLE
fix(ingest): let the fan-out restore reclaim a parent the sweep settled (#2016)

### DIFF
--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -1183,9 +1183,9 @@ async def fail_stale_jobs(
             error_code="never_started",
         )
 
-    # fix(#1709): a childless `fanned_out` parent past the grace, inside
-    # the retention horizon, is the signature of a dispatch interrupted
-    # pre-commit. `failed`, so /jobs/{id}/retry offers it.
+    # fix(#1709): a childless `fanned_out` parent past the grace, inside the
+    # retention horizon, is the signature of a dispatch interrupted pre-commit.
+    # fix(#2016): a dispatch still looping reclaims this row on its way out.
     childless_fanout_clauses = [
         IngestJob.status == "fanned_out",
         IngestJob.completed_at.is_not(None),

--- a/backend/app/processing/ingest/router.py
+++ b/backend/app/processing/ingest/router.py
@@ -1451,9 +1451,19 @@ async def commit_fan_out(
     # success keeps the parent `fanned_out`.
     queued_count = sum(1 for r in results if r.status == "queued")
     if queued_count == 0:
-        await restore_fan_out_parent_pending(
+        restored = await restore_fan_out_parent_pending(
             db, job, parent_attempt_id=parent_attempt_id
         )
+        if not restored:
+            # fix(#2016): the undo matched no row, so a third writer holds the
+            # parent terminal and this 202 hides it. Never silent again.
+            logger.warning(
+                "fan_out_parent_restore_missed",
+                job_id=str(job.id),
+                attempt_id=(
+                    str(parent_attempt_id) if parent_attempt_id is not None else None
+                ),
+            )
 
     return FanOutCommitResponse(fan_out_id=job.id, results=results)
 

--- a/backend/app/processing/ingest/service.py
+++ b/backend/app/processing/ingest/service.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import structlog
 from fastapi import HTTPException, UploadFile, status
-from sqlalchemy import or_, select, text
+from sqlalchemy import String, and_, literal, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.async_io import run_in_thread_draining
@@ -51,7 +51,11 @@ from app.platform.jobs.heartbeat import (
     ATTEMPT_STAGING_NAME_PATTERN,
     is_attempt_scoped_staging_table,
 )
-from app.platform.jobs.models import IngestJob, commit_attempted_marker
+from app.platform.jobs.models import (
+    FAN_OUT_INTERRUPTED_METADATA_KEY,
+    IngestJob,
+    commit_attempted_marker,
+)
 from app.platform.storage.titiler_url import resolve_current_storage_key
 
 logger = structlog.get_logger(__name__)
@@ -1114,14 +1118,25 @@ async def restore_fan_out_parent_pending(
     job: IngestJob,
     *,
     parent_attempt_id: uuid.UUID | None,
-) -> None:
+) -> bool:
     """Undo the pre-dispatch claim when EVERY layer failed to queue.
 
     Retry contract: an all-failed dispatch (e.g. Procrastinate outage) keeps
     the parent ``pending`` so the user can commit again without
-    re-uploading. The restore is itself a fenced CAS on
-    ``(fanned_out, attempt_id)``, undoing only the flip THIS request wrote —
-    a blind write would resurrect a row the round-2 fix removed that bug for.
+    re-uploading. The restore is itself a fenced CAS on the attempt id,
+    undoing only the flip THIS request wrote — a blind write would resurrect
+    a row the round-2 fix removed that bug for.
+
+    fix(#2016): a dispatch loop that outlives ``FAN_OUT_CHILDLESS_GRACE``
+    finds the childless-fanout sweep has already settled the same row
+    ``failed`` with the interrupted marker, which ``_retry_capability``
+    refuses — the re-upload this restore exists to spare the user. So the CAS
+    also accepts that row and drops the marker as it restores. Same row, same
+    attempt, and the sweep only reached it because THIS dispatch was still
+    running; the attempt fence is what keeps another attempt's ``failed`` row
+    out. Only that one key is cleared, off the row's own metadata.
+
+    Returns whether the CAS matched, so the caller can report a lost undo.
     """
     from sqlalchemy import update as sa_update
 
@@ -1130,16 +1145,31 @@ async def restore_fan_out_parent_pending(
         if parent_attempt_id is not None
         else IngestJob.attempt_id.is_(None)
     )
-    await session.execute(
+    restored = await session.execute(
         sa_update(IngestJob)
         .where(
             IngestJob.id == job.id,
-            IngestJob.status == "fanned_out",
+            or_(
+                IngestJob.status == "fanned_out",
+                and_(
+                    IngestJob.status == "failed",
+                    IngestJob.user_metadata[FAN_OUT_INTERRUPTED_METADATA_KEY].astext
+                    == "true",
+                ),
+            ),
             attempt_predicate,
         )
-        .values(status="pending", completed_at=None)
+        .values(
+            status="pending",
+            completed_at=None,
+            error_message=None,
+            user_metadata=IngestJob.user_metadata.op("-")(
+                literal(FAN_OUT_INTERRUPTED_METADATA_KEY, String)
+            ),
+        )
     )
     await session.commit()
+    return bool(restored.rowcount)
 
 
 def job_service_format(job: IngestJob) -> str | None:

--- a/backend/tests/test_job_cancel_fan_out.py
+++ b/backend/tests/test_job_cancel_fan_out.py
@@ -24,9 +24,10 @@ exists. Exactly two serializations remain:
   cancellable IngestJob (uniform scope, per the ratified design).
 
 The CR-02 all-failed contract survives as a fenced restore: when every
-layer fails to queue, ``restore_fan_out_parent_pending`` CASes
-``(fanned_out, attempt) -> pending`` so the user can retry without a
-re-upload — it can only undo the flip this request wrote.
+layer fails to queue, ``restore_fan_out_parent_pending`` CASes the parent
+back to ``pending`` on the attempt id so the user can retry without a
+re-upload — it can only undo the flip this request wrote. #2016 widened
+which rows that CAS accepts; see ``TestRestoreReclaimsASweptParent``.
 """
 
 from __future__ import annotations
@@ -585,3 +586,181 @@ class TestNeverQueuedChildRecovery:
         # never a silent default layer.
         assert (child.user_metadata or {}).get("layer_name") == "roads"
         assert (child.user_metadata or {}).get("fan_out_parent_id") == str(parent.id)
+
+
+class TestRestoreReclaimsASweptParent:
+    """fix(#2016): a dispatch loop that outlives the childless-fanout grace
+    lost its undo. The sweep settled the parent `failed` with the interrupted
+    marker, the `fanned_out`-only CAS then matched zero rows in silence, and
+    the marker makes /jobs/{id}/retry refuse — the user was told to re-upload,
+    the exact outcome the restore exists to prevent."""
+
+    async def _age_past_grace(self, session, job_id) -> None:
+        from datetime import datetime, timedelta, timezone
+
+        from app.platform.jobs.sweep import FAN_OUT_CHILDLESS_GRACE_SECONDS
+
+        await session.execute(
+            update(IngestJob)
+            .where(IngestJob.id == job_id)
+            .values(
+                completed_at=datetime.now(timezone.utc)
+                - timedelta(seconds=FAN_OUT_CHILDLESS_GRACE_SECONDS + 60)
+            )
+        )
+        await session.commit()
+
+    async def test_swept_parent_is_reclaimed_on_the_same_attempt(self, test_db_session):
+        from app.platform.jobs.models import FAN_OUT_INTERRUPTED_METADATA_KEY
+        from app.platform.jobs.sweep import fail_stale_jobs
+        from app.processing.ingest.service import restore_fan_out_parent_pending
+
+        job = await _make_pending_parent(test_db_session, layers=["buildings"])
+        attempt = job.attempt_id
+        assert await claim_fan_out_parent(
+            test_db_session, job, parent_attempt_id=attempt
+        )
+
+        await self._age_past_grace(test_db_session, job.id)
+        await fail_stale_jobs(test_db_session)
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert (job.user_metadata or {}).get(FAN_OUT_INTERRUPTED_METADATA_KEY) is True
+
+        assert (
+            await restore_fan_out_parent_pending(
+                test_db_session, job, parent_attempt_id=attempt
+            )
+            is True
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "pending"
+        assert job.completed_at is None
+        assert job.error_message is None
+        # The marker goes and nothing else does: a wholesale metadata write
+        # here would drop the layer list the next commit reads.
+        assert job.user_metadata == {
+            "all_layers": ["buildings"],
+            "file_type": "vector",
+        }
+
+    async def test_a_failed_row_from_another_attempt_is_refused(self, test_db_session):
+        from app.platform.jobs.models import FAN_OUT_INTERRUPTED_METADATA_KEY
+        from app.platform.jobs.sweep import (
+            FAN_OUT_DISPATCH_INTERRUPTED_MESSAGE,
+            fail_stale_jobs,
+        )
+        from app.processing.ingest.service import restore_fan_out_parent_pending
+
+        job = await _make_pending_parent(test_db_session, layers=["buildings"])
+        assert await claim_fan_out_parent(
+            test_db_session, job, parent_attempt_id=job.attempt_id
+        )
+        await self._age_past_grace(test_db_session, job.id)
+        await fail_stale_jobs(test_db_session)
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+
+        assert (
+            await restore_fan_out_parent_pending(
+                test_db_session, job, parent_attempt_id=uuid.uuid4()
+            )
+            is False
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+        assert job.error_message == FAN_OUT_DISPATCH_INTERRUPTED_MESSAGE
+        assert (job.user_metadata or {}).get(FAN_OUT_INTERRUPTED_METADATA_KEY) is True
+
+    async def test_a_lost_undo_is_logged_with_the_job_and_attempt(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        import structlog.testing
+
+        from app.core.db import async_session
+        from app.platform.jobs.models import FAN_OUT_INTERRUPTED_METADATA_KEY
+        from app.processing.ingest.service import restore_fan_out_parent_pending
+
+        job = await _make_pending_parent(test_db_session, layers=["buildings"])
+        attempt = job.attempt_id
+
+        async def _move_the_row_then_restore(session, parent_job, *, parent_attempt_id):
+            # The row settles under a DIFFERENT attempt while the loop runs:
+            # the fence must refuse it, and the caller must say so.
+            async with async_session() as side_session:
+                await side_session.execute(
+                    update(IngestJob)
+                    .where(IngestJob.id == parent_job.id)
+                    .values(
+                        status="failed",
+                        attempt_id=uuid.uuid4(),
+                        user_metadata={
+                            "all_layers": ["buildings"],
+                            "file_type": "vector",
+                            FAN_OUT_INTERRUPTED_METADATA_KEY: True,
+                        },
+                    )
+                )
+                await side_session.commit()
+            return await restore_fan_out_parent_pending(
+                session, parent_job, parent_attempt_id=parent_attempt_id
+            )
+
+        async def _raise(fn, rollback=None, db=None, job=None):
+            raise RuntimeError("queue down")
+
+        with (
+            patch(
+                "app.platform.jobs.defer_guard.defer_with_orphan_guard",
+                side_effect=_raise,
+            ),
+            patch(
+                "app.processing.ingest.router.restore_fan_out_parent_pending",
+                side_effect=_move_the_row_then_restore,
+            ),
+            structlog.testing.capture_logs() as captured,
+        ):
+            resp = await client.post(
+                f"/ingest/commit-fan-out/{job.id}",
+                json={"layers": [{"layer_name": "buildings"}]},
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 202, resp.text
+        missed = [
+            entry
+            for entry in captured
+            if entry.get("event") == "fan_out_parent_restore_missed"
+        ]
+        assert missed, [entry.get("event") for entry in captured]
+        assert missed[0]["job_id"] == str(job.id)
+        assert missed[0]["attempt_id"] == str(attempt)
+        assert missed[0]["log_level"] == "warning"
+
+        await test_db_session.refresh(job)
+        assert job.status == "failed"
+
+    async def test_the_ordinary_fanned_out_undo_still_lands(self, test_db_session):
+        from app.processing.ingest.service import restore_fan_out_parent_pending
+
+        job = await _make_pending_parent(test_db_session, layers=["buildings"])
+        attempt = job.attempt_id
+        assert await claim_fan_out_parent(
+            test_db_session, job, parent_attempt_id=attempt
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "fanned_out"
+
+        assert (
+            await restore_fan_out_parent_pending(
+                test_db_session, job, parent_attempt_id=attempt
+            )
+            is True
+        )
+        await test_db_session.refresh(job)
+        assert job.status == "pending"
+        assert job.completed_at is None
+        assert job.user_metadata == {
+            "all_layers": ["buildings"],
+            "file_type": "vector",
+        }

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3390,7 +3390,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1955): +15 — both VRT source doors admit through the shared
     # per-dataset lock instead of reading the status, and refuse with the
     # coded `dataset_busy` body. Cap 1969 -> 1984, exact.
-    "backend/app/processing/ingest/router.py": 1984,
+    # fix(#2016): +10. The fan-out door reports a lost undo: it reads the
+    # restore's CAS result and logs the job and attempt when it matched no row,
+    # so a parent stranded terminal stops hiding behind a 202. Measured on the
+    # file rebased across #1955, not added up. Cap 1984 -> 1994, exact.
+    "backend/app/processing/ingest/router.py": 1994,
     # fix(#888): +25 — the `mercator_clip` StagingResult field and the
     # `_append_mercator_clip_warning` emitter that keeps the three ingest call
     # sites a single statement each (`reupload_file` is already at the C901
@@ -5208,7 +5212,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # chore(#1940): -9, the fan-out error path no longer re-imports structlog or
     # guards on the result; the module binds `logger` unconditionally.
     # Cap 1622 -> 1613, exact.
-    "backend/app/processing/ingest/service.py": 1390,
+    # fix(#2016): +30. `restore_fan_out_parent_pending` returns its rowcount and
+    # widens the CAS to the row the childless-fanout sweep settled `failed` for
+    # this same attempt, clearing that one marker key. Most of the lines are the
+    # docstring recording why the attempt fence is what makes the wider
+    # predicate safe. Cap 1390 -> 1420, exact.
+    "backend/app/processing/ingest/service.py": 1420,
     # fix(#1738): first entry, crossed _RATCHET_INCLUSION_LOC (842 -> 1019) on
     # the change that gave this task a repair phase. What the growth bought:
     # `geom_4326` on a registered table was written once, at registration, and


### PR DESCRIPTION
## Summary

`commit_fan_out` flips the parent to `fanned_out` and commits before the first child exists, because that transition is the mutex for the whole dispatch. If every layer then fails to queue, `restore_fan_out_parent_pending` undoes the flip so the user can commit again without re-uploading.

A dispatch loop that runs past the 300 second childless-fanout grace loses that undo. The stale sweep reaches the same row first, writes `failed` and stamps the interrupted marker. The restore's compare-and-swap matched only `fanned_out`, so it matched zero rows, ignored the rowcount and logged nothing, and the request still returned 202. The marker it left behind is the one `_retry_capability` refuses on, so the user was told to re-upload the file and pick its layers again, which is the outcome the restore exists to prevent.

The restore now returns whether it matched, and the compare-and-swap also accepts the row the sweep settled for this same attempt. Fencing on the attempt id is what makes the wider predicate safe: a `failed` row belonging to another attempt is never reclaimed. Raising the grace or heartbeating the parent through the loop would only narrow the window, since the loop has no upper bound.

## Changes

- `restore_fan_out_parent_pending` returns its CAS rowcount, and the fan-out door logs `fan_out_parent_restore_missed` with the job and attempt id when the undo matched nothing.
- The CAS accepts `fanned_out`, or `failed` carrying the interrupted marker for the same attempt id. It clears that one key off the row's own metadata with the jsonb `-` operator, so the layer list and everything else the dispatch wrote survives, and it clears the sweep's `error_message` the way generic retry does.
- Corrected the sweep's own comment: it said the row settles `failed` "so /jobs/{id}/retry offers it", while the marker written in the same statement makes retry refuse.
- Four tests in `backend/tests/test_job_cancel_fan_out.py`, plus exact `_MODULE_LOC_CAPS` updates for the two modules that changed size.

## Area

- [x] Backend (API, services, models)
- [x] Import / Ingestion

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)
- [ ] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)

Each new test was counterfactual-verified against the pre-fix code:

- Narrowing the CAS back to `fanned_out` only fails `test_swept_parent_is_reclaimed_on_the_same_attempt`. That test drives the real sweep over a claimed parent aged past the real grace constant, so the marker under test is the one the sweep actually writes.
- Dropping the attempt fence fails `test_a_failed_row_from_another_attempt_is_refused` and `test_a_lost_undo_is_logged_with_the_job_and_attempt`.
- Dropping the caller's warning fails `test_a_lost_undo_is_logged_with_the_job_and_attempt`, which drives the endpoint end to end and reads the record with `structlog.testing.capture_logs`.

Suites run on the host: `test_job_cancel_fan_out.py`, `test_ingest_fan_out.py`, `test_ingest_job_attempt_fencing.py`, `test_stale_pending_reaper.py`, `test_jobs_router.py`, `test_admin_jobs_retry_capability.py`, `test_commit_attempted_marker_doors.py`, `test_rule1_structural.py`, `test_vrt_stale_sweep_gap002.py`, `test_stalled_queue_sweep_624.py`, `test_terminal_job_retention_1778.py`, `test_failed_job_token_purge_1746.py`, `test_tenant_job_recovery.py`, `test_defer_orphan_guard.py`, `test_layering.py`. Also `ruff check`, `ruff format --check` and `backend/tests/finding_markers.py`, all re-run after the rebase across #1955.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [x] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [x] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing

No published API shape changed, so no SDK or OpenAPI regeneration. No new user-facing strings, no schema change, no frontend change.

Closes #2016
