### PR TITLE
fix(jobs): purge a stalled queue row's token when the sweep fails it

### DIFF
--- a/backend/app/platform/jobs/sweep.py
+++ b/backend/app/platform/jobs/sweep.py
@@ -7,6 +7,7 @@ lifespan sweeper, worker startup recovery, and the admin cleanup endpoint in
 """
 
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -1019,6 +1020,27 @@ def publish_refresh_reconciliation(outcome: StaleCleanupOutcome) -> None:
     """
     if outcome._refresh_runs_reconciled:
         refresh_sweep_reconciled_total.inc(outcome._refresh_runs_reconciled)
+
+
+_PURGE_JOB_TOKENS_BY_ID_SQL = (
+    "UPDATE catalog.procrastinate_jobs SET args = args - 'token' "
+    "WHERE id = ANY(:job_ids)"
+)
+
+
+async def purge_queue_row_tokens(db: AsyncSession, job_ids: Sequence[int]) -> None:
+    """Drop the raw service token from the named queue rows.
+
+    fix(#1755 item 12): the one statement both immediate purge sites use —
+    a task that fails on its own (``purge_token_on_failure``) and the
+    stalled sweep, which is the first moment a crashed worker's token is
+    provably dead weight. Both service tasks are ``retry=0``, so nothing
+    re-runs from these args.
+    """
+    if not job_ids:
+        return
+    await db.execute(text(_PURGE_JOB_TOKENS_BY_ID_SQL), {"job_ids": list(job_ids)})
+    await db.commit()
 
 
 async def purge_terminal_job_tokens(db: AsyncSession) -> None:

--- a/backend/app/platform/jobs/worker.py
+++ b/backend/app/platform/jobs/worker.py
@@ -362,6 +362,28 @@ async def _leasing_ingest_job_ids(ids: set) -> set[str]:
         return {str(row[0]) for row in rows.all()}
 
 
+async def _purge_stalled_queue_row_tokens(job_ids: list) -> None:
+    """Drop the service tokens of the rows this sweep just failed. Never raises.
+
+    fix(#1755 item 12): a crashed worker never reaches
+    ``purge_token_on_failure``, so this transition is the first moment its
+    token is provably dead weight. Without it the row waits for
+    ``purge_terminal_job_tokens``, a whole API sweeper cadence later.
+    """
+    if not job_ids:
+        return
+    from app.core.db import async_session
+    from app.platform.jobs.sweep import purge_queue_row_tokens
+
+    try:
+        async with async_session() as session:
+            await purge_queue_row_tokens(session, job_ids)
+    except Exception:  # broad: the periodic backstop still covers these rows
+        log.warning(
+            "Stalled queue token purge failed", job_count=len(job_ids), exc_info=True
+        )
+
+
 async def fail_stalled_queue_jobs() -> int:
     """Fail procrastinate rows whose worker died mid-job. Returns the count.
 
@@ -384,6 +406,7 @@ async def fail_stalled_queue_jobs() -> int:
     stalled = list(await manager.get_stalled_jobs(seconds_since_heartbeat=seconds))
     alive = await _ingest_jobs_still_leasing(stalled)
     failed = 0
+    failed_ids: list = []
     for job in stalled:
         if job.id is None:  # unpersisted job — nothing to transition
             continue
@@ -406,11 +429,13 @@ async def fail_stalled_queue_jobs() -> int:
         # sweep mid-loop; metrics bookkeeping must never stop a sweep.
         count_failed_job(getattr(job, "queue", None))
         failed += 1
+        failed_ids.append(job.id)
         log.warning(
             "Failed stalled queue job — its worker stopped heartbeating",
             procrastinate_job_id=job.id,
             task_name=job.task_name,
         )
+    await _purge_stalled_queue_row_tokens(failed_ids)
     # Drop the dead workers' rows too, so the heartbeat table doesn't grow one
     # tombstone per killed worker.
     pruned = await manager.prune_stalled_workers(seconds_since_heartbeat=seconds)

--- a/backend/app/processing/ingest/tasks_common.py
+++ b/backend/app/processing/ingest/tasks_common.py
@@ -256,13 +256,7 @@ task_app = App(
 # fix(#1746): without a credential store, service tasks are dispatched with
 # the raw token in job kwargs; the worker only deletes SUCCESSFUL rows, so a
 # terminal failure leaves it in `procrastinate_jobs.args->>'token'`
-# indefinitely. Safe to delete here because both service tasks are
-# `retry=0` — the first exception is terminal, nothing re-runs from these args.
-_PURGE_JOB_TOKEN_SQL = (
-    "UPDATE catalog.procrastinate_jobs SET args = args - 'token' WHERE id = :job_id"
-)
-
-
+# indefinitely.
 async def purge_queued_job_token(job_context: Any) -> None:
     """Best-effort: drop `token` from the running job's own queue row.
 
