### PR TITLE
fix(ingest): bound the manifest admit step inside its reservation lease (#2017)

### DIFF
--- a/backend/app/processing/ingest/manifest_reservation.py
+++ b/backend/app/processing/ingest/manifest_reservation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta, timezone
 
+import structlog
 from sqlalchemy import desc, func, select, text, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,6 +17,8 @@ from sqlalchemy.orm.attributes import set_committed_value
 
 from app.platform.jobs.models import IngestJob
 from app.platform.jobs.sweep import JOB_TIMEOUT_SECONDS
+
+log = structlog.get_logger()
 
 # fix(#1814): the pre-queue stage a manifest job is in. This module's exits
 # clear it; a row the running sweep or worker recovery settles keeps it, which
@@ -156,6 +159,16 @@ async def bind_reservation_to_staged_source(
         .execution_options(synchronize_session=False)
     )
     if not result.rowcount:
+        # fix(#2017): distinguishes a sweep reaping the row from a cancel,
+        # for the same job the CAS just missed on.
+        observed = (
+            await db.execute(select(IngestJob.status).where(IngestJob.id == job.id))
+        ).scalar_one_or_none()
+        log.warning(
+            "Manifest reservation bind missed its CAS",
+            job_id=str(job.id),
+            observed_status=observed,
+        )
         return False
     # fix(#1814): `set_committed_value`, not assignment — a dirty attribute
     # would have the caller's own commit flush a second, unfenced update.

--- a/backend/app/processing/ingest/manifest_service.py
+++ b/backend/app/processing/ingest/manifest_service.py
@@ -72,6 +72,10 @@ _WRITE_BUFFER_BYTES = 4 * 1024 * 1024
 # reservation is judged by, so the budget and its judge cannot drift apart.
 MANIFEST_STAGE_MAX_SECONDS = JOB_TIMEOUT_SECONDS // 2
 
+# fix(#2017): total wall clock for admitting an already-staged entry against
+# quota and binding its reservation. stage + admit < lease, with margin.
+MANIFEST_ADMIT_MAX_SECONDS = JOB_TIMEOUT_SECONDS // 4
+
 log = structlog.get_logger()
 
 
@@ -911,19 +915,30 @@ async def _finalize_reserved_entry(
 
     admitted = False
     try:
-        staged = await _admit_staged_source(
-            db,
-            prepared,
-            user,
-            request,
-            file_path=file_path,
-            creates_dataset=reserved.creates_dataset,
-            quota=quota,
-        )
-        admitted = True
-        if not await bind_reservation_to_staged_source(db, job, file_path=file_path):
-            raise ManifestSourceError(RESERVATION_LOST_MESSAGE)
-        await _commit_staged_bind(db)
+        try:
+            # fix(#2017): stage + admit must stay under the lease with margin,
+            # so a heartbeat-less running row can't be reaped mid-admit.
+            async with asyncio.timeout(MANIFEST_ADMIT_MAX_SECONDS):
+                staged = await _admit_staged_source(
+                    db,
+                    prepared,
+                    user,
+                    request,
+                    file_path=file_path,
+                    creates_dataset=reserved.creates_dataset,
+                    quota=quota,
+                )
+                admitted = True
+                if not await bind_reservation_to_staged_source(
+                    db, job, file_path=file_path
+                ):
+                    raise ManifestSourceError(RESERVATION_LOST_MESSAGE)
+                await _commit_staged_bind(db)
+        except TimeoutError as exc:
+            raise ManifestSourceError(
+                "Manifest source did not finish admission within "
+                f"{MANIFEST_ADMIT_MAX_SECONDS} seconds"
+            ) from exc
     except BaseException as exc:
         if admitted:
             quota.release(

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2552,7 +2552,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1888): +16. The staged-entry settlement reads the row's status on
     # its own transaction and reaps the staged copy once a committed attempt
     # left the row failed, best effort. Cap 1130 -> 1146, exact.
-    "backend/app/processing/ingest/manifest_service.py": 1136,
+    # fix(#2017): +15. Bounds the admit-plus-bind step under its own deadline
+    # so a heartbeat-less running row can't be reaped mid-admit. Cap 1136 -> 1151.
+    "backend/app/processing/ingest/manifest_service.py": 1151,
     # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
     # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
     # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/

--- a/backend/tests/test_manifest_reservation_1814.py
+++ b/backend/tests/test_manifest_reservation_1814.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, patch
 
 import anyio
 import pytest
+import structlog
 from fastapi import HTTPException, Request
 from sqlalchemy import event, func, select, text, update
 
@@ -1314,6 +1315,51 @@ class TestStaleReservations:
             == 0
         )
 
+    async def test_bind_logs_the_observed_status_on_a_cas_miss(
+        self, test_db_session, clean_tables
+    ):
+        """fix(#2017): a CAS miss on the bind logs what the row actually is,
+        so an operator can tell a sweep from a cancel."""
+        user = await _admin_user(test_db_session)
+        request = _request(_manifest_dataset(key="manifest-2017-cas-miss"))
+        prepared = await classify_manifest_source(request.datasets[0].sources[0])
+        abandoned = self._reservation(
+            user,
+            request.datasets[0],
+            prepared,
+            age_seconds=JOB_TIMEOUT_SECONDS + 60,
+        )
+        test_db_session.add(abandoned)
+        await test_db_session.commit()
+
+        assert (
+            await expire_stale_manifest_reservations(
+                test_db_session, "manifest-2017-cas-miss"
+            )
+            == 1
+        )
+        await test_db_session.commit()
+
+        with structlog.testing.capture_logs() as captured:
+            bound = await manifest_service.bind_reservation_to_staged_source(
+                test_db_session,
+                abandoned,
+                file_path="/tmp/manifest-2017-cas-miss.geojson",
+            )
+
+        assert bound is False
+        misses = [
+            record
+            for record in captured
+            if record.get("event") == "Manifest reservation bind missed its CAS"
+        ]
+        assert len(misses) == 1, (
+            f"Expected exactly one CAS-miss warning; got: {captured}"
+        )
+        assert misses[0]["log_level"] == "warning"
+        assert misses[0]["job_id"] == str(abandoned.id)
+        assert misses[0]["observed_status"] == "failed"
+
 
 class TestManifestJobsAreNotGenericallyRetryable:
     async def test_generic_retry_is_refused_for_a_manifest_keyed_job(
@@ -1524,3 +1570,73 @@ class TestDryRunReservesNothing:
         queue.assert_not_awaited()
         assert await test_db_session.scalar(select(func.count(IngestJob.id))) == before
         assert await _jobs_for_key(test_db_session, "manifest-1814-dry") == []
+
+
+class TestManifestAdmitBound:
+    """fix(#2017): the admit-plus-bind step carries its own deadline, so a
+    heartbeat-less running row can't be reaped mid-admit."""
+
+    def test_stage_and_admit_budgets_stay_inside_the_lease_with_margin(self) -> None:
+        assert (
+            manifest_service.MANIFEST_STAGE_MAX_SECONDS
+            + manifest_service.MANIFEST_ADMIT_MAX_SECONDS
+            < JOB_TIMEOUT_SECONDS
+        )
+
+    async def test_an_admit_past_its_bound_settles_like_a_staging_timeout(
+        self, test_db_session, clean_tables
+    ):
+        """Reverting the admit timeout makes this fail: the slow admit would
+        then complete, bind for real, and queue the job instead of erroring."""
+        request = _request(
+            _manifest_dataset(
+                key="manifest-2017-slow-admit",
+                uri="https://data.example.test/slow-admit.geojson",
+            )
+        )
+        staged = _staged_bytes("manifest_2017_slow_admit.geojson")
+
+        async def _slow_admit(*args, **kwargs):
+            await anyio.sleep(0.3)
+            return manifest_service._StagedManifestSource(
+                file_path=str(staged), incoming_bytes=4096
+            )
+
+        with (
+            patch(
+                "app.processing.ingest.manifest_service.MANIFEST_ADMIT_MAX_SECONDS",
+                0.05,
+            ),
+            patch("app.platform.security.validate_url_for_ssrf", new=AsyncMock()),
+            patch(
+                "app.processing.ingest.manifest_service._download_http_source",
+                new=AsyncMock(return_value=str(staged)),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service._admit_staged_source",
+                new=AsyncMock(side_effect=_slow_admit),
+            ),
+            patch(
+                "app.processing.ingest.manifest_service.queue_ingest_job",
+                new=AsyncMock(),
+            ) as queue,
+        ):
+            response = await apply_manifest(
+                test_db_session,
+                request,
+                await _admin_user(test_db_session),
+                _http_request(),
+            )
+
+        assert response.results[0].action == "error"
+        assert "did not finish admission within 0.05 seconds" in (
+            response.results[0].message
+        )
+        queue.assert_not_awaited()
+        assert not staged.exists()
+
+        reservation = (
+            await _jobs_for_key(test_db_session, "manifest-2017-slow-admit")
+        )[-1]
+        assert reservation.status == "failed"
+        assert "did not finish admission" in reservation.error_message


### PR DESCRIPTION
## Summary

Bounds the manifest apply's admit-plus-bind step so it can't outlast the reservation's running lease. Only the download stage carried a deadline; the admit and bind steps that follow ran unbounded against a heartbeat-less `running` row. If the sweep reaped the row before the bind's compare-and-swap ran, a completed download surfaced as a generic reservation-lost error instead of the real cause.

Closes #2017

## Changes

- Add `MANIFEST_ADMIT_MAX_SECONDS`, derived from the same lease `MANIFEST_STAGE_MAX_SECONDS` already uses, and wrap the admit-plus-bind step in `asyncio.timeout` so `stage + admit` stays under the lease with margin.
- On timeout, settle the entry the same way the existing staging timeout does, through the same `ManifestSourceError` shape.
- Log the observed row status whenever `bind_reservation_to_staged_source`'s compare-and-swap misses, so an operator can tell a sweep from a cancel.

## Area

- [x] Backend (API, services, models)
- [x] Import / Ingestion

## Testing

- [x] Unit tests pass (`pytest`)
- [x] No tests needed (docs, config, etc.) — n/a, new tests added below

New tests in `backend/tests/test_manifest_reservation_1814.py`:
- `MANIFEST_STAGE_MAX_SECONDS + MANIFEST_ADMIT_MAX_SECONDS < JOB_TIMEOUT_SECONDS`
- An admit that exceeds its bound settles the entry failed with the same message shape a staging timeout produces (counterfactual: reverting the timeout wrap makes this test fail)
- A CAS miss on the bind logs the observed row status at warning level

Verification run: `ruff check`, `ruff format --check`, `tests/test_layering.py`, `finding_markers.py`, `tests/test_rule1_structural.py`, `tests/test_manifest_reservation_1814.py`, `tests/test_manifest_apply_service.py`, `tests/test_manifest_apply_api.py`, `tests/test_manifest_apply_roundtrip.py`, `tests/test_manifest_apply_vrt.py`, `tests/test_stalled_queue_sweep_624.py`, `tests/test_stale_pending_reaper.py` — all pass.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: no new user-facing strings
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors (no frontend changes)
- [x] Migration included (if DB schema changed) — n/a, no schema change
- [x] No secrets or credentials in the diff
