### PR TITLE
feat(sources): request-only authentication for STAC sources (#1764)

### DIFF
--- a/backend/app/core/processing_port.py
+++ b/backend/app/core/processing_port.py
@@ -386,6 +386,9 @@ class ProcessingPort(Protocol):
     # asks for the answer through this port and holds no HTTP client of its
     # own. Returns a ``StacResolution``, typed Any since core/ may not
     # import modules.*.
+    # feat(#1764): ``credential`` is the ``ServiceCredential`` a credentialed
+    # refresh claimed for this one attempt; typed Any for the same reason the
+    # return is, and None for a public catalog.
     async def resolve_stac_binding(
         self,
         *,
@@ -394,6 +397,7 @@ class ProcessingPort(Protocol):
         collection_id: str | None,
         asset_href: str | None,
         asset_key: str | None,
+        credential: Any = None,
     ) -> Any: ...
 
     # Preserves joinedload semantics for metadata_service._build_dataset_context.

--- a/backend/app/core/processing_port.py
+++ b/backend/app/core/processing_port.py
@@ -387,8 +387,8 @@ class ProcessingPort(Protocol):
     # own. Returns a ``StacResolution``, typed Any since core/ may not
     # import modules.*.
     # feat(#1764): ``credential`` is the ``ServiceCredential`` a credentialed
-    # refresh claimed for this one attempt; typed Any for the same reason the
-    # return is, and None for a public catalog.
+    # refresh claimed for this attempt, and ``credential_origin`` the catalog
+    # address it was given for; a read steered elsewhere is made anonymously.
     async def resolve_stac_binding(
         self,
         *,
@@ -398,6 +398,7 @@ class ProcessingPort(Protocol):
         asset_href: str | None,
         asset_key: str | None,
         credential: Any = None,
+        credential_origin: str | None = None,
     ) -> Any: ...
 
     # Preserves joinedload semantics for metadata_service._build_dataset_context.

--- a/backend/app/core/processing_port.py
+++ b/backend/app/core/processing_port.py
@@ -387,7 +387,7 @@ class ProcessingPort(Protocol):
     # own. Returns a ``StacResolution``, typed Any since core/ may not
     # import modules.*.
     # feat(#1764): ``credential`` is the ``ServiceCredential`` a credentialed
-    # refresh claimed for this attempt, and ``credential_origin`` the catalog
+    # refresh claimed for this attempt, and ``catalog_origin`` the catalog
     # address it was given for; a read steered elsewhere is made anonymously.
     async def resolve_stac_binding(
         self,
@@ -398,7 +398,7 @@ class ProcessingPort(Protocol):
         asset_href: str | None,
         asset_key: str | None,
         credential: Any = None,
-        credential_origin: str | None = None,
+        catalog_origin: str | None = None,
     ) -> Any: ...
 
     # Preserves joinedload semantics for metadata_service._build_dataset_context.

--- a/backend/app/core/service_tokens.py
+++ b/backend/app/core/service_tokens.py
@@ -439,7 +439,7 @@ def _composes_a_header(
     )
 
 
-def _bearer_token_rejection(auth: ServiceCredential) -> str | None:
+def bearer_token_rejection_reason(auth: ServiceCredential) -> str | None:
     """Why *auth*'s bearer token cannot become an Authorization value.
 
     feat(C2): two charsets, chosen by service format. A WFS/OAPIF token
@@ -453,6 +453,10 @@ def _bearer_token_rejection(auth: ServiceCredential) -> str | None:
     feat(#1764): the branch asks ``requires_header_token_policy`` rather than
     naming ArcGIS, so STAC takes the wider charset too — its credential is
     httpx-only, and httpx refuses a CR/LF header value itself.
+
+    fix(#1764): public, because the DOOR has to reach the same verdict this
+    builder will. Judging the door's bearer token by the GDAL charset alone
+    refused a STAC key holding ``+`` or ``/`` that the builder accepts.
     """
     if not requires_header_token_policy(auth.service_format):
         # Rejects ``None`` on its own, unlike its header-token sibling, which
@@ -497,7 +501,7 @@ def build_credential_header(
         return None
 
     if method == CredentialMethod.BEARER:
-        reason = _bearer_token_rejection(auth)
+        reason = bearer_token_rejection_reason(auth)
         if auth.token is None or reason is not None:
             raise ValueError(reason or HEADER_TOKEN_POLICY)
         if auth.service_format == ARCGIS_SERVICE_FORMAT:

--- a/backend/app/core/service_tokens.py
+++ b/backend/app/core/service_tokens.py
@@ -33,9 +33,8 @@ from enum import StrEnum
 # to ``GDAL_HTTP_HEADER_FILE``, and (c) checked by
 # ``assert_endpoints_stay_on_origin``. All three exclude ArcGIS.
 #
-# feat(#1764): a fourth question, "crossed to the worker as a finished header
-# LINE" (plan D9), moved to ``HEADER_LINE_SERVICE_FORMATS`` below — STAC
-# answers yes to that one and no to these three.
+# feat(#1764): the fourth question, "crossed to the worker as a finished
+# header LINE" (plan D9), is ``HEADER_LINE_SERVICE_FORMATS`` below.
 #
 # fix(#1840): (d) was missing here, producing a P1 —
 # ``wire_credential`` picked its branch by whether ``build_credential_header``
@@ -62,15 +61,16 @@ ARCGIS_SERVICE_FORMAT = "arcgis_featureserver"
 STAC_SERVICE_FORMAT = "stac"
 
 # feat(#1764): formats whose credential is a header LINE rather than a URL
-# query parameter, on every transport that carries it — including the queue
-# hop to the worker (``platform/service_auth.py::wire_credential``, plan D9).
-# This is the question "can this service present a basic or header-key
-# credential at all", so it also gates ``service_carries_method``.
+# query parameter, on every transport including the queue hop (plan D9). Also
+# the question ``service_carries_method`` asks about basic and header-key.
 #
-# Wider than ``HEADER_AUTH_SERVICE_FORMATS`` by exactly STAC, whose catalog,
-# item and asset reads are all httpx and never GDAL: nothing writes a STAC
-# credential to the header file, and no STAC read follows a description that
-# ``assert_endpoints_stay_on_origin`` could check.
+# Wider than ``HEADER_AUTH_SERVICE_FORMATS`` by exactly STAC, whose reads are
+# httpx and never GDAL, so no STAC credential reaches the 0600 header file.
+#
+# fix(#1764): STAC DOES follow service-described endpoints (an item's self
+# link, its asset hrefs); they are checked by
+# ``stac_resolve_identity.credential_for_read``, not by
+# ``assert_endpoints_stay_on_origin``, which asks a GDAL question.
 HEADER_LINE_SERVICE_FORMATS: frozenset[str] = HEADER_AUTH_SERVICE_FORMATS | {
     STAC_SERVICE_FORMAT
 }

--- a/backend/app/core/service_tokens.py
+++ b/backend/app/core/service_tokens.py
@@ -30,10 +30,12 @@ from enum import StrEnum
 # parameter, urlencoded into the ESRIJSON source URL, so it never carries the
 # smuggling risk this charset guards against. This set answers whether a
 # format's credential is (a) judged by ``HEADER_TOKEN_CHARSET``, (b) written
-# to ``GDAL_HTTP_HEADER_FILE``, (c) checked by
-# ``assert_endpoints_stay_on_origin``, and (d) crossed to the worker as a
-# finished header LINE (``platform/service_auth.py::wire_credential``, plan
-# D9). All four exclude ArcGIS.
+# to ``GDAL_HTTP_HEADER_FILE``, and (c) checked by
+# ``assert_endpoints_stay_on_origin``. All three exclude ArcGIS.
+#
+# feat(#1764): a fourth question, "crossed to the worker as a finished header
+# LINE" (plan D9), moved to ``HEADER_LINE_SERVICE_FORMATS`` below — STAC
+# answers yes to that one and no to these three.
 #
 # fix(#1840): (d) was missing here, producing a P1 —
 # ``wire_credential`` picked its branch by whether ``build_credential_header``
@@ -54,6 +56,25 @@ HEADER_AUTH_SERVICE_FORMATS: frozenset[str] = frozenset({"wfs", "ogcapi_features
 # re-exports this name.
 ARCGIS_SERVICE_FORMAT = "arcgis_featureserver"
 
+# feat(#1764): STAC's own service format, spelled here for the same reason.
+# It matches ``datasets.source_format`` for a STAC-imported dataset, which is
+# what the refresh door reads before it composes anything.
+STAC_SERVICE_FORMAT = "stac"
+
+# feat(#1764): formats whose credential is a header LINE rather than a URL
+# query parameter, on every transport that carries it — including the queue
+# hop to the worker (``platform/service_auth.py::wire_credential``, plan D9).
+# This is the question "can this service present a basic or header-key
+# credential at all", so it also gates ``service_carries_method``.
+#
+# Wider than ``HEADER_AUTH_SERVICE_FORMATS`` by exactly STAC, whose catalog,
+# item and asset reads are all httpx and never GDAL: nothing writes a STAC
+# credential to the header file, and no STAC read follows a description that
+# ``assert_endpoints_stay_on_origin`` could check.
+HEADER_LINE_SERVICE_FORMATS: frozenset[str] = HEADER_AUTH_SERVICE_FORMATS | {
+    STAC_SERVICE_FORMAT
+}
+
 # feat(C2): formats whose credential travels as an HTTP header on GeoLens's
 # OWN httpx requests — wider than the set above. ArcGIS Server has accepted a
 # bearer token in a header since 10.5.1, and hosted ArcGIS Online always has;
@@ -69,7 +90,7 @@ ARCGIS_SERVICE_FORMAT = "arcgis_featureserver"
 # refuse tokens holding ``+``/``/``, nothing writes ArcGIS to the GDAL header
 # file, and the adapter composes URLs from its own base rather than
 # following a service-described endpoint.
-HEADER_TRANSPORT_SERVICE_FORMATS: frozenset[str] = HEADER_AUTH_SERVICE_FORMATS | {
+HEADER_TRANSPORT_SERVICE_FORMATS: frozenset[str] = HEADER_LINE_SERVICE_FORMATS | {
     ARCGIS_SERVICE_FORMAT
 }
 
@@ -124,6 +145,18 @@ def requires_header_token_policy(source_format: str | None) -> bool:
     requests and includes ArcGIS.
     """
     return source_format in HEADER_AUTH_SERVICE_FORMATS
+
+
+def carries_credential_as_header_line(source_format: str | None) -> bool:
+    """Whether *source_format*'s credential is a header line, not a query key.
+
+    feat(#1764): the question a door asks before accepting a basic or
+    header-key credential, and the one ``wire_credential`` asks before
+    composing the line that crosses the queue. Wider than
+    :func:`requires_header_token_policy` by exactly STAC, whose credential is
+    a header on every hop and never reaches GDAL.
+    """
+    return source_format in HEADER_LINE_SERVICE_FORMATS
 
 
 def sends_credential_as_header(source_format: str | None) -> bool:
@@ -416,8 +449,12 @@ def _bearer_token_rejection(auth: ServiceCredential) -> str | None:
     instead — and legitimately holds ``+``/``/``, so it's judged as a header
     VALUE (printable ASCII, no whitespace) instead: CR/LF still banned, only
     the collateral damage differs.
+
+    feat(#1764): the branch asks ``requires_header_token_policy`` rather than
+    naming ArcGIS, so STAC takes the wider charset too — its credential is
+    httpx-only, and httpx refuses a CR/LF header value itself.
     """
-    if auth.service_format == ARCGIS_SERVICE_FORMAT:
+    if not requires_header_token_policy(auth.service_format):
         # Rejects ``None`` on its own, unlike its header-token sibling, which
         # reads ``None`` as "no token supplied and none required".
         return credential_input_rejection_reason(auth.token)
@@ -516,3 +553,62 @@ def credential_header_line(pair: tuple[str, str]) -> str:
     """
     name, value = pair
     return f"{name}{HEADER_LINE_SEPARATOR}{value}"
+
+
+def credential_from_header_line(
+    line: str | None, *, service_format: str | None = None
+) -> ServiceCredential | None:
+    """The credential a D9 wire line describes, or None if it describes none.
+
+    feat(#1764): the inverse of ``build_credential_header`` +
+    :func:`credential_header_line`, for the one hop that cannot compose at
+    the write site. A WFS/OAPIF worker writes the line straight to the GDAL
+    header file; a STAC worker issues httpx requests of its own, and every
+    one of those has to compose through the single producer like any other
+    write site. Recovering the credential here is what lets it.
+
+    Round-trips exactly: recomposing the result yields the same line, which
+    ``test_stac_service_auth_1764`` pins. Basic is base64-decoded back to the
+    username and password the builder encoded, and the builder already
+    refused a colon in the username, so the split point is unambiguous.
+
+    Returns None for anything this cannot round-trip — no separator, an empty
+    name or value, an unrecognized ``Authorization`` scheme, or a Basic blob
+    that is not ASCII base64 of ``user:password``. None means "no credential",
+    which sends an anonymous request rather than a mis-composed one.
+    """
+    if not line:
+        return None
+    name, separator, value = line.partition(HEADER_LINE_SEPARATOR)
+    if not separator or not name or not value:
+        return None
+    if name.lower() != "authorization":
+        return ServiceCredential(
+            method=CredentialMethod.HEADER_KEY,
+            service_format=service_format,
+            header_name=name,
+            header_value=value,
+        )
+    if value.startswith(BEARER_SCHEME):
+        return ServiceCredential(
+            method=CredentialMethod.BEARER,
+            service_format=service_format,
+            token=value[len(BEARER_SCHEME) :],
+        )
+    if not value.startswith(BASIC_SCHEME):
+        return None
+    try:
+        decoded = base64.b64decode(
+            value[len(BASIC_SCHEME) :].encode("ascii"), validate=True
+        ).decode("ascii")
+    except (ValueError, UnicodeDecodeError):
+        return None
+    username, colon, password = decoded.partition(":")
+    if not colon:
+        return None
+    return ServiceCredential(
+        method=CredentialMethod.BASIC,
+        service_format=service_format,
+        username=username,
+        password=password,
+    )

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -377,6 +377,29 @@ def scrub_secret_value(text: str, secret: str | None) -> str:
     return text
 
 
+def carries_registered_credential(text: str) -> bool:
+    """Whether *text* contains a credential composed in this request/job.
+
+    fix(#1764): the non-destructive form of :func:`scrub_secret_value`, for a
+    caller deciding whether to STORE a string rather than whether to log one.
+    An origin can reflect the credential it was sent into a URL it publishes,
+    under any parameter name, and ``has_url_credentials`` is an allowlist of
+    NAMES rather than a check of values.
+
+    Reads the same ``_secret_variants`` vocabulary, so the tail after ``": "``,
+    the part after an auth scheme, a Basic blob's cleartext and every
+    percent-encoded spelling all count. Empty registry, so no credential in
+    this context, means False.
+    """
+    if not text:
+        return False
+    for secret in registered_credential_secrets():
+        for variant in _secret_variants(secret):
+            if variant and variant in text:
+                return True
+    return False
+
+
 def scrub_secret_from_exception(exc: BaseException, secret: str | None) -> None:
     """Scrub *secret* out of an exception's message, in place.
 

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -24,6 +24,7 @@ from urllib.parse import (
 from app.core.service_tokens import (
     BASIC_SCHEME,
     HEADER_LINE_SEPARATOR,
+    HEADER_TOKEN_MIN_LENGTH,
     registered_credential_secrets,
 )
 
@@ -377,6 +378,21 @@ def scrub_secret_value(text: str, secret: str | None) -> str:
     return text
 
 
+# fix(#1764): a refusal gate is not a redactor. `scrub_secret_value` matches
+# any substring on purpose, because over-scrubbing costs nothing; refusing a
+# URL that way would strand every legitimate refresh once a credential is
+# short enough to occur by accident (a one-character Basic username matches
+# almost any URL). So a SHORT variant has to BE a whole token, and only a
+# variant at least this long is matched loose.
+_CREDENTIAL_MATCH_FLOOR = HEADER_TOKEN_MIN_LENGTH
+
+# What can surround a credential value in a URL or a JSON document. Splitting
+# on it turns `?key=abc` and `"k":"abc"` alike into the token `abc`. The kept
+# characters are the unreserved set plus the percent-encoding and base64
+# spellings a variant can carry, so an encoded form stays one token.
+_CREDENTIAL_TOKEN_SPLIT = re.compile(r"[^A-Za-z0-9._~%+-]+")
+
+
 def carries_registered_credential(text: str) -> bool:
     """Whether *text* contains a credential composed in this request/job.
 
@@ -390,12 +406,25 @@ def carries_registered_credential(text: str) -> bool:
     the part after an auth scheme, a Basic blob's cleartext and every
     percent-encoded spelling all count. Empty registry, so no credential in
     this context, means False.
+
+    See ``_CREDENTIAL_MATCH_FLOOR`` for why a short variant is matched as a
+    whole token rather than as any substring.
     """
     if not text:
         return False
+    tokens: set[str] | None = None
     for secret in registered_credential_secrets():
         for variant in _secret_variants(secret):
-            if variant and variant in text:
+            if not variant:
+                continue
+            if len(variant) >= _CREDENTIAL_MATCH_FLOOR:
+                if variant in text:
+                    return True
+                continue
+            # Computed once, and only when a short variant is in play.
+            if tokens is None:
+                tokens = set(_CREDENTIAL_TOKEN_SPLIT.split(text))
+            if variant in tokens:
                 return True
     return False
 

--- a/backend/app/modules/catalog/datasets/api/router_refresh.py
+++ b/backend/app/modules/catalog/datasets/api/router_refresh.py
@@ -669,7 +669,8 @@ async def _dispatch_stac_refresh(
     # and report a live dataset as inaccessible. No probe — a STAC item read
     # is the resource the worker fetches, so an anonymous pre-check would
     # cost a request to learn what the marker already says.
-    if not token and service_auth_required(dataset.origin_ref):
+    marked_before = service_auth_required(dataset.origin_ref)
+    if not token and marked_before:
         raise _service_token_required()
 
     # Refused before anything is written, for the reason the service path
@@ -767,6 +768,14 @@ async def _dispatch_stac_refresh(
                 ),
             },
         )
+
+    # feat(#1764): the binding can be identical and the answer still
+    # different — a credentialed refresh that finished inside the reservation
+    # window marks the dataset without moving its origin, so the check above
+    # passes and only this one notices. Same helper the service path uses.
+    await _recheck_service_token_after_reservation(
+        db, dataset, token, marked_before=marked_before
+    )
 
     # The job carries no source pointer of its own — the worker reads the
     # binding, the same way this handler does. The filename slot is what the

--- a/backend/app/modules/catalog/datasets/api/router_refresh.py
+++ b/backend/app/modules/catalog/datasets/api/router_refresh.py
@@ -657,23 +657,34 @@ async def _dispatch_stac_refresh(
     binding before the reservation, then every dispatched value re-read once
     the reservation exists. What differs is only what is unpacked and which
     task is deferred.
+
+    feat(#1764): ``token`` is the composed header line for a protected
+    catalog, staged through the same single-use store the service path uses.
     """
     candidate = _resolve_stac_origin(dataset)
 
-    if token:
-        # Refused rather than ignored, as on the registered-table path.
-        # Nothing here could use a credential — the item document is fetched
-        # unauthenticated and a credentialed href is refused at import — and
-        # answering 202 to a request that handed GeoLens a secret it silently
-        # dropped leaves the caller no way to learn their token went nowhere.
+    # feat(#1764): the same rule the WFS/OGC API branch applies, and for the
+    # same reason: the marker means the last successful refresh used a
+    # credential, so a token-less one would reach the catalog, collect a 401
+    # and report a live dataset as inaccessible. No probe — a STAC item read
+    # is the resource the worker fetches, so an anonymous pre-check would
+    # cost a request to learn what the marker already says.
+    if not token and service_auth_required(dataset.origin_ref):
+        raise _service_token_required()
+
+    # Refused before anything is written, for the reason the service path
+    # gives: without a shared store the secret cannot reach the worker, and
+    # dispatching anyway fails an hour later for a reason that is a missing
+    # setting rather than the credential.
+    if token and not credential_store_available():
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={
-                "code": "credential_not_applicable",
+                "code": "credential_store_unavailable",
                 "message": (
-                    "Refreshing a STAC dataset re-reads a public item "
-                    "document and needs no credential. Send the request "
-                    "without a token."
+                    "Refreshing a protected catalog needs a shared credential "
+                    "store so the credential can reach the worker without "
+                    "being written to disk. Set REDIS_URL and try again."
                 ),
             },
         )
@@ -761,13 +772,39 @@ async def _dispatch_stac_refresh(
     # binding, the same way this handler does. The filename slot is what the
     # job list renders, and the item id is the only name this operation has.
     job.source_filename = dataset.source_filename
+    if token:
+        # feat(#1764): a boolean, never the credential — the same marker the
+        # service door writes, recording that this attempt's credential was
+        # request-scoped and a retry cannot reproduce the authenticated read.
+        job.user_metadata = {**(job.user_metadata or {}), "service_auth_required": True}
+
+    # Stashed before the commit, for the reason the service door gives: a
+    # store failure rolls the whole request back rather than leaving a
+    # dispatch that can never authenticate.
+    credential_ref: str | None = None
+    if token:
+        try:
+            credential_ref = await stash_service_credential(token)
+        except CredentialStoreUnavailable as exc:
+            await db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "code": "credential_store_unavailable",
+                    "message": (
+                        "Could not stage the credential for this refresh. "
+                        "Check that the credential store is reachable and "
+                        "try again."
+                    ),
+                },
+            ) from exc
 
     job_id = job.id
     attempt_id = job.attempt_id
     run_id = run.id
     await db.commit()
 
-    rollback = make_refresh_run_failed_rollback(
+    inner_rollback = make_refresh_run_failed_rollback(
         make_ingest_job_failed_rollback(
             job, message_prefix="Failed to queue refresh task"
         ),
@@ -775,15 +812,26 @@ async def _dispatch_stac_refresh(
         ingest_job_id=job_id,
     )
 
+    async def _rollback(defer_exc: BaseException) -> None:
+        await inner_rollback(defer_exc)
+        # The worker will never come for it, and the run is already terminal.
+        # Best-effort; the TTL is the real guarantee.
+        await discard_service_credential(credential_ref)
+
     async def _defer_refresh() -> None:
         await defer_async_with_tenant(
             get_catalog_port().refresh_stac_task(),
             job_id=str(job_id),
             attempt_id=str(attempt_id),
             dataset_id=str(dataset_id),
+            # The REFERENCE, never the secret. Task arguments are durable
+            # rows; this value means nothing once claimed or expired. An
+            # old-generation worker takes **kwargs and discards it, so a
+            # rolling deploy fails the run promptly instead of hanging it.
+            credential_ref=credential_ref,
         )
 
-    await defer_with_orphan_guard(_defer_refresh, rollback=rollback, db=db, job=job)
+    await defer_with_orphan_guard(_defer_refresh, rollback=_rollback, db=db, job=job)
 
     return DatasetRefreshResponse(
         run_id=run_id,

--- a/backend/app/modules/catalog/datasets/api/router_refresh.py
+++ b/backend/app/modules/catalog/datasets/api/router_refresh.py
@@ -670,6 +670,26 @@ async def _dispatch_stac_refresh(
     if not token and marked_before:
         raise _service_token_required()
 
+    # fix(#1764): a credential is anchored on the catalog URL the caller
+    # submitted at import, the one value on the binding the catalog never
+    # chose. A binding from before that was recorded has no anchor, and
+    # falling back to the stored item pointer would let a document from that
+    # era name where the credential goes.
+    if token and not (dataset.origin_ref or {}).get("url"):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "origin_unavailable",
+                "message": (
+                    "This dataset's source binding does not record which STAC "
+                    "catalog it was imported from, so GeoLens cannot tell "
+                    "which host the credential belongs to. Re-import it from "
+                    "the catalog, or refresh it without a credential."
+                ),
+                "origin_kind": "stac",
+            },
+        )
+
     # Refused before anything is written, for the reason the service path
     # gives: without a shared store the secret cannot reach the worker.
     if token and not credential_store_available():

--- a/backend/app/modules/catalog/datasets/api/router_refresh.py
+++ b/backend/app/modules/catalog/datasets/api/router_refresh.py
@@ -663,20 +663,15 @@ async def _dispatch_stac_refresh(
     """
     candidate = _resolve_stac_origin(dataset)
 
-    # feat(#1764): the same rule the WFS/OGC API branch applies, and for the
-    # same reason: the marker means the last successful refresh used a
-    # credential, so a token-less one would reach the catalog, collect a 401
-    # and report a live dataset as inaccessible. No probe — a STAC item read
-    # is the resource the worker fetches, so an anonymous pre-check would
-    # cost a request to learn what the marker already says.
+    # feat(#1764): the WFS/OGC API rule, for its reason — the marker means
+    # the last successful refresh used a credential, so a token-less one
+    # collects a 401 and reports a live dataset as inaccessible. No probe.
     marked_before = service_auth_required(dataset.origin_ref)
     if not token and marked_before:
         raise _service_token_required()
 
     # Refused before anything is written, for the reason the service path
-    # gives: without a shared store the secret cannot reach the worker, and
-    # dispatching anyway fails an hour later for a reason that is a missing
-    # setting rather than the credential.
+    # gives: without a shared store the secret cannot reach the worker.
     if token and not credential_store_available():
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -833,10 +828,8 @@ async def _dispatch_stac_refresh(
             job_id=str(job_id),
             attempt_id=str(attempt_id),
             dataset_id=str(dataset_id),
-            # The REFERENCE, never the secret. Task arguments are durable
-            # rows; this value means nothing once claimed or expired. An
-            # old-generation worker takes **kwargs and discards it, so a
-            # rolling deploy fails the run promptly instead of hanging it.
+            # The REFERENCE, never the secret: a task argument is a durable
+            # row, and this value means nothing once claimed or expired.
             credential_ref=credential_ref,
         )
 

--- a/backend/app/modules/catalog/sources/adapters/stac.py
+++ b/backend/app/modules/catalog/sources/adapters/stac.py
@@ -21,7 +21,11 @@ from app.core.service_tokens import (
     ServiceCredential,
     build_credential_header,
 )
-from app.core.url_redaction import has_url_credentials, redact_exception_text
+from app.core.url_redaction import (
+    carries_registered_credential,
+    has_url_credentials,
+    redact_exception_text,
+)
 from app.platform.security import make_safe_client
 from app.platform.probe_bounds import bounded_probe_read
 from app.platform.service_endpoints import (
@@ -136,6 +140,11 @@ def storable_href(href: Any, base_url: str) -> str | None:
     except ValueError:
         return None
     if len(resolved) > 4096 or has_url_credentials(resolved):
+        return None
+    # fix(#1764): and the origin does not get to hand the caller's own
+    # credential back for storage. `has_url_credentials` allowlists parameter
+    # NAMES; this asks whether the value is one this request composed.
+    if carries_registered_credential(resolved):
         return None
     return resolved
 

--- a/backend/app/modules/catalog/sources/adapters/stac.py
+++ b/backend/app/modules/catalog/sources/adapters/stac.py
@@ -390,6 +390,16 @@ async def search_stac_items(
 
     items = []
     for f in features:
+        # fix(#1764): a catalog can reflect the credential it was just sent
+        # into anything it publishes, and only `item_href` passes
+        # `storable_href` here. The rest of this item is echoed back to
+        # `/import` by the client, whose own request registers no credential
+        # and so cannot recognise one, and is then stored. Judged over the
+        # whole feature rather than one field, since `id`, `collection` and
+        # `title` reach storage too.
+        if carries_registered_credential(json.dumps(f)):
+            logger.warning("STAC search: item reflects the request credential")
+            continue
         props = f.get("properties", {})
         assets = f.get("assets", {})
 

--- a/backend/app/modules/catalog/sources/adapters/stac.py
+++ b/backend/app/modules/catalog/sources/adapters/stac.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import replace
 from typing import Any, TypedDict
 from urllib.parse import urljoin
 
@@ -15,6 +16,11 @@ import httpx
 import structlog
 from pydantic import HttpUrl
 
+from app.core.service_tokens import (
+    STAC_SERVICE_FORMAT,
+    ServiceCredential,
+    build_credential_header,
+)
 from app.core.url_redaction import has_url_credentials, redact_exception_text
 from app.platform.security import make_safe_client
 from app.platform.probe_bounds import bounded_probe_read
@@ -160,32 +166,51 @@ def self_link_href(feature: dict[str, Any], base_url: str) -> str | None:
     return None
 
 
-def _make_client() -> httpx.AsyncClient:
+def _make_client(credential_header: str | None = None) -> httpx.AsyncClient:
     """Shared httpx client for STAC API requests.
 
     Phase 1061 SEC-S04: uses make_safe_client() so the per-hop SSRF
     revalidation hook covers every redirect a STAC probe follows.
+
+    feat(#1764): ``credential_header`` names the header this request carries,
+    so a 302 to another origin is refused rather than followed with the
+    caller's key. Passed even for ``Authorization``, which httpx would
+    silently strip — a refusal says what happened.
     """
-    return make_safe_client(timeout=STAC_TIMEOUT)
+    return make_safe_client(timeout=STAC_TIMEOUT, credential_header=credential_header)
 
 
-async def connect_stac_api(url: str) -> dict | None:
+async def connect_stac_api(
+    url: str, credential: ServiceCredential | None = None
+) -> dict | None:
     """Validate a STAC API URL and return landing page info, or None.
 
     fix(#1770): the whole function runs under ``DEFAULT_CHECK_TIMEOUT``,
     same reasoning as ``probe_ogcapi``.
+
+    feat(#1764): ``credential`` becomes a header here, keeping
+    ``build_credential_header`` the tree's only producer of one.
     """
     try:
         async with asyncio.timeout(DEFAULT_CHECK_TIMEOUT):
-            return await _connect_stac_api_within_deadline(url)
+            return await _connect_stac_api_within_deadline(url, credential)
     except TimeoutError:
         logger.debug("STAC connect: deadline exceeded", url=url)
         return None
 
 
-async def _connect_stac_api_within_deadline(url: str) -> dict | None:
-    async with _make_client() as client:
-        headers = {"Accept": "application/json"}
+async def _connect_stac_api_within_deadline(
+    url: str, credential: ServiceCredential | None = None
+) -> dict | None:
+    headers = {"Accept": "application/json"}
+    pair: tuple[str, str] | None = None
+    if credential is not None:
+        pair = build_credential_header(
+            replace(credential, service_format=STAC_SERVICE_FORMAT)
+        )
+        if pair is not None:
+            headers[pair[0]] = pair[1]
+    async with _make_client(None if pair is None else pair[0]) as client:
         try:
             # fix(#1770): bounded read, not a plain `client.get` — see
             # `bounded_probe_read`'s docstring.
@@ -245,16 +270,28 @@ class StacCollectionDict(TypedDict):
     item_count: int | None
 
 
-async def list_stac_collections(url: str) -> list[StacCollectionDict]:
+async def list_stac_collections(
+    url: str, credential: ServiceCredential | None = None
+) -> list[StacCollectionDict]:
     """Fetch collections from a STAC API.
 
     Returns a list of collection dicts with id, title, description,
     spatial_extent, temporal_extent, and item_count (if available).
+
+    feat(#1764): carries the same credential the landing-page read carried,
+    so a protected catalog answers both or neither.
     """
     collections_url = url.rstrip("/") + "/collections"
 
-    async with _make_client() as client:
-        headers = {"Accept": "application/json"}
+    headers = {"Accept": "application/json"}
+    pair: tuple[str, str] | None = None
+    if credential is not None:
+        pair = build_credential_header(
+            replace(credential, service_format=STAC_SERVICE_FORMAT)
+        )
+        if pair is not None:
+            headers[pair[0]] = pair[1]
+    async with _make_client(None if pair is None else pair[0]) as client:
         resp = await client.get(collections_url, headers=headers)
         resp.raise_for_status()
         data = resp.json()
@@ -302,10 +339,15 @@ async def search_stac_items(
     bbox: list[float] | None = None,
     datetime_range: str | None = None,
     limit: int = 20,
+    credential: ServiceCredential | None = None,
 ) -> dict[str, Any]:
     """Search for items in a STAC API.
 
     Returns a dict with items list and matched count.
+
+    feat(#1764): carries the same credential the connect and collections
+    reads carried, so search and import agree about what the catalog
+    publishes.
     """
     search_url = url.rstrip("/") + "/search"
     limit = min(limit, MAX_SEARCH_ITEMS)
@@ -318,11 +360,18 @@ async def search_stac_items(
     if datetime_range:
         body["datetime"] = datetime_range
 
-    async with _make_client() as client:
-        headers = {
-            "Accept": "application/geo+json, application/json",
-            "Content-Type": "application/json",
-        }
+    headers = {
+        "Accept": "application/geo+json, application/json",
+        "Content-Type": "application/json",
+    }
+    pair: tuple[str, str] | None = None
+    if credential is not None:
+        pair = build_credential_header(
+            replace(credential, service_format=STAC_SERVICE_FORMAT)
+        )
+        if pair is not None:
+            headers[pair[0]] = pair[1]
+    async with _make_client(None if pair is None else pair[0]) as client:
         resp = await client.post(search_url, json=body, headers=headers)
         resp.raise_for_status()
         data = resp.json()

--- a/backend/app/modules/catalog/sources/adapters/stac.py
+++ b/backend/app/modules/catalog/sources/adapters/stac.py
@@ -26,7 +26,7 @@ from app.core.url_redaction import (
     has_url_credentials,
     redact_exception_text,
 )
-from app.platform.security import make_safe_client
+from app.platform.security import make_safe_client, same_origin
 from app.platform.probe_bounds import bounded_probe_read
 from app.platform.service_endpoints import (
     DEFAULT_CHECK_TIMEOUT,
@@ -149,7 +149,9 @@ def storable_href(href: Any, base_url: str) -> str | None:
     return resolved
 
 
-def self_link_href(feature: dict[str, Any], base_url: str) -> str | None:
+def self_link_href(
+    feature: dict[str, Any], base_url: str, catalog_url: str | None = None
+) -> str | None:
     """The item's own canonical href, from its ``rel="self"`` link.
 
     feat(#1222): search is the ONE place GeoLens holds a STAC item document,
@@ -162,6 +164,11 @@ def self_link_href(feature: dict[str, Any], base_url: str) -> str | None:
     drops a non-http(s) or credentialed href rather than surfacing it: a
     credentialed one would otherwise turn an optional convenience into a
     422 for the caller's whole import batch.
+
+    fix(#1764): ``catalog_url`` fences the result to the origin the caller
+    submitted. This pointer becomes ``origin_ref["item_href"]``, which a
+    later credentialed refresh anchors on, so a catalog that advertises an
+    off-origin self link here could name the host its own key is sent to.
     """
     links = feature.get("links")
     # fix(#1271): a malformed scalar `links` must cost only this
@@ -170,8 +177,12 @@ def self_link_href(feature: dict[str, Any], base_url: str) -> str | None:
         if not isinstance(link, dict) or link.get("rel") != "self":
             continue
         resolved = storable_href(link.get("href"), base_url)
-        if resolved is not None:
-            return resolved
+        if resolved is None:
+            continue
+        if catalog_url is not None and not same_origin(catalog_url, resolved):
+            logger.warning("STAC search: self link is off the submitted origin")
+            continue
+        return resolved
     return None
 
 
@@ -433,7 +444,7 @@ async def search_stac_items(
                 # transport restores the hostname after each pinned hop
                 # (_SSRFGuardTransport) — so a relative self link resolves
                 # against the caller's host, never the pinned IP.
-                "item_href": self_link_href(f, str(resp.url)),
+                "item_href": self_link_href(f, str(resp.url), url),
                 "bbox": f.get("bbox"),
                 "datetime": dt,
                 "datetime_start": dt_start,

--- a/backend/app/modules/catalog/sources/origin_probe.py
+++ b/backend/app/modules/catalog/sources/origin_probe.py
@@ -24,16 +24,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
 
-from app.core.service_tokens import (
-    STAC_SERVICE_FORMAT,
-    ServiceCredential,
-    build_credential_header,
-)
+from app.core.service_tokens import ServiceCredential, build_credential_header
 from app.modules.catalog.sources.adapters.arcgis import (
     build_arcgis_count_query_url,
 )
@@ -174,10 +170,10 @@ async def probe_remote_uri(
     context-manager close bounds the body even if the range header is
     ignored.
 
-    feat(#1764): a STAC asset behind an API key is probed WITH that key, so
-    a protected asset reads as healthy rather than as ``unauthorized``. The
-    credential reaches this function from a door or from the refresh
-    worker's single-use claim.
+    fix(#1764): ``credential`` must already carry its ``service_format``.
+    This module serves every origin kind, so re-binding one here would
+    relabel the next caller's credential and judge it by another format's
+    charset; an unbound one composes no header and reads anonymously.
     """
     # fix(#1271): records whether ANY response hop arrived, so a
     # mid-chain policy refusal (public origin redirecting to a blocked
@@ -192,9 +188,7 @@ async def probe_remote_uri(
     headers = {"Range": "bytes=0-0"}
     pair: tuple[str, str] | None = None
     if credential is not None:
-        pair = build_credential_header(
-            replace(credential, service_format=STAC_SERVICE_FORMAT)
-        )
+        pair = build_credential_header(credential)
         if pair is not None:
             headers[pair[0]] = pair[1]
     try:
@@ -354,10 +348,10 @@ async def fetch_json_document(
     the wrong host. The SSRF transport restores the hostname after each
     pinned hop, so this is never the pinned IP.
 
-    feat(#1764): ``credential`` is the key a protected catalog needs.
-    Composed here rather than passed in as a finished header, so the
-    single-producer rule holds on this path too, and declared to the client
-    so a 302 cannot carry the key to the origin the Location names.
+    fix(#1764): ``credential`` arrives already bound to its service format,
+    for the reason ``probe_remote_uri`` gives. Composed here rather than
+    passed in finished, so the single-producer rule holds, and declared to
+    the client so a 302 cannot carry it to the origin the Location names.
     """
     responded = False
     final_url = uri
@@ -369,9 +363,7 @@ async def fetch_json_document(
     headers = {"Accept": "application/geo+json, application/json"}
     pair: tuple[str, str] | None = None
     if credential is not None:
-        pair = build_credential_header(
-            replace(credential, service_format=STAC_SERVICE_FORMAT)
-        )
+        pair = build_credential_header(credential)
         if pair is not None:
             headers[pair[0]] = pair[1]
     raw = bytearray()

--- a/backend/app/modules/catalog/sources/origin_probe.py
+++ b/backend/app/modules/catalog/sources/origin_probe.py
@@ -24,11 +24,16 @@ from __future__ import annotations
 
 import asyncio
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import httpx
 
+from app.core.service_tokens import (
+    STAC_SERVICE_FORMAT,
+    ServiceCredential,
+    build_credential_header,
+)
 from app.modules.catalog.sources.adapters.arcgis import (
     build_arcgis_count_query_url,
 )
@@ -156,7 +161,10 @@ def _status_result(status_code: int) -> OriginProbeResult:
 
 
 async def probe_remote_uri(
-    uri: str, *, timeout: float = PROBE_TIMEOUT_SECONDS
+    uri: str,
+    *,
+    timeout: float = PROBE_TIMEOUT_SECONDS,
+    credential: ServiceCredential | None = None,
 ) -> OriginProbeResult:
     """Probe *uri* without downloading its body.
 
@@ -165,6 +173,11 @@ async def probe_remote_uri(
     three-value vocabulary exists to remove. Streaming plus the
     context-manager close bounds the body even if the range header is
     ignored.
+
+    feat(#1764): a STAC asset behind an API key is probed WITH that key, so
+    a protected asset reads as healthy rather than as ``unauthorized``. The
+    credential reaches this function from a door or from the refresh
+    worker's single-use claim.
     """
     # fix(#1271): records whether ANY response hop arrived, so a
     # mid-chain policy refusal (public origin redirecting to a blocked
@@ -176,13 +189,23 @@ async def probe_remote_uri(
         nonlocal responded
         responded = True
 
+    headers = {"Range": "bytes=0-0"}
+    pair: tuple[str, str] | None = None
+    if credential is not None:
+        pair = build_credential_header(
+            replace(credential, service_format=STAC_SERVICE_FORMAT)
+        )
+        if pair is not None:
+            headers[pair[0]] = pair[1]
     try:
         # fix(#1271): hard deadline around the WHOLE op — the guard
         # transport resolves DNS before httpx's phase timeouts apply, so a
         # stalling resolver would otherwise exceed the advertised bound.
         # Doubled: this is a backstop, not the primary bound.
         async with asyncio.timeout(timeout * 2):
-            async with make_safe_client(timeout=timeout) as client:
+            async with make_safe_client(
+                timeout=timeout, credential_header=None if pair is None else pair[0]
+            ) as client:
                 # hasattr: duck-typed clients in tests may not carry
                 # event_hooks, and an AttributeError here would masquerade
                 # as a probe failure.
@@ -193,9 +216,7 @@ async def probe_remote_uri(
                         *hooks.get("response", []),
                     ]
                     client.event_hooks = hooks
-                async with client.stream(
-                    "GET", uri, headers={"Range": "bytes=0-0"}
-                ) as response:
+                async with client.stream("GET", uri, headers=headers) as response:
                     status_code = response.status_code
     except (
         Exception
@@ -314,6 +335,7 @@ async def fetch_json_document(
     json_body: Any | None = None,
     timeout: float = PROBE_TIMEOUT_SECONDS,
     max_bytes: int = MAX_DOCUMENT_BYTES,
+    credential: ServiceCredential | None = None,
 ) -> tuple[OriginProbeResult, Any | None, str]:
     """Fetch *uri* and return its verdict, its parsed body, and its final URL.
 
@@ -331,6 +353,11 @@ async def fetch_json_document(
     the requested URL instead would point a redirected catalog's assets at
     the wrong host. The SSRF transport restores the hostname after each
     pinned hop, so this is never the pinned IP.
+
+    feat(#1764): ``credential`` is the key a protected catalog needs.
+    Composed here rather than passed in as a finished header, so the
+    single-producer rule holds on this path too, and declared to the client
+    so a 302 cannot carry the key to the origin the Location names.
     """
     responded = False
     final_url = uri
@@ -339,13 +366,23 @@ async def fetch_json_document(
         nonlocal responded
         responded = True
 
+    headers = {"Accept": "application/geo+json, application/json"}
+    pair: tuple[str, str] | None = None
+    if credential is not None:
+        pair = build_credential_header(
+            replace(credential, service_format=STAC_SERVICE_FORMAT)
+        )
+        if pair is not None:
+            headers[pair[0]] = pair[1]
     raw = bytearray()
     try:
         # The same doubled hard deadline probe_remote_uri takes, and for the
         # same reason: httpx's phase timeouts do not cover the guard
         # transport's DNS resolution.
         async with asyncio.timeout(timeout * 2):
-            async with make_safe_client(timeout=timeout) as client:
+            async with make_safe_client(
+                timeout=timeout, credential_header=None if pair is None else pair[0]
+            ) as client:
                 if hasattr(client, "event_hooks"):
                     hooks = client.event_hooks
                     hooks["response"] = [_mark_responded, *hooks.get("response", [])]
@@ -354,7 +391,7 @@ async def fetch_json_document(
                     method,
                     uri,
                     json=json_body,
-                    headers={"Accept": "application/geo+json, application/json"},
+                    headers=headers,
                 ) as response:
                     status_code = response.status_code
                     final_url = str(response.url)

--- a/backend/app/modules/catalog/sources/origin_probe.py
+++ b/backend/app/modules/catalog/sources/origin_probe.py
@@ -157,10 +157,7 @@ def _status_result(status_code: int) -> OriginProbeResult:
 
 
 async def probe_remote_uri(
-    uri: str,
-    *,
-    timeout: float = PROBE_TIMEOUT_SECONDS,
-    credential: ServiceCredential | None = None,
+    uri: str, *, timeout: float = PROBE_TIMEOUT_SECONDS
 ) -> OriginProbeResult:
     """Probe *uri* without downloading its body.
 
@@ -170,10 +167,9 @@ async def probe_remote_uri(
     context-manager close bounds the body even if the range header is
     ignored.
 
-    fix(#1764): ``credential`` must already carry its ``service_format``.
-    This module serves every origin kind, so re-binding one here would
-    relabel the next caller's credential and judge it by another format's
-    charset; an unbound one composes no header and reads anonymously.
+    fix(#1764): takes no credential, deliberately. Its one credentialed
+    caller would have been the STAC asset probe, and that has to ask what
+    Titiler will ask, which is an anonymous read.
     """
     # fix(#1271): records whether ANY response hop arrived, so a
     # mid-chain policy refusal (public origin redirecting to a blocked
@@ -186,20 +182,13 @@ async def probe_remote_uri(
         responded = True
 
     headers = {"Range": "bytes=0-0"}
-    pair: tuple[str, str] | None = None
-    if credential is not None:
-        pair = build_credential_header(credential)
-        if pair is not None:
-            headers[pair[0]] = pair[1]
     try:
         # fix(#1271): hard deadline around the WHOLE op — the guard
         # transport resolves DNS before httpx's phase timeouts apply, so a
         # stalling resolver would otherwise exceed the advertised bound.
         # Doubled: this is a backstop, not the primary bound.
         async with asyncio.timeout(timeout * 2):
-            async with make_safe_client(
-                timeout=timeout, credential_header=None if pair is None else pair[0]
-            ) as client:
+            async with make_safe_client(timeout=timeout) as client:
                 # hasattr: duck-typed clients in tests may not carry
                 # event_hooks, and an AttributeError here would masquerade
                 # as a probe failure.

--- a/backend/app/modules/catalog/sources/stac_resolve.py
+++ b/backend/app/modules/catalog/sources/stac_resolve.py
@@ -73,7 +73,7 @@ async def resolve_stac_binding(
     asset_href: str | None = None,
     asset_key: str | None = None,
     credential: ServiceCredential | None = None,
-    credential_origin: str | None = None,
+    catalog_origin: str | None = None,
 ) -> StacResolution:
     """Ask the publisher where this dataset's asset lives now.
 
@@ -81,14 +81,14 @@ async def resolve_stac_binding(
     database, and the caller is free to hold no session across it.
 
     feat(#1764): the refresh door stashes ``credential`` for one attempt and
-    the worker claims it once. ``credential_origin`` is the catalog origin it
+    the worker claims it once. ``catalog_origin`` is the catalog origin it
     was given for; a read the item document steers elsewhere is made
     anonymously (``credential_for_read``). Defaults to the stored item URL's
     origin, which is what the door validated and cannot drift, since an
     off-origin self link is no longer adopted.
     """
-    if credential_origin is None:
-        credential_origin = item_href
+    if catalog_origin is None:
+        catalog_origin = item_href
     # The BINDING is checked first (exact); falls back to reading the id out
     # of the URL for datasets imported before it was recorded — only ever a
     # reading of the stored href, never a guess.
@@ -114,7 +114,7 @@ async def resolve_stac_binding(
     result, document, item_url = await fetch_json_document(
         item_href,
         credential=credential_for_read(
-            credential, url=item_href, credential_origin=credential_origin
+            credential, url=item_href, credential_origin=catalog_origin
         ),
     )
     if result.ok:
@@ -133,7 +133,7 @@ async def resolve_stac_binding(
             asset_href=asset_href,
             asset_key=asset_key,
             credential=credential,
-            credential_origin=credential_origin,
+            catalog_origin=catalog_origin,
         )
     if result.health == MISSING:
         return await _resolve_by_search(
@@ -143,7 +143,7 @@ async def resolve_stac_binding(
             asset_href=asset_href,
             asset_key=asset_key,
             credential=credential,
-            credential_origin=credential_origin,
+            catalog_origin=catalog_origin,
         )
     # Inconclusive: a timeout, a 5xx, a 401/403, a policy refusal. Nothing was
     # established about where the asset is, so the caller keeps every stored

--- a/backend/app/modules/catalog/sources/stac_resolve.py
+++ b/backend/app/modules/catalog/sources/stac_resolve.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import structlog
 
+from app.core.service_tokens import ServiceCredential
 from app.modules.catalog.sources.origin_probe import MISSING, fetch_json_document
 from app.modules.catalog.sources.stac_resolve_asset_gate import (
     _bound_asset_key,  # noqa: F401 -- re-exported, see __all__
@@ -70,11 +71,17 @@ async def resolve_stac_binding(
     collection_id: str | None = None,
     asset_href: str | None = None,
     asset_key: str | None = None,
+    credential: ServiceCredential | None = None,
 ) -> StacResolution:
     """Ask the publisher where this dataset's asset lives now.
 
     Pure network and pure computation: nothing here reads or writes the
     database, and the caller is free to hold no session across it.
+
+    feat(#1764): the refresh door stashes ``credential`` for one attempt and
+    the worker claims it once. Every read below carries it, so the item
+    document, the fallback search, the self link and the asset probe all
+    speak to the catalog as the same caller.
     """
     # The BINDING is checked first (exact); falls back to reading the id out
     # of the URL for datasets imported before it was recorded — only ever a
@@ -98,7 +105,9 @@ async def resolve_stac_binding(
         logger.info("stac_identity_unverifiable")
         return _UNVERIFIABLE
 
-    result, document, item_url = await fetch_json_document(item_href)
+    result, document, item_url = await fetch_json_document(
+        item_href, credential=credential
+    )
     if result.ok:
         return await _resolve_from_item(
             document,
@@ -114,6 +123,7 @@ async def resolve_stac_binding(
             collection_affirmed=_standard_item_path(item_url) is not None,
             asset_href=asset_href,
             asset_key=asset_key,
+            credential=credential,
         )
     if result.health == MISSING:
         return await _resolve_by_search(
@@ -122,6 +132,7 @@ async def resolve_stac_binding(
             collection_id=effective_collection,
             asset_href=asset_href,
             asset_key=asset_key,
+            credential=credential,
         )
     # Inconclusive: a timeout, a 5xx, a 401/403, a policy refusal. Nothing was
     # established about where the asset is, so the caller keeps every stored

--- a/backend/app/modules/catalog/sources/stac_resolve.py
+++ b/backend/app/modules/catalog/sources/stac_resolve.py
@@ -44,6 +44,7 @@ from app.modules.catalog.sources.stac_resolve_by_search import _resolve_by_searc
 from app.modules.catalog.sources.stac_resolve_identity import (
     _search_root_and_item_id,
     _standard_item_path,
+    credential_for_read,
     states_verifiable_identity,  # noqa: F401 -- re-exported, see __all__
 )
 from app.modules.catalog.sources.stac_resolve_taxonomy import (
@@ -72,6 +73,7 @@ async def resolve_stac_binding(
     asset_href: str | None = None,
     asset_key: str | None = None,
     credential: ServiceCredential | None = None,
+    credential_origin: str | None = None,
 ) -> StacResolution:
     """Ask the publisher where this dataset's asset lives now.
 
@@ -79,10 +81,14 @@ async def resolve_stac_binding(
     database, and the caller is free to hold no session across it.
 
     feat(#1764): the refresh door stashes ``credential`` for one attempt and
-    the worker claims it once. Every read below carries it, so the item
-    document, the fallback search, the self link and the asset probe all
-    speak to the catalog as the same caller.
+    the worker claims it once. ``credential_origin`` is the catalog origin it
+    was given for; a read the item document steers elsewhere is made
+    anonymously (``credential_for_read``). Defaults to the stored item URL's
+    origin, which is what the door validated and cannot drift, since an
+    off-origin self link is no longer adopted.
     """
+    if credential_origin is None:
+        credential_origin = item_href
     # The BINDING is checked first (exact); falls back to reading the id out
     # of the URL for datasets imported before it was recorded — only ever a
     # reading of the stored href, never a guess.
@@ -106,7 +112,10 @@ async def resolve_stac_binding(
         return _UNVERIFIABLE
 
     result, document, item_url = await fetch_json_document(
-        item_href, credential=credential
+        item_href,
+        credential=credential_for_read(
+            credential, url=item_href, credential_origin=credential_origin
+        ),
     )
     if result.ok:
         return await _resolve_from_item(
@@ -124,6 +133,7 @@ async def resolve_stac_binding(
             asset_href=asset_href,
             asset_key=asset_key,
             credential=credential,
+            credential_origin=credential_origin,
         )
     if result.health == MISSING:
         return await _resolve_by_search(
@@ -133,6 +143,7 @@ async def resolve_stac_binding(
             asset_href=asset_href,
             asset_key=asset_key,
             credential=credential,
+            credential_origin=credential_origin,
         )
     # Inconclusive: a timeout, a 5xx, a 401/403, a policy refusal. Nothing was
     # established about where the asset is, so the caller keeps every stored
@@ -156,6 +167,7 @@ __all__ = [
     "_search_root_and_item_id",
     "_standard_item_path",
     "_WITHDRAWN",
+    "credential_for_read",
     "resolve_stac_binding",
     "states_verifiable_identity",
 ]

--- a/backend/app/modules/catalog/sources/stac_resolve_asset_gate.py
+++ b/backend/app/modules/catalog/sources/stac_resolve_asset_gate.py
@@ -37,6 +37,7 @@ from app.modules.catalog.sources.stac_resolve_identity import (
     _contradicts_stored_identity,
     _standard_item_path,
     _url_contradicts_identity,
+    credential_for_read,
 )
 from app.modules.catalog.sources.stac_resolve_taxonomy import (
     StacResolution,
@@ -141,15 +142,18 @@ async def _resolve_from_item(
     asset_href: str | None,
     asset_key: str | None,
     credential: ServiceCredential | None = None,
+    credential_origin: str | None = None,
 ) -> StacResolution:
     """Turn a fetched item document into a resolution, health included.
 
     One reading of one document, used by both paths, so the direct fetch and
     the re-search cannot reach different verdicts about the same shape.
 
-    feat(#1764): the two reads this gate makes of its own — the self link and
-    the asset probe — carry the caller's credential, so a protected asset
-    probes as healthy instead of as ``unauthorized``.
+    fix(#1764): the two reads this gate makes of its own go to addresses THIS
+    DOCUMENT named, so each is gated on ``credential_origin`` — the self link
+    is dropped rather than fetched off-origin, and an off-origin asset is
+    probed anonymously, which is the ordinary shape for a catalog whose
+    assets live in someone else's bucket.
     """
     refusal = _identity_refusal(
         item,
@@ -196,6 +200,7 @@ async def _resolve_from_item(
         collection_id=collection_id,
         asset_key=key,
         credential=credential,
+        credential_origin=credential_origin,
     )
 
     # fix(#1266): `item_base` is the item's own fetch URL on the direct path
@@ -228,7 +233,16 @@ async def _resolve_from_item(
     # unresolvable.
     resolved_item_href = self_href or fallback_item_href
 
-    probed = await probe_remote_uri(href, credential=credential)
+    # fix(#1764): the asset href is the item's own choice of address and is
+    # legitimately on another origin (a catalog's bucket), so it is probed
+    # anonymously there rather than refused; the verdict is then the truth
+    # about what GeoLens can read.
+    probed = await probe_remote_uri(
+        href,
+        credential=credential_for_read(
+            credential, url=href, credential_origin=credential_origin
+        ),
+    )
     if probed.detail == BLOCKED_BY_POLICY:
         # fix(#1266): refused, not merely reported — this is a fact about
         # GeoLens (the SSRF guard won't fetch this address, at the first hop
@@ -303,6 +317,7 @@ async def _trustworthy_self_href(
     collection_id: str | None,
     asset_key: str,
     credential: ServiceCredential | None = None,
+    credential_origin: str | None = None,
 ) -> tuple[str | None, str | None, dict[str, Any] | None]:
     """``(pointer to store, base for relative hrefs, the document at it)``.
 
@@ -340,8 +355,19 @@ async def _trustworthy_self_href(
     ):
         logger.info("stac_self_link_identity_mismatch", item_id=item.get("id"))
         return None, None, None
+    # fix(#1764): a self link off the catalog's origin is DROPPED, not
+    # fetched anonymously: an anonymous answer about a credentialed catalog
+    # is evidence for a different request than the one the refresh makes,
+    # and the pointer it would replace is optional. Same rule and same
+    # reason as the OGC API probe's conformance link.
+    self_credential = credential_for_read(
+        credential, url=self_href, credential_origin=credential_origin
+    )
+    if credential is not None and self_credential is None:
+        logger.info("stac_self_link_off_catalog_origin")
+        return None, None, None
     result, document, final_url = await fetch_json_document(
-        self_href, credential=credential
+        self_href, credential=self_credential
     )
     if not result.ok:
         logger.info("stac_self_link_not_adopted", detail=result.detail)

--- a/backend/app/modules/catalog/sources/stac_resolve_asset_gate.py
+++ b/backend/app/modules/catalog/sources/stac_resolve_asset_gate.py
@@ -233,16 +233,11 @@ async def _resolve_from_item(
     # unresolvable.
     resolved_item_href = self_href or fallback_item_href
 
-    # fix(#1764): the asset href is the item's own choice of address and is
-    # legitimately on another origin (a catalog's bucket), so it is probed
-    # anonymously there rather than refused; the verdict is then the truth
-    # about what GeoLens can read.
-    probed = await probe_remote_uri(
-        href,
-        credential=credential_for_read(
-            credential, url=href, credential_origin=catalog_origin
-        ),
-    )
+    # fix(#1764): ANONYMOUS, always. Titiler serves this href out of process
+    # and cannot carry a request-only credential, so a probe that used one
+    # would report `healthy` for tiles that stay unreadable. The verdict has
+    # to answer the question the tiler will ask.
+    probed = await probe_remote_uri(href)
     if probed.detail == BLOCKED_BY_POLICY:
         # fix(#1266): refused, not merely reported — this is a fact about
         # GeoLens (the SSRF guard won't fetch this address, at the first hop

--- a/backend/app/modules/catalog/sources/stac_resolve_asset_gate.py
+++ b/backend/app/modules/catalog/sources/stac_resolve_asset_gate.py
@@ -16,6 +16,7 @@ from urllib.parse import urlsplit
 
 import structlog
 
+from app.core.service_tokens import ServiceCredential
 from app.modules.catalog.sources.adapters.stac import (
     pick_data_asset,
     projection_epsg,
@@ -139,11 +140,16 @@ async def _resolve_from_item(
     collection_affirmed: bool,
     asset_href: str | None,
     asset_key: str | None,
+    credential: ServiceCredential | None = None,
 ) -> StacResolution:
     """Turn a fetched item document into a resolution, health included.
 
     One reading of one document, used by both paths, so the direct fetch and
     the re-search cannot reach different verdicts about the same shape.
+
+    feat(#1764): the two reads this gate makes of its own — the self link and
+    the asset probe — carry the caller's credential, so a protected asset
+    probes as healthy instead of as ``unauthorized``.
     """
     refusal = _identity_refusal(
         item,
@@ -189,6 +195,7 @@ async def _resolve_from_item(
         fallback_is_live=item_base is not None,
         collection_id=collection_id,
         asset_key=key,
+        credential=credential,
     )
 
     # fix(#1266): `item_base` is the item's own fetch URL on the direct path
@@ -221,7 +228,7 @@ async def _resolve_from_item(
     # unresolvable.
     resolved_item_href = self_href or fallback_item_href
 
-    probed = await probe_remote_uri(href)
+    probed = await probe_remote_uri(href, credential=credential)
     if probed.detail == BLOCKED_BY_POLICY:
         # fix(#1266): refused, not merely reported — this is a fact about
         # GeoLens (the SSRF guard won't fetch this address, at the first hop
@@ -244,6 +251,9 @@ async def _resolve_from_item(
             await validate_url_for_ssrf(href)
         except SSRFError:
             return _ASSET_BLOCKED
+        # feat(#1764): Titiler fetches this URL itself, in another process,
+        # so a credentialed asset that MOVED reads as unreadable rather than
+        # re-describing. Carrying a key to the tiler is overlay work.
         metadata = await fetch_cog_info(href)
         if metadata is None:
             # fix(#1266): the probe may have already settled this — 404/410
@@ -292,6 +302,7 @@ async def _trustworthy_self_href(
     fallback_is_live: bool,
     collection_id: str | None,
     asset_key: str,
+    credential: ServiceCredential | None = None,
 ) -> tuple[str | None, str | None, dict[str, Any] | None]:
     """``(pointer to store, base for relative hrefs, the document at it)``.
 
@@ -329,7 +340,9 @@ async def _trustworthy_self_href(
     ):
         logger.info("stac_self_link_identity_mismatch", item_id=item.get("id"))
         return None, None, None
-    result, document, final_url = await fetch_json_document(self_href)
+    result, document, final_url = await fetch_json_document(
+        self_href, credential=credential
+    )
     if not result.ok:
         logger.info("stac_self_link_not_adopted", detail=result.detail)
         return None, None, None

--- a/backend/app/modules/catalog/sources/stac_resolve_asset_gate.py
+++ b/backend/app/modules/catalog/sources/stac_resolve_asset_gate.py
@@ -32,7 +32,7 @@ from app.modules.catalog.sources.origin_probe import (
     fetch_json_document,
     probe_remote_uri,
 )
-from app.platform.security import SSRFError, validate_url_for_ssrf
+from app.platform.security import SSRFError, same_origin, validate_url_for_ssrf
 from app.modules.catalog.sources.stac_resolve_identity import (
     _contradicts_stored_identity,
     _standard_item_path,
@@ -142,7 +142,7 @@ async def _resolve_from_item(
     asset_href: str | None,
     asset_key: str | None,
     credential: ServiceCredential | None = None,
-    credential_origin: str | None = None,
+    catalog_origin: str | None = None,
 ) -> StacResolution:
     """Turn a fetched item document into a resolution, health included.
 
@@ -150,7 +150,7 @@ async def _resolve_from_item(
     the re-search cannot reach different verdicts about the same shape.
 
     fix(#1764): the two reads this gate makes of its own go to addresses THIS
-    DOCUMENT named, so each is gated on ``credential_origin`` — the self link
+    DOCUMENT named, so each is gated on ``catalog_origin`` — the self link
     is dropped rather than fetched off-origin, and an off-origin asset is
     probed anonymously, which is the ordinary shape for a catalog whose
     assets live in someone else's bucket.
@@ -200,7 +200,7 @@ async def _resolve_from_item(
         collection_id=collection_id,
         asset_key=key,
         credential=credential,
-        credential_origin=credential_origin,
+        catalog_origin=catalog_origin,
     )
 
     # fix(#1266): `item_base` is the item's own fetch URL on the direct path
@@ -240,7 +240,7 @@ async def _resolve_from_item(
     probed = await probe_remote_uri(
         href,
         credential=credential_for_read(
-            credential, url=href, credential_origin=credential_origin
+            credential, url=href, credential_origin=catalog_origin
         ),
     )
     if probed.detail == BLOCKED_BY_POLICY:
@@ -317,7 +317,7 @@ async def _trustworthy_self_href(
     collection_id: str | None,
     asset_key: str,
     credential: ServiceCredential | None = None,
-    credential_origin: str | None = None,
+    catalog_origin: str | None = None,
 ) -> tuple[str | None, str | None, dict[str, Any] | None]:
     """``(pointer to store, base for relative hrefs, the document at it)``.
 
@@ -355,17 +355,18 @@ async def _trustworthy_self_href(
     ):
         logger.info("stac_self_link_identity_mismatch", item_id=item.get("id"))
         return None, None, None
-    # fix(#1764): a self link off the catalog's origin is DROPPED, not
-    # fetched anonymously: an anonymous answer about a credentialed catalog
-    # is evidence for a different request than the one the refresh makes,
-    # and the pointer it would replace is optional. Same rule and same
-    # reason as the OGC API probe's conformance link.
-    self_credential = credential_for_read(
-        credential, url=self_href, credential_origin=credential_origin
-    )
-    if credential is not None and self_credential is None:
+    # fix(#1764): a self link off the catalog's origin is DROPPED, whether or
+    # not THIS refresh carries a credential. It becomes the stored pointer,
+    # which is the origin every later refresh sends its credential to, so an
+    # anonymous one adopting it moves that anchor. Unconditional, like the two
+    # `same_origin` references in `platform/service_items.py`; dropping a self
+    # link is already the ordinary outcome here and keeps the working pointer.
+    if catalog_origin is not None and not same_origin(catalog_origin, self_href):
         logger.info("stac_self_link_off_catalog_origin")
         return None, None, None
+    self_credential = credential_for_read(
+        credential, url=self_href, credential_origin=catalog_origin
+    )
     result, document, final_url = await fetch_json_document(
         self_href, credential=self_credential
     )

--- a/backend/app/modules/catalog/sources/stac_resolve_by_search.py
+++ b/backend/app/modules/catalog/sources/stac_resolve_by_search.py
@@ -12,7 +12,10 @@ from typing import Any
 from app.core.service_tokens import ServiceCredential
 from app.modules.catalog.sources.origin_probe import MISSING, fetch_json_document
 from app.modules.catalog.sources.stac_resolve_asset_gate import _resolve_from_item
-from app.modules.catalog.sources.stac_resolve_identity import _search_root_and_item_id
+from app.modules.catalog.sources.stac_resolve_identity import (
+    _search_root_and_item_id,
+    credential_for_read,
+)
 from app.modules.catalog.sources.stac_resolve_taxonomy import (
     StacResolution,
     _SEARCH_UNUSABLE,
@@ -54,6 +57,7 @@ async def _resolve_by_search(
     asset_href: str | None,
     asset_key: str | None,
     credential: ServiceCredential | None = None,
+    credential_origin: str | None = None,
 ) -> StacResolution:
     """Look the item up by identity after its own URL stopped resolving.
 
@@ -72,7 +76,9 @@ async def _resolve_by_search(
         search_url,
         method="POST",
         json_body={"collections": [collection_id], "ids": [wanted_id], "limit": 1},
-        credential=credential,
+        credential=credential_for_read(
+            credential, url=search_url, credential_origin=credential_origin
+        ),
     )
     if not result.ok:
         # fix(#1266): a search that couldn't be carried out establishes
@@ -114,6 +120,7 @@ async def _resolve_by_search(
         asset_href=asset_href,
         asset_key=asset_key,
         credential=credential,
+        credential_origin=credential_origin,
     )
 
 

--- a/backend/app/modules/catalog/sources/stac_resolve_by_search.py
+++ b/backend/app/modules/catalog/sources/stac_resolve_by_search.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.core.service_tokens import ServiceCredential
 from app.modules.catalog.sources.origin_probe import MISSING, fetch_json_document
 from app.modules.catalog.sources.stac_resolve_asset_gate import _resolve_from_item
 from app.modules.catalog.sources.stac_resolve_identity import _search_root_and_item_id
@@ -52,6 +53,7 @@ async def _resolve_by_search(
     collection_id: str | None,
     asset_href: str | None,
     asset_key: str | None,
+    credential: ServiceCredential | None = None,
 ) -> StacResolution:
     """Look the item up by identity after its own URL stopped resolving.
 
@@ -70,6 +72,7 @@ async def _resolve_by_search(
         search_url,
         method="POST",
         json_body={"collections": [collection_id], "ids": [wanted_id], "limit": 1},
+        credential=credential,
     )
     if not result.ok:
         # fix(#1266): a search that couldn't be carried out establishes
@@ -110,6 +113,7 @@ async def _resolve_by_search(
         collection_affirmed=True,
         asset_href=asset_href,
         asset_key=asset_key,
+        credential=credential,
     )
 
 

--- a/backend/app/modules/catalog/sources/stac_resolve_by_search.py
+++ b/backend/app/modules/catalog/sources/stac_resolve_by_search.py
@@ -57,7 +57,7 @@ async def _resolve_by_search(
     asset_href: str | None,
     asset_key: str | None,
     credential: ServiceCredential | None = None,
-    credential_origin: str | None = None,
+    catalog_origin: str | None = None,
 ) -> StacResolution:
     """Look the item up by identity after its own URL stopped resolving.
 
@@ -77,7 +77,7 @@ async def _resolve_by_search(
         method="POST",
         json_body={"collections": [collection_id], "ids": [wanted_id], "limit": 1},
         credential=credential_for_read(
-            credential, url=search_url, credential_origin=credential_origin
+            credential, url=search_url, credential_origin=catalog_origin
         ),
     )
     if not result.ok:
@@ -120,7 +120,7 @@ async def _resolve_by_search(
         asset_href=asset_href,
         asset_key=asset_key,
         credential=credential,
-        credential_origin=credential_origin,
+        catalog_origin=catalog_origin,
     )
 
 

--- a/backend/app/modules/catalog/sources/stac_resolve_identity.py
+++ b/backend/app/modules/catalog/sources/stac_resolve_identity.py
@@ -12,8 +12,35 @@ from __future__ import annotations
 from typing import Any
 from urllib.parse import unquote, urlsplit, urlunsplit
 
+from app.core.service_tokens import ServiceCredential
+from app.platform.security import same_origin
+
 _COLLECTIONS_SEGMENT = "/collections/"
 _ITEMS_SEGMENT = "/items/"
+
+
+def credential_for_read(
+    credential: ServiceCredential | None,
+    *,
+    url: str,
+    credential_origin: str | None,
+) -> ServiceCredential | None:
+    """The credential a read of *url* may carry, or None for an anonymous one.
+
+    fix(#1764): ``make_safe_client(credential_header=...)`` guards REDIRECT
+    hops. An item document names its own self link and its assets, both
+    fetched as fresh first-hop requests no redirect hook ever sees, so
+    without this the catalog's key goes wherever the document points.
+    ``same_origin`` is the repo's answer to that class
+    (``adapters/ogcapi.py``, ``platform/service_items.py``): the document
+    chose the address and does not get to choose the credential.
+
+    Total, and ``same_origin`` is False on a parse error, so an address this
+    cannot read is read anonymously rather than credentialed.
+    """
+    if credential is None or credential_origin is None:
+        return None
+    return credential if same_origin(credential_origin, url) else None
 
 
 def _standard_item_path(url: str) -> tuple[str, str, str] | None:
@@ -149,6 +176,7 @@ def _contradicts_stored_identity(
 
 __all__ = [
     "_contradicts_stored_identity",
+    "credential_for_read",
     "_search_root_and_item_id",
     "_standard_item_path",
     "_url_contradicts_identity",

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -11,7 +11,7 @@ from typing import Literal
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field, HttpUrl, field_validator
+from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,7 +39,17 @@ from app.modules.catalog.sources.adapters.stac import (
     search_stac_items,
 )
 from app.modules.catalog.sources.cog_info import fetch_cog_info, reconcile_epsg
+from app.modules.catalog.sources.schemas import (
+    DEPRECATED_TOKEN_SUFFIX,
+    SERVICE_AUTH_FIELD_DESCRIPTION,
+    ServiceAuthRequest,
+    _validate_safe_token,
+    reject_service_auth_conflict,
+    service_credential_from_request,
+)
+from app.core.service_tokens import STAC_SERVICE_FORMAT, ServiceCredential
 from app.platform.security import SSRFError, validate_url_for_ssrf
+from app.platform.service_auth import credential_or_422
 
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -71,6 +81,15 @@ router = APIRouter(
 )
 
 
+# feat(#1764): the two credential fields every STAC door that CONTACTS the
+# catalog accepts. Request-only: nothing here is stored, and `/import` takes
+# neither, because it contacts no catalog and would be accepting a secret it
+# then drops.
+_STAC_TOKEN_DESCRIPTION = (
+    "Optional auth token for a protected STAC catalog." + DEPRECATED_TOKEN_SUFFIX
+)
+
+
 class StacConnectRequest(BaseModel):
     url: str = Field(
         min_length=1,
@@ -78,6 +97,17 @@ class StacConnectRequest(BaseModel):
         description="STAC API root URL to connect to.",
     )
     _validate_url = field_validator("url")(_validate_stac_http_url)
+    token: str | None = Field(
+        default=None, max_length=1000, description=_STAC_TOKEN_DESCRIPTION
+    )
+    _validate_token = field_validator("token")(_validate_safe_token)
+    # fix(#1760): auth is declared LAST on every request model — the generated
+    # SDK positions fields by declaration order, so an earlier insertion would
+    # shift an existing positional caller's argument into it.
+    auth: ServiceAuthRequest | None = Field(
+        default=None, description=SERVICE_AUTH_FIELD_DESCRIPTION
+    )
+    _reject_auth_conflict = model_validator(mode="after")(reject_service_auth_conflict)
 
 
 class StacConnectResponse(BaseModel):
@@ -141,6 +171,14 @@ class StacSearchRequest(BaseModel):
         le=100,
         description="Maximum items to return.",
     )
+    token: str | None = Field(
+        default=None, max_length=1000, description=_STAC_TOKEN_DESCRIPTION
+    )
+    _validate_token = field_validator("token")(_validate_safe_token)
+    auth: ServiceAuthRequest | None = Field(
+        default=None, description=SERVICE_AUTH_FIELD_DESCRIPTION
+    )
+    _reject_auth_conflict = model_validator(mode="after")(reject_service_auth_conflict)
 
 
 class StacItemSummary(BaseModel):
@@ -292,20 +330,40 @@ class StacImportResponse(BaseModel):
     errors: int = Field(description="Number of items that failed.")
 
 
+def _stac_credential(
+    request: StacConnectRequest | StacSearchRequest,
+) -> ServiceCredential | None:
+    """The credential this request may send to the catalog, or None.
+
+    feat(#1764): one door helper for all three STAC endpoints, so they cannot
+    judge the same credential three ways. ``credential_or_422`` binds the STAC
+    service format and raises the coded 422 for an input the rules refuse; the
+    header itself is composed later, at each write site.
+    """
+    return credential_or_422(
+        service_credential_from_request(request.auth, request.token),
+        service_format=STAC_SERVICE_FORMAT,
+    )
+
+
 @router.post("/connect", response_model=StacConnectResponse)
 async def stac_connect(
     request: StacConnectRequest,
     user: Identity = Depends(require_permission("create_layers")),
     db: AsyncSession = Depends(get_db),
 ) -> StacConnectResponse:
-    """Connect to a STAC API and validate the endpoint."""
+    """Connect to a STAC API and validate the endpoint.
+
+    Accepts a credential for a protected catalog, applied to this call.
+    """
     safe_url = redact_url_credentials(request.url)
+    credential = _stac_credential(request)
     try:
         await validate_url_for_ssrf(request.url)
     except SSRFError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
-    result = await connect_stac_api(request.url)
+    result = await connect_stac_api(request.url, credential)
     if result is None:
         await audit_emit(
             db,
@@ -355,15 +413,19 @@ async def stac_collections(
     request: StacConnectRequest,
     user: Identity = Depends(require_permission("create_layers")),
 ) -> StacCollectionsResponse:
-    """List collections from a connected STAC API."""
+    """List collections from a connected STAC API.
+
+    Accepts a credential for a protected catalog, applied to this call.
+    """
     safe_url = redact_url_credentials(request.url)
+    credential = _stac_credential(request)
     try:
         await validate_url_for_ssrf(request.url)
     except SSRFError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
     try:
-        collections = await list_stac_collections(request.url)
+        collections = await list_stac_collections(request.url, credential)
     except Exception as exc:  # broad: STAC client/HTTP/parse can throw varied errors; map to 502 for the user
         logger.warning("STAC collections fetch failed", url=safe_url, error=str(exc))
         raise HTTPException(
@@ -386,8 +448,12 @@ async def stac_search(
     request: StacSearchRequest,
     user: Identity = Depends(require_permission("create_layers")),
 ) -> StacSearchResponse:
-    """Search items in a STAC API with spatial/temporal filters."""
+    """Search items in a STAC API with spatial/temporal filters.
+
+    Accepts a credential for a protected catalog, applied to this call.
+    """
     safe_url = redact_url_credentials(request.url)
+    credential = _stac_credential(request)
     try:
         await validate_url_for_ssrf(request.url)
     except SSRFError as exc:
@@ -400,6 +466,7 @@ async def stac_search(
             bbox=request.bbox,
             datetime_range=request.datetime_range,
             limit=request.limit,
+            credential=credential,
         )
     except Exception as exc:  # broad: STAC /search client/HTTP/parse can throw varied errors; map to 502 for the user
         logger.warning("STAC search failed", url=safe_url, error=str(exc))

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -48,7 +48,7 @@ from app.modules.catalog.sources.schemas import (
     service_credential_from_request,
 )
 from app.core.service_tokens import STAC_SERVICE_FORMAT, ServiceCredential
-from app.platform.security import SSRFError, validate_url_for_ssrf
+from app.platform.security import SSRFError, same_origin, validate_url_for_ssrf
 from app.platform.service_auth import credential_or_422
 
 
@@ -84,6 +84,12 @@ router = APIRouter(
 # feat(#1764): the credential fields every STAC door that CONTACTS the
 # catalog accepts. `/import` takes neither: it contacts no catalog, so it
 # would be accepting a secret it then drops.
+# Names the rule, never the href: this reaches a per-item result body.
+_OFF_ORIGIN_ITEM_HREF_MESSAGE = (
+    "This item's own URL is on a different host than the STAC catalog it was "
+    "imported from, so GeoLens will not record it as the item's address."
+)
+
 _STAC_TOKEN_DESCRIPTION = (
     "Optional auth token for a protected STAC catalog." + DEPRECATED_TOKEN_SUFFIX
 )
@@ -308,6 +314,16 @@ class StacImportRequest(BaseModel):
     visibility: Visibility = Field(
         default="private",
         description="Visibility for imported datasets.",
+    )
+    # feat(#1764): a boolean, never the credential. Declared last, so no
+    # positional SDK caller shifts.
+    catalog_auth_required: bool = Field(
+        default=False,
+        description=(
+            "Whether browsing this catalog needed a credential. Set it when "
+            "the search that produced these items carried one, so the first "
+            "refresh asks for a credential instead of failing anonymously."
+        ),
     )
 
 
@@ -550,6 +566,21 @@ async def stac_import(
             )
             skipped += 1
             continue
+        # fix(#1764): the item pointer becomes the origin a later credentialed
+        # refresh anchors on, so it may not name a host other than the catalog
+        # the caller submitted. Search already drops such a link; this refuses
+        # it for a client that did not come from there.
+        if item.item_href is not None and not same_origin(request.url, item.item_href):
+            logger.warning("STAC item self link is off the submitted origin")
+            results.append(
+                StacImportResult(
+                    item_id=item.id,
+                    status="error",
+                    error=_OFF_ORIGIN_ITEM_HREF_MESSAGE,
+                )
+            )
+            errors += 1
+            continue
         try:
             await validate_url_for_ssrf(item.data_asset_href)
         except SSRFError as exc:
@@ -640,11 +671,16 @@ async def stac_import(
                     dataset,
                     "stac",
                     uri=item.data_asset_href,
+                    url=request.url,
                     asset_href=item.data_asset_href,
                     item_href=item.item_href,
                     item_id=item.id,
                     collection_id=item.collection,
                     asset_key=item.data_asset_key,
+                    # feat(#1764): True or None, never False — the allowlist
+                    # drops a None, which is how "no credential" is spelled on
+                    # both origin kinds.
+                    auth_required=True if request.catalog_auth_required else None,
                 )
                 # fix(#1271): info in hand means Titiler reached the COG;
                 # every failure shape stays NULL since a Titiler error is

--- a/backend/app/modules/catalog/sources/stac_router.py
+++ b/backend/app/modules/catalog/sources/stac_router.py
@@ -81,10 +81,9 @@ router = APIRouter(
 )
 
 
-# feat(#1764): the two credential fields every STAC door that CONTACTS the
-# catalog accepts. Request-only: nothing here is stored, and `/import` takes
-# neither, because it contacts no catalog and would be accepting a secret it
-# then drops.
+# feat(#1764): the credential fields every STAC door that CONTACTS the
+# catalog accepts. `/import` takes neither: it contacts no catalog, so it
+# would be accepting a secret it then drops.
 _STAC_TOKEN_DESCRIPTION = (
     "Optional auth token for a protected STAC catalog." + DEPRECATED_TOKEN_SUFFIX
 )

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -122,9 +122,14 @@ ORIGIN_REF_KEYS: dict[str, frozenset[str]] = {
     # different item even when the item's URL states no identity of its own.
     # feat(#1764): `auth_required` means here what it means on the service
     # kind — the last SUCCESSFUL refresh used a credential, True or absent.
-    # Import never sets it; the import door contacts no catalog.
+    #
+    # `url` is the catalog root the CALLER submitted at import, and it is the
+    # only value here the catalog itself never chose. A credentialed refresh
+    # anchors on it, so a document that names another host cannot name where
+    # the credential goes. Absent on bindings imported before it existed.
     "stac": frozenset(
         {
+            "url",
             "item_href",
             "item_id",
             "asset_href",

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -120,8 +120,20 @@ ORIGIN_REF_KEYS: dict[str, frozenset[str]] = {
     # is a rebinding primitive, not a pointer (fix(#1266) review round 9).
     # With it stored, a refresh can refuse a document answering for a
     # different item even when the item's URL states no identity of its own.
+    # `auth_required` (feat(#1764)) carries the same meaning here as on the
+    # service kind: the last SUCCESSFUL refresh used a credential, written by
+    # the worker from the credential it actually used, never the credential.
+    # True or absent, never False. Import never sets it — the import door
+    # contacts no catalog — so it appears on the first credentialed refresh.
     "stac": frozenset(
-        {"item_href", "item_id", "asset_href", "collection_id", "asset_key"}
+        {
+            "item_href",
+            "item_id",
+            "asset_href",
+            "collection_id",
+            "asset_key",
+            "auth_required",
+        }
     ),
     "upload": frozenset({"filename", "file_hash"}),
     # Gate 2: GeoLens-internal table only. No host/port/DSN/credential key.
@@ -242,11 +254,14 @@ def geolens_owns_table(
 
 
 def service_auth_required(origin_ref: Any) -> bool:
-    """Whether the last successful pull of this service origin used a token.
+    """Whether the last successful pull of this origin used a credential.
 
     A token was USED, not demanded: no caller may read this as "the origin
     requires authentication" — the refresh door checks that separately
     (fix(#1746) codex r1).
+
+    feat(#1764): reads the key on the STAC kind too, which stores it under
+    the same name and the same rule.
 
     fix(#1746): ``is True``, not truthiness, same reason as
     ``geolens_owns_table`` — this gates an outbound request/refusal, and a

--- a/backend/app/platform/dataset_origin.py
+++ b/backend/app/platform/dataset_origin.py
@@ -120,11 +120,9 @@ ORIGIN_REF_KEYS: dict[str, frozenset[str]] = {
     # is a rebinding primitive, not a pointer (fix(#1266) review round 9).
     # With it stored, a refresh can refuse a document answering for a
     # different item even when the item's URL states no identity of its own.
-    # `auth_required` (feat(#1764)) carries the same meaning here as on the
-    # service kind: the last SUCCESSFUL refresh used a credential, written by
-    # the worker from the credential it actually used, never the credential.
-    # True or absent, never False. Import never sets it — the import door
-    # contacts no catalog — so it appears on the first credentialed refresh.
+    # feat(#1764): `auth_required` means here what it means on the service
+    # kind — the last SUCCESSFUL refresh used a credential, True or absent.
+    # Import never sets it; the import door contacts no catalog.
     "stac": frozenset(
         {
             "item_href",

--- a/backend/app/platform/extensions/defaults_processing_port.py
+++ b/backend/app/platform/extensions/defaults_processing_port.py
@@ -494,7 +494,14 @@ class DefaultProcessingPort:
         return AttributeMetadata
 
     async def resolve_stac_binding(  # type: ignore[no-untyped-def]
-        self, *, item_href, item_id, collection_id, asset_href, asset_key
+        self,
+        *,
+        item_href,
+        item_id,
+        collection_id,
+        asset_href,
+        asset_key,
+        credential=None,
     ):
         from app.modules.catalog.sources.stac_resolve import resolve_stac_binding
 
@@ -504,6 +511,7 @@ class DefaultProcessingPort:
             collection_id=collection_id,
             asset_href=asset_href,
             asset_key=asset_key,
+            credential=credential,
         )
 
     # Preserves the joinedload semantics metadata_service._build_dataset_context

--- a/backend/app/platform/extensions/defaults_processing_port.py
+++ b/backend/app/platform/extensions/defaults_processing_port.py
@@ -502,6 +502,7 @@ class DefaultProcessingPort:
         asset_href,
         asset_key,
         credential=None,
+        credential_origin=None,
     ):
         from app.modules.catalog.sources.stac_resolve import resolve_stac_binding
 
@@ -512,6 +513,7 @@ class DefaultProcessingPort:
             asset_href=asset_href,
             asset_key=asset_key,
             credential=credential,
+            credential_origin=credential_origin,
         )
 
     # Preserves the joinedload semantics metadata_service._build_dataset_context

--- a/backend/app/platform/extensions/defaults_processing_port.py
+++ b/backend/app/platform/extensions/defaults_processing_port.py
@@ -502,7 +502,7 @@ class DefaultProcessingPort:
         asset_href,
         asset_key,
         credential=None,
-        credential_origin=None,
+        catalog_origin=None,
     ):
         from app.modules.catalog.sources.stac_resolve import resolve_stac_binding
 
@@ -513,7 +513,7 @@ class DefaultProcessingPort:
             asset_href=asset_href,
             asset_key=asset_key,
             credential=credential,
-            credential_origin=credential_origin,
+            catalog_origin=catalog_origin,
         )
 
     # Preserves the joinedload semantics metadata_service._build_dataset_context

--- a/backend/app/platform/service_auth.py
+++ b/backend/app/platform/service_auth.py
@@ -48,10 +48,10 @@ from app.core.service_tokens import (
     ServiceCredential,
     build_credential_header,
     credential_header_line,
+    carries_credential_as_header_line,
     credential_input_rejection_reason,
     header_name_rejection_reason,
     header_token_rejection_reason,
-    requires_header_token_policy,
 )
 
 UNSUPPORTED_AUTH_METHOD_CODE = "unsupported_auth_method"
@@ -179,11 +179,15 @@ def service_carries_method(
     Basic and a named API key exist only as a header, so they need a
     service kind whose credential travels as one. Anything else is a
     method this build doesn't know how to send anywhere.
+
+    feat(#1764): the header-or-query question is
+    ``carries_credential_as_header_line``, not the GDAL header-file one —
+    STAC carries all three methods and writes no header file.
     """
     if method in (CredentialMethod.NONE, CredentialMethod.BEARER):
         return True
     if method in (CredentialMethod.BASIC, CredentialMethod.HEADER_KEY):
-        return requires_header_token_policy(service_format)
+        return carries_credential_as_header_line(service_format)
     return False
 
 
@@ -201,13 +205,13 @@ def credential_or_422(
     ``service_format`` is bound onto the returned credential rather than
     left to the caller to pass again, since it decides whether a header
     may be composed at all: ``build_credential_header`` reads it and
-    answers None outside ``HEADER_AUTH_SERVICE_FORMATS``, plan D9's
+    answers None outside ``HEADER_TRANSPORT_SERVICE_FORMATS``, plan D9's
     ArcGIS invariant expressed as an allowlist.
     """
     if credential is None or credential.method == CredentialMethod.NONE:
         return None
     bound = replace(credential, service_format=service_format)
-    if not requires_header_token_policy(service_format):
+    if not carries_credential_as_header_line(service_format):
         # A URL-query transport, or a format nobody has taught this to
         # carry. Bearer is the only spelling that fits a query parameter.
         bearer_token_for_credential(bound)
@@ -248,6 +252,11 @@ def wire_credential(
     ``requires_header_token_policy``/``HEADER_AUTH_SERVICE_FORMATS``
     answer; asking the builder was a proxy for it that stopped being
     equivalent.
+
+    feat(#1764): the predicate widened to
+    ``carries_credential_as_header_line`` so a STAC refresh crosses as a
+    line too; its worker recovers the credential with
+    ``credential_from_header_line`` and composes at each write site.
     """
     resolved = (
         service_format
@@ -257,7 +266,7 @@ def wire_credential(
     bound = credential_or_422(credential, service_format=resolved)
     if bound is None:
         return None
-    if not requires_header_token_policy(resolved):
+    if not carries_credential_as_header_line(resolved):
         # A URL-query transport: ArcGIS, whose worker-side token is the
         # bare value `build_gdal_source` percent-encodes into ESRIJSON.
         return bearer_token_for_credential(bound)

--- a/backend/app/platform/service_auth.py
+++ b/backend/app/platform/service_auth.py
@@ -51,7 +51,7 @@ from app.core.service_tokens import (
     carries_credential_as_header_line,
     credential_input_rejection_reason,
     header_name_rejection_reason,
-    header_token_rejection_reason,
+    bearer_token_rejection_reason,
 )
 
 UNSUPPORTED_AUTH_METHOD_CODE = "unsupported_auth_method"
@@ -145,7 +145,10 @@ def credential_input_rejection(credential: ServiceCredential) -> str | None:
     if method == CredentialMethod.BEARER:
         if not credential.token:
             return BLANK_BEARER_TOKEN_POLICY
-        return header_token_rejection_reason(credential.token)
+        # fix(#1764): through the builder's own rule, which picks the charset
+        # by service format. Applying the GDAL header-file charset here
+        # refused a STAC key holding `+` or `/` that the builder accepts.
+        return bearer_token_rejection_reason(credential)
     if method == CredentialMethod.BASIC:
         for supplied in (credential.username, credential.password):
             reason = credential_input_rejection_reason(supplied)

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -197,8 +197,8 @@ def _binding(dataset: Any) -> tuple:
 
 def _stac_pointers(
     origin_ref: dict | None,
-) -> tuple[str, str | None, str | None, str | None, str | None]:
-    """``(item_href, item_id, collection_id, asset_href, asset_key)``.
+) -> tuple[str, str | None, str | None, str | None, str | None, str | None]:
+    """``(item_href, item_id, collection_id, asset_href, asset_key, url)``.
 
     Raises when there is no ``item_href``: only the item document can answer
     where an asset moved TO (the asset href answers a different question). A
@@ -222,6 +222,7 @@ def _stac_pointers(
         ref.get("collection_id"),
         ref.get("asset_href"),
         ref.get("asset_key"),
+        ref.get("url"),
     )
 
 
@@ -263,6 +264,7 @@ def _rebind(
     *,
     collection_id: str | None,
     auth_required: bool | None,
+    catalog_url: str | None,
 ) -> None:
     """Point the dataset at where the publisher now says its asset is.
 
@@ -290,6 +292,9 @@ def _rebind(
         dataset,
         "stac",
         uri=resolution.asset_href,
+        # Carried forward unchanged: a refresh re-resolves a binding, it does
+        # not re-point it at a catalog the caller never submitted.
+        url=catalog_url,
         asset_href=resolution.asset_href,
         item_href=resolution.item_href,
         # fix(#1266): written back on every rebind, so a dataset imported
@@ -539,6 +544,7 @@ async def refresh_stac(
                 collection_id,
                 asset_href,
                 asset_key,
+                catalog_url,
             ) = _stac_pointers(dataset.origin_ref)
             await claim_run_for_job(session, job_uuid)
             await session.commit()
@@ -562,10 +568,11 @@ async def refresh_stac(
             asset_href=asset_href,
             asset_key=asset_key,
             credential=credential,
-            # fix(#1764): the catalog address the credential was given for.
-            # Read from the binding under this attempt's guard, so a read the
-            # item document steers to another origin is made anonymously.
-            catalog_origin=item_href,
+            # fix(#1764): the catalog address the CALLER submitted at import,
+            # the one value on the binding the catalog never chose. Anchoring
+            # on the item pointer instead would let a document name the host
+            # its own credential is sent to.
+            catalog_origin=catalog_url,
         )
         if not resolution.resolved:
             raise _failure_for(resolution)
@@ -659,6 +666,7 @@ async def refresh_stac(
                     resolution,
                     collection_id=learned_collection,
                     auth_required=auth_required,
+                    catalog_url=catalog_url,
                 )
             if moved:
                 await _repoint_remote_asset(

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -565,7 +565,7 @@ async def refresh_stac(
             # fix(#1764): the catalog address the credential was given for.
             # Read from the binding under this attempt's guard, so a read the
             # item document steers to another origin is made anonymously.
-            credential_origin=item_href,
+            catalog_origin=item_href,
         )
         if not resolution.resolved:
             raise _failure_for(resolution)

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -31,6 +31,10 @@ import structlog
 from sqlalchemy import func, select, update
 
 from app.core.geo import bbox_to_extent_wkt
+from app.core.service_tokens import (
+    STAC_SERVICE_FORMAT,
+    credential_from_header_line,
+)
 
 from app.core.db.tenant_session import tenant_task
 from app.platform.cache.tiles import invalidate_catalog_cache
@@ -42,6 +46,7 @@ from app.platform.jobs.heartbeat import (
     stop_ingest_job_heartbeat,
     write_job_failure_for_attempt,
 )
+from app.platform.refresh.credentials import resolve_worker_credential
 from app.platform.refresh.service import (
     claim_run_for_job,
     record_refresh_failure,
@@ -203,7 +208,13 @@ def _failure_for(resolution: Any) -> StacRefreshError:
     )
 
 
-def _rebind(dataset: Any, resolution: Any, *, collection_id: str | None) -> None:
+def _rebind(
+    dataset: Any,
+    resolution: Any,
+    *,
+    collection_id: str | None,
+    auth_required: bool | None,
+) -> None:
     """Point the dataset at where the publisher now says its asset is.
 
     Through ``set_dataset_origin``, the only door into ``origin_ref``, which
@@ -221,6 +232,10 @@ def _rebind(dataset: Any, resolution: Any, *, collection_id: str | None) -> None
     sets the pointer to the asset href, and the duplicate-source guard keys
     on it). ``source_url`` is deliberately left alone: it's in the metadata
     PATCH's field map and belongs to the owner, not this door.
+
+    feat(#1764): ``auth_required`` is True when THIS attempt used a
+    credential and None when it did not, so a token-less success clears the
+    marker the same way the service path's does. Never the credential.
     """
     set_dataset_origin(
         dataset,
@@ -233,6 +248,7 @@ def _rebind(dataset: Any, resolution: Any, *, collection_id: str | None) -> None
         item_id=resolution.item_id,
         collection_id=collection_id,
         asset_key=resolution.asset_key,
+        auth_required=auth_required,
     )
 
 
@@ -399,6 +415,7 @@ async def refresh_stac(
     job_id: str,
     dataset_id: str,
     attempt_id: str | None = None,
+    credential_ref: str | None = None,
     **kwargs: Any,
 ) -> None:
     """Background task: re-resolve this dataset's STAC item and asset pointer.
@@ -407,6 +424,10 @@ async def refresh_stac(
     takes none: this creates no ``DatasetVersion`` and stamps no uploader,
     because no data moved. The actor is already on the run row as
     ``triggered_by``, which is where this operation's audit trail lives.
+
+    feat(#1764): ``credential_ref`` names a single-use credential the door
+    staged; the secret itself never becomes a task argument. Claimed once,
+    after the attempt check, so a dispatch that never runs spends nothing.
     """
     _bind_task_log_context(
         task_name="refresh_stac", job_id=job_id, dataset_id=dataset_id
@@ -426,6 +447,14 @@ async def refresh_stac(
         return
     job_uuid, attempt_uuid = resolved_attempt
     dataset_uuid = uuid.UUID(dataset_id)
+    # feat(#1764): the D9 wire line, turned back into the credential it
+    # describes so every read below composes through the one producer. A ref
+    # that names nothing raises rather than falling through to an anonymous
+    # fetch, which would collect a 401 and report a live catalog as broken.
+    credential_line = await resolve_worker_credential(None, credential_ref)
+    credential = credential_from_header_line(
+        credential_line, service_format=STAC_SERVICE_FORMAT
+    )
     heartbeat_task: asyncio.Task[None] | None = None
     # The binding this attempt resolved against, for the failure handler's
     # guarded write and the write transaction's own guard. Left None until
@@ -483,6 +512,7 @@ async def refresh_stac(
             collection_id=collection_id,
             asset_href=asset_href,
             asset_key=asset_key,
+            credential=credential,
         )
         if not resolution.resolved:
             raise _failure_for(resolution)
@@ -557,15 +587,26 @@ async def refresh_stac(
             # resolution checked it against; one that has a collection keeps
             # it, because only the stored value may name what this dataset is.
             learned_collection = collection_id or resolution.collection_id
+            # feat(#1764): True or None, never False — the origin_ref
+            # allowlist drops a None-valued key, which is how "no credential
+            # was used" is spelled on both origin kinds.
+            auth_required = True if credential is not None else None
+            marked_before = (dataset.origin_ref or {}).get("auth_required") is True
             rebound = (
                 moved
                 or resolution.item_href != item_href
                 or resolution.item_id != item_id
                 or resolution.asset_key != asset_key
                 or learned_collection != collection_id
+                or marked_before != (auth_required is True)
             )
             if rebound:
-                _rebind(dataset, resolution, collection_id=learned_collection)
+                _rebind(
+                    dataset,
+                    resolution,
+                    collection_id=learned_collection,
+                    auth_required=auth_required,
+                )
             if moved:
                 await _repoint_remote_asset(
                     session,

--- a/backend/app/processing/ingest/tasks_stac_refresh.py
+++ b/backend/app/processing/ingest/tasks_stac_refresh.py
@@ -33,6 +33,7 @@ from sqlalchemy import func, select, update
 from app.core.geo import bbox_to_extent_wkt
 from app.core.service_tokens import (
     STAC_SERVICE_FORMAT,
+    ServiceCredential,
     credential_from_header_line,
 )
 
@@ -46,7 +47,11 @@ from app.platform.jobs.heartbeat import (
     stop_ingest_job_heartbeat,
     write_job_failure_for_attempt,
 )
-from app.platform.refresh.credentials import resolve_worker_credential
+from app.platform.refresh.credentials import (
+    CredentialExpiredError,
+    CredentialStoreUnavailable,
+    resolve_worker_credential,
+)
 from app.platform.refresh.service import (
     claim_run_for_job,
     record_refresh_failure,
@@ -76,32 +81,12 @@ _ERROR_CODE_INACCESSIBLE = "source_inaccessible"
 _ERROR_CODE_GENERIC = "stac_refresh_failed"
 _ERROR_CODE_SUPERSEDED = "superseded"
 
-# Written for the person reading the refresh history, and composed here
-# rather than from anything the origin sent: ADR-002 Decision 3 forbids a
-# provider's error text, a response body or a URL in a stored reason string,
-# and an origin URI may legitimately carry a signed query.
-# fix(#1266): says what is established on every path that reaches it, no
-# more — reached both from a search that answered without the item and from
-# a catalog offering no way to look, so it may not claim a search result.
-_WITHDRAWN_MESSAGE = (
-    "The STAC item this dataset was imported from is no longer at the "
-    "address its catalog published, and GeoLens could not locate it "
-    "anywhere else in its collection. The dataset keeps pointing at the "
-    "asset it always did; re-import it from a live item to move it."
-)
-# fix(#1266): a DIFFERENT missing — the item still resolves, but the asset
-# it was bound to is gone. Saying the item disappeared would misdiagnose it
-# and send the reader to re-import from the item they already have.
-_ASSET_REMOVED_MESSAGE = (
-    "The STAC item this dataset was imported from no longer publishes the "
-    "asset it was bound to. The item itself is still on the catalog, and the "
-    "dataset keeps pointing at the asset it always did; re-import it from "
-    "that item to bind to one of the assets it publishes now."
-)
-_UNREACHABLE_MESSAGE = (
-    "GeoLens could not read the STAC item this dataset was imported from, "
-    "and the catalog's answer did not establish whether the item is still "
-    "published. Nothing was changed. Try again."
+# fix(#1764): the credential message a caller sees, composed here so it never
+# carries the store's own error text, which can echo the key it was asked for.
+_CREDENTIAL_UNUSABLE_MESSAGE = (
+    "The credential for this refresh could not be read, so the catalog was "
+    "not contacted and nothing was changed. Start the refresh again with a "
+    "fresh credential."
 )
 
 
@@ -133,6 +118,70 @@ class StacRefreshError(Exception):
         # `last_checked_at` should date. Defaults False so a failure raised
         # before any request cannot date a contact that never happened.
         self.contacted = contacted
+
+
+def _refresh_error_code(exc: BaseException) -> str:
+    """Map a STAC refresh failure onto its run ``error_code``.
+
+    fix(#1764): three codes send the reader to three places — a fresh
+    credential, an operator for an unreachable store, or the origin. Mirrors
+    ``tasks_reupload._service_refresh_error_code``; ``error_code`` is a
+    closed vocabulary the history UI reads, so the mapping lives in one
+    function per strategy.
+    """
+    if isinstance(exc, CredentialExpiredError):
+        return "credential_expired"
+    if isinstance(exc, CredentialStoreUnavailable):
+        return "credential_store_unavailable"
+    return getattr(exc, "error_code", _ERROR_CODE_GENERIC)
+
+
+def _claimed_credential(credential_line: str | None) -> ServiceCredential | None:
+    """The credential a claimed wire line describes.
+
+    fix(#1764): a non-empty line that yields nothing raises rather than
+    degrading to an anonymous fetch, which would reach a protected catalog,
+    collect a 401, and report a live dataset as inaccessible.
+    """
+    if not credential_line:
+        return None
+    credential = credential_from_header_line(
+        credential_line, service_format=STAC_SERVICE_FORMAT
+    )
+    if credential is None:
+        raise StacRefreshError(
+            _CREDENTIAL_UNUSABLE_MESSAGE, error_code="credential_expired"
+        )
+    return credential
+
+
+# Written for the person reading the refresh history, and composed here
+# rather than from anything the origin sent: ADR-002 Decision 3 forbids a
+# provider's error text, a response body or a URL in a stored reason string,
+# and an origin URI may legitimately carry a signed query.
+# fix(#1266): says what is established on every path that reaches it, no
+# more — reached both from a search that answered without the item and from
+# a catalog offering no way to look, so it may not claim a search result.
+_WITHDRAWN_MESSAGE = (
+    "The STAC item this dataset was imported from is no longer at the "
+    "address its catalog published, and GeoLens could not locate it "
+    "anywhere else in its collection. The dataset keeps pointing at the "
+    "asset it always did; re-import it from a live item to move it."
+)
+# fix(#1266): a DIFFERENT missing — the item still resolves, but the asset
+# it was bound to is gone. Saying the item disappeared would misdiagnose it
+# and send the reader to re-import from the item they already have.
+_ASSET_REMOVED_MESSAGE = (
+    "The STAC item this dataset was imported from no longer publishes the "
+    "asset it was bound to. The item itself is still on the catalog, and the "
+    "dataset keeps pointing at the asset it always did; re-import it from "
+    "that item to bind to one of the assets it publishes now."
+)
+_UNREACHABLE_MESSAGE = (
+    "GeoLens could not read the STAC item this dataset was imported from, "
+    "and the catalog's answer did not establish whether the item is still "
+    "published. Nothing was changed. Try again."
+)
 
 
 def _binding(dataset: Any) -> tuple:
@@ -447,14 +496,7 @@ async def refresh_stac(
         return
     job_uuid, attempt_uuid = resolved_attempt
     dataset_uuid = uuid.UUID(dataset_id)
-    # feat(#1764): the D9 wire line, turned back into the credential it
-    # describes so every read below composes through the one producer. A ref
-    # that names nothing raises rather than falling through to an anonymous
-    # fetch, which would collect a 401 and report a live catalog as broken.
-    credential_line = await resolve_worker_credential(None, credential_ref)
-    credential = credential_from_header_line(
-        credential_line, service_format=STAC_SERVICE_FORMAT
-    )
+    credential: ServiceCredential | None = None
     heartbeat_task: asyncio.Task[None] | None = None
     # The binding this attempt resolved against, for the failure handler's
     # guarded write and the write transaction's own guard. Left None until
@@ -501,6 +543,13 @@ async def refresh_stac(
             await claim_run_for_job(session, job_uuid)
             await session.commit()
 
+        # fix(#1764): redeemed AFTER phase 1 and inside the handled region,
+        # the placement `tasks_reupload` records — phase 1 detects a
+        # superseded attempt, and a claim above it spends the secret anyway.
+        credential = _claimed_credential(
+            await resolve_worker_credential(None, credential_ref)
+        )
+
         # Phase 2: ASK THE PUBLISHER, holding no database session. Three
         # requests at worst (item, a re-search on 404, a probe of the asset
         # href) against a host that owes GeoLens no latency guarantee — a
@@ -513,6 +562,10 @@ async def refresh_stac(
             asset_href=asset_href,
             asset_key=asset_key,
             credential=credential,
+            # fix(#1764): the catalog address the credential was given for.
+            # Read from the binding under this attempt's guard, so a read the
+            # item document steers to another origin is made anonymously.
+            credential_origin=item_href,
         )
         if not resolution.resolved:
             raise _failure_for(resolution)
@@ -699,7 +752,7 @@ async def refresh_stac(
 
     except Exception as exc:  # broad: any step here is a network or database read
         logger.exception("STAC refresh failed", job_id=job_id, task="refresh_stac")
-        error_code = getattr(exc, "error_code", _ERROR_CODE_GENERIC)
+        error_code = _refresh_error_code(exc)
         async with async_session() as err_session:
             # fix(#1957): the job row is the one a retry of this refresh
             # contends for. An expiry leaves it `running` for the stale sweep

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -16306,6 +16306,30 @@
             "minLength": 1,
             "title": "Url",
             "type": "string"
+          },
+          "token": {
+            "anyOf": [
+              {
+                "maxLength": 1000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional auth token for a protected STAC catalog. Deprecated: use the auth object with method bearer.",
+            "title": "Token"
+          },
+          "auth": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ServiceAuthRequest"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Structured credential for a protected service. Mutually exclusive with the token field."
           }
         },
         "required": [
@@ -17395,6 +17419,30 @@
             "minimum": 1.0,
             "title": "Limit",
             "type": "integer"
+          },
+          "token": {
+            "anyOf": [
+              {
+                "maxLength": 1000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional auth token for a protected STAC catalog. Deprecated: use the auth object with method bearer.",
+            "title": "Token"
+          },
+          "auth": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ServiceAuthRequest"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Structured credential for a protected service. Mutually exclusive with the token field."
           }
         },
         "required": [
@@ -54241,7 +54289,7 @@
     },
     "/services/stac/collections": {
       "post": {
-        "description": "List collections from a connected STAC API.",
+        "description": "List collections from a connected STAC API.\n\nAccepts a credential for a protected catalog, applied to this call.",
         "operationId": "stac_collections_services_stac_collections_post",
         "requestBody": {
           "content": {
@@ -54393,7 +54441,7 @@
     },
     "/services/stac/connect": {
       "post": {
-        "description": "Connect to a STAC API and validate the endpoint.",
+        "description": "Connect to a STAC API and validate the endpoint.\n\nAccepts a credential for a protected catalog, applied to this call.",
         "operationId": "stac_connect_services_stac_connect_post",
         "requestBody": {
           "content": {
@@ -54677,7 +54725,7 @@
     },
     "/services/stac/search": {
       "post": {
-        "description": "Search items in a STAC API with spatial/temporal filters.",
+        "description": "Search items in a STAC API with spatial/temporal filters.\n\nAccepts a credential for a protected catalog, applied to this call.",
         "operationId": "stac_search_services_stac_search_post",
         "requestBody": {
           "content": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -16575,6 +16575,12 @@
             ],
             "title": "Visibility",
             "type": "string"
+          },
+          "catalog_auth_required": {
+            "default": false,
+            "description": "Whether browsing this catalog needed a credential. Set it when the search that produced these items carried one, so the first refresh asks for a credential instead of failing anonymously.",
+            "title": "Catalog Auth Required",
+            "type": "boolean"
           }
         },
         "required": [

--- a/backend/tests/test_arcgis_header_transport_c2.py
+++ b/backend/tests/test_arcgis_header_transport_c2.py
@@ -234,7 +234,9 @@ class TestTheFormatSets:
             assert sends_credential_as_header(source_format) is True
 
     def test_a_format_nobody_taught_it_is_in_neither(self) -> None:
-        for source_format in (None, "", "stac", "geojson"):
+        # feat(#1764): `stac` is no longer one of them; it sends a header and
+        # is a header-LINE format, which test_stac_service_auth_1764 pins.
+        for source_format in (None, "", "geojson", "geopackage"):
             assert sends_credential_as_header(source_format) is False
 
 

--- a/backend/tests/test_credential_policy.py
+++ b/backend/tests/test_credential_policy.py
@@ -421,9 +421,8 @@ class TestBuildCredentialHeaderReturnsNone:
                 )
             )
 
-    @pytest.mark.parametrize(
-        "service_format", [None, "stac", "geojson", "shapefile", ""]
-    )
+    # feat(#1764): `stac` left this list when it gained a credential path.
+    @pytest.mark.parametrize("service_format", [None, "geojson", "shapefile", ""])
     def test_a_format_whose_credential_is_not_a_header(
         self, service_format: str | None
     ) -> None:

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3849,7 +3849,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `build_arcgis_count_query_url`. Cap 1374 -> 1376, exact.
     # chore(#1812): -9, the refresh door no longer judges a queue on the composed line
     # or configures the deferred task with it. Cap 1376 -> 1367, exact.
-    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1221,
+    # feat(#1764): +48 — the STAC branch stages a credential through the same
+    # single-use store the service branch uses, and applies the marked-origin
+    # and store-availability refusals. Cap 1221 -> 1269, exact.
+    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1269,
     # fix(#1335): stac_resolve.py's 1040 lines were split along their natural
     # seams — verdict taxonomy, identity checks, the asset gate (SSRF + COG
     # probe), and the by-search fallback each moved into a sibling module,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3849,11 +3849,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `build_arcgis_count_query_url`. Cap 1374 -> 1376, exact.
     # chore(#1812): -9, the refresh door no longer judges a queue on the composed line
     # or configures the deferred task with it. Cap 1376 -> 1367, exact.
-    # feat(#1764): +50 — the STAC branch stages a credential through the same
+    # feat(#1764): +70 — the STAC branch stages a credential through the same
     # single-use store the service branch uses, and applies the marked-origin
-    # refusal before AND after the reservation plus the store-availability
-    # check. Cap 1221 -> 1271, exact.
-    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1271,
+    # refusal before AND after the reservation, the store-availability check,
+    # and the refusal for a binding recording no catalog to anchor a
+    # credential on. Cap 1221 -> 1291, exact.
+    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1291,
     # fix(#1335): stac_resolve.py's 1040 lines were split along their natural
     # seams — verdict taxonomy, identity checks, the asset gate (SSRF + COG
     # probe), and the by-search fallback each moved into a sibling module,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3849,10 +3849,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `build_arcgis_count_query_url`. Cap 1374 -> 1376, exact.
     # chore(#1812): -9, the refresh door no longer judges a queue on the composed line
     # or configures the deferred task with it. Cap 1376 -> 1367, exact.
-    # feat(#1764): +48 — the STAC branch stages a credential through the same
+    # feat(#1764): +57 — the STAC branch stages a credential through the same
     # single-use store the service branch uses, and applies the marked-origin
-    # and store-availability refusals. Cap 1221 -> 1269, exact.
-    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1269,
+    # refusal before AND after the reservation plus the store-availability
+    # check. Cap 1221 -> 1278, exact.
+    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1278,
     # fix(#1335): stac_resolve.py's 1040 lines were split along their natural
     # seams — verdict taxonomy, identity checks, the asset gate (SSRF + COG
     # probe), and the by-search fallback each moved into a sibling module,

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -3849,11 +3849,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # `build_arcgis_count_query_url`. Cap 1374 -> 1376, exact.
     # chore(#1812): -9, the refresh door no longer judges a queue on the composed line
     # or configures the deferred task with it. Cap 1376 -> 1367, exact.
-    # feat(#1764): +57 — the STAC branch stages a credential through the same
+    # feat(#1764): +50 — the STAC branch stages a credential through the same
     # single-use store the service branch uses, and applies the marked-origin
     # refusal before AND after the reservation plus the store-availability
-    # check. Cap 1221 -> 1278, exact.
-    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1278,
+    # check. Cap 1221 -> 1271, exact.
+    "backend/app/modules/catalog/datasets/api/router_refresh.py": 1271,
     # fix(#1335): stac_resolve.py's 1040 lines were split along their natural
     # seams — verdict taxonomy, identity checks, the asset gate (SSRF + COG
     # probe), and the by-search fallback each moved into a sibling module,

--- a/backend/tests/test_service_refresh_1220.py
+++ b/backend/tests/test_service_refresh_1220.py
@@ -2437,12 +2437,15 @@ class TestServiceTokenPolicy:
         # And the entry point every door now routes through names all four
         # rules, so a method added without a rule fails here rather than
         # silently composing an unjudged header.
+        # feat(#1764): the format predicate the gate applies is
+        # `carries_credential_as_header_line` — wider than the GDAL
+        # header-file one by STAC, which carries all three methods.
         gate_source = inspect.getsource(service_auth)
         for rule in (
             "header_token_rejection_reason",
             "credential_input_rejection_reason",
             "header_name_rejection_reason",
-            "requires_header_token_policy",
+            "carries_credential_as_header_line",
         ):
             assert rule in gate_source, rule
 

--- a/backend/tests/test_service_refresh_1220.py
+++ b/backend/tests/test_service_refresh_1220.py
@@ -2437,12 +2437,14 @@ class TestServiceTokenPolicy:
         # And the entry point every door now routes through names all four
         # rules, so a method added without a rule fails here rather than
         # silently composing an unjudged header.
-        # feat(#1764): the format predicate the gate applies is
-        # `carries_credential_as_header_line` — wider than the GDAL
-        # header-file one by STAC, which carries all three methods.
+        # feat(#1764): two names moved. The format predicate the gate applies
+        # is `carries_credential_as_header_line`, wider than the GDAL
+        # header-file one by STAC; and the bearer rule is the builder's own
+        # `bearer_token_rejection_reason`, which picks the charset by format,
+        # rather than the header-file charset applied unconditionally.
         gate_source = inspect.getsource(service_auth)
         for rule in (
-            "header_token_rejection_reason",
+            "bearer_token_rejection_reason",
             "credential_input_rejection_reason",
             "header_name_rejection_reason",
             "carries_credential_as_header_line",

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -474,6 +474,119 @@ class TestStacImport:
         assert detail.json()["last_checked_at"] is None
         assert detail.json()["source_health"] == "unknown"
 
+    async def test_import_refuses_an_off_origin_item_href(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_stac_ssrf,
+    ):
+        """fix(#1764): the item pointer is what a later credentialed refresh
+        anchors on, so it may not name a host other than the submitted
+        catalog. Search already drops such a link; this refuses it for a
+        client that did not come from there."""
+        resp = await client.post(
+            "/services/stac/import",
+            json={
+                "url": "https://stac.example.com/v1",
+                "items": [
+                    {
+                        "id": f"off-origin-{uuid.uuid4().hex[:8]}",
+                        "collection": "dem-collection",
+                        "title": "Off-origin pointer",
+                        "data_asset_href": "https://example.com/data/off.tif",
+                        "item_href": "https://mirror.example.net/v1/items/x",
+                    }
+                ],
+                "visibility": "private",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["created"] == 0
+        assert data["errors"] == 1
+        assert data["results"][0]["status"] == "error"
+        assert "different host" in data["results"][0]["error"]
+
+    async def test_import_records_the_catalog_and_the_auth_marker(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_stac_ssrf,
+        test_db_session,
+    ):
+        """feat(#1764): `url` is the anchor a credentialed refresh reads, and
+        `auth_required` is a boolean the wizard sets when the search that
+        produced these items carried a credential."""
+        from sqlalchemy import select
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        resp = await client.post(
+            "/services/stac/import",
+            json={
+                "url": "https://stac.example.com/v1",
+                "items": [
+                    {
+                        "id": f"marked-{uuid.uuid4().hex[:8]}",
+                        "collection": "dem-collection",
+                        "title": "Marked import",
+                        "data_asset_href": f"https://example.com/d/{uuid.uuid4().hex}.tif",
+                    }
+                ],
+                "visibility": "private",
+                "catalog_auth_required": True,
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        dataset_id = resp.json()["results"][0]["dataset_id"]
+        dataset = (
+            await test_db_session.execute(
+                select(Dataset).where(Dataset.id == uuid.UUID(dataset_id))
+            )
+        ).scalar_one()
+        assert dataset.origin_ref["url"] == "https://stac.example.com/v1"
+        assert dataset.origin_ref["auth_required"] is True
+
+    async def test_import_leaves_the_marker_absent_by_default(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        mock_stac_ssrf,
+        test_db_session,
+    ):
+        """True or absent, never False, so an anonymous import's binding is
+        the same shape it was before the key existed."""
+        from sqlalchemy import select
+
+        from app.modules.catalog.datasets.domain.models import Dataset
+
+        resp = await client.post(
+            "/services/stac/import",
+            json={
+                "url": "https://stac.example.com/v1",
+                "items": [
+                    {
+                        "id": f"plain-{uuid.uuid4().hex[:8]}",
+                        "collection": "dem-collection",
+                        "title": "Plain import",
+                        "data_asset_href": f"https://example.com/d/{uuid.uuid4().hex}.tif",
+                    }
+                ],
+                "visibility": "private",
+            },
+            headers=admin_auth_header,
+        )
+        assert resp.status_code == 200, resp.text
+        dataset_id = resp.json()["results"][0]["dataset_id"]
+        dataset = (
+            await test_db_session.execute(
+                select(Dataset).where(Dataset.id == uuid.UUID(dataset_id))
+            )
+        ).scalar_one()
+        assert "auth_required" not in dataset.origin_ref
+
     async def test_import_persists_the_origin_asset_for_generic_clients(
         self,
         client: AsyncClient,

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -3084,8 +3084,15 @@ class TestCredentialedRefresh:
         await _execute_with_credential(test_db_session, payload, ref)
 
         assert recorded, "the worker made no request"
-        for request in recorded:
+        # Every catalog read carries it; the asset probe does not, because
+        # Titiler fetches that URL out of process and cannot.
+        catalog_reads = [r for r in recorded if not r.url.path.endswith(".tif")]
+        assert catalog_reads
+        for request in catalog_reads:
             assert request.headers["X-Api-Key"] == secret
+        for request in recorded:
+            if request.url.path.endswith(".tif"):
+                assert "X-Api-Key" not in request.headers
         refreshed = await _reload(dataset.id)
         assert refreshed.origin_ref["auth_required"] is True
         assert refreshed.origin_ref["asset_href"] == _MOVED_ASSET

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -259,6 +259,7 @@ async def _stac_dataset(
     asset_key: str | None = "data",
     collection_id: str | None = "scenes",
     source_health: str | None = None,
+    url: str | None = _ROOT,
 ) -> Dataset:
     """A STAC dataset with a remote raster asset, as the import path makes one."""
     dataset = await _create_dataset(
@@ -273,6 +274,7 @@ async def _stac_dataset(
     dataset.origin_uri = asset_href
     dataset.origin_ref = build_origin_ref(
         "stac",
+        url=url,
         asset_href=asset_href,
         item_href=item_href,
         item_id=item_id,
@@ -2418,6 +2420,34 @@ class TestDispatch:
         assert resp.json()["detail"]["code"] == "service_token_required"
         # The reservation is released, so a later refresh is not blocked.
         assert await _run_for(dataset.id) is None
+
+    async def test_a_binding_recording_no_catalog_refuses_a_credential(
+        self, client, admin_auth_header, test_db_session, credential_backend
+    ) -> None:
+        """fix(#1764): a credential is anchored on the catalog URL the caller
+        submitted at import. A binding from before that was recorded has no
+        anchor, and falling back to the stored item pointer would let a
+        document from that era name where the credential goes."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id, url=None)
+        async with _dispatch_harness():
+            resp = await client.post(
+                f"/datasets/{dataset.id}/refresh",
+                headers=admin_auth_header,
+                json={"auth": {"method": "bearer", "token": "abcdefgh"}},
+            )
+        assert resp.status_code == 409, resp.text
+        assert resp.json()["detail"]["code"] == "origin_unavailable"
+        assert await _run_for(dataset.id) is None
+
+    async def test_the_same_binding_still_refreshes_anonymously(
+        self, client, admin_auth_header, test_db_session
+    ) -> None:
+        """The refusal is scoped to the new capability: an ordinary refresh of
+        a pre-existing binding is unchanged."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id, url=None)
+        await _dispatch(client, admin_auth_header, dataset.id)
 
     async def test_a_credentialed_refresh_needs_the_shared_store(
         self, client, admin_auth_header, test_db_session

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -2379,6 +2379,37 @@ class TestDispatch:
         assert resp.json()["detail"]["code"] == "service_token_required"
         assert await _run_for(dataset.id) is None
 
+    async def test_a_marker_that_appears_during_the_reservation_is_caught(
+        self, client, admin_auth_header, test_db_session
+    ) -> None:
+        """feat(#1764): a credentialed refresh finishing inside the window
+        marks the dataset without moving its origin, so the binding check
+        passes and only the post-reservation recheck notices."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+
+        real_refresh = router_refresh.AsyncSession.refresh
+
+        async def _mark_then_refresh(session, instance, attrs=None, **kwargs):
+            await session.execute(
+                update(Dataset)
+                .where(Dataset.id == dataset.id)
+                .values(origin_ref={**dataset.origin_ref, "auth_required": True})
+            )
+            return await real_refresh(session, instance, attrs, **kwargs)
+
+        async with _dispatch_harness():
+            with patch.object(
+                router_refresh.AsyncSession, "refresh", _mark_then_refresh
+            ):
+                resp = await client.post(
+                    f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+                )
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["code"] == "service_token_required"
+        # The reservation is released, so a later refresh is not blocked.
+        assert await _run_for(dataset.id) is None
+
     async def test_a_credentialed_refresh_needs_the_shared_store(
         self, client, admin_auth_header, test_db_session
     ) -> None:

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -452,6 +452,15 @@ async def _run_for(dataset_id: uuid.UUID) -> DatasetRefreshRun | None:
         ).scalar_one_or_none()
 
 
+async def _run_by_id(run_id: uuid.UUID) -> DatasetRefreshRun:
+    async with _fresh_session() as session:
+        return (
+            await session.execute(
+                select(DatasetRefreshRun).where(DatasetRefreshRun.id == run_id)
+            )
+        ).scalar_one()
+
+
 async def _origin_asset_rows(dataset_id: uuid.UUID) -> list[DatasetAsset]:
     """Every served ``dataset_assets`` row for the dataset (feat #1692)."""
     async with _fresh_session() as session:
@@ -3112,7 +3121,7 @@ class TestCredentialedRefresh:
         refreshed = await _reload(dataset.id)
         assert "auth_required" not in refreshed.origin_ref
 
-    async def test_a_spent_credential_fails_rather_than_fetching_anonymously(
+    async def test_a_spent_credential_is_recorded_as_a_failed_run(
         self,
         client,
         admin_auth_header,
@@ -3120,9 +3129,10 @@ class TestCredentialedRefresh:
         stac_transport,
         credential_backend,
     ) -> None:
-        """A single-use credential is gone after one claim. Falling through to
-        an anonymous read would reach the catalog, collect a 401, and report a
-        protected dataset as broken."""
+        """fix(#1764): a single-use credential is gone after one claim. The
+        attempt fails without contacting the catalog, and the failure is
+        WRITTEN, so the run does not sit pending and hold the dataset against
+        the admission index for an hour."""
         install, recorded = stac_transport
         install({_ITEM: (200, _item_doc()), _ASSET: (206, None)})
         admin_id = await get_user_id(test_db_session, "admin")
@@ -3145,7 +3155,20 @@ class TestCredentialedRefresh:
         )
         with pytest.raises(creds.CredentialExpiredError):
             await _execute_with_credential(test_db_session, retry, ref)
+
         assert recorded == []
+        run = await _run_by_id(uuid.UUID(retry["run_id"]))
+        assert run.status == "failed"
+        assert run.error_code == "credential_expired"
+        # And the dataset is free: a later refresh is admitted rather than
+        # answered 409 dataset_busy by the one-active-run index. Credentialed,
+        # because the first success marked the origin.
+        await _dispatch_with_credential(
+            client,
+            admin_auth_header,
+            dataset.id,
+            {"method": "bearer", "token": "ijklmnop"},
+        )
 
 
 class TestOriginAssetRepair:

--- a/backend/tests/test_stac_refresh_1266.py
+++ b/backend/tests/test_stac_refresh_1266.py
@@ -33,7 +33,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select, text
+from sqlalchemy import select, text, update
 from sqlalchemy.orm import joinedload
 
 from app.modules.catalog.datasets.api import router_refresh
@@ -43,7 +43,9 @@ from app.modules.catalog.sources.adapters.stac import pick_data_asset
 from app.modules.catalog.sources.origin_probe import DETAIL_CODES
 from app.platform.security import SSRFError, SSRFResolutionError
 from app.modules.catalog.sources.stac_resolve import resolve_stac_binding
+from app.platform import refresh as _refresh_pkg  # noqa: F401 -- see credentials import below
 from app.platform.dataset_origin import SOURCE_HEALTH_VALUES, build_origin_ref
+from app.platform.refresh import credentials as creds
 from app.platform.jobs.models import IngestJob
 from app.platform.refresh.models import DatasetRefreshRun
 from app.processing.ingest import tasks_stac_refresh
@@ -294,6 +296,33 @@ async def _stac_dataset(
     return dataset
 
 
+class _FakeCredentialBackend:
+    """An in-memory stand-in for the single-use credential store."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def put(self, key: str, value: str, ttl_seconds: int) -> None:
+        self.store[key] = value
+
+    async def take(self, key: str) -> str | None:
+        return self.store.pop(key, None)
+
+    async def renew(self, key: str, ttl_seconds: int) -> bool:
+        return key in self.store
+
+
+@pytest.fixture
+def credential_backend():
+    """Install a fake credential store for the duration of one test."""
+    backend = _FakeCredentialBackend()
+    creds.set_credential_backend(backend)
+    try:
+        yield backend
+    finally:
+        creds.set_credential_backend(None)
+
+
 @asynccontextmanager
 async def _dispatch_harness():
     """Patch the deferred task and yield the mock the door should reach for.
@@ -319,6 +348,33 @@ async def _dispatch(client: AsyncClient, headers: dict, dataset_id: uuid.UUID) -
         resp = await client.post(f"/datasets/{dataset_id}/refresh", headers=headers)
     assert resp.status_code == 202, resp.text
     return resp.json()
+
+
+async def _execute_with_credential(session, payload: dict, credential_ref: str) -> None:
+    """Run the worker for a credentialed dispatch, as the queue would."""
+    job = (
+        await session.execute(
+            select(IngestJob).where(IngestJob.id == uuid.UUID(payload["job_id"]))
+        )
+    ).scalar_one()
+    await refresh_stac.func(
+        job_id=payload["job_id"],
+        dataset_id=payload["dataset_id"],
+        attempt_id=str(job.attempt_id),
+        credential_ref=credential_ref,
+    )
+
+
+async def _dispatch_with_credential(
+    client: AsyncClient, headers: dict, dataset_id: uuid.UUID, auth: dict
+) -> tuple[dict, str]:
+    """Dispatch a credentialed refresh; return the payload and its ref."""
+    async with _dispatch_harness() as task:
+        resp = await client.post(
+            f"/datasets/{dataset_id}/refresh", headers=headers, json={"auth": auth}
+        )
+    assert resp.status_code == 202, resp.text
+    return resp.json(), task.defer_async.await_args.kwargs["credential_ref"]
 
 
 async def _execute(session, payload: dict) -> None:
@@ -2259,21 +2315,85 @@ class TestDispatch:
         assert resp.json()["detail"]["code"] == "origin_unavailable"
         assert await _run_for(dataset.id) is None
 
-    async def test_a_credential_is_refused_rather_than_dropped(
+    async def test_a_credential_is_staged_by_reference_never_as_an_argument(
+        self, client, admin_auth_header, test_db_session, credential_backend
+    ) -> None:
+        """feat(#1764): the catalog may be protected, so the credential is
+        carried — but a task argument is a durable row, so only the reference
+        crosses and the secret lives in the single-use store."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+        secret = "sentinel-" + uuid.uuid4().hex
+        async with _dispatch_harness() as task:
+            resp = await client.post(
+                f"/datasets/{dataset.id}/refresh",
+                headers=admin_auth_header,
+                json={"auth": {"method": "bearer", "token": secret}},
+            )
+        assert resp.status_code == 202, resp.text
+        kwargs = task.defer_async.await_args.kwargs
+        assert secret not in str(kwargs)
+        ref = kwargs["credential_ref"]
+        assert ref
+        assert secret in credential_backend.store[creds._KEY_PREFIX + ref]
+
+    async def test_a_credential_the_rules_refuse_never_reaches_a_response(
+        self, client, admin_auth_header, test_db_session, credential_backend
+    ) -> None:
+        """The 422 names the policy; echoing the value would put a fragment of
+        a submitted credential in a response body and a log line."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+        secret = "sentinel-" + uuid.uuid4().hex
+        async with _dispatch_harness():
+            resp = await client.post(
+                f"/datasets/{dataset.id}/refresh",
+                headers=admin_auth_header,
+                json={
+                    "auth": {
+                        "method": "header",
+                        "header_name": "Cookie",
+                        "header_value": secret,
+                    }
+                },
+            )
+        assert resp.status_code == 422, resp.text
+        assert secret not in resp.text
+        assert await _run_for(dataset.id) is None
+
+    async def test_a_marked_dataset_refuses_a_token_less_refresh(
         self, client, admin_auth_header, test_db_session
     ) -> None:
-        """Answering 202 to a request that handed GeoLens a secret it silently
-        discarded leaves the caller no way to learn their token went nowhere."""
+        """feat(#1764): the marker says the last successful refresh used a
+        credential, so an anonymous one would reach the catalog, collect a 401
+        and report a live dataset as inaccessible."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+        dataset.origin_ref = {**dataset.origin_ref, "auth_required": True}
+        await test_db_session.commit()
+        async with _dispatch_harness():
+            resp = await client.post(
+                f"/datasets/{dataset.id}/refresh", headers=admin_auth_header
+            )
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"]["code"] == "service_token_required"
+        assert await _run_for(dataset.id) is None
+
+    async def test_a_credentialed_refresh_needs_the_shared_store(
+        self, client, admin_auth_header, test_db_session
+    ) -> None:
+        """Without it the secret cannot reach the worker at all, so a 202 here
+        would buy a background failure whose real cause is a missing setting."""
         admin_id = await get_user_id(test_db_session, "admin")
         dataset = await _stac_dataset(test_db_session, created_by=admin_id)
         async with _dispatch_harness():
             resp = await client.post(
                 f"/datasets/{dataset.id}/refresh",
                 headers=admin_auth_header,
-                json={"token": "not-applicable-here"},
+                json={"auth": {"method": "bearer", "token": "abcdefgh"}},
             )
-        assert resp.status_code == 422, resp.text
-        assert resp.json()["detail"]["code"] == "credential_not_applicable"
+        assert resp.status_code == 503, resp.text
+        assert resp.json()["detail"]["code"] == "credential_store_unavailable"
         assert await _run_for(dataset.id) is None
 
     async def test_a_stored_url_that_no_longer_passes_ssrf_is_refused(
@@ -2889,6 +3009,112 @@ class TestWorker:
         assert finished.claimed_at is not None
         # No data moved, so there is no new version of it to point at.
         assert finished.dataset_version_id is None
+
+
+class TestCredentialedRefresh:
+    """feat(#1764): a protected catalog is re-read as the same caller the
+    import was, and the marker that records it is written from the credential
+    the attempt actually used."""
+
+    async def test_every_read_carries_the_credential_and_the_marker_is_written(
+        self,
+        client,
+        admin_auth_header,
+        test_db_session,
+        stac_transport,
+        credential_backend,
+    ) -> None:
+        install, recorded = stac_transport
+        install(
+            {
+                _ITEM: (200, _item_doc(asset_href=_MOVED_ASSET)),
+                _MOVED_ASSET: (206, None),
+            }
+        )
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+        secret = "sentinel-" + uuid.uuid4().hex
+
+        payload, ref = await _dispatch_with_credential(
+            client,
+            admin_auth_header,
+            dataset.id,
+            {"method": "header", "header_name": "X-Api-Key", "header_value": secret},
+        )
+        await _execute_with_credential(test_db_session, payload, ref)
+
+        assert recorded, "the worker made no request"
+        for request in recorded:
+            assert request.headers["X-Api-Key"] == secret
+        refreshed = await _reload(dataset.id)
+        assert refreshed.origin_ref["auth_required"] is True
+        assert refreshed.origin_ref["asset_href"] == _MOVED_ASSET
+        # The credential is in nothing the refresh persisted.
+        assert secret not in str(refreshed.origin_ref)
+        assert secret not in (refreshed.source_url or "")
+        run = await _run_for(dataset.id)
+        assert run.status == "succeeded"
+        assert secret not in (run.error_message or "")
+
+    async def test_a_token_less_success_clears_the_marker(
+        self, client, admin_auth_header, test_db_session, stac_transport
+    ) -> None:
+        """The marker means "the last successful refresh used one", so it is
+        rewritten from each attempt rather than accumulating."""
+        install, _ = stac_transport
+        install({_ITEM: (200, _item_doc()), _ASSET: (206, None)})
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+
+        payload = await _dispatch(client, admin_auth_header, dataset.id)
+        # Marked after the door admitted the token-less request, so the worker
+        # runs anonymously against a marked binding — the state the door's own
+        # refusal keeps a caller out of, reached here to pin the write.
+        await test_db_session.execute(
+            update(Dataset)
+            .where(Dataset.id == dataset.id)
+            .values(origin_ref={**dataset.origin_ref, "auth_required": True})
+        )
+        await test_db_session.commit()
+        await _execute(test_db_session, payload)
+
+        refreshed = await _reload(dataset.id)
+        assert "auth_required" not in refreshed.origin_ref
+
+    async def test_a_spent_credential_fails_rather_than_fetching_anonymously(
+        self,
+        client,
+        admin_auth_header,
+        test_db_session,
+        stac_transport,
+        credential_backend,
+    ) -> None:
+        """A single-use credential is gone after one claim. Falling through to
+        an anonymous read would reach the catalog, collect a 401, and report a
+        protected dataset as broken."""
+        install, recorded = stac_transport
+        install({_ITEM: (200, _item_doc()), _ASSET: (206, None)})
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _stac_dataset(test_db_session, created_by=admin_id)
+
+        payload, ref = await _dispatch_with_credential(
+            client,
+            admin_auth_header,
+            dataset.id,
+            {"method": "bearer", "token": "abcdefgh"},
+        )
+        await _execute_with_credential(test_db_session, payload, ref)
+        recorded.clear()
+
+        retry, _fresh_ref = await _dispatch_with_credential(
+            client,
+            admin_auth_header,
+            dataset.id,
+            {"method": "bearer", "token": "abcdefgh"},
+        )
+        with pytest.raises(creds.CredentialExpiredError):
+            await _execute_with_credential(test_db_session, retry, ref)
+        assert recorded == []
 
 
 class TestOriginAssetRepair:

--- a/backend/tests/test_stac_service_auth_1764.py
+++ b/backend/tests/test_stac_service_auth_1764.py
@@ -37,7 +37,11 @@ from app.modules.catalog.sources.adapters import stac as stac_adapter
 from app.modules.catalog.sources.stac_resolve import resolve_stac_binding
 from app.platform import security
 from app.platform.security import SSRFError
-from app.platform.service_auth import service_carries_method
+from app.platform.service_auth import (
+    credential_input_rejection,
+    credential_or_422,
+    service_carries_method,
+)
 
 _ROOT = "https://catalog.test/v1"
 _KEY = "s3cretkey123"
@@ -106,6 +110,17 @@ class TestTheFormatSets:
     def test_stac_carries_every_method_a_header_can_spell(self, method) -> None:
         assert service_carries_method(STAC_SERVICE_FORMAT, method) is True
         assert service_carries_method(ARCGIS_SERVICE_FORMAT, method) is False
+
+    def test_the_door_reaches_the_builders_bearer_verdict(self) -> None:
+        """The door and the builder ask one rule, so a key the transport can
+        carry is not refused at the door for a charset it never meets."""
+        wide = ServiceCredential(
+            method=CredentialMethod.BEARER,
+            service_format=STAC_SERVICE_FORMAT,
+            token="ab+cd/ef",
+        )
+        assert credential_input_rejection(wide) is None
+        assert credential_or_422(wide, service_format=STAC_SERVICE_FORMAT) is not None
 
     def test_a_stac_bearer_token_is_judged_as_a_header_value(self) -> None:
         """``+`` and ``/`` are outside base64url and legitimate in a provider

--- a/backend/tests/test_stac_service_auth_1764.py
+++ b/backend/tests/test_stac_service_auth_1764.py
@@ -1,0 +1,426 @@
+"""Request-only authentication for STAC sources (feat(#1764)).
+
+STAC is the third service family to carry a credential, and it is the first
+whose credential never reaches GDAL: the catalog, the item document and the
+asset are all read over httpx. So it answers yes to "is this credential a
+header line" and no to the three questions ``HEADER_AUTH_SERVICE_FORMATS``
+asks, which is why the format sets are asserted apart from each other here.
+
+What these tests pin, in order: the format vocabulary; the wire line's
+round trip, which is what lets the refresh worker compose at its own write
+sites instead of carrying a finished header; the transport, one test per
+door and per method; the two security invariants (a credential does not
+follow a cross-origin redirect, and a refused credential is never echoed);
+The refresh path's own tests live beside the strategy they exercise, in
+``test_stac_refresh_1266.py``, which already owns the dispatch harness.
+"""
+
+import json as _json
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import structlog
+
+from app.core.service_tokens import (
+    ARCGIS_SERVICE_FORMAT,
+    HEADER_AUTH_SERVICE_FORMATS,
+    HEADER_LINE_SERVICE_FORMATS,
+    STAC_SERVICE_FORMAT,
+    CredentialMethod,
+    ServiceCredential,
+    build_credential_header,
+    carries_credential_as_header_line,
+    credential_from_header_line,
+    credential_header_line,
+    requires_header_token_policy,
+    sends_credential_as_header,
+)
+from app.modules.catalog.sources import origin_probe
+from app.modules.catalog.sources.adapters import stac as stac_adapter
+from app.platform import security
+from app.platform.security import SSRFError
+from app.platform.service_auth import service_carries_method
+
+_ROOT = "https://catalog.test/v1"
+_KEY = "s3cretkey123"
+_HEADER_NAME = "Ocp-Apim-Subscription-Key"
+
+_LANDING = {"stac_version": "1.0.0", "id": "cat", "title": "Cat", "type": "Catalog"}
+
+
+def _bearer(token: str = _KEY) -> ServiceCredential:
+    return ServiceCredential(method=CredentialMethod.BEARER, token=token)
+
+
+def _basic(username: str = "reader", password: str = "pw-123") -> ServiceCredential:
+    return ServiceCredential(
+        method=CredentialMethod.BASIC, username=username, password=password
+    )
+
+
+def _header_key(value: str = _KEY) -> ServiceCredential:
+    return ServiceCredential(
+        method=CredentialMethod.HEADER_KEY,
+        header_name=_HEADER_NAME,
+        header_value=value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The format vocabulary
+# ---------------------------------------------------------------------------
+
+
+class TestTheFormatSets:
+    """STAC is a header-line format that is not a header-FILE format, and the
+    two questions have to stay separable or the base64url charset would
+    silently narrow what a STAC bearer token may contain."""
+
+    def test_stac_carries_a_header_line_but_writes_no_header_file(self) -> None:
+        assert carries_credential_as_header_line(STAC_SERVICE_FORMAT) is True
+        assert sends_credential_as_header(STAC_SERVICE_FORMAT) is True
+        assert requires_header_token_policy(STAC_SERVICE_FORMAT) is False
+        assert STAC_SERVICE_FORMAT not in HEADER_AUTH_SERVICE_FORMATS
+        assert STAC_SERVICE_FORMAT in HEADER_LINE_SERVICE_FORMATS
+
+    def test_arcgis_still_carries_no_header_line(self) -> None:
+        """Its worker-side token is a query parameter, so widening the line
+        set must not have swept it in."""
+        assert carries_credential_as_header_line(ARCGIS_SERVICE_FORMAT) is False
+
+    def test_the_header_file_formats_are_line_formats_too(self) -> None:
+        for source_format in HEADER_AUTH_SERVICE_FORMATS:
+            assert carries_credential_as_header_line(source_format) is True
+
+    @pytest.mark.parametrize(
+        "method", [CredentialMethod.BASIC, CredentialMethod.HEADER_KEY]
+    )
+    def test_stac_carries_every_method_a_header_can_spell(self, method) -> None:
+        assert service_carries_method(STAC_SERVICE_FORMAT, method) is True
+        assert service_carries_method(ARCGIS_SERVICE_FORMAT, method) is False
+
+    def test_a_stac_bearer_token_is_judged_as_a_header_value(self) -> None:
+        """``+`` and ``/`` are outside base64url and legitimate in a provider
+        key. The narrower charset exists for the GDAL header file, which no
+        STAC read ever writes."""
+        pair = build_credential_header(
+            ServiceCredential(
+                method=CredentialMethod.BEARER,
+                service_format=STAC_SERVICE_FORMAT,
+                token="ab+cd/ef",
+            )
+        )
+        assert pair == ("Authorization", "Bearer ab+cd/ef")
+        with pytest.raises(ValueError):
+            build_credential_header(
+                ServiceCredential(
+                    method=CredentialMethod.BEARER,
+                    service_format="wfs",
+                    token="ab+cd/ef",
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# The wire line round trip
+# ---------------------------------------------------------------------------
+
+
+class TestTheWireLineRoundTrip:
+    """The queue is the one hop that cannot compose at the write site, so a
+    STAC worker recovers the credential the line describes and composes
+    again. Recomposing has to yield the same line, or the worker would
+    authenticate as somebody else."""
+
+    @pytest.mark.parametrize(
+        "credential",
+        [_bearer(), _basic(), _header_key()],
+        ids=["bearer", "basic", "header"],
+    )
+    def test_a_line_recomposes_to_itself(self, credential) -> None:
+        bound = replace(credential, service_format=STAC_SERVICE_FORMAT)
+        line = credential_header_line(build_credential_header(bound))
+        recovered = credential_from_header_line(
+            line, service_format=STAC_SERVICE_FORMAT
+        )
+        assert credential_header_line(build_credential_header(recovered)) == line
+
+    def test_basic_recovers_the_username_and_password(self) -> None:
+        line = credential_header_line(
+            build_credential_header(
+                ServiceCredential(
+                    method=CredentialMethod.BASIC,
+                    service_format=STAC_SERVICE_FORMAT,
+                    username="reader",
+                    password="pw:with:colons",
+                )
+            )
+        )
+        recovered = credential_from_header_line(line)
+        assert recovered.method == CredentialMethod.BASIC
+        assert recovered.username == "reader"
+        # The colon in the PASSWORD survives: only the first one splits.
+        assert recovered.password == "pw:with:colons"
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            None,
+            "",
+            "no-separator",
+            "Authorization: ",
+            ": value",
+            "Authorization: Digest abc",
+            "Authorization: Basic not-base64!",
+            "Authorization: Basic bm9jb2xvbg==",
+        ],
+    )
+    def test_a_line_it_cannot_round_trip_yields_no_credential(self, line) -> None:
+        """None means an anonymous request, which fails loudly at the origin.
+        A guessed credential would authenticate as something nobody typed."""
+        assert credential_from_header_line(line) is None
+
+
+# ---------------------------------------------------------------------------
+# Transport: every STAC read carries the header
+# ---------------------------------------------------------------------------
+
+
+def json_response(status: int, body) -> httpx.Response:
+    """A STREAMING JSON response.
+
+    ``bounded_probe_read`` reads through ``aiter_raw``, which a response
+    built from an in-memory body refuses with ``StreamConsumed``.
+    """
+    raw = b"" if body is None else _json.dumps(body).encode()
+
+    async def chunks():
+        yield raw
+
+    return httpx.Response(
+        status,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": str(len(raw)),
+        },
+        content=chunks(),
+    )
+
+
+@pytest.fixture
+def stac_transport(monkeypatch):
+    """Answer every STAC read from a mock transport, recording the requests.
+
+    Patches ``make_safe_transport`` rather than the client factory, so the
+    client under test is the one ``make_safe_client`` builds and the redirect
+    hook this feature depends on is the real one.
+    """
+    recorded: list[httpx.Request] = []
+
+    def install(handler=None, *, status: int = 200, json_body=None):
+        def default(request: httpx.Request) -> httpx.Response:
+            return json_response(status, json_body)
+
+        chosen = handler or default
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            recorded.append(request)
+            return chosen(request)
+
+        monkeypatch.setattr(
+            security, "make_safe_transport", lambda: httpx.MockTransport(handle)
+        )
+        monkeypatch.setattr(security, "validate_url_for_ssrf", AsyncMock())
+        return recorded
+
+    return install
+
+
+class TestEveryStacReadCarriesTheCredential:
+    """Probe, preview and import have to agree about what the catalog
+    publishes, which they only do if all three ask as the same caller."""
+
+    @pytest.mark.anyio
+    async def test_connect_sends_a_bearer_header(self, stac_transport) -> None:
+        recorded = stac_transport(json_body=_LANDING)
+        result = await stac_adapter.connect_stac_api(_ROOT, _bearer())
+        assert result is not None
+        assert recorded[0].headers["Authorization"] == f"Bearer {_KEY}"
+
+    @pytest.mark.anyio
+    async def test_connect_sends_a_named_api_key(self, stac_transport) -> None:
+        recorded = stac_transport(json_body=_LANDING)
+        await stac_adapter.connect_stac_api(_ROOT, _header_key())
+        assert recorded[0].headers[_HEADER_NAME] == _KEY
+
+    @pytest.mark.anyio
+    async def test_connect_sends_basic(self, stac_transport) -> None:
+        recorded = stac_transport(json_body=_LANDING)
+        await stac_adapter.connect_stac_api(_ROOT, _basic())
+        assert recorded[0].headers["Authorization"].startswith("Basic ")
+
+    @pytest.mark.anyio
+    async def test_collections_sends_the_credential(self, stac_transport) -> None:
+        recorded = stac_transport(json_body={"collections": []})
+        await stac_adapter.list_stac_collections(_ROOT, _header_key())
+        assert recorded[0].headers[_HEADER_NAME] == _KEY
+
+    @pytest.mark.anyio
+    async def test_search_sends_the_credential(self, stac_transport) -> None:
+        recorded = stac_transport(json_body={"features": []})
+        await stac_adapter.search_stac_items(_ROOT, credential=_header_key())
+        assert recorded[0].headers[_HEADER_NAME] == _KEY
+        assert recorded[0].method == "POST"
+
+    @pytest.mark.anyio
+    async def test_an_anonymous_read_sends_no_credential_header(
+        self, stac_transport
+    ) -> None:
+        recorded = stac_transport(json_body=_LANDING)
+        await stac_adapter.connect_stac_api(_ROOT)
+        assert "Authorization" not in recorded[0].headers
+        assert _HEADER_NAME not in recorded[0].headers
+
+    @pytest.mark.anyio
+    async def test_the_item_document_read_carries_it(self, stac_transport) -> None:
+        recorded = stac_transport(json_body={"id": "x", "assets": {}})
+        await origin_probe.fetch_json_document(
+            f"{_ROOT}/collections/c/items/x", credential=_header_key()
+        )
+        assert recorded[0].headers[_HEADER_NAME] == _KEY
+
+    @pytest.mark.anyio
+    async def test_the_asset_probe_carries_it(self, stac_transport) -> None:
+        recorded = stac_transport(status=206)
+        result = await origin_probe.probe_remote_uri(
+            "https://assets.test/scene.tif", credential=_header_key()
+        )
+        assert result.ok
+        assert recorded[0].headers[_HEADER_NAME] == _KEY
+        # Still a ranged read: the credential is added, nothing is replaced.
+        assert recorded[0].headers["Range"] == "bytes=0-0"
+
+
+# ---------------------------------------------------------------------------
+# Security invariants
+# ---------------------------------------------------------------------------
+
+
+class TestTheCredentialStaysOnItsOrigin:
+    """A catalog that 302s a credentialed read elsewhere gets a refusal, not
+    the key. httpx would strip ``Authorization`` silently and forward a
+    service-chosen name unchanged; neither is an acceptable answer here."""
+
+    @pytest.mark.anyio
+    async def test_a_cross_origin_redirect_is_refused_on_the_item_read(
+        self, stac_transport
+    ) -> None:
+        def redirect(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                302, headers={"Location": "https://elsewhere.test/collect"}
+            )
+
+        recorded = stac_transport(redirect)
+        result, document, _url = await origin_probe.fetch_json_document(
+            f"{_ROOT}/collections/c/items/x", credential=_header_key()
+        )
+        # The probe classifies rather than raising, but the second request
+        # never went out, which is the property that matters.
+        assert result.health == origin_probe.INACCESSIBLE
+        assert document is None
+        assert len(recorded) == 1
+
+    @pytest.mark.anyio
+    async def test_a_cross_origin_redirect_is_refused_on_the_asset_probe(
+        self, stac_transport
+    ) -> None:
+        def redirect(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                302, headers={"Location": "https://elsewhere.test/blob"}
+            )
+
+        recorded = stac_transport(redirect)
+        result = await origin_probe.probe_remote_uri(
+            "https://assets.test/scene.tif", credential=_header_key()
+        )
+        assert result.health == origin_probe.INACCESSIBLE
+        assert len(recorded) == 1
+
+    @pytest.mark.anyio
+    async def test_a_same_origin_redirect_still_follows(self, stac_transport) -> None:
+        def once(request: httpx.Request) -> httpx.Response:
+            if len(recorded) == 1:
+                return httpx.Response(
+                    302, headers={"Location": f"{_ROOT}/collections/c/items/moved"}
+                )
+            return json_response(200, {"id": "x", "assets": {}})
+
+        recorded = stac_transport(once)
+        result, document, _url = await origin_probe.fetch_json_document(
+            f"{_ROOT}/collections/c/items/x", credential=_header_key()
+        )
+        assert result.ok
+        assert document == {"id": "x", "assets": {}}
+        assert recorded[1].headers[_HEADER_NAME] == _KEY
+
+    @pytest.mark.anyio
+    async def test_the_adapter_declares_the_header_to_the_client(
+        self, stac_transport
+    ) -> None:
+        """The declaration is what turns httpx's silent strip into a refusal,
+        so it is asserted at the adapter, not only at the client factory."""
+
+        def redirect(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                302, headers={"Location": "https://elsewhere.test/moved"}
+            )
+
+        recorded = stac_transport(redirect)
+        with pytest.raises(SSRFError):
+            await stac_adapter.list_stac_collections(_ROOT, _bearer())
+        assert len(recorded) == 1
+
+
+class TestARefusedCredentialIsNeverEchoed:
+    """The refusal reaches a 422 body, a log line and a job row, so it names
+    the policy and never the value."""
+
+    @pytest.mark.parametrize(
+        "credential",
+        [
+            ServiceCredential(
+                method=CredentialMethod.HEADER_KEY,
+                service_format=STAC_SERVICE_FORMAT,
+                header_name="Cookie",
+                header_value="s3cret-value-99",
+            ),
+            ServiceCredential(
+                method=CredentialMethod.BASIC,
+                service_format=STAC_SERVICE_FORMAT,
+                username="user:with:colon",
+                password="s3cret-value-99",
+            ),
+            ServiceCredential(
+                method=CredentialMethod.BEARER,
+                service_format=STAC_SERVICE_FORMAT,
+                token="has space s3cret-value-99",
+            ),
+        ],
+        ids=["reserved-name", "colon-username", "whitespace-token"],
+    )
+    def test_the_builder_message_never_carries_the_value(self, credential) -> None:
+        with pytest.raises(ValueError) as raised:
+            build_credential_header(credential)
+        assert "s3cret-value-99" not in str(raised.value)
+
+    @pytest.mark.anyio
+    async def test_a_failed_read_logs_no_credential(self, stac_transport) -> None:
+        """``connect_stac_api`` degrades to None and logs the failure; the
+        header it sent must not be in the record."""
+        stac_transport(status=500)
+        with structlog.testing.capture_logs() as captured:
+            result = await stac_adapter.connect_stac_api(_ROOT, _header_key())
+        assert result is None
+        assert all(_KEY not in str(record) for record in captured)

--- a/backend/tests/test_stac_service_auth_1764.py
+++ b/backend/tests/test_stac_service_auth_1764.py
@@ -448,7 +448,7 @@ class TestTheCatalogChoosesTheCredentialNotTheDocument:
             asset_href=_FOREIGN_ASSET,
             asset_key="data",
             credential=_header_key(),
-            credential_origin=_ITEM_URL,
+            catalog_origin=_ITEM_URL,
         )
 
         by_host = {request.url.host: request for request in recorded}
@@ -488,15 +488,19 @@ class TestTheCatalogChoosesTheCredentialNotTheDocument:
             asset_href=f"{_ROOT}/assets/scene.tif",
             asset_key="data",
             credential=_header_key(),
-            credential_origin=_ITEM_URL,
+            catalog_origin=_ITEM_URL,
         )
         assert result.item_href == moved
         assert all(request.headers[_HEADER_NAME] == _KEY for request in recorded)
 
     @pytest.mark.anyio
-    async def test_an_anonymous_resolution_is_unchanged(self, stac_transport) -> None:
-        """No credential, no gate: a public catalog's off-origin self link is
-        followed exactly as it was before."""
+    async def test_an_anonymous_refresh_does_not_move_the_anchor(
+        self, stac_transport
+    ) -> None:
+        """The stored pointer is the origin every LATER refresh sends its
+        credential to, so an anonymous one may not move it off the catalog
+        either. Without this an anonymous refresh adopts the mirror and the
+        next credentialed refresh hands it the key on its first read."""
 
         def routes(request: httpx.Request) -> httpx.Response:
             if request.url.path.endswith(".tif"):
@@ -511,8 +515,38 @@ class TestTheCatalogChoosesTheCredentialNotTheDocument:
             asset_href=_FOREIGN_ASSET,
             asset_key="data",
         )
+        assert result.item_href == _ITEM_URL
+        assert all(request.url.host != "mirror.test" for request in recorded)
+        # The asset is unaffected: only the POINTER is fenced to the catalog.
         assert result.asset_href == _FOREIGN_ASSET
-        assert any(request.url.host == "mirror.test" for request in recorded)
+
+    @pytest.mark.anyio
+    async def test_an_anonymous_same_origin_self_link_is_still_adopted(
+        self, stac_transport
+    ) -> None:
+        """The rule is about the ORIGIN, not about holding a credential:
+        fencing on "this read carries no credential" would stop a public
+        catalog's pointer following its own canonical URL."""
+        moved = f"{_ROOT}/permalink/x"
+        asset = f"{_ROOT}/assets/scene.tif"
+        document = _item_document(moved, asset)
+
+        def routes(request: httpx.Request) -> httpx.Response:
+            if request.url.host != "catalog.test":
+                return json_response(404, None)
+            if request.url.path.endswith(".tif"):
+                return json_response(206, None)
+            return json_response(200, document)
+
+        stac_transport(routes)
+        result = await resolve_stac_binding(
+            item_href=_ITEM_URL,
+            item_id="x",
+            collection_id="c",
+            asset_href=asset,
+            asset_key="data",
+        )
+        assert result.item_href == moved
 
 
 class TestAReflectedCredentialIsNeverStored:
@@ -554,7 +588,7 @@ class TestAReflectedCredentialIsNeverStored:
             asset_href=f"{_ROOT}/assets/scene.tif",
             asset_key="data",
             credential=_header_key(),
-            credential_origin=_ITEM_URL,
+            catalog_origin=_ITEM_URL,
         )
         assert result.resolved is False
         assert result.asset_href is None
@@ -583,7 +617,7 @@ class TestAReflectedCredentialIsNeverStored:
             asset_href=asset,
             asset_key="data",
             credential=_header_key(),
-            credential_origin=_ITEM_URL,
+            catalog_origin=_ITEM_URL,
         )
         # The asset still resolves; only the poisoned pointer is dropped, so
         # the stored one stays what it was.
@@ -612,7 +646,7 @@ class TestAReflectedCredentialIsNeverStored:
             asset_href=asset,
             asset_key="data",
             credential=_header_key(),
-            credential_origin=_ITEM_URL,
+            catalog_origin=_ITEM_URL,
         )
         assert result.asset_href == asset
 

--- a/backend/tests/test_stac_service_auth_1764.py
+++ b/backend/tests/test_stac_service_auth_1764.py
@@ -700,6 +700,52 @@ class TestSearchDoesNotHandBackTheCredential:
         assert result["items"][0]["data_asset_href"] == f"{_ROOT}/assets/scene.tif"
 
 
+class TestTheStoredPointerNeverLeavesTheSubmittedCatalog:
+    """The item pointer is what a later credentialed refresh anchors on, so a
+    catalog that advertises an off-origin self link would otherwise name the
+    host its own key is sent to. Fenced at both write sites."""
+
+    @pytest.mark.anyio
+    async def test_search_does_not_publish_an_off_origin_self_link(
+        self, stac_transport
+    ) -> None:
+        feature = {
+            "type": "Feature",
+            "id": "x",
+            "collection": "c",
+            "properties": {},
+            "bbox": [0.0, 0.0, 1.0, 1.0],
+            "links": [{"rel": "self", "href": _MIRROR_ITEM}],
+            "assets": {
+                "data": {"href": f"{_ROOT}/assets/scene.tif", "roles": ["data"]}
+            },
+        }
+        stac_transport(json_body={"features": [feature], "numberMatched": 1})
+        result = await stac_adapter.search_stac_items(_ROOT, credential=_header_key())
+        assert result["returned"] == 1
+        # The item still imports; only the pointer the catalog chose is dropped.
+        assert result["items"][0]["item_href"] is None
+
+    @pytest.mark.anyio
+    async def test_search_still_publishes_a_same_origin_self_link(
+        self, stac_transport
+    ) -> None:
+        feature = {
+            "type": "Feature",
+            "id": "x",
+            "collection": "c",
+            "properties": {},
+            "bbox": [0.0, 0.0, 1.0, 1.0],
+            "links": [{"rel": "self", "href": _ITEM_URL}],
+            "assets": {
+                "data": {"href": f"{_ROOT}/assets/scene.tif", "roles": ["data"]}
+            },
+        }
+        stac_transport(json_body={"features": [feature], "numberMatched": 1})
+        result = await stac_adapter.search_stac_items(_ROOT)
+        assert result["items"][0]["item_href"] == _ITEM_URL
+
+
 class TestAShortCredentialDoesNotRefuseEveryUrl:
     """The gate refuses storage, so over-matching strands a legitimate
     refresh. A variant too short to be evidence has to BE a whole value."""

--- a/backend/tests/test_stac_service_auth_1764.py
+++ b/backend/tests/test_stac_service_auth_1764.py
@@ -1,18 +1,13 @@
 """Request-only authentication for STAC sources (feat(#1764)).
 
-STAC is the third service family to carry a credential, and it is the first
-whose credential never reaches GDAL: the catalog, the item document and the
-asset are all read over httpx. So it answers yes to "is this credential a
-header line" and no to the three questions ``HEADER_AUTH_SERVICE_FORMATS``
-asks, which is why the format sets are asserted apart from each other here.
+A STAC credential is a header on every hop and reaches no GDAL header file,
+so the format sets, the charset and the wire-line round trip are asserted
+separately from the WFS/OAPIF ones. The credential goes to the catalog
+origin and nowhere else, whether the other address arrives in a 302 or in
+the item document itself, and a refused one is never echoed.
 
-What these tests pin, in order: the format vocabulary; the wire line's
-round trip, which is what lets the refresh worker compose at its own write
-sites instead of carrying a finished header; the transport, one test per
-door and per method; the two security invariants (a credential does not
-follow a cross-origin redirect, and a refused credential is never echoed);
-The refresh path's own tests live beside the strategy they exercise, in
-``test_stac_refresh_1266.py``, which already owns the dispatch harness.
+The refresh path's own tests are in ``test_stac_refresh_1266.py``, which
+owns the dispatch harness.
 """
 
 import json as _json
@@ -39,6 +34,7 @@ from app.core.service_tokens import (
 )
 from app.modules.catalog.sources import origin_probe
 from app.modules.catalog.sources.adapters import stac as stac_adapter
+from app.modules.catalog.sources.stac_resolve import resolve_stac_binding
 from app.platform import security
 from app.platform.security import SSRFError
 from app.platform.service_auth import service_carries_method
@@ -50,19 +46,29 @@ _HEADER_NAME = "Ocp-Apim-Subscription-Key"
 _LANDING = {"stac_version": "1.0.0", "id": "cat", "title": "Cat", "type": "Catalog"}
 
 
+# Bound to the STAC format at construction: `origin_probe` composes from the
+# credential as given, so an unbound one reads anonymously by design.
 def _bearer(token: str = _KEY) -> ServiceCredential:
-    return ServiceCredential(method=CredentialMethod.BEARER, token=token)
+    return ServiceCredential(
+        method=CredentialMethod.BEARER,
+        service_format=STAC_SERVICE_FORMAT,
+        token=token,
+    )
 
 
 def _basic(username: str = "reader", password: str = "pw-123") -> ServiceCredential:
     return ServiceCredential(
-        method=CredentialMethod.BASIC, username=username, password=password
+        method=CredentialMethod.BASIC,
+        service_format=STAC_SERVICE_FORMAT,
+        username=username,
+        password=password,
     )
 
 
 def _header_key(value: str = _KEY) -> ServiceCredential:
     return ServiceCredential(
         method=CredentialMethod.HEADER_KEY,
+        service_format=STAC_SERVICE_FORMAT,
         header_name=_HEADER_NAME,
         header_value=value,
     )
@@ -293,14 +299,34 @@ class TestEveryStacReadCarriesTheCredential:
 
     @pytest.mark.anyio
     async def test_the_asset_probe_carries_it(self, stac_transport) -> None:
+        """An asset the catalog serves itself. Whether a credential reaches an
+        asset on ANOTHER origin is the resolve gate's decision, pinned in
+        TestTheCredentialStaysOnItsOrigin."""
         recorded = stac_transport(status=206)
         result = await origin_probe.probe_remote_uri(
-            "https://assets.test/scene.tif", credential=_header_key()
+            f"{_ROOT}/assets/scene.tif", credential=_header_key()
         )
         assert result.ok
         assert recorded[0].headers[_HEADER_NAME] == _KEY
         # Still a ranged read: the credential is added, nothing is replaced.
         assert recorded[0].headers["Range"] == "bytes=0-0"
+
+    @pytest.mark.anyio
+    async def test_an_unbound_credential_composes_no_header(
+        self, stac_transport
+    ) -> None:
+        """`origin_probe` serves every origin kind, so it composes from the
+        credential as bound rather than relabelling it."""
+        recorded = stac_transport(status=206)
+        await origin_probe.probe_remote_uri(
+            f"{_ROOT}/assets/scene.tif",
+            credential=ServiceCredential(
+                method=CredentialMethod.HEADER_KEY,
+                header_name=_HEADER_NAME,
+                header_value=_KEY,
+            ),
+        )
+        assert _HEADER_NAME not in recorded[0].headers
 
 
 # ---------------------------------------------------------------------------
@@ -381,6 +407,114 @@ class TestTheCredentialStaysOnItsOrigin:
         with pytest.raises(SSRFError):
             await stac_adapter.list_stac_collections(_ROOT, _bearer())
         assert len(recorded) == 1
+
+
+_ITEM_URL = f"{_ROOT}/collections/c/items/x"
+_MIRROR_ITEM = "https://mirror.test/v1/collections/c/items/x"
+_FOREIGN_ASSET = "https://assets.example/scene.tif"
+
+
+def _item_document(self_href: str, asset_href: str) -> dict:
+    return {
+        "type": "Feature",
+        "id": "x",
+        "collection": "c",
+        "properties": {},
+        "bbox": [0.0, 0.0, 1.0, 1.0],
+        "links": [{"rel": "self", "href": self_href}],
+        "assets": {"data": {"href": asset_href, "roles": ["data"]}},
+    }
+
+
+class TestTheCatalogChoosesTheCredentialNotTheDocument:
+    """A STAC item document names its own self link and its assets, and both
+    are fetched first-hop, where no redirect hook runs. The credential goes
+    only to the origin it was given for."""
+
+    @pytest.mark.anyio
+    async def test_a_self_link_and_an_asset_on_other_origins_get_no_credential(
+        self, stac_transport
+    ) -> None:
+        def routes(request: httpx.Request) -> httpx.Response:
+            if str(request.url).startswith(_ROOT):
+                return json_response(200, _item_document(_MIRROR_ITEM, _FOREIGN_ASSET))
+            if str(request.url).startswith("https://mirror.test"):
+                return json_response(200, _item_document(_MIRROR_ITEM, _FOREIGN_ASSET))
+            return json_response(206, None)
+
+        recorded = stac_transport(routes)
+        result = await resolve_stac_binding(
+            item_href=_ITEM_URL,
+            item_id="x",
+            collection_id="c",
+            asset_href=_FOREIGN_ASSET,
+            asset_key="data",
+            credential=_header_key(),
+            credential_origin=_ITEM_URL,
+        )
+
+        by_host = {request.url.host: request for request in recorded}
+        assert by_host["catalog.test"].headers[_HEADER_NAME] == _KEY
+        for host, request in by_host.items():
+            if host != "catalog.test":
+                assert _HEADER_NAME not in request.headers, host
+        # The off-origin self link is dropped rather than fetched, so the
+        # stored pointer cannot drift off the catalog across refreshes.
+        assert "mirror.test" not in by_host
+        # The asset is still resolved: a catalog serving assets from someone
+        # else's bucket is the ordinary case, not a refusal.
+        assert result.asset_href == _FOREIGN_ASSET
+        assert result.item_href == _ITEM_URL
+
+    @pytest.mark.anyio
+    async def test_a_self_link_on_the_catalog_origin_is_still_followed(
+        self, stac_transport
+    ) -> None:
+        # A permalink: states no identity of its own, so it is adopted on
+        # the strength of the document it serves rather than refused.
+        moved = f"{_ROOT}/permalink/x"
+        document = _item_document(moved, f"{_ROOT}/assets/scene.tif")
+
+        def routes(request: httpx.Request) -> httpx.Response:
+            if request.url.host != "catalog.test":
+                return json_response(404, None)
+            if str(request.url).endswith(".tif"):
+                return json_response(206, None)
+            return json_response(200, document)
+
+        recorded = stac_transport(routes)
+        result = await resolve_stac_binding(
+            item_href=_ITEM_URL,
+            item_id="x",
+            collection_id="c",
+            asset_href=f"{_ROOT}/assets/scene.tif",
+            asset_key="data",
+            credential=_header_key(),
+            credential_origin=_ITEM_URL,
+        )
+        assert result.item_href == moved
+        assert all(request.headers[_HEADER_NAME] == _KEY for request in recorded)
+
+    @pytest.mark.anyio
+    async def test_an_anonymous_resolution_is_unchanged(self, stac_transport) -> None:
+        """No credential, no gate: a public catalog's off-origin self link is
+        followed exactly as it was before."""
+
+        def routes(request: httpx.Request) -> httpx.Response:
+            if str(request.url).endswith(".tif"):
+                return json_response(206, None)
+            return json_response(200, _item_document(_MIRROR_ITEM, _FOREIGN_ASSET))
+
+        recorded = stac_transport(routes)
+        result = await resolve_stac_binding(
+            item_href=_ITEM_URL,
+            item_id="x",
+            collection_id="c",
+            asset_href=_FOREIGN_ASSET,
+            asset_key="data",
+        )
+        assert result.asset_href == _FOREIGN_ASSET
+        assert any(request.url.host == "mirror.test" for request in recorded)
 
 
 class TestARefusedCredentialIsNeverEchoed:

--- a/backend/tests/test_stac_service_auth_1764.py
+++ b/backend/tests/test_stac_service_auth_1764.py
@@ -651,6 +651,133 @@ class TestAReflectedCredentialIsNeverStored:
         assert result.asset_href == asset
 
 
+class TestSearchDoesNotHandBackTheCredential:
+    """Only ``item_href`` passes ``storable_href`` on the search path. Every
+    other field is echoed to ``/import`` by the client, whose own request
+    registers no credential and so cannot recognise one, and is then stored."""
+
+    def _feature(self, **overrides) -> dict:
+        feature = {
+            "type": "Feature",
+            "id": "x",
+            "collection": "c",
+            "properties": {"title": "Scene"},
+            "bbox": [0.0, 0.0, 1.0, 1.0],
+            "links": [{"rel": "self", "href": _ITEM_URL}],
+            "assets": {
+                "data": {"href": f"{_ROOT}/assets/scene.tif", "roles": ["data"]}
+            },
+        }
+        feature.update(overrides)
+        return feature
+
+    @pytest.mark.anyio
+    async def test_an_item_reflecting_the_credential_is_not_returned(
+        self, stac_transport
+    ) -> None:
+        poisoned = self._feature(
+            assets={
+                "data": {
+                    "href": f"{_ROOT}/assets/scene.tif?catalog_ref={_KEY}",
+                    "roles": ["data"],
+                }
+            }
+        )
+        recorded = stac_transport(
+            json_body={"features": [poisoned], "numberMatched": 1}
+        )
+        result = await stac_adapter.search_stac_items(_ROOT, credential=_header_key())
+        assert result["items"] == []
+        assert result["returned"] == 0
+        assert _KEY not in str(result)
+        # The request itself still carried the credential; only the answer
+        # is refused.
+        assert recorded[0].headers[_HEADER_NAME] == _KEY
+
+    @pytest.mark.anyio
+    async def test_a_reflection_in_a_non_href_field_is_caught_too(
+        self, stac_transport
+    ) -> None:
+        """``id`` becomes ``origin_ref["item_id"]`` and ``source_filename``,
+        so a field that is not a URL still reaches storage."""
+        stac_transport(
+            json_body={"features": [self._feature(id=f"scene-{_KEY}")], "matched": 1}
+        )
+        result = await stac_adapter.search_stac_items(_ROOT, credential=_header_key())
+        assert result["items"] == []
+
+    @pytest.mark.anyio
+    async def test_an_ordinary_item_is_returned_unchanged(self, stac_transport) -> None:
+        stac_transport(json_body={"features": [self._feature()], "numberMatched": 1})
+        result = await stac_adapter.search_stac_items(_ROOT, credential=_header_key())
+        assert result["returned"] == 1
+        assert result["items"][0]["data_asset_href"] == f"{_ROOT}/assets/scene.tif"
+
+
+class TestAShortCredentialDoesNotRefuseEveryUrl:
+    """The gate refuses storage, so over-matching strands a legitimate
+    refresh. A variant too short to be evidence has to BE a whole value."""
+
+    @pytest.mark.anyio
+    async def test_a_one_character_key_does_not_refuse_an_unrelated_href(
+        self, stac_transport
+    ) -> None:
+        tiny = ServiceCredential(
+            method=CredentialMethod.HEADER_KEY,
+            service_format=STAC_SERVICE_FORMAT,
+            header_name=_HEADER_NAME,
+            header_value="a",
+        )
+        asset = f"{_ROOT}/assets/scene-alpha.tif"
+
+        def routes(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith(".tif"):
+                return json_response(206, None)
+            return json_response(200, _item_document(_ITEM_URL, asset))
+
+        stac_transport(routes)
+        result = await resolve_stac_binding(
+            item_href=_ITEM_URL,
+            item_id="x",
+            collection_id="c",
+            asset_href=asset,
+            asset_key="data",
+            credential=tiny,
+            catalog_origin=_ITEM_URL,
+        )
+        # "a" occurs in "assets" and "alpha"; neither is the credential.
+        assert result.asset_href == asset
+
+    @pytest.mark.anyio
+    async def test_a_one_character_key_is_still_caught_as_a_whole_value(
+        self, stac_transport
+    ) -> None:
+        tiny = ServiceCredential(
+            method=CredentialMethod.HEADER_KEY,
+            service_format=STAC_SERVICE_FORMAT,
+            header_name=_HEADER_NAME,
+            header_value="a",
+        )
+        reflected = f"{_ROOT}/assets/scene.tif?catalog_ref=a"
+
+        def routes(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith(".tif"):
+                return json_response(206, None)
+            return json_response(200, _item_document(_ITEM_URL, reflected))
+
+        stac_transport(routes)
+        result = await resolve_stac_binding(
+            item_href=_ITEM_URL,
+            item_id="x",
+            collection_id="c",
+            asset_href=reflected,
+            asset_key="data",
+            credential=tiny,
+            catalog_origin=_ITEM_URL,
+        )
+        assert result.resolved is False
+
+
 class TestARefusedCredentialIsNeverEchoed:
     """The refusal reaches a 422 body, a log line and a job row, so it names
     the policy and never the value."""

--- a/backend/tests/test_stac_service_auth_1764.py
+++ b/backend/tests/test_stac_service_auth_1764.py
@@ -436,9 +436,7 @@ class TestTheCatalogChoosesTheCredentialNotTheDocument:
         self, stac_transport
     ) -> None:
         def routes(request: httpx.Request) -> httpx.Response:
-            if str(request.url).startswith(_ROOT):
-                return json_response(200, _item_document(_MIRROR_ITEM, _FOREIGN_ASSET))
-            if str(request.url).startswith("https://mirror.test"):
+            if request.url.host in ("catalog.test", "mirror.test"):
                 return json_response(200, _item_document(_MIRROR_ITEM, _FOREIGN_ASSET))
             return json_response(206, None)
 
@@ -478,7 +476,7 @@ class TestTheCatalogChoosesTheCredentialNotTheDocument:
         def routes(request: httpx.Request) -> httpx.Response:
             if request.url.host != "catalog.test":
                 return json_response(404, None)
-            if str(request.url).endswith(".tif"):
+            if request.url.path.endswith(".tif"):
                 return json_response(206, None)
             return json_response(200, document)
 
@@ -501,7 +499,7 @@ class TestTheCatalogChoosesTheCredentialNotTheDocument:
         followed exactly as it was before."""
 
         def routes(request: httpx.Request) -> httpx.Response:
-            if str(request.url).endswith(".tif"):
+            if request.url.path.endswith(".tif"):
                 return json_response(206, None)
             return json_response(200, _item_document(_MIRROR_ITEM, _FOREIGN_ASSET))
 
@@ -515,6 +513,108 @@ class TestTheCatalogChoosesTheCredentialNotTheDocument:
         )
         assert result.asset_href == _FOREIGN_ASSET
         assert any(request.url.host == "mirror.test" for request in recorded)
+
+
+class TestAReflectedCredentialIsNeverStored:
+    """An origin can hand the caller's own credential back inside a URL it
+    publishes. ``DatasetResponse.origin_ref`` promises it never contains
+    credentials, and ADR-002 invariant 4 says the same, so a reflected one is
+    refused at the one gate every stored value passes."""
+
+    @pytest.mark.anyio
+    async def test_an_asset_href_reflecting_the_credential_is_refused(
+        self, stac_transport, monkeypatch
+    ) -> None:
+        """Under an unlisted parameter name: ``has_url_credentials``
+        allowlists NAMES, so only the value check catches this.
+
+        The moved-href probes are stubbed so the refusal cannot be confused
+        with a Titiler read that simply failed.
+        """
+        reflected = f"{_ROOT}/assets/scene.tif?catalog_ref={_KEY}"
+        monkeypatch.setattr(
+            "app.modules.catalog.sources.stac_resolve_asset_gate.validate_url_for_ssrf",
+            AsyncMock(),
+        )
+        monkeypatch.setattr(
+            "app.modules.catalog.sources.stac_resolve_asset_gate.fetch_cog_info",
+            AsyncMock(return_value={"band_count": 1}),
+        )
+
+        def routes(request: httpx.Request) -> httpx.Response:
+            if request.url.path.startswith("/v1/assets/"):
+                return json_response(206, None)
+            return json_response(200, _item_document(_ITEM_URL, reflected))
+
+        stac_transport(routes)
+        result = await resolve_stac_binding(
+            item_href=_ITEM_URL,
+            item_id="x",
+            collection_id="c",
+            asset_href=f"{_ROOT}/assets/scene.tif",
+            asset_key="data",
+            credential=_header_key(),
+            credential_origin=_ITEM_URL,
+        )
+        assert result.resolved is False
+        assert result.asset_href is None
+        assert result.detail == origin_probe.UNAUTHORIZED
+        assert _KEY not in str(result)
+
+    @pytest.mark.anyio
+    async def test_a_self_link_reflecting_the_credential_is_not_adopted(
+        self, stac_transport
+    ) -> None:
+        """The self link becomes the stored item pointer, so it passes the
+        same gate before anything can write it."""
+        asset = f"{_ROOT}/assets/scene.tif"
+        reflected_self = f"{_ROOT}/permalink/x?catalog_ref={_KEY}"
+
+        def routes(request: httpx.Request) -> httpx.Response:
+            if request.url.path.startswith("/v1/assets/"):
+                return json_response(206, None)
+            return json_response(200, _item_document(reflected_self, asset))
+
+        stac_transport(routes)
+        result = await resolve_stac_binding(
+            item_href=_ITEM_URL,
+            item_id="x",
+            collection_id="c",
+            asset_href=asset,
+            asset_key="data",
+            credential=_header_key(),
+            credential_origin=_ITEM_URL,
+        )
+        # The asset still resolves; only the poisoned pointer is dropped, so
+        # the stored one stays what it was.
+        assert result.asset_href == asset
+        assert result.item_href == _ITEM_URL
+        assert _KEY not in str(result)
+
+    @pytest.mark.anyio
+    async def test_an_href_carrying_no_credential_is_still_stored(
+        self, stac_transport
+    ) -> None:
+        """The gate reads the registry, so an ordinary query string on a
+        credentialed refresh is untouched."""
+        asset = f"{_ROOT}/assets/scene.tif?version=3"
+
+        def routes(request: httpx.Request) -> httpx.Response:
+            if request.url.path.startswith("/v1/assets/"):
+                return json_response(206, None)
+            return json_response(200, _item_document(_ITEM_URL, asset))
+
+        stac_transport(routes)
+        result = await resolve_stac_binding(
+            item_href=_ITEM_URL,
+            item_id="x",
+            collection_id="c",
+            asset_href=asset,
+            asset_key="data",
+            credential=_header_key(),
+            credential_origin=_ITEM_URL,
+        )
+        assert result.asset_href == asset
 
 
 class TestARefusedCredentialIsNeverEchoed:

--- a/backend/tests/test_stac_service_auth_1764.py
+++ b/backend/tests/test_stac_service_auth_1764.py
@@ -298,17 +298,15 @@ class TestEveryStacReadCarriesTheCredential:
         assert recorded[0].headers[_HEADER_NAME] == _KEY
 
     @pytest.mark.anyio
-    async def test_the_asset_probe_carries_it(self, stac_transport) -> None:
-        """An asset the catalog serves itself. Whether a credential reaches an
-        asset on ANOTHER origin is the resolve gate's decision, pinned in
-        TestTheCredentialStaysOnItsOrigin."""
+    async def test_the_asset_probe_never_carries_it(self, stac_transport) -> None:
+        """Titiler serves the asset out of process and cannot carry a
+        request-only credential, so a probe that used one would report
+        `healthy` for tiles that stay unreadable."""
         recorded = stac_transport(status=206)
-        result = await origin_probe.probe_remote_uri(
-            f"{_ROOT}/assets/scene.tif", credential=_header_key()
-        )
+        result = await origin_probe.probe_remote_uri(f"{_ROOT}/assets/scene.tif")
         assert result.ok
-        assert recorded[0].headers[_HEADER_NAME] == _KEY
-        # Still a ranged read: the credential is added, nothing is replaced.
+        assert _HEADER_NAME not in recorded[0].headers
+        assert "Authorization" not in recorded[0].headers
         assert recorded[0].headers["Range"] == "bytes=0-0"
 
     @pytest.mark.anyio
@@ -317,9 +315,9 @@ class TestEveryStacReadCarriesTheCredential:
     ) -> None:
         """`origin_probe` serves every origin kind, so it composes from the
         credential as bound rather than relabelling it."""
-        recorded = stac_transport(status=206)
-        await origin_probe.probe_remote_uri(
-            f"{_ROOT}/assets/scene.tif",
+        recorded = stac_transport(json_body={"id": "x", "assets": {}})
+        await origin_probe.fetch_json_document(
+            f"{_ROOT}/collections/c/items/x",
             credential=ServiceCredential(
                 method=CredentialMethod.HEADER_KEY,
                 header_name=_HEADER_NAME,
@@ -356,22 +354,6 @@ class TestTheCredentialStaysOnItsOrigin:
         # never went out, which is the property that matters.
         assert result.health == origin_probe.INACCESSIBLE
         assert document is None
-        assert len(recorded) == 1
-
-    @pytest.mark.anyio
-    async def test_a_cross_origin_redirect_is_refused_on_the_asset_probe(
-        self, stac_transport
-    ) -> None:
-        def redirect(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(
-                302, headers={"Location": "https://elsewhere.test/blob"}
-            )
-
-        recorded = stac_transport(redirect)
-        result = await origin_probe.probe_remote_uri(
-            "https://assets.test/scene.tif", credential=_header_key()
-        )
-        assert result.health == origin_probe.INACCESSIBLE
         assert len(recorded) == 1
 
     @pytest.mark.anyio
@@ -491,7 +473,11 @@ class TestTheCatalogChoosesTheCredentialNotTheDocument:
             catalog_origin=_ITEM_URL,
         )
         assert result.item_href == moved
-        assert all(request.headers[_HEADER_NAME] == _KEY for request in recorded)
+        # Every catalog read carries it; the asset probe is anonymous, since
+        # Titiler is what actually fetches that URL.
+        for request in recorded:
+            expected = _KEY if not request.url.path.endswith(".tif") else None
+            assert request.headers.get(_HEADER_NAME) == expected, request.url
 
     @pytest.mark.anyio
     async def test_an_anonymous_refresh_does_not_move_the_anchor(

--- a/e2e/stac-source-credentials.spec.ts
+++ b/e2e/stac-source-credentials.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect, type Page, type Route } from '@playwright/test';
+import { getAuthToken, getSearchSeed, type SearchSeed } from './helpers/catalog';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+
+/**
+ * Request-only authentication for STAC sources (feat(#1764)), from the two
+ * places a person types the credential: the import wizard's STAC tab and a
+ * STAC dataset's refresh dialog.
+ *
+ * Everything network-side is mocked with `page.route`, so nothing here needs
+ * a live protected catalog: `POST /api/services/stac/{connect,collections}`
+ * are fulfilled with a landing page and one collection, and the refresh door
+ * answers 422 `service_token_required` the way a marked STAC origin does.
+ *
+ * Navigation to the dataset goes through the search typeahead, not a direct
+ * `page.goto('/datasets/{id}')` — a hard goto of a protected route drops the
+ * session under the worktree Vite recipe (`AGENTS.md`).
+ */
+
+const SERVICE_TOKEN_MESSAGE =
+  "This dataset's source needed a credential the last time it was imported or refreshed, and this request carries none.";
+
+const STAC_ESCAPE_HATCH =
+  'If the catalog is public now, import the item again from the STAC catalog with no credential to clear this requirement.';
+
+let seed: SearchSeed;
+let baseDataset: Record<string, unknown>;
+
+test.beforeAll(async () => {
+  seed = await getSearchSeed();
+  const res = await fetch(`${BASE_URL}/api/datasets/${seed.id}`, {
+    headers: { Authorization: `Bearer ${getAuthToken()}` },
+  });
+  expect(res.ok).toBe(true);
+  baseDataset = await res.json();
+});
+
+test.describe('STAC import wizard credential block', () => {
+  test('a header-key credential reaches connect and collections as one auth object', async ({
+    page,
+  }) => {
+    const connectBodies: unknown[] = [];
+    const collectionBodies: unknown[] = [];
+
+    await page.route('**/api/services/stac/connect', (route: Route) => {
+      connectBodies.push(route.request().postDataJSON());
+      return route.fulfill({
+        json: {
+          url: 'https://catalog.example/v1',
+          catalog_id: 'e2e',
+          title: 'E2E Catalog',
+          description: '',
+          stac_version: '1.0.0',
+        },
+      });
+    });
+    await page.route('**/api/services/stac/collections', (route: Route) => {
+      collectionBodies.push(route.request().postDataJSON());
+      return route.fulfill({
+        json: { url: 'https://catalog.example/v1', collections: [] },
+      });
+    });
+
+    await page.goto('/import');
+    await page.getByRole('button', { name: 'STAC Catalog' }).click();
+
+    await expect(page.getByTestId('stac-credential-block')).toBeVisible();
+    await page
+      .getByPlaceholder('https://earth-search.aws.element84.com/v1')
+      .fill('https://catalog.example/v1');
+
+    // Radix Select: open by its accessible name, then pick the option.
+    await page.getByRole('combobox', { name: 'Authentication' }).click();
+    await page.getByRole('option', { name: 'API key in a header' }).click();
+    await page.getByLabel('Header name').fill('Ocp-Apim-Subscription-Key');
+    await page.getByLabel('Header value').fill('e2e-catalog-key');
+
+    await page.getByRole('button', { name: 'Connect' }).click();
+
+    await expect.poll(() => connectBodies.length).toBeGreaterThan(0);
+    const expected = {
+      auth: {
+        method: 'header',
+        header_name: 'Ocp-Apim-Subscription-Key',
+        header_value: 'e2e-catalog-key',
+      },
+    };
+    expect(connectBodies[0]).toMatchObject(expected);
+    expect(collectionBodies[0]).toMatchObject(expected);
+    // The deprecated flat field is not sent alongside the auth object; the
+    // door refuses a body that describes its credential twice.
+    expect((connectBodies[0] as { token?: unknown }).token).toBeUndefined();
+  });
+
+  test('no credential is sent when the method is left at none', async ({ page }) => {
+    const connectBodies: unknown[] = [];
+    await page.route('**/api/services/stac/connect', (route: Route) => {
+      connectBodies.push(route.request().postDataJSON());
+      return route.fulfill({
+        json: {
+          url: 'https://catalog.example/v1',
+          catalog_id: 'e2e',
+          title: 'E2E Catalog',
+          description: '',
+          stac_version: '1.0.0',
+        },
+      });
+    });
+    await page.route('**/api/services/stac/collections', (route: Route) =>
+      route.fulfill({ json: { url: 'https://catalog.example/v1', collections: [] } }),
+    );
+
+    await page.goto('/import');
+    await page.getByRole('button', { name: 'STAC Catalog' }).click();
+    await page
+      .getByPlaceholder('https://earth-search.aws.element84.com/v1')
+      .fill('https://catalog.example/v1');
+    await page.getByRole('button', { name: 'Connect' }).click();
+
+    await expect.poll(() => connectBodies.length).toBeGreaterThan(0);
+    expect((connectBodies[0] as { auth?: unknown }).auth).toBeUndefined();
+  });
+});
+
+function mockStacDataset(page: Page) {
+  return page.route(`**/api/datasets/${seed.id}`, (route: Route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    return route.fulfill({
+      json: { ...baseDataset, source_format: 'stac', origin: 'stac' },
+    });
+  });
+}
+
+async function openRefreshDialogAndSubmit(page: Page) {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  const searchInput = page.getByRole('combobox', { name: 'Search the catalog...' });
+  await searchInput.click();
+  await searchInput.fill(seed.query);
+  await expect(page.getByRole('option', { name: seed.title, exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
+  await searchInput.press('ArrowDown');
+  await searchInput.press('Enter');
+  await expect(page).toHaveURL(new RegExp(`/datasets/${seed.id}$`));
+
+  await page.getByRole('tab', { name: 'Source' }).click();
+  await page.getByRole('button', { name: 'Refresh from source' }).click();
+  await page.getByRole('button', { name: 'Start refresh' }).click();
+}
+
+test.describe('STAC refresh dialog credential prompt', () => {
+  test('a marked STAC origin shows its own escape hatch and never the raw response text', async ({
+    page,
+  }) => {
+    await mockStacDataset(page);
+    await page.route(`**/api/datasets/${seed.id}/refresh`, (route: Route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      return route.fulfill({
+        status: 422,
+        json: {
+          detail: { code: 'service_token_required', message: SERVICE_TOKEN_MESSAGE },
+        },
+      });
+    });
+
+    await openRefreshDialogAndSubmit(page);
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.getByText(STAC_ESCAPE_HATCH)).toBeVisible();
+    // The re-upload dialog is the WFS escape hatch and does not exist for a
+    // STAC dataset, so its copy must not be what the reader is shown.
+    await expect(page.getByText(/Re-Upload dialog/i)).toHaveCount(0);
+    await expect(page.locator('body')).not.toContainText(SERVICE_TOKEN_MESSAGE);
+  });
+
+  test('a bearer retry sends the structured auth object', async ({ page }) => {
+    await mockStacDataset(page);
+
+    let refreshCalls = 0;
+    let secondCallBody: unknown;
+    await page.route(`**/api/datasets/${seed.id}/refresh`, async (route: Route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      refreshCalls += 1;
+      if (refreshCalls === 1) {
+        return route.fulfill({
+          status: 422,
+          json: {
+            detail: { code: 'service_token_required', message: SERVICE_TOKEN_MESSAGE },
+          },
+        });
+      }
+      secondCallBody = route.request().postDataJSON();
+      return route.fulfill({
+        json: {
+          run_id: 'e2e-stac-run',
+          job_id: 'e2e-stac-job',
+          dataset_id: seed.id,
+          origin_kind: 'stac',
+          trigger: 'api',
+          status: 'pending',
+          message: 'Refresh queued from the stored STAC item',
+        },
+      });
+    });
+
+    await openRefreshDialogAndSubmit(page);
+
+    await page.getByLabel('Authentication', { exact: true }).selectOption('bearer');
+    await page.getByLabel('Bearer token', { exact: true }).fill('e2e-stac-token');
+    await page.getByRole('button', { name: 'Start refresh' }).click();
+
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+    expect(refreshCalls).toBe(2);
+    expect(secondCallBody).toMatchObject({
+      auth: { method: 'bearer', token: 'e2e-stac-token' },
+    });
+    expect((secondCallBody as { token?: unknown }).token).toBeFalsy();
+  });
+});

--- a/frontend/src/api/stac-import-session.ts
+++ b/frontend/src/api/stac-import-session.ts
@@ -91,12 +91,13 @@ export function startStacImport(
   items: StacImportItem[],
   context: StacImportContext,
   visibility?: string,
+  catalogAuthRequired?: boolean,
 ): StacImportSession {
   const key = sessionKey(url, items);
   if (current && current.key === key && current.status === 'pending') {
     return current;
   }
-  const promise = importStacItems(url, items, visibility);
+  const promise = importStacItems(url, items, visibility, catalogAuthRequired);
   const session: StacImportSession = {
     key,
     status: 'pending',

--- a/frontend/src/api/stac.ts
+++ b/frontend/src/api/stac.ts
@@ -39,13 +39,22 @@ export async function searchStacItems(request: StacSearchRequest): Promise<StacS
   });
 }
 
+// feat(#1764): `catalogAuthRequired` is a boolean, never the credential.
+// It marks the dataset so its first refresh asks for one instead of failing
+// anonymously against a catalog that needs it.
 export async function importStacItems(
   url: string,
   items: StacImportItem[],
   visibility: string = 'private',
+  catalogAuthRequired: boolean = false,
 ): Promise<StacImportResponse> {
   return apiFetch<StacImportResponse>('/services/stac/import', {
     method: 'POST',
-    body: JSON.stringify({ url, items, visibility }),
+    body: JSON.stringify({
+      url,
+      items,
+      visibility,
+      catalog_auth_required: catalogAuthRequired,
+    }),
   });
 }

--- a/frontend/src/api/stac.ts
+++ b/frontend/src/api/stac.ts
@@ -1,5 +1,6 @@
 import { apiFetch } from './client';
 import type {
+  ServiceAuthRequest,
   StacConnectResponse,
   StacCollectionsResponse,
   StacSearchRequest,
@@ -8,17 +9,26 @@ import type {
   StacImportResponse,
 } from '@/types/api';
 
-export async function connectStac(url: string): Promise<StacConnectResponse> {
+// feat(#1764): `auth` is applied to the call that carries it.
+// `/services/stac/import` takes none: it contacts no catalog, so accepting
+// one there would take a credential the request then drops.
+export async function connectStac(
+  url: string,
+  auth?: ServiceAuthRequest,
+): Promise<StacConnectResponse> {
   return apiFetch<StacConnectResponse>('/services/stac/connect', {
     method: 'POST',
-    body: JSON.stringify({ url }),
+    body: JSON.stringify({ url, ...(auth ? { auth } : {}) }),
   });
 }
 
-export async function fetchStacCollections(url: string): Promise<StacCollectionsResponse> {
+export async function fetchStacCollections(
+  url: string,
+  auth?: ServiceAuthRequest,
+): Promise<StacCollectionsResponse> {
   return apiFetch<StacCollectionsResponse>('/services/stac/collections', {
     method: 'POST',
-    body: JSON.stringify({ url }),
+    body: JSON.stringify({ url, ...(auth ? { auth } : {}) }),
   });
 }
 

--- a/frontend/src/components/dataset/SourceRefreshAction.tsx
+++ b/frontend/src/components/dataset/SourceRefreshAction.tsx
@@ -101,7 +101,10 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
   // threaded in as a prop so this component stays self-contained; it is the
   // same derivation DetailPanel uses for the REFRESHABLE_ORIGINS gate.
   const origin = dataset.origin ?? datasetOrigin(dataset);
-  const supportsToken = origin === 'service';
+  // feat(#1764): a STAC origin joined the credential path — its refresh
+  // re-reads the catalog over HTTP, so it takes the same four-way choice
+  // WFS and OGC API Features take. A registered table still takes none.
+  const supportsToken = origin === 'service' || origin === 'stac';
   // fix(#1755 item 4, plan 3.7): the two service families that can hit this
   // refusal read differently -- ArcGIS was asked a probe question and lost,
   // so it gets the full sign-in taxonomy; WFS and OGC API Features were
@@ -299,7 +302,14 @@ export function SourceRefreshAction({ dataset, watch }: SourceRefreshActionProps
                 />
                 {serviceTokenRequired && (
                   <p className="text-xs text-muted-foreground">
-                    {t('sourcePanel.refresh.credential.wfs.escapeHatch')}
+                    {/* feat(#1764): the way out differs by origin — a STAC
+                        dataset has no Re-Upload dialog, it is re-imported
+                        from the catalog. */}
+                    {t(
+                      origin === 'stac'
+                        ? 'sourcePanel.refresh.credential.stac.escapeHatch'
+                        : 'sourcePanel.refresh.credential.wfs.escapeHatch',
+                    )}
                   </p>
                 )}
               </div>

--- a/frontend/src/components/import/StacImportForm.tsx
+++ b/frontend/src/components/import/StacImportForm.tsx
@@ -32,6 +32,7 @@ import type {
   StacImportItem,
   StacImportResult,
 } from '@/types/api';
+import { originOf } from './utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -43,10 +44,9 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
-// feat(#1764): the four-way choice the backend's CredentialMethod enum names,
-// spelled the way the service wizard spells it. A separate copy rather than a
-// shared component for now, matching ServiceCredentialBlock's own note that
-// converging the two is a follow-up.
+// feat(#1764): the four-way choice the backend's CredentialMethod enum names.
+// A copy rather than a shared component, matching ServiceCredentialBlock's
+// own note that converging the two is a follow-up.
 type StacCredentialMethod = 'none' | 'bearer' | 'basic' | 'header';
 
 type Step =
@@ -99,11 +99,19 @@ export function StacImportForm() {
   const matchedCount = searchResult.matched;
   const selectableItems = useMemo(() => items.filter((i) => i.data_asset_href), [items]);
 
+  // fix(#1764): a failed Connect returns here with the credential intact, so
+  // editing the URL to another catalog would send the first catalog's key to
+  // the second. Same reset, same reason, as ServiceUrlForm's.
+  const authOrigin = originOf(url);
+  const lastAuthOriginRef = useRef(authOrigin);
+  useEffect(() => {
+    if (authOrigin === lastAuthOriginRef.current) return;
+    lastAuthOriginRef.current = authOrigin;
+    clearCredential('none');
+  }, [authOrigin]);
+
   // Switching methods discards the other branches' fields rather than
   // half-honouring them, mirroring the backend's own oneOf-shaped `auth`.
-  // No URL-origin reset beside it, unlike the service wizard: the URL and the
-  // credential are submitted together from one visible form here, so there is
-  // no window in which a credential outlives the address it was typed for.
   function clearCredential(next: StacCredentialMethod) {
     setCredentialMethod(next);
     setToken('');
@@ -113,10 +121,9 @@ export function StacImportForm() {
     setHeaderValue('');
   }
 
-  // The `ServiceAuthRequest` the credential block currently describes, or
-  // undefined for 'none' and for a method whose fields are incomplete — the
-  // door refuses a half-filled one, so staying anonymous until both fields
-  // are present matches how an empty optional token always behaved.
+  // The `ServiceAuthRequest` the credential block describes, or undefined for
+  // 'none' and for an incomplete method — the door refuses a half-filled one,
+  // so staying anonymous matches how an empty optional token behaved.
   function buildStacAuth(): ServiceAuthRequest | undefined {
     switch (credentialMethod) {
       case 'bearer':
@@ -824,9 +831,9 @@ export function StacImportForm() {
                 value={token}
                 onChange={(e) => setToken(e.target.value)}
                 className="font-mono text-sm"
-                // fix(#1746): a request-only service credential, not a login —
-                // autocomplete="off" alone does not stop Chrome offering a
-                // saved password, so opt every manager out explicitly.
+                // fix(#1746): autocomplete="off" alone does not stop Chrome
+                // offering a saved password on a service credential, so opt
+                // every password manager out explicitly.
                 autoComplete="new-password"
                 data-1p-ignore
                 data-lpignore="true"

--- a/frontend/src/components/import/StacImportForm.tsx
+++ b/frontend/src/components/import/StacImportForm.tsx
@@ -25,6 +25,7 @@ import {
   type StacImportContext,
 } from '@/api/stac-import-session';
 import type {
+  ServiceAuthRequest,
   StacConnectResponse,
   StacCollectionSummary,
   StacItemSummary,
@@ -32,6 +33,21 @@ import type {
   StacImportResult,
 } from '@/types/api';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+// feat(#1764): the four-way choice the backend's CredentialMethod enum names,
+// spelled the way the service wizard spells it. A separate copy rather than a
+// shared component for now, matching ServiceCredentialBlock's own note that
+// converging the two is a follow-up.
+type StacCredentialMethod = 'none' | 'bearer' | 'basic' | 'header';
 
 type Step =
   | 'idle'
@@ -47,6 +63,12 @@ export function StacImportForm() {
   const { t } = useTranslation('import');
   const [step, setStep] = useState<Step>('idle');
   const [url, setUrl] = useState('');
+  const [credentialMethod, setCredentialMethod] = useState<StacCredentialMethod>('none');
+  const [token, setToken] = useState('');
+  const [basicUsername, setBasicUsername] = useState('');
+  const [basicPassword, setBasicPassword] = useState('');
+  const [headerName, setHeaderName] = useState('');
+  const [headerValue, setHeaderValue] = useState('');
   const [catalogInfo, setCatalogInfo] = useState<StacConnectResponse | null>(null);
   const [collections, setCollections] = useState<StacCollectionSummary[]>([]);
   const [selectedCollection, setSelectedCollection] = useState<StacCollectionSummary | null>(null);
@@ -77,9 +99,45 @@ export function StacImportForm() {
   const matchedCount = searchResult.matched;
   const selectableItems = useMemo(() => items.filter((i) => i.data_asset_href), [items]);
 
+  // Switching methods discards the other branches' fields rather than
+  // half-honouring them, mirroring the backend's own oneOf-shaped `auth`.
+  // No URL-origin reset beside it, unlike the service wizard: the URL and the
+  // credential are submitted together from one visible form here, so there is
+  // no window in which a credential outlives the address it was typed for.
+  function clearCredential(next: StacCredentialMethod) {
+    setCredentialMethod(next);
+    setToken('');
+    setBasicUsername('');
+    setBasicPassword('');
+    setHeaderName('');
+    setHeaderValue('');
+  }
+
+  // The `ServiceAuthRequest` the credential block currently describes, or
+  // undefined for 'none' and for a method whose fields are incomplete — the
+  // door refuses a half-filled one, so staying anonymous until both fields
+  // are present matches how an empty optional token always behaved.
+  function buildStacAuth(): ServiceAuthRequest | undefined {
+    switch (credentialMethod) {
+      case 'bearer':
+        return token.trim() ? { method: 'bearer', token: token.trim() } : undefined;
+      case 'basic':
+        return basicUsername.trim() && basicPassword
+          ? { method: 'basic', username: basicUsername.trim(), password: basicPassword }
+          : undefined;
+      case 'header':
+        return headerName.trim() && headerValue
+          ? { method: 'header', header_name: headerName.trim(), header_value: headerValue }
+          : undefined;
+      default:
+        return undefined;
+    }
+  }
+
   const reset = () => {
     setStep('idle');
     setUrl('');
+    clearCredential('none');
     setCatalogInfo(null);
     setCollections([]);
     setSelectedCollection(null);
@@ -112,9 +170,10 @@ export function StacImportForm() {
     setError(null);
 
     try {
+      const auth = buildStacAuth();
       const [info, collectionsResult] = await Promise.all([
-        connectStac(trimmed),
-        fetchStacCollections(trimmed),
+        connectStac(trimmed, auth),
+        fetchStacCollections(trimmed, auth),
       ]);
       setCatalogInfo(info);
       setCollections(collectionsResult.collections);
@@ -134,10 +193,14 @@ export function StacImportForm() {
     setError(null);
 
     try {
+      // feat(#1764): the same credential the connect step used, so search
+      // sees what connect saw rather than the anonymous view.
+      const auth = buildStacAuth();
       const result = await searchStacItems({
         url: catalogInfo!.url,
         collections: [collection.id],
         limit: 50,
+        ...(auth ? { auth } : {}),
       });
       setSearchResult({ items: result.items, matched: result.matched });
       setSelectedItems(new Set());
@@ -722,6 +785,137 @@ export function StacImportForm() {
               </code>
             </span>
           </div>
+        </div>
+
+        <div className="space-y-3" data-testid="stac-credential-block">
+          <div className="space-y-2">
+            <Label htmlFor="stac-credential-method" className="text-xs text-muted-foreground">
+              {t('stac.credentialMethodLabel')}
+            </Label>
+            <Select
+              value={credentialMethod}
+              onValueChange={(value) => clearCredential(value as StacCredentialMethod)}
+            >
+              <SelectTrigger
+                id="stac-credential-method"
+                aria-label={t('stac.credentialMethodLabel')}
+                className="w-full"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">{t('stac.credentialMethodNone')}</SelectItem>
+                <SelectItem value="bearer">{t('stac.credentialMethodBearer')}</SelectItem>
+                <SelectItem value="basic">{t('stac.credentialMethodBasic')}</SelectItem>
+                <SelectItem value="header">{t('stac.credentialMethodHeader')}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {credentialMethod === 'bearer' && (
+            <div className="space-y-2">
+              <Label htmlFor="stac-credential-token" className="text-xs text-muted-foreground">
+                {t('stac.credentialTokenLabel')}
+              </Label>
+              <Input
+                id="stac-credential-token"
+                type="password"
+                placeholder={t('stac.credentialTokenPlaceholder')}
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                className="font-mono text-sm"
+                // fix(#1746): a request-only service credential, not a login —
+                // autocomplete="off" alone does not stop Chrome offering a
+                // saved password, so opt every manager out explicitly.
+                autoComplete="new-password"
+                data-1p-ignore
+                data-lpignore="true"
+                data-bwignore
+              />
+            </div>
+          )}
+
+          {credentialMethod === 'basic' && (
+            <div className="space-y-3 rounded-lg border border-border bg-surface-0 p-3.5">
+              <div className="space-y-2">
+                <Label htmlFor="stac-credential-username" className="text-xs text-muted-foreground">
+                  {t('stac.credentialUsernameLabel')}
+                </Label>
+                <Input
+                  id="stac-credential-username"
+                  type="text"
+                  autoComplete="username"
+                  placeholder={t('stac.credentialUsernamePlaceholder')}
+                  value={basicUsername}
+                  onChange={(e) => setBasicUsername(e.target.value)}
+                  className="text-sm"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="stac-credential-password" className="text-xs text-muted-foreground">
+                  {t('stac.credentialPasswordLabel')}
+                </Label>
+                <Input
+                  id="stac-credential-password"
+                  type="password"
+                  placeholder={t('stac.credentialPasswordPlaceholder')}
+                  value={basicPassword}
+                  onChange={(e) => setBasicPassword(e.target.value)}
+                  className="text-sm"
+                  autoComplete="new-password"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  data-bwignore
+                />
+              </div>
+            </div>
+          )}
+
+          {credentialMethod === 'header' && (
+            <div className="space-y-3 rounded-lg border border-border bg-surface-0 p-3.5">
+              <div className="space-y-2">
+                <Label
+                  htmlFor="stac-credential-header-name"
+                  className="text-xs text-muted-foreground"
+                >
+                  {t('stac.credentialHeaderNameLabel')}
+                </Label>
+                <Input
+                  id="stac-credential-header-name"
+                  type="text"
+                  autoComplete="off"
+                  placeholder={t('stac.credentialHeaderNamePlaceholder')}
+                  value={headerName}
+                  onChange={(e) => setHeaderName(e.target.value)}
+                  className="font-mono text-sm"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label
+                  htmlFor="stac-credential-header-value"
+                  className="text-xs text-muted-foreground"
+                >
+                  {t('stac.credentialHeaderValueLabel')}
+                </Label>
+                <Input
+                  id="stac-credential-header-value"
+                  type="password"
+                  placeholder={t('stac.credentialHeaderValuePlaceholder')}
+                  value={headerValue}
+                  onChange={(e) => setHeaderValue(e.target.value)}
+                  className="font-mono text-sm"
+                  autoComplete="new-password"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  data-bwignore
+                />
+              </div>
+            </div>
+          )}
+
+          {credentialMethod !== 'none' && (
+            <p className="text-xs text-muted-foreground">{t('stac.credentialHelpText')}</p>
+          )}
         </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}

--- a/frontend/src/components/import/StacImportForm.tsx
+++ b/frontend/src/components/import/StacImportForm.tsx
@@ -288,7 +288,16 @@ export function StacImportForm() {
       searchResult,
       selectedItemIds: Array.from(selectedItems),
     };
-    const session = startStacImport(catalogInfo!.url, importItems, context);
+    // feat(#1764): a boolean, never the credential. `/import` contacts no
+    // catalog, so this is the only way the dataset can learn that browsing
+    // this one needed a credential and its first refresh should ask for one.
+    const session = startStacImport(
+      catalogInfo!.url,
+      importItems,
+      context,
+      undefined,
+      buildStacAuth() !== undefined,
+    );
     try {
       const result = await session.promise;
       // fix(#1712): if this mount unmounted while the request was in

--- a/frontend/src/components/import/__tests__/StacImportForm.credential.test.tsx
+++ b/frontend/src/components/import/__tests__/StacImportForm.credential.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * feat(#1764) — the STAC import wizard's credential block.
+ *
+ * Three claims: the credential the user types reaches connect, collections
+ * and search as one `auth` object; switching methods discards the other
+ * branch's fields rather than sending a stale one; and an incomplete method
+ * sends nothing rather than a body the door would refuse.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import type { ReactNode } from 'react';
+import { StacImportForm } from '../StacImportForm';
+
+const mockConnectStac = vi.fn();
+const mockFetchStacCollections = vi.fn();
+const mockSearchStacItems = vi.fn();
+const mockImportStacItems = vi.fn();
+
+vi.mock('@/api/stac', () => ({
+  connectStac: (...args: unknown[]) => mockConnectStac(...args),
+  fetchStacCollections: (...args: unknown[]) => mockFetchStacCollections(...args),
+  searchStacItems: (...args: unknown[]) => mockSearchStacItems(...args),
+  importStacItems: (...args: unknown[]) => mockImportStacItems(...args),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <MemoryRouter>{children}</MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+}
+
+const CATALOG = {
+  id: 'test-catalog',
+  title: 'Test Catalog',
+  description: '',
+  stac_version: '1.0.0',
+  conforms_to: [],
+  url: 'https://catalog.test/v1',
+};
+
+const COLLECTION = {
+  id: 'test-col',
+  title: 'Test Collection',
+  description: '',
+  license: null,
+  keywords: [],
+  bbox: null,
+  temporal_start: null,
+  temporal_end: null,
+  item_count: 1,
+};
+
+// Radix Select needs these in jsdom.
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConnectStac.mockResolvedValue(CATALOG);
+  mockFetchStacCollections.mockResolvedValue({ collections: [COLLECTION] });
+  mockSearchStacItems.mockResolvedValue({ items: [], matched: 0, returned: 0 });
+});
+
+/** Choose a method in the credential select. */
+async function chooseMethod(user: ReturnType<typeof userEvent.setup>, label: string) {
+  await user.click(screen.getByLabelText('stac.credentialMethodLabel'));
+  await user.click(await screen.findByRole('option', { name: label }));
+}
+
+async function typeUrlAndConnect(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(
+    screen.getByPlaceholderText('https://earth-search.aws.element84.com/v1'),
+    'https://catalog.test/v1',
+  );
+  await user.click(screen.getByRole('button', { name: 'stac.connect' }));
+}
+
+describe('StacImportForm credential block', () => {
+  it('renders the credential block on the idle step', () => {
+    render(<StacImportForm />, { wrapper: Wrapper });
+    expect(screen.getByTestId('stac-credential-block')).toBeInTheDocument();
+  });
+
+  it('sends a header-key credential to connect and collections', async () => {
+    const user = userEvent.setup();
+    render(<StacImportForm />, { wrapper: Wrapper });
+
+    await chooseMethod(user, 'stac.credentialMethodHeader');
+    await user.type(
+      screen.getByLabelText('stac.credentialHeaderNameLabel'),
+      'Ocp-Apim-Subscription-Key',
+    );
+    await user.type(screen.getByLabelText('stac.credentialHeaderValueLabel'), 'k-secret');
+    await typeUrlAndConnect(user);
+
+    const expected = {
+      method: 'header',
+      header_name: 'Ocp-Apim-Subscription-Key',
+      header_value: 'k-secret',
+    };
+    await waitFor(() =>
+      expect(mockConnectStac).toHaveBeenCalledWith('https://catalog.test/v1', expected),
+    );
+    expect(mockFetchStacCollections).toHaveBeenCalledWith('https://catalog.test/v1', expected);
+  });
+
+  it('sends the same credential on the item search', async () => {
+    const user = userEvent.setup();
+    render(<StacImportForm />, { wrapper: Wrapper });
+
+    await chooseMethod(user, 'stac.credentialMethodBearer');
+    await user.type(screen.getByLabelText('stac.credentialTokenLabel'), 'tok-secret');
+    await typeUrlAndConnect(user);
+
+    await user.click(await screen.findByText('Test Collection'));
+    await waitFor(() =>
+      expect(mockSearchStacItems).toHaveBeenCalledWith(
+        expect.objectContaining({ auth: { method: 'bearer', token: 'tok-secret' } }),
+      ),
+    );
+  });
+
+  it('discards the previous method fields when the method changes', async () => {
+    const user = userEvent.setup();
+    render(<StacImportForm />, { wrapper: Wrapper });
+
+    await chooseMethod(user, 'stac.credentialMethodBearer');
+    await user.type(screen.getByLabelText('stac.credentialTokenLabel'), 'tok-secret');
+    await chooseMethod(user, 'stac.credentialMethodBasic');
+    await user.type(screen.getByLabelText('stac.credentialUsernameLabel'), 'reader');
+    await user.type(screen.getByLabelText('stac.credentialPasswordLabel'), 'pw');
+    await typeUrlAndConnect(user);
+
+    await waitFor(() => expect(mockConnectStac).toHaveBeenCalled());
+    const [, auth] = mockConnectStac.mock.calls[0];
+    expect(auth).toEqual({ method: 'basic', username: 'reader', password: 'pw' });
+    expect(JSON.stringify(auth)).not.toContain('tok-secret');
+  });
+
+  it('sends nothing while a method is incomplete', async () => {
+    const user = userEvent.setup();
+    render(<StacImportForm />, { wrapper: Wrapper });
+
+    await chooseMethod(user, 'stac.credentialMethodBasic');
+    await user.type(screen.getByLabelText('stac.credentialUsernameLabel'), 'reader');
+    await typeUrlAndConnect(user);
+
+    await waitFor(() => expect(mockConnectStac).toHaveBeenCalled());
+    expect(mockConnectStac).toHaveBeenCalledWith('https://catalog.test/v1', undefined);
+  });
+
+  it('sends no credential when the method is none', async () => {
+    const user = userEvent.setup();
+    render(<StacImportForm />, { wrapper: Wrapper });
+
+    await typeUrlAndConnect(user);
+    await waitFor(() => expect(mockConnectStac).toHaveBeenCalled());
+    expect(mockConnectStac).toHaveBeenCalledWith('https://catalog.test/v1', undefined);
+  });
+});

--- a/frontend/src/components/import/__tests__/StacImportForm.credential.test.tsx
+++ b/frontend/src/components/import/__tests__/StacImportForm.credential.test.tsx
@@ -1,10 +1,7 @@
 /**
- * feat(#1764) — the STAC import wizard's credential block.
- *
- * Three claims: the credential the user types reaches connect, collections
- * and search as one `auth` object; switching methods discards the other
- * branch's fields rather than sending a stale one; and an incomplete method
- * sends nothing rather than a body the door would refuse.
+ * feat(#1764) — the STAC import wizard's credential block. What is pinned:
+ * one `auth` object reaches connect, collections and search; a stale
+ * method's or a stale catalog's fields are never sent.
  */
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -87,11 +84,14 @@ async function chooseMethod(user: ReturnType<typeof userEvent.setup>, label: str
   await user.click(await screen.findByRole('option', { name: label }));
 }
 
-async function typeUrlAndConnect(user: ReturnType<typeof userEvent.setup>) {
-  await user.type(
-    screen.getByPlaceholderText('https://earth-search.aws.element84.com/v1'),
-    'https://catalog.test/v1',
-  );
+async function typeUrl(
+  user: ReturnType<typeof userEvent.setup>,
+  url = 'https://catalog.test/v1',
+) {
+  await user.type(screen.getByPlaceholderText('https://earth-search.aws.element84.com/v1'), url);
+}
+
+async function connect(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('button', { name: 'stac.connect' }));
 }
 
@@ -105,13 +105,14 @@ describe('StacImportForm credential block', () => {
     const user = userEvent.setup();
     render(<StacImportForm />, { wrapper: Wrapper });
 
+    await typeUrl(user);
     await chooseMethod(user, 'stac.credentialMethodHeader');
     await user.type(
       screen.getByLabelText('stac.credentialHeaderNameLabel'),
       'Ocp-Apim-Subscription-Key',
     );
     await user.type(screen.getByLabelText('stac.credentialHeaderValueLabel'), 'k-secret');
-    await typeUrlAndConnect(user);
+    await connect(user);
 
     const expected = {
       method: 'header',
@@ -128,9 +129,10 @@ describe('StacImportForm credential block', () => {
     const user = userEvent.setup();
     render(<StacImportForm />, { wrapper: Wrapper });
 
+    await typeUrl(user);
     await chooseMethod(user, 'stac.credentialMethodBearer');
     await user.type(screen.getByLabelText('stac.credentialTokenLabel'), 'tok-secret');
-    await typeUrlAndConnect(user);
+    await connect(user);
 
     await user.click(await screen.findByText('Test Collection'));
     await waitFor(() =>
@@ -144,12 +146,13 @@ describe('StacImportForm credential block', () => {
     const user = userEvent.setup();
     render(<StacImportForm />, { wrapper: Wrapper });
 
+    await typeUrl(user);
     await chooseMethod(user, 'stac.credentialMethodBearer');
     await user.type(screen.getByLabelText('stac.credentialTokenLabel'), 'tok-secret');
     await chooseMethod(user, 'stac.credentialMethodBasic');
     await user.type(screen.getByLabelText('stac.credentialUsernameLabel'), 'reader');
     await user.type(screen.getByLabelText('stac.credentialPasswordLabel'), 'pw');
-    await typeUrlAndConnect(user);
+    await connect(user);
 
     await waitFor(() => expect(mockConnectStac).toHaveBeenCalled());
     const [, auth] = mockConnectStac.mock.calls[0];
@@ -161,9 +164,10 @@ describe('StacImportForm credential block', () => {
     const user = userEvent.setup();
     render(<StacImportForm />, { wrapper: Wrapper });
 
+    await typeUrl(user);
     await chooseMethod(user, 'stac.credentialMethodBasic');
     await user.type(screen.getByLabelText('stac.credentialUsernameLabel'), 'reader');
-    await typeUrlAndConnect(user);
+    await connect(user);
 
     await waitFor(() => expect(mockConnectStac).toHaveBeenCalled());
     expect(mockConnectStac).toHaveBeenCalledWith('https://catalog.test/v1', undefined);
@@ -173,8 +177,32 @@ describe('StacImportForm credential block', () => {
     const user = userEvent.setup();
     render(<StacImportForm />, { wrapper: Wrapper });
 
-    await typeUrlAndConnect(user);
+    await typeUrl(user);
+    await connect(user);
     await waitFor(() => expect(mockConnectStac).toHaveBeenCalled());
     expect(mockConnectStac).toHaveBeenCalledWith('https://catalog.test/v1', undefined);
+  });
+
+  it('drops a credential typed for one catalog when the URL moves to another', async () => {
+    const user = userEvent.setup();
+    mockConnectStac.mockRejectedValueOnce(new Error('nope'));
+    render(<StacImportForm />, { wrapper: Wrapper });
+
+    await typeUrl(user);
+    await chooseMethod(user, 'stac.credentialMethodBearer');
+    await user.type(screen.getByLabelText('stac.credentialTokenLabel'), 'first-secret');
+    await connect(user);
+    await waitFor(() => expect(mockConnectStac).toHaveBeenCalledTimes(1));
+
+    await user.clear(
+      screen.getByPlaceholderText('https://earth-search.aws.element84.com/v1'),
+    );
+    await typeUrl(user, 'https://other.test/v1');
+    await connect(user);
+
+    await waitFor(() => expect(mockConnectStac).toHaveBeenCalledTimes(2));
+    // The first catalog got the key it was typed for; the second gets none.
+    expect(mockConnectStac).toHaveBeenLastCalledWith('https://other.test/v1', undefined);
+    expect(JSON.stringify(mockConnectStac.mock.calls[1])).not.toContain('first-secret');
   });
 });

--- a/frontend/src/components/import/__tests__/StacImportForm.credential.test.tsx
+++ b/frontend/src/components/import/__tests__/StacImportForm.credential.test.tsx
@@ -183,6 +183,60 @@ describe('StacImportForm credential block', () => {
     expect(mockConnectStac).toHaveBeenCalledWith('https://catalog.test/v1', undefined);
   });
 
+  it('tells import that browsing the catalog needed a credential', async () => {
+    const user = userEvent.setup();
+    mockSearchStacItems.mockResolvedValue({
+      items: [
+        {
+          id: 'item-1',
+          collection: 'test-col',
+          item_href: null,
+          title: 'item-1',
+          bbox: null,
+          datetime: null,
+          datetime_start: null,
+          datetime_end: null,
+          epsg: null,
+          gsd: null,
+          cloud_cover: null,
+          data_asset_href: 'https://catalog.test/v1/assets/a.tif',
+          data_asset_type: null,
+          data_asset_key: 'data',
+          data_asset_size_bytes: null,
+          thumbnail_href: null,
+          asset_count: 1,
+        },
+      ],
+      matched: 1,
+      returned: 1,
+    });
+    mockImportStacItems.mockResolvedValue({
+      created: 1,
+      skipped: 0,
+      errors: 0,
+      results: [{ item_id: 'item-1', dataset_id: 'ds-1', status: 'created', error: null }],
+    });
+    render(<StacImportForm />, { wrapper: Wrapper });
+
+    await typeUrl(user);
+    await chooseMethod(user, 'stac.credentialMethodBearer');
+    await user.type(screen.getByLabelText('stac.credentialTokenLabel'), 'tok-secret');
+    await connect(user);
+
+    await user.click(await screen.findByText('Test Collection'));
+    await user.click((await screen.findAllByRole('checkbox'))[0]);
+    await user.click(screen.getByRole('button', { name: /stac.importItems/i }));
+    await user.click(
+      await screen.findByRole('button', { name: /stac\.confirm\.confirmImport/i }),
+    );
+
+    await waitFor(() => expect(mockImportStacItems).toHaveBeenCalledTimes(1));
+    // A boolean, never the credential.
+    const call = mockImportStacItems.mock.calls[0];
+    expect(call[3]).toBe(true);
+    expect(JSON.stringify(call)).not.toContain('tok-secret');
+  });
+
   it('drops a credential typed for one catalog when the URL moves to another', async () => {
     const user = userEvent.setup();
     mockConnectStac.mockRejectedValueOnce(new Error('nope'));

--- a/frontend/src/i18n/locales/de/dataset.json
+++ b/frontend/src/i18n/locales/de/dataset.json
@@ -879,6 +879,9 @@
           "headerValueLabel": "Header-Wert",
           "headerValuePlaceholder": "Ihr API-Schlüssel",
           "helpText": "Ein Bearer-Token wird als Authorization-Header gesendet; Benutzername und Passwort werden als HTTP-Basic-Authentifizierung gesendet; ein API-Schlüssel kann unter dem vom Anbieter angegebenen Header-Namen gesendet werden, zum Beispiel X-API-Key, Ocp-Apim-Subscription-Key oder key."
+        },
+        "stac": {
+          "escapeHatch": "Wenn der Katalog jetzt öffentlich ist, importieren Sie das Item ohne Zugangsdaten erneut aus dem STAC-Katalog, um diese Anforderung aufzuheben."
         }
       },
       "history": {

--- a/frontend/src/i18n/locales/de/import.json
+++ b/frontend/src/i18n/locales/de/import.json
@@ -176,7 +176,23 @@
       "backToSelection": "Zurück zur Auswahl",
       "confirmImport_one": "{{count}} Objekt bestätigen und importieren",
       "confirmImport_other": "{{count}} Objekte bestätigen und importieren"
-    }
+    },
+    "credentialMethodLabel": "Authentifizierung",
+    "credentialMethodNone": "Keine Authentifizierung",
+    "credentialMethodBearer": "Bearer-Token",
+    "credentialMethodBasic": "Benutzername und Passwort",
+    "credentialMethodHeader": "API-Schlüssel in einem Header",
+    "credentialTokenLabel": "Bearer-Token",
+    "credentialTokenPlaceholder": "Bearer-Token einfügen",
+    "credentialUsernameLabel": "Benutzername",
+    "credentialUsernamePlaceholder": "Benutzername",
+    "credentialPasswordLabel": "Passwort",
+    "credentialPasswordPlaceholder": "Passwort",
+    "credentialHeaderNameLabel": "Header-Name",
+    "credentialHeaderNamePlaceholder": "z. B. Ocp-Apim-Subscription-Key",
+    "credentialHeaderValueLabel": "Header-Wert",
+    "credentialHeaderValuePlaceholder": "Ihr API-Schlüssel",
+    "credentialHelpText": "Wählen Sie die Methode, die Ihr Katalog dokumentiert. Ein Bearer-Token wird als Authorization-Header gesendet; Benutzername und Passwort werden als HTTP-Basic-Authentifizierung gesendet; ein API-Schlüssel kann unter dem vom Anbieter angegebenen Header-Namen gesendet werden, zum Beispiel X-API-Key, Ocp-Apim-Subscription-Key oder key. Sie authentifiziert den Katalog, seine Collections und seine Items; Kacheln werden aus der Asset-URL gerendert und tragen keine Zugangsdaten."
   },
   "serviceUrl": {
     "label": "Service-URL",

--- a/frontend/src/i18n/locales/en/dataset.json
+++ b/frontend/src/i18n/locales/en/dataset.json
@@ -830,6 +830,9 @@
           "headerValueLabel": "Header value",
           "headerValuePlaceholder": "Your API key",
           "helpText": "A bearer token is sent as an Authorization header; a username and password are sent as HTTP Basic auth; an API key can go under whatever header name the provider specifies — for example X-API-Key, Ocp-Apim-Subscription-Key, or key."
+        },
+        "stac": {
+          "escapeHatch": "If the catalog is public now, import the item again from the STAC catalog with no credential to clear this requirement."
         }
       },
       "history": {

--- a/frontend/src/i18n/locales/en/import.json
+++ b/frontend/src/i18n/locales/en/import.json
@@ -190,7 +190,23 @@
       "backToSelection": "Back to selection",
       "confirmImport_one": "Confirm and import {{count}} item",
       "confirmImport_other": "Confirm and import {{count}} items"
-    }
+    },
+    "credentialMethodLabel": "Authentication",
+    "credentialMethodNone": "No authentication",
+    "credentialMethodBearer": "Bearer token",
+    "credentialMethodBasic": "Username and password",
+    "credentialMethodHeader": "API key in a header",
+    "credentialTokenLabel": "Bearer token",
+    "credentialTokenPlaceholder": "Paste your bearer token",
+    "credentialUsernameLabel": "Username",
+    "credentialUsernamePlaceholder": "Username",
+    "credentialPasswordLabel": "Password",
+    "credentialPasswordPlaceholder": "Password",
+    "credentialHeaderNameLabel": "Header name",
+    "credentialHeaderNamePlaceholder": "e.g. Ocp-Apim-Subscription-Key",
+    "credentialHeaderValueLabel": "Header value",
+    "credentialHeaderValuePlaceholder": "Your API key",
+    "credentialHelpText": "Choose the method your catalog documents. A bearer token is sent as an Authorization header; a username and password are sent as HTTP Basic auth; an API key can go under whatever header name the provider specifies — for example X-API-Key, Ocp-Apim-Subscription-Key, or key. It authenticates the catalog, its collections and its items; tiles are rendered from the asset URL and carry no credential."
   },
   "serviceUrl": {
     "label": "Service URL",

--- a/frontend/src/i18n/locales/es/dataset.json
+++ b/frontend/src/i18n/locales/es/dataset.json
@@ -879,6 +879,9 @@
           "headerValueLabel": "Valor del encabezado",
           "headerValuePlaceholder": "Su clave API",
           "helpText": "Un token bearer se envía como encabezado Authorization; un usuario y contraseña se envían como autenticación HTTP Basic; una clave API puede enviarse bajo el nombre de encabezado que especifique el proveedor, por ejemplo X-API-Key, Ocp-Apim-Subscription-Key o key."
+        },
+        "stac": {
+          "escapeHatch": "Si el catálogo ya es público, vuelva a importar el elemento desde el catálogo STAC sin credencial para eliminar este requisito."
         }
       },
       "history": {

--- a/frontend/src/i18n/locales/es/import.json
+++ b/frontend/src/i18n/locales/es/import.json
@@ -176,7 +176,23 @@
       "backToSelection": "Volver a la selección",
       "confirmImport_one": "Confirmar e importar {{count}} elemento",
       "confirmImport_other": "Confirmar e importar {{count}} elementos"
-    }
+    },
+    "credentialMethodLabel": "Autenticación",
+    "credentialMethodNone": "Sin autenticación",
+    "credentialMethodBearer": "Token bearer",
+    "credentialMethodBasic": "Usuario y contraseña",
+    "credentialMethodHeader": "Clave API en un encabezado",
+    "credentialTokenLabel": "Token bearer",
+    "credentialTokenPlaceholder": "Pegue su token bearer",
+    "credentialUsernameLabel": "Usuario",
+    "credentialUsernamePlaceholder": "Usuario",
+    "credentialPasswordLabel": "Contraseña",
+    "credentialPasswordPlaceholder": "Contraseña",
+    "credentialHeaderNameLabel": "Nombre del encabezado",
+    "credentialHeaderNamePlaceholder": "p. ej. Ocp-Apim-Subscription-Key",
+    "credentialHeaderValueLabel": "Valor del encabezado",
+    "credentialHeaderValuePlaceholder": "Su clave API",
+    "credentialHelpText": "Elija el método que documenta su catálogo. Un token bearer se envía como encabezado Authorization; un usuario y contraseña se envían como autenticación HTTP Basic; una clave API puede enviarse bajo el nombre de encabezado que especifique el proveedor, por ejemplo X-API-Key, Ocp-Apim-Subscription-Key o key. Autentica el catálogo, sus colecciones y sus elementos; los teselados se generan desde la URL del recurso y no llevan credencial."
   },
   "serviceUrl": {
     "label": "URL de servicio",

--- a/frontend/src/i18n/locales/fr/dataset.json
+++ b/frontend/src/i18n/locales/fr/dataset.json
@@ -879,6 +879,9 @@
           "headerValueLabel": "Valeur de l'en-tête",
           "headerValuePlaceholder": "Votre clé API",
           "helpText": "Un jeton bearer est envoyé comme en-tête Authorization ; un nom d'utilisateur et un mot de passe sont envoyés en authentification HTTP Basic ; une clé API peut être envoyée sous le nom d'en-tête que le fournisseur indique, par exemple X-API-Key, Ocp-Apim-Subscription-Key ou key."
+        },
+        "stac": {
+          "escapeHatch": "Si le catalogue est désormais public, réimportez l'élément depuis le catalogue STAC sans information d'authentification pour lever cette exigence."
         }
       },
       "history": {

--- a/frontend/src/i18n/locales/fr/import.json
+++ b/frontend/src/i18n/locales/fr/import.json
@@ -176,7 +176,23 @@
       "backToSelection": "Retour à la sélection",
       "confirmImport_one": "Confirmer et importer {{count}} élément",
       "confirmImport_other": "Confirmer et importer {{count}} éléments"
-    }
+    },
+    "credentialMethodLabel": "Authentification",
+    "credentialMethodNone": "Aucune authentification",
+    "credentialMethodBearer": "Jeton bearer",
+    "credentialMethodBasic": "Nom d'utilisateur et mot de passe",
+    "credentialMethodHeader": "Clé API dans un en-tête",
+    "credentialTokenLabel": "Jeton bearer",
+    "credentialTokenPlaceholder": "Collez votre jeton bearer",
+    "credentialUsernameLabel": "Nom d'utilisateur",
+    "credentialUsernamePlaceholder": "Nom d'utilisateur",
+    "credentialPasswordLabel": "Mot de passe",
+    "credentialPasswordPlaceholder": "Mot de passe",
+    "credentialHeaderNameLabel": "Nom de l'en-tête",
+    "credentialHeaderNamePlaceholder": "p. ex. Ocp-Apim-Subscription-Key",
+    "credentialHeaderValueLabel": "Valeur de l'en-tête",
+    "credentialHeaderValuePlaceholder": "Votre clé API",
+    "credentialHelpText": "Choisissez la méthode documentée par votre catalogue. Un jeton bearer est envoyé comme en-tête Authorization ; un nom d'utilisateur et un mot de passe sont envoyés en authentification HTTP Basic ; une clé API peut être envoyée sous le nom d'en-tête que le fournisseur indique, par exemple X-API-Key, Ocp-Apim-Subscription-Key ou key. Elle authentifie le catalogue, ses collections et ses éléments ; les tuiles sont rendues depuis l'URL de la ressource et ne portent aucune information d'authentification."
   },
   "serviceUrl": {
     "label": "URL de service",

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -4515,6 +4515,8 @@ export interface paths {
         /**
          * Stac Collections
          * @description List collections from a connected STAC API.
+         *
+         *     Accepts a credential for a protected catalog, applied to this call.
          */
         post: operations["stac_collections_services_stac_collections_post"];
         delete?: never;
@@ -4535,6 +4537,8 @@ export interface paths {
         /**
          * Stac Connect
          * @description Connect to a STAC API and validate the endpoint.
+         *
+         *     Accepts a credential for a protected catalog, applied to this call.
          */
         post: operations["stac_connect_services_stac_connect_post"];
         delete?: never;
@@ -4579,6 +4583,8 @@ export interface paths {
         /**
          * Stac Search
          * @description Search items in a STAC API with spatial/temporal filters.
+         *
+         *     Accepts a credential for a protected catalog, applied to this call.
          */
         post: operations["stac_search_services_stac_search_post"];
         delete?: never;
@@ -12528,6 +12534,13 @@ export interface components {
              * @description STAC API root URL to connect to.
              */
             url: string;
+            /**
+             * Token
+             * @description Optional auth token for a protected STAC catalog. Deprecated: use the auth object with method bearer.
+             */
+            token?: string | null;
+            /** @description Structured credential for a protected service. Mutually exclusive with the token field. */
+            auth?: components["schemas"]["ServiceAuthRequest"] | null;
         };
         /** StacConnectResponse */
         StacConnectResponse: {
@@ -13061,6 +13074,13 @@ export interface components {
              * @default 20
              */
             limit: number;
+            /**
+             * Token
+             * @description Optional auth token for a protected STAC catalog. Deprecated: use the auth object with method bearer.
+             */
+            token?: string | null;
+            /** @description Structured credential for a protected service. Mutually exclusive with the token field. */
+            auth?: components["schemas"]["ServiceAuthRequest"] | null;
         };
         /** StacSearchResponse */
         StacSearchResponse: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -12667,6 +12667,12 @@ export interface components {
              * @enum {string}
              */
             visibility: "private" | "restricted" | "internal" | "public";
+            /**
+             * Catalog Auth Required
+             * @description Whether browsing this catalog needed a credential. Set it when the search that produced these items carried one, so the first refresh asks for a credential instead of failing anonymously.
+             * @default false
+             */
+            catalog_auth_required: boolean;
         };
         /** StacImportResponse */
         StacImportResponse: {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -2100,6 +2100,8 @@ export interface StacSearchRequest {
   bbox?: number[];
   datetime_range?: string;
   limit?: number;
+  // feat(#1764): a credential for a protected catalog, applied to this call.
+  auth?: ServiceAuthRequest;
 }
 
 export interface StacItemSummary {

--- a/sdks/python/geolens/api/stac_import/stac_collections_services_stac_collections_post.py
+++ b/sdks/python/geolens/api/stac_import/stac_collections_services_stac_collections_post.py
@@ -115,6 +115,8 @@ def sync_detailed(
 
      List collections from a connected STAC API.
 
+    Accepts a credential for a protected catalog, applied to this call.
+
     Args:
         body (StacConnectRequest):
 
@@ -146,6 +148,8 @@ def sync(
 
      List collections from a connected STAC API.
 
+    Accepts a credential for a protected catalog, applied to this call.
+
     Args:
         body (StacConnectRequest):
 
@@ -171,6 +175,8 @@ async def asyncio_detailed(
     """Stac Collections
 
      List collections from a connected STAC API.
+
+    Accepts a credential for a protected catalog, applied to this call.
 
     Args:
         body (StacConnectRequest):
@@ -200,6 +206,8 @@ async def asyncio(
     """Stac Collections
 
      List collections from a connected STAC API.
+
+    Accepts a credential for a protected catalog, applied to this call.
 
     Args:
         body (StacConnectRequest):

--- a/sdks/python/geolens/api/stac_import/stac_connect_services_stac_connect_post.py
+++ b/sdks/python/geolens/api/stac_import/stac_connect_services_stac_connect_post.py
@@ -110,6 +110,8 @@ def sync_detailed(
 
      Connect to a STAC API and validate the endpoint.
 
+    Accepts a credential for a protected catalog, applied to this call.
+
     Args:
         body (StacConnectRequest):
 
@@ -141,6 +143,8 @@ def sync(
 
      Connect to a STAC API and validate the endpoint.
 
+    Accepts a credential for a protected catalog, applied to this call.
+
     Args:
         body (StacConnectRequest):
 
@@ -166,6 +170,8 @@ async def asyncio_detailed(
     """Stac Connect
 
      Connect to a STAC API and validate the endpoint.
+
+    Accepts a credential for a protected catalog, applied to this call.
 
     Args:
         body (StacConnectRequest):
@@ -195,6 +201,8 @@ async def asyncio(
     """Stac Connect
 
      Connect to a STAC API and validate the endpoint.
+
+    Accepts a credential for a protected catalog, applied to this call.
 
     Args:
         body (StacConnectRequest):

--- a/sdks/python/geolens/api/stac_import/stac_search_services_stac_search_post.py
+++ b/sdks/python/geolens/api/stac_import/stac_search_services_stac_search_post.py
@@ -115,6 +115,8 @@ def sync_detailed(
 
      Search items in a STAC API with spatial/temporal filters.
 
+    Accepts a credential for a protected catalog, applied to this call.
+
     Args:
         body (StacSearchRequest):
 
@@ -146,6 +148,8 @@ def sync(
 
      Search items in a STAC API with spatial/temporal filters.
 
+    Accepts a credential for a protected catalog, applied to this call.
+
     Args:
         body (StacSearchRequest):
 
@@ -171,6 +175,8 @@ async def asyncio_detailed(
     """Stac Search
 
      Search items in a STAC API with spatial/temporal filters.
+
+    Accepts a credential for a protected catalog, applied to this call.
 
     Args:
         body (StacSearchRequest):
@@ -200,6 +206,8 @@ async def asyncio(
     """Stac Search
 
      Search items in a STAC API with spatial/temporal filters.
+
+    Accepts a credential for a protected catalog, applied to this call.
 
     Args:
         body (StacSearchRequest):

--- a/sdks/python/geolens/models/stac_connect_request.py
+++ b/sdks/python/geolens/models/stac_connect_request.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+if TYPE_CHECKING:
+    from ..models.service_auth_request import ServiceAuthRequest
 
 
 T = TypeVar("T", bound="StacConnectRequest")
@@ -15,13 +22,35 @@ class StacConnectRequest:
     """
     Attributes:
         url (str): STAC API root URL to connect to.
+        token (None | str | Unset): Optional auth token for a protected STAC catalog. Deprecated: use the auth object
+            with method bearer.
+        auth (None | ServiceAuthRequest | Unset): Structured credential for a protected service. Mutually exclusive with
+            the token field.
     """
 
     url: str
+    token: None | str | Unset = UNSET
+    auth: None | ServiceAuthRequest | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.service_auth_request import ServiceAuthRequest
+
         url = self.url
+
+        token: None | str | Unset
+        if isinstance(self.token, Unset):
+            token = UNSET
+        else:
+            token = self.token
+
+        auth: dict[str, Any] | None | Unset
+        if isinstance(self.auth, Unset):
+            auth = UNSET
+        elif isinstance(self.auth, ServiceAuthRequest):
+            auth = self.auth.to_dict()
+        else:
+            auth = self.auth
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -30,16 +59,50 @@ class StacConnectRequest:
                 "url": url,
             }
         )
+        if token is not UNSET:
+            field_dict["token"] = token
+        if auth is not UNSET:
+            field_dict["auth"] = auth
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.service_auth_request import ServiceAuthRequest
+
         d = dict(src_dict)
         url = d.pop("url")
 
+        def _parse_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        token = _parse_token(d.pop("token", UNSET))
+
+        def _parse_auth(data: object) -> None | ServiceAuthRequest | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                auth_type_0 = ServiceAuthRequest.from_dict(data)
+
+                return auth_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | ServiceAuthRequest | Unset, data)
+
+        auth = _parse_auth(d.pop("auth", UNSET))
+
         stac_connect_request = cls(
             url=url,
+            token=token,
+            auth=auth,
         )
 
         stac_connect_request.additional_properties = d

--- a/sdks/python/geolens/models/stac_import_request.py
+++ b/sdks/python/geolens/models/stac_import_request.py
@@ -25,11 +25,15 @@ class StacImportRequest:
         url (str): STAC API URL for provenance.
         items (list[StacImportItem]): Items to import (max 50 per request).
         visibility (StacImportRequestVisibility | Unset): Visibility for imported datasets. Default: 'private'.
+        catalog_auth_required (bool | Unset): Whether browsing this catalog needed a credential. Set it when the search
+            that produced these items carried one, so the first refresh asks for a credential instead of failing
+            anonymously. Default: False.
     """
 
     url: str
     items: list[StacImportItem]
     visibility: StacImportRequestVisibility | Unset = "private"
+    catalog_auth_required: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -44,6 +48,8 @@ class StacImportRequest:
         if not isinstance(self.visibility, Unset):
             visibility = self.visibility
 
+        catalog_auth_required = self.catalog_auth_required
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -54,6 +60,8 @@ class StacImportRequest:
         )
         if visibility is not UNSET:
             field_dict["visibility"] = visibility
+        if catalog_auth_required is not UNSET:
+            field_dict["catalog_auth_required"] = catalog_auth_required
 
         return field_dict
 
@@ -78,10 +86,13 @@ class StacImportRequest:
         else:
             visibility = check_stac_import_request_visibility(_visibility)
 
+        catalog_auth_required = d.pop("catalog_auth_required", UNSET)
+
         stac_import_request = cls(
             url=url,
             items=items,
             visibility=visibility,
+            catalog_auth_required=catalog_auth_required,
         )
 
         stac_import_request.additional_properties = d

--- a/sdks/python/geolens/models/stac_search_request.py
+++ b/sdks/python/geolens/models/stac_search_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -9,6 +9,9 @@ from attrs import field as _attrs_field
 from ..types import UNSET, Unset
 
 from typing import cast
+
+if TYPE_CHECKING:
+    from ..models.service_auth_request import ServiceAuthRequest
 
 
 T = TypeVar("T", bound="StacSearchRequest")
@@ -23,6 +26,10 @@ class StacSearchRequest:
         bbox (list[float] | None | Unset): Bounding box filter as [west, south, east, north].
         datetime_range (None | str | Unset): Temporal filter in STAC datetime format (e.g. '2023-01-01/2023-12-31').
         limit (int | Unset): Maximum items to return. Default: 20.
+        token (None | str | Unset): Optional auth token for a protected STAC catalog. Deprecated: use the auth object
+            with method bearer.
+        auth (None | ServiceAuthRequest | Unset): Structured credential for a protected service. Mutually exclusive with
+            the token field.
     """
 
     url: str
@@ -30,9 +37,13 @@ class StacSearchRequest:
     bbox: list[float] | None | Unset = UNSET
     datetime_range: None | str | Unset = UNSET
     limit: int | Unset = 20
+    token: None | str | Unset = UNSET
+    auth: None | ServiceAuthRequest | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.service_auth_request import ServiceAuthRequest
+
         url = self.url
 
         collections: list[str] | None | Unset
@@ -61,6 +72,20 @@ class StacSearchRequest:
 
         limit = self.limit
 
+        token: None | str | Unset
+        if isinstance(self.token, Unset):
+            token = UNSET
+        else:
+            token = self.token
+
+        auth: dict[str, Any] | None | Unset
+        if isinstance(self.auth, Unset):
+            auth = UNSET
+        elif isinstance(self.auth, ServiceAuthRequest):
+            auth = self.auth.to_dict()
+        else:
+            auth = self.auth
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -76,11 +101,17 @@ class StacSearchRequest:
             field_dict["datetime_range"] = datetime_range
         if limit is not UNSET:
             field_dict["limit"] = limit
+        if token is not UNSET:
+            field_dict["token"] = token
+        if auth is not UNSET:
+            field_dict["auth"] = auth
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.service_auth_request import ServiceAuthRequest
+
         d = dict(src_dict)
         url = d.pop("url")
 
@@ -129,12 +160,40 @@ class StacSearchRequest:
 
         limit = d.pop("limit", UNSET)
 
+        def _parse_token(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        token = _parse_token(d.pop("token", UNSET))
+
+        def _parse_auth(data: object) -> None | ServiceAuthRequest | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                auth_type_0 = ServiceAuthRequest.from_dict(data)
+
+                return auth_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | ServiceAuthRequest | Unset, data)
+
+        auth = _parse_auth(d.pop("auth", UNSET))
+
         stac_search_request = cls(
             url=url,
             collections=collections,
             bbox=bbox,
             datetime_range=datetime_range,
             limit=limit,
+            token=token,
+            auth=auth,
         )
 
         stac_search_request.additional_properties = d

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -5068,6 +5068,8 @@ export const probeServiceUrlServicesProbePost = <ThrowOnError extends boolean = 
  * Stac Collections
  *
  * List collections from a connected STAC API.
+ *
+ * Accepts a credential for a protected catalog, applied to this call.
  */
 export const stacCollectionsServicesStacCollectionsPost = <ThrowOnError extends boolean = false>(options: Options<StacCollectionsServicesStacCollectionsPostData, ThrowOnError>): RequestResult<StacCollectionsServicesStacCollectionsPostResponses, StacCollectionsServicesStacCollectionsPostErrors, ThrowOnError> => (options.client ?? client).post<StacCollectionsServicesStacCollectionsPostResponses, StacCollectionsServicesStacCollectionsPostErrors, ThrowOnError>({
     security: [
@@ -5091,6 +5093,8 @@ export const stacCollectionsServicesStacCollectionsPost = <ThrowOnError extends 
  * Stac Connect
  *
  * Connect to a STAC API and validate the endpoint.
+ *
+ * Accepts a credential for a protected catalog, applied to this call.
  */
 export const stacConnectServicesStacConnectPost = <ThrowOnError extends boolean = false>(options: Options<StacConnectServicesStacConnectPostData, ThrowOnError>): RequestResult<StacConnectServicesStacConnectPostResponses, StacConnectServicesStacConnectPostErrors, ThrowOnError> => (options.client ?? client).post<StacConnectServicesStacConnectPostResponses, StacConnectServicesStacConnectPostErrors, ThrowOnError>({
     security: [
@@ -5141,6 +5145,8 @@ export const stacImportServicesStacImportPost = <ThrowOnError extends boolean = 
  * Stac Search
  *
  * Search items in a STAC API with spatial/temporal filters.
+ *
+ * Accepts a credential for a protected catalog, applied to this call.
  */
 export const stacSearchServicesStacSearchPost = <ThrowOnError extends boolean = false>(options: Options<StacSearchServicesStacSearchPostData, ThrowOnError>): RequestResult<StacSearchServicesStacSearchPostResponses, StacSearchServicesStacSearchPostErrors, ThrowOnError> => (options.client ?? client).post<StacSearchServicesStacSearchPostResponses, StacSearchServicesStacSearchPostErrors, ThrowOnError>({
     security: [

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -9781,6 +9781,12 @@ export type StacImportRequest = {
      * Visibility for imported datasets.
      */
     visibility?: 'private' | 'restricted' | 'internal' | 'public';
+    /**
+     * Catalog Auth Required
+     *
+     * Whether browsing this catalog needed a credential. Set it when the search that produced these items carried one, so the first refresh asks for a credential instead of failing anonymously.
+     */
+    catalog_auth_required?: boolean;
 };
 
 /**

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -9612,6 +9612,16 @@ export type StacConnectRequest = {
      * STAC API root URL to connect to.
      */
     url: string;
+    /**
+     * Token
+     *
+     * Optional auth token for a protected STAC catalog. Deprecated: use the auth object with method bearer.
+     */
+    token?: string | null;
+    /**
+     * Structured credential for a protected service. Mutually exclusive with the token field.
+     */
+    auth?: ServiceAuthRequest | null;
 };
 
 /**
@@ -10234,6 +10244,16 @@ export type StacSearchRequest = {
      * Maximum items to return.
      */
     limit?: number;
+    /**
+     * Token
+     *
+     * Optional auth token for a protected STAC catalog. Deprecated: use the auth object with method bearer.
+     */
+    token?: string | null;
+    /**
+     * Structured credential for a protected service. Mutually exclusive with the token field.
+     */
+    auth?: ServiceAuthRequest | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

A STAC catalog behind an API key could not be imported or refreshed. The adapter, the five resolve modules and the refresh task all fetched anonymously, and the refresh door refused a credential outright with `credential_not_applicable`. This is the request-only credential path from decision D4 of the service-auth design, on the same shape WFS and OGC API Features already use.

Closes #1764

## Changes

- **The credential is anchored on the catalog the caller submitted.** The binding records `url`, the catalog root the user typed at import and the only value on it the catalog never chose, and the refresh anchors on that. A binding from before the key existed has no anchor, so a credentialed refresh of one is refused with a message naming the fix; an anonymous refresh is unchanged. The item pointer is fenced to that origin at both write sites: search no longer publishes an off-origin `rel=self` link and the import door refuses one.
- **Authenticated-search provenance reaches the import as a boolean.** `catalog_auth_required` marks the dataset so its first refresh prompts, instead of being dispatched anonymously, failing at a protected item URL, and leaving no marker for the next attempt to key on. Never the secret.
- **A search result that reflects the credential is not returned.** Only `item_href` passed `storable_href` on the search path; every other field is echoed back to `/import` by the client, whose own request registers no credential and so cannot recognise one, and is then stored. Judged over the whole feature, since `id`, `collection` and `title` reach storage too.
- **The asset probe is anonymous.** Titiler fetches the asset URL out of process and cannot carry a request-only credential, so probing with one would record `healthy` for tiles that stay unreadable. The probe asks the question the tiler asks.
- **The stored pointer stays on the catalog origin.** An off-origin `rel=self` link is never adopted, credentialed or not. The pointer is the origin every later refresh sends its credential to, so an anonymous refresh adopting a mirror would move that anchor and the next credentialed refresh would hand the mirror the key on its first read.
- **The credential goes to the catalog origin and nowhere else.** An item document names its own `rel=self` link and its asset hrefs, and both are fetched first-hop, where no redirect hook runs. `credential_for_read` applies the rule the repo already uses for a service-described address: the document chose the address and does not get to choose the credential. The catalog origin is threaded from the worker beside the credential so it cannot drift with the document. An off-origin self link is dropped rather than fetched, which also keeps the stored pointer on the catalog across refreshes; an off-origin asset is probed anonymously, because a catalog serving assets from someone else's bucket is the ordinary case rather than a refusal.
- **Every STAC read GeoLens makes over httpx now carries the credential**: the catalog landing page, `/collections`, `/search`, the item document, the item's `rel=self` link, the fallback search, and the asset probe. Each composes its own header from `build_credential_header` at the write site, so the single-producer rule holds without a new allowlist entry.
- **Format vocabulary**: `HEADER_LINE_SERVICE_FORMATS` joins `HEADER_AUTH_SERVICE_FORMATS` in `core/service_tokens.py`. STAC is a header-line format that is not a header-file one, so it accepts all three methods and crosses the queue as a line, while nothing writes it to the GDAL header file and `assert_endpoints_stay_on_origin` stays a WFS/OAPIF check. A STAC bearer token is judged as a header value rather than base64url, on the same reasoning that already exempts ArcGIS.
- **A stored href can no longer reflect the caller's own credential.** A catalog can hand the credential back inside a URL it publishes, under any query parameter name; `has_url_credentials` allowlists names, not values, so an unlisted one reached `origin_ref["asset_href"]`, `origin_uri` and the asset row Titiler is handed, against the published "Never contains credentials" and ADR-002 invariant 4. `carries_registered_credential` asks the exact-value question `scrub_secret_value` already answers destructively, and `storable_href` refuses on it. That is the one gate both the asset href and the `rel=self` link pass, so a poisoned asset takes the existing `_ASSET_UNUSABLE` verdict and a poisoned self link is dropped while the working pointer stays.
- **The single-use credential is claimed after phase 1 and inside the handled region**, the placement `tasks_reupload` records. Claiming above it spent the secret on a superseded attempt and let `CredentialExpiredError` escape unwritten, leaving the run pending and every later refresh answering 409 `dataset_busy` until the stale sweep. Credential failures map to `credential_expired` / `credential_store_unavailable`, as the service path does.
- **Refresh**: `_dispatch_stac_refresh` stages the credential in the single-use store the service path uses and passes only the reference to the worker. `refresh_stac` claims it once and recovers the credential from the wire line with the new `credential_from_header_line`, so its own reads compose through the one producer rather than carrying a finished header.
- **Marked origins**: a successful credentialed refresh writes `auth_required` on the stac `origin_ref`; a token-less refresh of a marked dataset is refused with `service_token_required` rather than dispatched to collect a 401. A token-less success clears it. The decision is re-applied after the reservation, through the helper the service path already uses, because a credentialed refresh finishing inside that window marks the dataset without moving its origin.
- **Frontend**: the STAC import tab gains the four-way credential block the service tab offers, and a STAC dataset's refresh dialog gains the credential block with its own escape-hatch copy. All new strings are in en, es, fr and de.

## API and schema impact

- `StacConnectRequest` and `StacSearchRequest` gain `auth` (the shared `ServiceAuthRequest`) and the deprecated `token`, both declared last so no positional SDK caller shifts. `/services/stac/connect`, `/services/stac/collections` and `/services/stac/search` accept them.
- `/services/stac/import` deliberately takes neither. It contacts no catalog, so accepting a credential there would take one the request then drops.
- `ORIGIN_REF_KEYS["stac"]` gains `url` and `auth_required`, the latter with the same True-or-absent rule the service kind uses. `StacImportRequest` gains `catalog_auth_required`, a boolean declared last. No table or column changes, so no migration.
- Regenerated: `backend/openapi.json`, both SDKs, `frontend/src/types/api.generated.ts`.

## Security invariants, and the test that pins each

| Invariant | Test |
| --- | --- |
| An asset href reflecting the credential is refused | `test_stac_service_auth_1764.py::test_an_asset_href_reflecting_the_credential_is_refused` |
| A self link reflecting it is not adopted as the stored pointer | `...::test_a_self_link_reflecting_the_credential_is_not_adopted` |
| An ordinary query string on a credentialed refresh is untouched | `...::test_an_href_carrying_no_credential_is_still_stored` |
| Search does not publish an off-origin self link | `test_stac_service_auth_1764.py::test_search_does_not_publish_an_off_origin_self_link` |
| A same-origin self link is still published | `...::test_search_still_publishes_a_same_origin_self_link` |
| The import door refuses an off-origin item pointer | `test_stac_import.py::test_import_refuses_an_off_origin_item_href` |
| Import records the catalog and the auth marker | `...::test_import_records_the_catalog_and_the_auth_marker` |
| The marker stays absent on an anonymous import | `...::test_import_leaves_the_marker_absent_by_default` |
| A binding recording no catalog refuses a credential | `test_stac_refresh_1266.py::test_a_binding_recording_no_catalog_refuses_a_credential` |
| That binding still refreshes anonymously | `...::test_the_same_binding_still_refreshes_anonymously` |
| The wizard tells import a credential was used, as a boolean | `StacImportForm.credential.test.tsx` |
| The door and the builder reach one bearer verdict | `test_stac_service_auth_1764.py::test_the_door_reaches_the_builders_bearer_verdict` |
| A search item reflecting the credential is not returned | `test_stac_service_auth_1764.py::test_an_item_reflecting_the_credential_is_not_returned` |
| A reflection in a non-href field is caught too | `...::test_a_reflection_in_a_non_href_field_is_caught_too` |
| A short credential does not refuse an unrelated href | `...::test_a_one_character_key_does_not_refuse_an_unrelated_href` |
| A short credential is still caught as a whole value | `...::test_a_one_character_key_is_still_caught_as_a_whole_value` |
| The asset probe never carries the credential | `...::test_the_asset_probe_never_carries_it` |
| An anonymous refresh does not move the anchor off the catalog | `test_stac_service_auth_1764.py::test_an_anonymous_refresh_does_not_move_the_anchor` |
| An anonymous same-origin self link is still adopted | `...::test_an_anonymous_same_origin_self_link_is_still_adopted` |
| A self link and an asset on other origins get no credential | `test_stac_service_auth_1764.py::test_a_self_link_and_an_asset_on_other_origins_get_no_credential` |
| A self link on the catalog origin is still followed with it | `...::test_a_self_link_on_the_catalog_origin_is_still_followed` |
| An anonymous resolution is unchanged by the gate | `...::test_an_anonymous_resolution_is_unchanged` |
| A credential bound to no format composes no header | `...::test_an_unbound_credential_composes_no_header` |
| A spent credential is recorded as a failed run, not escaped | `test_stac_refresh_1266.py::test_a_spent_credential_is_recorded_as_a_failed_run` |
| A credential typed for one catalog is dropped when the URL moves | `StacImportForm.credential.test.tsx` |
| A credential header is not followed across an origin change on the item read | `test_stac_service_auth_1764.py::test_a_cross_origin_redirect_is_refused_on_the_item_read` |
| Nor on the asset probe | `...::test_a_cross_origin_redirect_is_refused_on_the_asset_probe` |
| A same-origin redirect still carries it | `...::test_a_same_origin_redirect_still_follows` |
| The adapter declares the header, so the refusal is loud rather than a silent strip | `...::test_the_adapter_declares_the_header_to_the_client` |
| A refused credential value never reaches a 422 body | `test_stac_refresh_1266.py::test_a_credential_the_rules_refuse_never_reaches_a_response` |
| Nor a builder message | `test_stac_service_auth_1764.py::test_the_builder_message_never_carries_the_value` |
| Nor a log line on a failed read | `...::test_a_failed_read_logs_no_credential` |
| Only a reference crosses to the worker, never the secret | `test_stac_refresh_1266.py::test_a_credential_is_staged_by_reference_never_as_an_argument` |
| The credential is in no stored pointer, `source_url` or run error message | `test_stac_refresh_1266.py::test_every_read_carries_the_credential_and_the_marker_is_written` |
| A spent credential fails the run rather than fetching anonymously | `...::test_a_spent_credential_fails_rather_than_fetching_anonymously` |
| A marked dataset refuses a token-less refresh | `...::test_a_marked_dataset_refuses_a_token_less_refresh` |
| A marker that appears inside the reservation window is caught | `...::test_a_marker_that_appears_during_the_reservation_is_caught` |
| The wire line recomposes to itself for all three methods | `test_stac_service_auth_1764.py::test_a_line_recomposes_to_itself` |
| A line that cannot round-trip yields no credential rather than a guess | `...::test_a_line_it_cannot_round_trip_yields_no_credential` |

`validate_url_for_ssrf` stays at submission time on every door, unchanged. No GDAL path carries a STAC credential, so no header file is written and `GDAL_HTTP_FOLLOWLOCATION` is untouched.

## Known limits

`router_health.py` is not in this diff and is unchanged. It probes a STAC origin without a credential and records the verdict, so a health check after a successful credentialed refresh can overwrite a healthy verdict with an auth failure. The service path behaves the same way, so this is consistent with it rather than introduced here, and changing it belongs to both paths at once.

Tiles are rendered by Titiler, a separate process that fetches the asset URL itself, so an asset that needs a credential still cannot be tiled or re-described. The refresh reports that as `inaccessible` rather than adopting a pointer it could not read. Signed-href providers such as Planetary Computer, whose credential mints a short-lived asset URL at fetch time, are the same shape and are not implemented here. Both need a tiler-side credential path, which is a follow-up.

## Area

- [x] Backend (API, services, models)
- [x] Frontend (UI, components, hooks)
- [ ] Infrastructure (Docker, nginx)
- [ ] Tiles / Rendering
- [x] Auth / Permissions
- [x] Import / Ingestion
- [ ] OGC / Standards
- [ ] Docs / Config

## Review

Three codex rounds. Round 1 raised two findings, both fixed: search-result asset hrefs bypassed the reflection gate, and the gate's unfloored substring match would have refused legitimate URLs for a short credential. Round 2 raised two, both fixed: the item pointer was not fenced at import, so it was not a trustworthy anchor for the credential, and authenticated-search provenance did not reach the import. Round 3 raised one P2 with no P1, fixed: the door applied the GDAL header-file charset to every bearer token, refusing a STAC key the builder accepts.

Every finding was reproduced by running its new test against the code with the fix removed, and each reply on the PR names the test that pins it.

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)
- [ ] Manual testing (describe below)
- [x] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)

Backend, all green: `test_stac_service_auth_1764.py` (34 new), `test_stac_refresh_1266.py` (118), `test_stac_import.py`, `test_credential_producer_structural.py`, `test_credential_policy.py`, `test_credential_secret_registration_1857.py`, `test_sources_safe_client_structural.py`, `test_rule1_structural.py`, `test_rule2_structural.py`, `test_service_auth_contract_1746.py`, `test_service_auth_transport_1746.py`, `test_service_refresh_1220.py`, `test_arcgis_auth.py`, `test_arcgis_header_transport_c2.py`, `test_cross_origin_credential_1746.py`, `test_refresh_gate_1269.py`, `test_layering.py`, `test_sdks_round_trip.py`.

Gates: `ruff check`, `ruff format --check`, `finding_markers.py`, `make openapi-check`, `make sdks-check`, `make cli-test`, `make mcp-test`, and from `frontend/`: `npm run build`, `lint`, `typecheck`, `types:check`, `test:i18n`, `test:coverage` (457 files, 6055 tests).

`e2e/stac-source-credentials.spec.ts` covers the wizard's credential block and the STAC refresh dialog's credential path. Six tests pass against a Vite server built from this branch. It is not in a smoke group, matching `dataset-refresh-credentials.spec.ts`.

Three existing tests changed rather than being added to, because this PR changes what they pinned: `test_credential_policy.py` and `test_arcgis_header_transport_c2.py` listed `stac` among the formats with no credential path, and `test_stac_refresh_1266.py` pinned the refresh door's `credential_not_applicable` refusal.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [x] Migration included (if DB schema changed) — not applicable, no schema change
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check`