@@ -276,14 +270,12 @@ async def purge_queued_job_token(job_context: Any) -> None:
     row_id = getattr(getattr(job_context, "job", None), "id", None)
     if row_id is None:
         return
-    from sqlalchemy import text
-
     from app.core.db import async_session
+    from app.platform.jobs.sweep import purge_queue_row_tokens
 
     try:
         async with async_session() as session:
-            await session.execute(text(_PURGE_JOB_TOKEN_SQL), {"job_id": row_id})
-            await session.commit()
+            await purge_queue_row_tokens(session, [row_id])
     except Exception:  # broad: a purge failure must not replace the real one
         structlog.get_logger().warning(
             "queued_job_token_purge_failed", procrastinate_job_id=row_id

--- a/backend/tests/test_failed_job_token_purge_1746.py
+++ b/backend/tests/test_failed_job_token_purge_1746.py
@@ -34,7 +34,7 @@ from app.platform.jobs.heartbeat import (
     stop_ingest_job_heartbeat as _real_stop_heartbeat,
 )
 from app.platform.jobs.models import IngestJob
-from app.platform.jobs.sweep import purge_terminal_job_tokens
+from app.platform.jobs.sweep import purge_queue_row_tokens, purge_terminal_job_tokens
 from app.processing.ingest import tasks_reupload, tasks_vector
 from app.processing.ingest.tasks_common import (
     purge_queued_job_token,
@@ -167,6 +167,38 @@ class TestThePurgeStripsTerminalRows:
             await purge_terminal_job_tokens(test_db_session)
 
             assert await _read_args(test_db_session, row_id) == clean_args
+        finally:
+            await _drop_queue(test_db_session, queue)
+
+
+class TestTheStalledSweepStripsWhatItFails:
+    async def test_a_named_row_loses_its_token_while_a_live_one_keeps_everything(
+        self, test_db_session: AsyncSession
+    ):
+        """fix(#1755 item 12): the stalled sweep names the rows it just failed.
+
+        Both rows are `doing`, which the status-gated backstop deliberately
+        skips, so only the by-id statement can be what stripped one of them.
+        """
+        queue = f"tok-purge-{uuid.uuid4().hex[:12]}"
+        swept_args = _args()
+        live_args = _args()
+        try:
+            swept_id = await _queue_row(
+                test_db_session, status="doing", queue_name=queue, args=swept_args
+            )
+            live_id = await _queue_row(
+                test_db_session, status="doing", queue_name=queue, args=live_args
+            )
+
+            await purge_queue_row_tokens(test_db_session, [swept_id])
+
+            after_swept = await _read_args(test_db_session, swept_id)
+            assert "token" not in after_swept
+            assert after_swept == {
+                k: v for k, v in swept_args.items() if k != "token"
+            }, "the purge must remove the token key and nothing else"
+            assert await _read_args(test_db_session, live_id) == live_args
         finally:
             await _drop_queue(test_db_session, queue)
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3635,7 +3635,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1950 codex r2-r5): +55 — `load_job_for_error_write`, the guarded job
     # load the two re-upload tails share, which also ends the transaction on a
     # miss so the run row they write next is unbudgeted. Cap 2668 -> 2723, exact.
-    "backend/app/processing/ingest/tasks_common.py": 2421,
+    # fix(#1755 item 12): -8 — the by-id purge statement moved to
+    # `platform/jobs/sweep.py`, which the stalled sweep also calls.
+    # Cap 2421 -> 2413, exact.
+    "backend/app/processing/ingest/tasks_common.py": 2413,
     # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
     # tasks_reupload crossed 1000 when two independently-reviewed features
     # met in one file: #1222's failed-contact bookkeeping (spawn-armed
@@ -4045,7 +4048,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # is the comment stating why a set-based UPDATE cannot use `lock_timeout`
     # the way a single-row write does. Cap 2374 -> 2392, exact.
     # chore(#1873): review-history comments trimmed. Cap 2392 -> 1506, exact.
-    "backend/app/platform/jobs/sweep.py": 1472,
+    # fix(#1755 item 12): +22 — `purge_queue_row_tokens`, the by-id token
+    # purge the stalled sweep and the task-side purge now share.
+    # Cap 1472 -> 1494, exact.
+    "backend/app/platform/jobs/sweep.py": 1494,
     # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
     # threshold at 1010 when refresh.cancelled attribution was corrected to
     # name the CANCELLING user (cancel_active_run_for_job and

--- a/backend/tests/test_stalled_queue_sweep_624.py
+++ b/backend/tests/test_stalled_queue_sweep_624.py
@@ -231,6 +231,50 @@ async def test_job_whose_ingest_row_is_still_leasing_is_left_alone():
 
 
 @pytest.mark.anyio
+async def test_the_sweep_purges_the_tokens_of_only_the_rows_it_failed():
+    """fix(#1755 item 12): a crashed worker never reaches
+    `purge_token_on_failure`, so the sweep that declares its row dead is where
+    the token stops being needed. A job left alone may still be running.
+    """
+    live = "11111111-1111-1111-1111-111111111111"
+    dead = "22222222-2222-2222-2222-222222222222"
+    fake = _fake_task_app([_job(1, live), _job(2, dead), _job(None, "unpersisted")])
+    purge = AsyncMock()
+
+    with (
+        patch("app.processing.ingest.tasks.task_app", fake),
+        patch(
+            "app.platform.jobs.worker._ingest_jobs_still_leasing",
+            AsyncMock(return_value={live}),
+        ),
+        patch("app.platform.jobs.sweep.purge_queue_row_tokens", purge),
+    ):
+        await fail_stalled_queue_jobs()
+
+    assert purge.await_args.args[1] == [2]
+
+
+@pytest.mark.anyio
+async def test_a_purge_failure_does_not_abort_the_sweep():
+    """The periodic backstop still covers these rows, so a purge that raises
+    must not cost the transition the sweep just made.
+    """
+    fake = _fake_task_app([_job(5, task_name="ingest_service")])
+
+    with (
+        patch("app.processing.ingest.tasks.task_app", fake),
+        patch(
+            "app.platform.jobs.sweep.purge_queue_row_tokens",
+            AsyncMock(side_effect=OSError("queue table unreachable")),
+        ),
+    ):
+        failed = await fail_stalled_queue_jobs()
+
+    assert failed == 1
+    fake.job_manager.prune_stalled_workers.assert_awaited_once()
+
+
+@pytest.mark.anyio
 async def test_job_with_no_lease_to_read_still_gets_swept():
     """The liveness check must not become a blanket amnesty.
 


### PR DESCRIPTION
## Summary

Item 12 of #1755. A raw service token rides in `procrastinate_jobs.args` on
the default install, where no credential store is configured. Two purges
already exist: the task strips its own row on the way out
(`purge_token_on_failure`), and `purge_terminal_job_tokens` sweeps terminal
rows once per API sweeper pass.

Neither covers a crashed worker. The task-side purge needs the process to be
alive to run, and the periodic backstop is gated on
`status NOT IN ('todo', 'doing')`, so it skips the row until something else
makes it terminal. That something is the stalled-queue sweep in the worker,
which is also the first moment the token is provably dead weight: both service
tasks are `retry=0`, so nothing re-runs from those args. It now purges the rows
it just failed.

## What the args can carry

| Field | Durable | Handled |
| --- | --- | --- |
| `token` | Yes, the raw service credential on a store-less install | This PR, plus the two existing purges |
| `credential_ref` | No. The secret lives in Valkey under a random reference with `CREDENTIAL_TTL_SECONDS`, claimed once by `GETDEL`. The reference names nothing once claimed or expired | Left in place, see below |
| `source_url` | Yes, and a submitted URL can carry credentials in userinfo or the query | Not touched, see below |

## Changes

- `platform/jobs/sweep.py`: `purge_queue_row_tokens`, one by-id statement.
- `platform/jobs/worker.py`: `fail_stalled_queue_jobs` collects the ids it
  transitions and purges them. A job skipped because its ingest row is still
  leasing keeps its args, since it may still be running.
- The purge is best-effort and logs on failure. The periodic backstop still
  covers those rows, so a purge that raises must not cost the transition the
  sweep just made.
- `processing/ingest/tasks_common.py`: the task-side purge calls the shared
  statement instead of keeping a second copy of the same SQL.
- LOC caps re-measured exactly: sweep.py 1472 to 1494, tasks_common.py 2421 to
  2413.

## Which window remains

Detection, not cleanup. A worker counts as dead after `stalled_worker_seconds()`
of heartbeat silence, floored at the 60 minute `JOB_TIMEOUT_SECONDS`, and the
worker sweeps on a 60 second interval. So the token now clears within about a
minute of the row being declared dead, where before it waited a further API
sweeper cadence on top of that.

That hour is not reducible here. The threshold is global and deliberately
generous because a silent worker does not imply dead work: a split-queue fleet's
raster pool can configure a longer graceful shutdown than this threshold, and
failing a job that is provably still running loses work. `_ingest_jobs_still_leasing`
already prefers a live lease over any timeout for the same reason.

## Deferred, with reasons

- **`credential_ref`** is not purged. It is a reference, not a secret: the value
  lives in Valkey under a short TTL and `GETDEL` makes it single use, so a
  residual reference on a dead row names a key that is already claimed or
  expired. Purging it would buy nothing durable.
- **`source_url`** is not purged. It is the row's only record of what was being
  imported, so stripping it would cost the post-mortem the retention window
  exists for, and it is not credential-shaped by design. If submitted URLs
  should be stored redacted, that is a decision about the whole ingest path
  rather than about the queue row, and belongs in its own issue.

## Area

- [x] Backend (API, services, models)
- [x] Import / Ingestion
- [x] Auth / Permissions

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)

Counterfactuals, both run:

- Removing the sweep's purge call makes
  `test_the_sweep_purges_the_tokens_of_only_the_rows_it_failed` fail on
  `purge.await_args` being `None`.
- Adding `AND status NOT IN ('todo', 'doing')` to the by-id statement makes the
  DB-backed `test_a_named_row_loses_its_token_while_a_live_one_keeps_everything`
  fail with the token still present, which is what proves the by-id statement,
  not the status-gated backstop, is what strips a `doing` row.

Host pytest at `localhost:5434`:

```
tests/test_stalled_queue_sweep_624.py + 6 queue/token files       434 passed
tests/test_layering.py + rule1 + rule2                            168 passed
```

`ruff check`, `ruff format --check` and `backend/tests/finding_markers.py`
pass.

## Checklist

- [x] Code follows existing project conventions
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] No secrets or credentials in the diff

Refs #1755
