### PR TITLE
fix(tiles): key cached tile responses on the publication version (#2007)

### DIFF
--- a/backend/app/core/tile_scope.py
+++ b/backend/app/core/tile_scope.py
@@ -1,4 +1,4 @@
-"""The signed scope a tile template carries.
+"""What a tile template carries: its signed scope and its cache-key version.
 
 One derivation for every minter and every verifier. A divergence between the
 two is a silent authorization bypass rather than a test failure, so this lives
@@ -7,6 +7,8 @@ without a port, which no overlay can replace on one side only.
 """
 
 from __future__ import annotations
+
+from urllib.parse import urlencode
 
 from app.core.tenancy import tenant_bound_scope
 
@@ -25,3 +27,36 @@ def tile_signature_scope(resource: str, publication_version: int | None) -> str:
     ordinary edit. A NULL counter reads as 0 on both sides.
     """
     return tenant_bound_scope(f"{resource}:p{int(publication_version or 0)}")
+
+
+TILE_PUBLICATION_VERSION_PARAM = "pv"
+
+
+def tile_template_params(
+    tile_cache_version: int | None, publication_version: int | None
+) -> dict[str, int]:
+    """Return the cache-key query params an emitted tile template carries.
+
+    ``v`` is the content version nginx's raster cache already keys on (#1372).
+    ``pv`` is the publication version: a status or visibility transition rolls
+    it, so a template the product emits afterwards cannot read an entry stored
+    before the change (#2007). Neither can hold a credential, which is what
+    makes them safe cache-key segments.
+
+    A falsy ``v`` is omitted, keeping the unversioned form older clients send.
+    ``pv`` is always present, because 0 is a real counter value.
+    """
+    params: dict[str, int] = {}
+    if tile_cache_version:
+        params["v"] = int(tile_cache_version)
+    params[TILE_PUBLICATION_VERSION_PARAM] = int(publication_version or 0)
+    return params
+
+
+def tile_template_query(
+    tile_cache_version: int | None, publication_version: int | None
+) -> str:
+    """:func:`tile_template_params` as the query string of a tile template."""
+    return "?" + urlencode(
+        tile_template_params(tile_cache_version, publication_version)
+    )

--- a/backend/app/core/tile_scope.py
+++ b/backend/app/core/tile_scope.py
@@ -60,3 +60,37 @@ def tile_template_query(
     return "?" + urlencode(
         tile_template_params(tile_cache_version, publication_version)
     )
+
+
+# The vector tile routes a stored distribution row can name. A raster row is
+# never stored: ``published_distributions`` synthesizes that entry per request.
+_STORED_TILE_TEMPLATE_PREFIXES = ("/tiles/data.", "/tiles/clusters/data.")
+
+
+def republished_tile_url(url: str, publication_version: int | None) -> str:
+    """Return a stored tile template carrying the CURRENT publication version.
+
+    A ``record_distributions`` row is written once at ingest, so it cannot hold
+    a value that rolls (#2007). A feed republishes the row's template with the
+    dataset's counter instead of as stored, which is the same reason the raster
+    template is synthesized per request rather than persisted.
+
+    Any other URL, including an operator's own link to another service, is
+    returned untouched. Other query params on the row survive; a stale ``pv``
+    on it does not.
+    """
+    base, _, query = url.partition("?")
+    if not base.startswith(_STORED_TILE_TEMPLATE_PREFIXES):
+        return url
+    # Split raw rather than decoding: a shared cache reads the name the same
+    # way, so a stale `pv` is dropped by exactly the spelling that would key it.
+    kept = [
+        pair
+        for pair in query.split("&")
+        if pair and pair.split("=", 1)[0].lower() != TILE_PUBLICATION_VERSION_PARAM
+    ]
+    kept += [
+        f"{name}={value}"
+        for name, value in tile_template_params(None, publication_version).items()
+    ]
+    return f"{base}?{'&'.join(kept)}"

--- a/backend/app/modules/catalog/datasets/domain/helpers.py
+++ b/backend/app/modules/catalog/datasets/domain/helpers.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
+from app.core.tile_scope import tile_template_query
 from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.source_freshness import (
     compute_source_freshness,
@@ -72,12 +73,12 @@ def _build_raster_metadata(
     # fix(#821): ?api_key= is deprecated, but desktop GIS XYZ tile clients
     # can't send headers -- this placeholder is the sanctioned remaining use.
     tile_url_path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
-    # fix(#1372): `v` is tile_cache_version -- nginx keys raster_cache on
-    # $arg_v, so a replace rolls the cache. connect URL stays unversioned:
-    # it's copied once into GIS tools, where a frozen `v` pins staleness.
-    tile_version = getattr(dataset, "tile_cache_version", None)
-    tile_url_meta = (
-        f"{tile_url_path}?v={tile_version}" if tile_version else tile_url_path
+    # fix(#1372, #2007): nginx keys raster_cache on `v` and `pv`, so a replace
+    # or a publication transition rolls the cache. connect URL stays
+    # unversioned: copied once into GIS tools, a frozen pair pins staleness.
+    tile_url_meta = tile_url_path + tile_template_query(
+        getattr(dataset, "tile_cache_version", None),
+        getattr(dataset, "publication_version", None),
     )
 
     if base_url:

--- a/backend/app/modules/catalog/maps/service_public.py
+++ b/backend/app/modules/catalog/maps/service_public.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.identity import Identity
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
+from app.core.tile_scope import tile_template_query
 from app.core.text import escape_ilike
 from app.modules.auth.models import User
 from app.modules.catalog.authorization import apply_visibility_filter
@@ -351,6 +352,7 @@ def _build_shared_layer_dict(
     ds_is_dem: bool | None,
     ds_dem_vertical_units: str | None,
     ds_tile_version: int | None,
+    ds_publication_version: int | None,
     ds_attribution: str | None,
 ) -> tuple[dict, bool]:
     """Build a shared-layer response dict from a joined layer row.
@@ -359,16 +361,21 @@ def _build_shared_layer_dict(
     """
     is_public = ds_visibility == "public"
     if ds_record_type in RASTER_FAMILY_RECORD_TYPES:
-        tile_url = f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png"
-        # fix(#1372): version the raster template so nginx's $arg_v cache-key
-        # segment rolls the shared tile cache when a replace bumps the version.
-        if ds_tile_version:
-            tile_url = f"{tile_url}?v={ds_tile_version}"
+        # fix(#1372, #2007): version the raster template so nginx's $arg_v and
+        # $arg_pv cache-key segments roll the shared tile cache when a replace
+        # or a publication transition bumps either counter.
+        tile_url = f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png" + (
+            tile_template_query(ds_tile_version, ds_publication_version)
+        )
     else:
         # No `/tiles/public/...` route exists
         # — the single `/tiles` catch-all does its own auth check
         # (visibility + HMAC-or-anonymous), so every consumer uses one URL.
-        tile_url = f"/tiles/data.{ds_table_name}/{{z}}/{{x}}/{{y}}.pbf"
+        # fix(#2007): this template is unsigned, so `pv` is the only thing
+        # carrying the publication counter a shared cache keys it on.
+        tile_url = f"/tiles/data.{ds_table_name}/{{z}}/{{x}}/{{y}}.pbf" + (
+            tile_template_query(None, ds_publication_version)
+        )
     return {
         "id": str(layer.id),
         "dataset_id": str(layer.dataset_id),
@@ -471,6 +478,7 @@ async def get_shared_map(
             # current_version only changes on reupload, so feature edits and
             # column DDL never rolled the _v= param (stale CDN/browser tiles).
             Dataset.tile_cache_version,
+            Dataset.publication_version,
             Record.attribution,
         )
         .join(Map, Map.id == MapLayer.map_id)
@@ -542,6 +550,7 @@ async def get_shared_map(
         ds_is_dem,
         ds_band_info,
         ds_tile_version,
+        ds_publication_version,
         ds_attribution,
     ) in layer_rows:
         layer_dict, is_non_public = _build_shared_layer_dict(
@@ -557,6 +566,7 @@ async def get_shared_map(
             ds_is_dem,
             _extract_dem_vertical_units(ds_band_info),
             ds_tile_version,
+            ds_publication_version,
             ds_attribution,
         )
         if is_non_public:

--- a/backend/app/modules/catalog/maps/style_json.py
+++ b/backend/app/modules/catalog/maps/style_json.py
@@ -39,7 +39,11 @@ from app.modules.catalog.maps.style_sanitizers import (
     finite_number as _finite_number,
 )
 from app.platform.extensions import get_catalog_port
-from app.core.tile_scope import tile_signature_scope
+from app.core.tile_scope import (
+    tile_signature_scope,
+    tile_template_params,
+    tile_template_query,
+)
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
 
 __all__ = ["ImportedStyleMap", "build_maplibre_style", "parse_maplibre_style_import"]
@@ -343,19 +347,22 @@ def _tile_url_for_layer(layer: MapLayerResponse) -> str:
         layer.layer_type == "raster_geolens"
         or layer.dataset_record_type in RASTER_FAMILY_RECORD_TYPES
     ):
-        url = f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png"
-        # fix(#1372): version the raster template so nginx's $arg_v cache-key
-        # segment rolls the shared tile cache when a replace bumps the version.
-        if layer.tile_version:
-            url = f"{url}?v={layer.tile_version}"
-        return url
+        # fix(#1372, #2007): version the raster template so nginx's $arg_v and
+        # $arg_pv cache-key segments roll the shared tile cache when a replace
+        # or a publication transition bumps either counter.
+        return f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png" + (
+            tile_template_query(layer.tile_version, layer.publication_version)
+        )
     port = get_catalog_port()
     exp = port.round_tile_expiry()
     scope = tile_signature_scope(layer.dataset_table_name, layer.publication_version)
+    # fix(#2007): the counter is inside `scope` for the signature to bind, and
+    # beside it as `pv` because that is the name both cache layers key on.
     params: dict[str, Any] = {
         "sig": port.generate_tile_signature(scope, exp),
         "exp": exp,
         "scope": scope,
+        **tile_template_params(None, layer.publication_version),
     }
     # Include the stable attribute projection needed by data-driven styles at z<10.
     cols = _data_driven_columns_for_layer(layer)

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.core.identity import Identity
+from app.core.tile_scope import republished_tile_url
 from app.modules.audit.service import AuditEvent, audit_emit
 from app.modules.auth.dependencies import get_optional_user, require_permission
 from app.modules.catalog.authorization import (
@@ -58,6 +59,7 @@ from app.modules.catalog.records.service import (
     list_distributions,
     list_keywords,
     list_translations,
+    record_publication_version,
     upsert_translation,
     delete_translation,
     update_contact,
@@ -666,8 +668,16 @@ async def list_distributions_endpoint(
         await list_distributions(db, record_id, skip=skip, limit=limit),
         await count_distributions(db, record_id),
     )
+    # fix(#2007): the Connect panel copies the vector template out of this
+    # endpoint, so republish it at the dataset's counter like every feed does.
+    counter = await record_publication_version(db, record_id)
     return DistributionListResponse(
-        distributions=[DistributionResponse.model_validate(d) for d in distributions],
+        distributions=[
+            DistributionResponse.model_validate(d).model_copy(
+                update={"url": republished_tile_url(d.url, counter)}
+            )
+            for d in distributions
+        ],
         total=total,
     )
 

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -11,6 +11,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.catalog.datasets.domain.models import (
+    Dataset,
     Record,
     RecordContact,
     RecordDistribution,
@@ -307,6 +308,22 @@ async def delete_keyword(
 # ---------------------------------------------------------------------------
 # Distributions
 # ---------------------------------------------------------------------------
+
+
+async def record_publication_version(
+    session: AsyncSession, record_id: uuid.UUID
+) -> int | None:
+    """The counter a stored tile template on this record is republished at.
+
+    fix(#2007): a distribution row is written once at ingest, so the vector
+    template it stores has to be rewritten at read time to name the dataset's
+    current publication version. None when the record has no dataset.
+    """
+    return (
+        await session.execute(
+            select(Dataset.publication_version).where(Dataset.record_id == record_id)
+        )
+    ).scalar_one_or_none()
 
 
 async def list_distributions(

--- a/backend/app/modules/catalog/search/router.py
+++ b/backend/app/modules/catalog/search/router.py
@@ -46,6 +46,7 @@ from app.standards.ogc.utils import (
 from app.standards.ogc.errors import BAD_REQUEST_RESPONSE, ERROR_RESPONSES_PUBLIC
 from app.core.geo import extent_to_bbox, rollup_bbox, rollup_bbox_columns
 from app.core.public_urls import get_public_api_url, get_public_app_url
+from app.core.tile_scope import tile_template_query
 from app.modules.catalog.search.schemas import (
     FacetCountResponse,
     OGCCollectionMetadataResponse,
@@ -875,11 +876,11 @@ async def list_collections(
                 }
             )
         else:
-            # fix(#1372): versioned like every rendered template so a
+            # fix(#1372, #2007): versioned like every rendered template so a
             # refetching client stops sharing the unversioned cache entry.
-            raster_tiles_path = f"/raster-tiles/{ds.id}/tiles/{{z}}/{{x}}/{{y}}.png"
-            if ds.tile_cache_version:
-                raster_tiles_path = f"{raster_tiles_path}?v={ds.tile_cache_version}"
+            raster_tiles_path = f"/raster-tiles/{ds.id}/tiles/{{z}}/{{x}}/{{y}}.png" + (
+                tile_template_query(ds.tile_cache_version, ds.publication_version)
+            )
             links.append(
                 {
                     "rel": "tiles",

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -15,7 +15,7 @@ import structlog
 from app.core.config import settings
 from app.core.raster_bands import band_display_name, stac_band_nodata
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
-from app.core.tile_scope import tile_template_query
+from app.core.tile_scope import republished_tile_url, tile_template_query
 from app.modules.catalog.datasets.domain.models import Dataset
 from app.modules.catalog.datasets.domain.source_freshness import (
     compute_source_freshness,
@@ -408,8 +408,16 @@ def dataset_to_ogc_record(
                 {
                     "type": d.distribution_type,
                     "format": d.format,
+                    # fix(#2007): as in published_distributions -- a stored
+                    # vector-tile template cannot hold a counter that rolls.
                     "url": (
-                        build_url(d.url, base_url=public_api_url)
+                        build_url(
+                            republished_tile_url(
+                                d.url,
+                                getattr(dataset, "publication_version", None),
+                            ),
+                            base_url=public_api_url,
+                        )
                         if d.url.startswith("/")
                         else d.url
                     ),

--- a/backend/app/modules/catalog/search/service_records.py
+++ b/backend/app/modules/catalog/search/service_records.py
@@ -15,6 +15,7 @@ import structlog
 from app.core.config import settings
 from app.core.raster_bands import band_display_name, stac_band_nodata
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
+from app.core.tile_scope import tile_template_query
 from app.modules.catalog.datasets.domain.models import Dataset
 from app.modules.catalog.datasets.domain.source_freshness import (
     compute_source_freshness,
@@ -97,7 +98,10 @@ def build_assets(
         if dataset.table_name is not None:
             assets["vector_tiles"] = {
                 "href": build_url(
-                    f"/tiles/data.{dataset.table_name}/{{z}}/{{x}}/{{y}}.pbf",
+                    f"/tiles/data.{dataset.table_name}/{{z}}/{{x}}/{{y}}.pbf"
+                    + tile_template_query(
+                        None, getattr(dataset, "publication_version", None)
+                    ),
                     base_url=public_api_url,
                 ),
                 "type": "application/vnd.mapbox-vector-tile",
@@ -115,12 +119,18 @@ def build_assets(
             }
 
     elif record_type in RASTER_FAMILY_RECORD_TYPES:
-        # Public APP origin, not /api. fix(#1372): versioned so a refetching
-        # STAC/OGC client stops sharing the unversioned cache entry.
-        raster_tiles_path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
-        tile_version = getattr(dataset, "tile_cache_version", None)
-        if tile_version:
-            raster_tiles_path = f"{raster_tiles_path}?v={tile_version}"
+        # Public APP origin, not /api. fix(#1372, #2007): versioned so a
+        # refetching STAC/OGC client stops sharing the unversioned entry, and
+        # a publication transition rolls what it may share.
+        raster_tiles_path = (
+            f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
+            + (
+                tile_template_query(
+                    getattr(dataset, "tile_cache_version", None),
+                    getattr(dataset, "publication_version", None),
+                )
+            )
+        )
         assets["raster_tiles"] = {
             "href": build_url(
                 raster_tiles_path,

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -35,6 +35,10 @@ from app.core.geo import (
 )
 from app.core.identity import Identity
 from app.core.record_types import RASTER_FAMILY_RECORD_TYPES
+from app.core.tile_scope import (
+    TILE_PUBLICATION_VERSION_PARAM,
+    tile_template_params,
+)
 from app.modules.auth.dependencies import (
     capability_declined,
     get_optional_user,
@@ -613,6 +617,31 @@ def _require_tile_tenant_context() -> str | None:
     return tenant_id
 
 
+def _cache_key_arg_values(request: Request, name: str) -> list[str]:
+    """Every value nginx's ``$arg_<name>`` could resolve, in query order.
+
+    nginx matches an arg NAME case-insensitively and reads the FIRST
+    occurrence, while ``QueryParams.get()`` returns the LAST occurrence of an
+    exact-case name. Both cache-key params are read through here so the edge
+    and the api cannot disagree about which value keyed an entry.
+    """
+    return [
+        value
+        for arg_name, value in request.query_params.multi_items()
+        if arg_name.lower() == name
+    ]
+
+
+def _cache_key_version_mismatch(values: list[str], current: int) -> bool:
+    """Whether a cache-key version param disagrees with the row it names.
+
+    An ABSENT param is not a mismatch: an unversioned client (a copied connect
+    URL) keys on the empty segment and keeps the old bounded staleness. A
+    duplicated one is, since the two layers would read different occurrences.
+    """
+    return bool(values) and (len(values) != 1 or values[0] != str(current))
+
+
 def _meta_cache_version_segment(raw: str | None) -> str | None:
     """Normalize a request's ``v`` into a raster meta cache-key segment.
 
@@ -891,11 +920,7 @@ async def raster_auth_check(
     # fix(#1372): nginx keys on the FIRST occurrence of `v` and matches the
     # name case-insensitively; `QueryParams.get()` returns the LAST occurrence
     # of an exact-case name. Read once, because two decisions below use it.
-    v_values = [
-        value
-        for name, value in request.query_params.multi_items()
-        if name.lower() == "v"
-    ]
+    v_values = _cache_key_arg_values(request, "v")
     meta, storage_backend = await _resolve_raster_access(
         db,
         dataset_id,
@@ -918,10 +943,14 @@ async def raster_auth_check(
     # fix(#1372): a shared-cache entry may only be written under the
     # CURRENT version, or a caller pre-warms the NEXT key with pre-replace
     # bytes. So: exactly one case-insensitive `v`, or served no-store.
-    if (
-        cache_status == "public"
-        and v_values
-        and (len(v_values) != 1 or v_values[0] != str(meta.tile_cache_version))
+    # fix(#2007): and on the publication version, or a mismatched `pv`
+    # pre-warms the key the next unpublish makes current.
+    if cache_status == "public" and (
+        _cache_key_version_mismatch(v_values, meta.tile_cache_version)
+        or _cache_key_version_mismatch(
+            _cache_key_arg_values(request, TILE_PUBLICATION_VERSION_PARAM),
+            meta.publication_version,
+        )
     ):
         cache_status = "private"
     if meta.is_dem:
@@ -1313,12 +1342,19 @@ def _build_tile_token_for_dataset(
         )
         raster_sig = generate_tile_signature(raster_scope, raster_exp)
         tile_path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
-        # fix(#1372): `v` rides outside the signature (which binds scope+exp
-        # only, like the colormap params) and feeds nginx's $arg_v cache-key
-        # segment, so a raster replace rolls the shared tile cache.
-        query_params = {"sig": raster_sig, "exp": raster_exp, "scope": raster_scope}
-        if dataset.tile_cache_version:
-            query_params["v"] = dataset.tile_cache_version
+        # fix(#1372, #2007): `v` and `pv` ride outside the signature (which
+        # binds scope+exp only) and feed nginx's cache-key segments, so a
+        # replace or a publication transition rolls the shared tile cache.
+        query_params: dict[str, Any] = {
+            "sig": raster_sig,
+            "exp": raster_exp,
+            "scope": raster_scope,
+        }
+        query_params.update(
+            tile_template_params(
+                dataset.tile_cache_version, dataset.publication_version
+            )
+        )
         query = urlencode(query_params)
 
         return RasterTileToken(
@@ -1734,6 +1770,23 @@ async def _assert_dataset_still_registered(
     )
 
 
+def _demote_prewarmed_cache_scope(
+    request: Request, meta: _DatasetMeta, cache_scope: str
+) -> str:
+    """Refuse the shared cache to a request whose ``pv`` names another row state.
+
+    fix(#2007): the emitted vector template carries the publication version, so
+    a caller supplying the counter an unpublish is about to make current would
+    otherwise fill that key with bytes from before the transition.
+    """
+    if cache_scope == "public" and _cache_key_version_mismatch(
+        _cache_key_arg_values(request, TILE_PUBLICATION_VERSION_PARAM),
+        meta.publication_version,
+    ):
+        return "private"
+    return cache_scope
+
+
 async def _authorize_vector_tile_request(
     request: Request,
     meta: _DatasetMeta,
@@ -1860,8 +1913,11 @@ def _ensure_clusterable_dataset(meta: _DatasetMeta) -> None:
         )
 
 
-def _generation_table_key(table_name: str, dataset_id: uuid.UUID) -> str:
-    """Table segment plus the generation that makes a reused name safe.
+def _generation_table_key(
+    table_name: str, dataset_id: uuid.UUID, publication_version: int
+) -> str:
+    """Table segment, the generation that makes a reused name safe, and the
+    publication version that makes a superseded entry unreachable.
 
     A cache key of the table name alone would let the next dataset to draw
     ``roads`` read the previous one's cached bytes under its own visibility.
@@ -1869,17 +1925,22 @@ def _generation_table_key(table_name: str, dataset_id: uuid.UUID) -> str:
     impossible rather than merely short-lived — GH-1443's name-retirement
     is not relied on for this.
 
-    Position is load-bearing: the id goes AFTER the table segment so the
+    fix(#2007): the publication version joins them, so bytes cached while the
+    dataset was public and published stop being reachable the moment a status
+    or visibility transition rolls it, rather than serving out the TTL.
+
+    Position is load-bearing: both segments go AFTER the table name so the
     ``tile:{table}:*`` patterns in ``invalidate_table`` still match every
     key for a table, whichever dataset wrote it.
     """
-    return f"{table_name}:ds{dataset_id.hex}"
+    return f"{table_name}:ds{dataset_id.hex}:p{publication_version}"
 
 
 def _cluster_cache_table_key(
     table_name: str,
     *,
     dataset_id: uuid.UUID,
+    publication_version: int,
     cluster_radius: int,
     cluster_max_zoom: int,
 ) -> str:
@@ -1887,7 +1948,7 @@ def _cluster_cache_table_key(
     # _build_cluster_tile_query changes the emitted tile geometry/properties, or a
     # deploy keeps serving stale cluster tiles until TTL expiry. v2 -> v3: #874.
     return (
-        f"{_generation_table_key(table_name, dataset_id)}"
+        f"{_generation_table_key(table_name, dataset_id, publication_version)}"
         f":cluster:v3:r{cluster_radius}:z{cluster_max_zoom}"
     )
 
@@ -2095,6 +2156,7 @@ async def cluster_tile_endpoint(
         scope=scope,
         user=user,
     )
+    cache_scope = _demote_prewarmed_cache_scope(request, meta, cache_scope)
     # fix(#1518): after authorization, not before. "Not a point dataset"
     # is a property of the RESOURCE, and it told an unauthorized caller that a
     # private dataset exists and what geometry it holds.
@@ -2124,6 +2186,7 @@ async def cluster_tile_endpoint(
     cluster_cache_key = _cluster_tenant_prefix + _cluster_cache_table_key(
         table_name,
         dataset_id=meta.dataset_id,
+        publication_version=meta.publication_version,
         cluster_radius=cluster_radius,
         cluster_max_zoom=cluster_max_zoom,
     )
@@ -2284,6 +2347,7 @@ async def tile_endpoint(
         scope=scope,
         user=user,
     )
+    cache_scope = _demote_prewarmed_cache_scope(request, meta, cache_scope)
 
     columns = meta.column_info
 
@@ -2300,7 +2364,9 @@ async def tile_endpoint(
     # tenants sharing a table_name never share a cached tile binary.
     # single_tenant: no prefix, byte-identical to pre-1209.
     _tile_tid = _require_tile_tenant_context()
-    _tile_generation_key = _generation_table_key(table_name, meta.dataset_id)
+    _tile_generation_key = _generation_table_key(
+        table_name, meta.dataset_id, meta.publication_version
+    )
     _tile_cache_key = (
         f"{_tile_tid}:{_tile_generation_key}"
         if _tile_tid is not None

--- a/backend/app/processing/tiles/router.py
+++ b/backend/app/processing/tiles/router.py
@@ -1625,6 +1625,11 @@ async def _resolve_dataset_meta(table_name: str, db: AsyncSession) -> _DatasetMe
     query adds a ``tenant_id`` filter, closing the cross-dataset authz leak
     on the data plane. In ``single_tenant`` the key is the bare
     ``table_name``, byte-identical to pre-1209.
+
+    fix(#2007): the tile cache key is derived from THIS snapshot, the same one
+    that decides visibility and record_status, so it can never be staler than
+    the authorization that admitted the request. Re-reading the counter alone
+    would leave that decision on the stale row and fix nothing.
     """
     now = time.monotonic()
 

--- a/backend/app/standards/distributions.py
+++ b/backend/app/standards/distributions.py
@@ -12,7 +12,7 @@ rejects internal pointers (only http(s) or root-relative API paths
 pass); ``published_distributions`` adds, for the raster family, the
 tile template the product serves anonymously — derived per request
 since it lives at the APP origin, nginx-rewritten to the tile proxy, and
-carries ``tile_cache_version``, values a stored row can't hold. Mirrors
+carries the tile cache-key params, values a stored row can't hold. Mirrors
 ``build_assets`` in ``modules/catalog/search/service_records.py`` (what
 STAC advertises for the same datasets) — the discrepancy #1469 reported.
 """
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 from app.core.record_types import is_raster_family
+from app.core.tile_scope import tile_template_query
 
 if TYPE_CHECKING:
     from app.modules.catalog.datasets.domain.models import Dataset
@@ -76,14 +77,16 @@ def _absolute(url: str, base_url: str) -> str:
 def raster_tiles_path(dataset: Dataset) -> str:
     """The XYZ template for a raster dataset, versioned like every renderer.
 
-    fix(#1372) versions the template so a replace that bumps
-    ``tile_cache_version`` rolls the shared tile cache. Kept identical to
-    ``build_assets``: a client that reads both the STAC asset and the DCAT
-    distribution must get the same URL.
+    fix(#1372) and fix(#2007) version the template on the content and the
+    publication counters, so a replace or a publication transition rolls the
+    shared tile cache. Kept identical to ``build_assets``: a client that reads
+    both the STAC asset and the DCAT distribution must get the same URL.
     """
     path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
-    version = getattr(dataset, "tile_cache_version", None)
-    return f"{path}?v={version}" if version else path
+    return path + tile_template_query(
+        getattr(dataset, "tile_cache_version", None),
+        getattr(dataset, "publication_version", None),
+    )
 
 
 def _raster_tiles_distribution(

--- a/backend/app/standards/distributions.py
+++ b/backend/app/standards/distributions.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 from app.core.record_types import is_raster_family
-from app.core.tile_scope import tile_template_query
+from app.core.tile_scope import republished_tile_url, tile_template_query
 
 if TYPE_CHECKING:
     from app.modules.catalog.datasets.domain.models import Dataset
@@ -140,7 +140,14 @@ def published_distributions(
             PublishedDistribution(
                 distribution_type=row.distribution_type,
                 format=row.format,
-                url=_absolute(row.url, api_base_url),
+                # fix(#2007): a stored vector-tile template predates every
+                # transition since ingest, so republish it at the row's counter.
+                url=_absolute(
+                    republished_tile_url(
+                        row.url, getattr(dataset, "publication_version", None)
+                    ),
+                    api_base_url,
+                ),
                 title=row.title,
                 description=row.description,
                 media_type=row.media_type,

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -18,6 +18,7 @@ from app.core.identity import Identity
 from app.core.persistent_config import OGC_ITEMS_MAX_PAGE_SIZE
 from app.core.public_urls import get_public_api_url, get_public_app_url
 from app.core.tenancy import is_multi_tenant
+from app.core.tile_scope import tile_template_query
 from app.modules.auth.dependencies import get_optional_user
 from app.modules.catalog.authorization import apply_visibility_filter, get_user_roles
 from app.modules.catalog.datasets.domain.models import Dataset, DatasetGrant, Record
@@ -417,11 +418,14 @@ async def get_dataset_collection(
         # APP origin (/raster-tiles/...), which nginx rewrites to the internal
         # tile proxy; the /api origin has no such route, so use public_app_url.
         public_app_url = await get_public_app_url(db, request=request)
-        # fix(#1372): versioned like every rendered template so a
+        # fix(#1372, #2007): versioned like every rendered template so a
         # refetching client stops sharing the unversioned cache entry.
-        raster_tiles_path = f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
-        if dataset.tile_cache_version:
-            raster_tiles_path = f"{raster_tiles_path}?v={dataset.tile_cache_version}"
+        raster_tiles_path = (
+            f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
+            + tile_template_query(
+                dataset.tile_cache_version, dataset.publication_version
+            )
+        )
         links.append(
             OGCLink(
                 rel="tiles",

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5967,7 +5967,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1778): +3 -- RecordContact.id tiebreaker on the paginated contacts
     # list, sort_order being a non-unique server-default. Cap 1026 -> 1029,
     # exact.
-    "backend/app/modules/catalog/records/service.py": 883,
+    # fix(#2007): +17. The distributions endpoint reads the dataset counter a
+    # stored tile template is republished at. Cap 883 -> 900, exact.
+    "backend/app/modules/catalog/records/service.py": 900,
     # fix(#1528): crossed the inclusion threshold, and this is the file the
     # inclusion rule's own comment named as one of the two "routers-by-role the
     # glob's filename match cannot see ... watched by nothing until they cross

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2277,7 +2277,10 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
     # fix(#1778 round 3): +9 — the export's zoom no-op conditions read the
     # shared BUILDER_MIN_ZOOM / BUILDER_MAX_ZOOM instead of repeating 0 and 22,
     # so the two directions of the round trip cannot drift. Cap 1710 -> 1719.
-    "backend/app/modules/catalog/maps/style_json.py": 1590,
+    # fix(#2007): +7. The raster and vector templates carry the publication
+    # counter both cache layers key on, through the one shared builder.
+    # Cap 1590 -> 1597, exact.
+    "backend/app/modules/catalog/maps/style_json.py": 1597,
     # fix(#1626): +50 — `_restore_master_opacity` undoes the export fold from
     # `metadata.geolens.feature_opacity` and maps a v6 `-layer-opacity` key onto
     # `layer.opacity` (number) or drops it with a warning (expression); plus
@@ -5701,7 +5704,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # once; no override_defaults, since the middleware already charges the
     # global default unconditionally for this callable-valued limit
     # (test_semantic_search_rate_limit_1778.py). Cap 1380 -> 1432, exact.
-    "backend/app/modules/catalog/search/router.py": 1432,
+    # fix(#2007): +1. The advertised raster template is built by the shared
+    # cache-key helper. Cap 1432 -> 1433, exact.
+    "backend/app/modules/catalog/search/router.py": 1433,
     # fix(#474): negotiate localized STAC record text; fix(#475) adds the
     # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
     # validated STAC item responses wire-compatible with serializer output.
@@ -5854,7 +5859,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1963): +17. Mint and verify derive the signed scope through the one
     # shared helper, and both meta snapshots carry the publication counter that
     # scope binds. Cap 2392 -> 2409, exact.
-    "backend/app/processing/tiles/router.py": 2409,
+    # fix(#2007): +66. The two nginx cache-key params are read through one
+    # helper the edge and the api share, a mismatched one loses the shared
+    # cache on all three routes, and the vector/cluster key carries the
+    # publication counter. Cap 2409 -> 2475, exact.
+    "backend/app/processing/tiles/router.py": 2475,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5859,11 +5859,12 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1963): +17. Mint and verify derive the signed scope through the one
     # shared helper, and both meta snapshots carry the publication counter that
     # scope binds. Cap 2392 -> 2409, exact.
-    # fix(#2007): +66. The two nginx cache-key params are read through one
+    # fix(#2007): +71. The two nginx cache-key params are read through one
     # helper the edge and the api share, a mismatched one loses the shared
     # cache on all three routes, and the vector/cluster key carries the
-    # publication counter. Cap 2409 -> 2475, exact.
-    "backend/app/processing/tiles/router.py": 2475,
+    # publication counter, off the same snapshot that authorized the request.
+    # Cap 2409 -> 2480, exact.
+    "backend/app/processing/tiles/router.py": 2480,
     # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
     # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
     # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),

--- a/backend/tests/test_modality_assets.py
+++ b/backend/tests/test_modality_assets.py
@@ -30,13 +30,22 @@ class TestRasterTilesAssetVersion:
         entry after a replace."""
         ds = _make_dataset(record_type="raster_dataset", table_name=None)
         ds.tile_cache_version = 7
+        ds.publication_version = 3
         assets = build_assets(ds, API_URL)
-        assert assets["raster_tiles"]["href"].endswith(".png?v=7")
+        assert assets["raster_tiles"]["href"].endswith(".png?v=7&pv=3")
 
-    def test_raster_tiles_href_bare_without_version(self):
+    def test_raster_tiles_href_carries_pv_without_a_version(self):
         ds = _make_dataset(record_type="raster_dataset", table_name=None)
         assets = build_assets(ds, API_URL)
-        assert assets["raster_tiles"]["href"].endswith(".png")
+        assert assets["raster_tiles"]["href"].endswith(".png?pv=0")
+
+    def test_vector_tiles_href_carries_the_publication_version(self):
+        """fix(#2007): the one tile template here that is never signed, so `pv`
+        is what a shared cache keys its response on."""
+        ds = _make_dataset(record_type="vector_dataset", table_name="parcels")
+        ds.publication_version = 4
+        assets = build_assets(ds, API_URL)
+        assert assets["vector_tiles"]["href"].endswith(".pbf?pv=4")
 
 
 class TestModalityAssets:

--- a/backend/tests/test_raster_tile_url_version_1372.py
+++ b/backend/tests/test_raster_tile_url_version_1372.py
@@ -1,11 +1,12 @@
-"""fix(#1372): raster tile URLs carry ``v=<tile_cache_version>``.
+"""fix(#1372, #2007): raster tile URLs carry ``v=`` and ``pv=``.
 
-nginx's shared raster_cache keys on ``$arg_v`` (frontend/nginx.conf), so a
-raster replace — which bumps ``Dataset.tile_cache_version`` — rolls the shared
-cache immediately instead of serving pre-replace bytes for up to
-``proxy_cache_valid``. These pins cover the response builders that emit the
-versioned template; the token endpoint's pin lives in
-``tests/test_raster_tiles.py::TestRasterTokenEndpoint``.
+nginx's shared raster_cache keys on ``$arg_v`` and ``$arg_pv``
+(frontend/nginx.conf), so a raster replace — which bumps
+``Dataset.tile_cache_version`` — and a publication transition — which bumps
+``Dataset.publication_version`` — each roll the shared cache immediately
+instead of serving pre-change bytes for up to ``proxy_cache_valid``. These
+pins cover the response builders that emit the versioned template; the token
+endpoint's pin lives in ``tests/test_raster_tiles.py::TestRasterTokenEndpoint``.
 """
 
 import uuid
@@ -23,6 +24,7 @@ class TestRasterMetadataTileUrlVersion:
     def test_tile_url_carries_tile_cache_version(self):
         dataset = _make_mock_dataset("raster_dataset")
         dataset.tile_cache_version = 7
+        dataset.publication_version = 3
         asset = _make_mock_raster_asset(
             vrt_type=None, resolution_strategy=None, status="ready"
         )
@@ -30,12 +32,12 @@ class TestRasterMetadataTileUrlVersion:
         result = _build_raster_metadata(dataset, asset, is_admin=False)
 
         assert result.tile_url == (
-            f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png?v=7"
+            f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png?v=7&pv=3"
         )
 
     def test_connect_tile_url_stays_unversioned(self):
         """The connect template is copied once into desktop GIS tools, where a
-        frozen ``v`` would pin exactly the staleness the param exists to bust."""
+        frozen counter would pin exactly the staleness the params exist to bust."""
         dataset = _make_mock_dataset("raster_dataset")
         dataset.tile_cache_version = 7
         asset = _make_mock_raster_asset(
@@ -48,6 +50,7 @@ class TestRasterMetadataTileUrlVersion:
 
         assert "?v=" not in result.connect.tile_url
         assert "&v=" not in result.connect.tile_url
+        assert "pv=" not in result.connect.tile_url
         assert "api_key={your_key}" in result.connect.tile_url
 
 
@@ -71,7 +74,7 @@ def _shared_layer() -> SimpleNamespace:
 
 
 class TestSharedLayerTileUrlVersion:
-    def _build(self, tile_version):
+    def _build(self, tile_version, publication_version=3):
         layer = _shared_layer()
         layer_dict, _ = _build_shared_layer_dict(
             layer,
@@ -86,6 +89,7 @@ class TestSharedLayerTileUrlVersion:
             ds_is_dem=None,
             ds_dem_vertical_units=None,
             ds_tile_version=tile_version,
+            ds_publication_version=publication_version,
             ds_attribution=None,
         )
         return layer, layer_dict
@@ -93,29 +97,31 @@ class TestSharedLayerTileUrlVersion:
     def test_raster_tile_url_carries_version(self):
         layer, layer_dict = self._build(7)
         assert layer_dict["tile_url"] == (
-            f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png?v=7"
+            f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png?v=7&pv=3"
         )
 
-    def test_raster_tile_url_bare_without_version(self):
+    def test_raster_tile_url_keeps_the_publication_version_without_v(self):
         layer, layer_dict = self._build(None)
         assert layer_dict["tile_url"] == (
-            f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png"
+            f"/raster-tiles/{layer.dataset_id}/tiles/{{z}}/{{x}}/{{y}}.png?pv=3"
         )
 
 
 class TestStyleJsonRasterTileVersion:
     def test_raster_dem_source_tiles_carry_version(self):
         dem_id = uuid.uuid4()
-        layer = _dem_layer(dem_id=dem_id).model_copy(update={"tile_version": 7})
+        layer = _dem_layer(dem_id=dem_id).model_copy(
+            update={"tile_version": 7, "publication_version": 3}
+        )
         style = build_maplibre_style(_map(), [layer])
         assert style["sources"][f"geolens-{dem_id}"]["tiles"][0] == (
-            f"/raster-tiles/{dem_id}/tiles/{{z}}/{{x}}/{{y}}.png?v=7"
+            f"/raster-tiles/{dem_id}/tiles/{{z}}/{{x}}/{{y}}.png?v=7&pv=3"
         )
 
-    def test_raster_dem_source_tiles_bare_without_version(self):
+    def test_raster_dem_source_tiles_keep_pv_without_a_version(self):
         dem_id = uuid.uuid4()
         layer = _dem_layer(dem_id=dem_id)
         style = build_maplibre_style(_map(), [layer])
         assert style["sources"][f"geolens-{dem_id}"]["tiles"][0] == (
-            f"/raster-tiles/{dem_id}/tiles/{{z}}/{{x}}/{{y}}.png"
+            f"/raster-tiles/{dem_id}/tiles/{{z}}/{{x}}/{{y}}.png?pv=0"
         )

--- a/backend/tests/test_tile_cache_generation_key_1429.py
+++ b/backend/tests/test_tile_cache_generation_key_1429.py
@@ -68,9 +68,15 @@ async def _provider(kind: str):
         await provider._client.aclose()
 
 
-def _cluster_key(table: str, dataset_id: uuid.UUID) -> str:
+def _cluster_key(
+    table: str, dataset_id: uuid.UUID, publication_version: int = 0
+) -> str:
     return _cluster_cache_table_key(
-        table, dataset_id=dataset_id, cluster_radius=50, cluster_max_zoom=12
+        table,
+        dataset_id=dataset_id,
+        publication_version=publication_version,
+        cluster_radius=50,
+        cluster_max_zoom=12,
     )
 
 
@@ -91,11 +97,11 @@ async def test_successor_cannot_read_predecessor_tiles(kind):
     async with _provider(kind) as provider:
         dataset_a, dataset_b = uuid.uuid4(), uuid.uuid4()
 
-        key_a = _generation_table_key(TABLE, dataset_a)
+        key_a = _generation_table_key(TABLE, dataset_a, 0)
         await provider.set(key_a, *TILE, gzip.compress(b"A private geometry"), ttl=300)
         assert await provider.get(key_a, *TILE) is not None
 
-        key_b = _generation_table_key(TABLE, dataset_b)
+        key_b = _generation_table_key(TABLE, dataset_b, 0)
         assert await provider.get(key_b, *TILE) is None, (
             "the successor of a reused table name read the deleted dataset's tile"
         )
@@ -117,7 +123,7 @@ async def test_successor_cannot_read_predecessor_cluster_tiles(kind):
 def test_generation_key_places_the_id_after_the_table_segment():
     """Position is what keeps `tile:{table}:*` invalidation working."""
     dataset_id = uuid.uuid4()
-    key = _generation_table_key(TABLE, dataset_id)
+    key = _generation_table_key(TABLE, dataset_id, 0)
 
     assert key.startswith(f"{TABLE}:"), (
         "the dataset id must follow the table segment — a leading id would "
@@ -142,21 +148,29 @@ async def test_invalidate_table_still_purges_every_generation(kind):
     async with _provider(kind) as provider:
         older, newer = uuid.uuid4(), uuid.uuid4()
 
-        await provider.set(_generation_table_key(TABLE, older), *TILE, b"old", ttl=300)
-        await provider.set(_generation_table_key(TABLE, newer), *TILE, b"new", ttl=300)
+        await provider.set(
+            _generation_table_key(TABLE, older, 0), *TILE, b"old", ttl=300
+        )
+        await provider.set(
+            _generation_table_key(TABLE, newer, 0), *TILE, b"new", ttl=300
+        )
         await provider.set(_cluster_key(TABLE, newer), *TILE, b"clustered", ttl=300)
         await provider.set(
-            _generation_table_key(TABLE, newer), *TILE, b"cols", ttl=300, cols_key="a,b"
+            _generation_table_key(TABLE, newer, 0),
+            *TILE,
+            b"cols",
+            ttl=300,
+            cols_key="a,b",
         )
 
         await provider.invalidate_table(TABLE)
 
-        assert await provider.get(_generation_table_key(TABLE, older), *TILE) is None
-        assert await provider.get(_generation_table_key(TABLE, newer), *TILE) is None
+        assert await provider.get(_generation_table_key(TABLE, older, 0), *TILE) is None
+        assert await provider.get(_generation_table_key(TABLE, newer, 0), *TILE) is None
         assert await provider.get(_cluster_key(TABLE, newer), *TILE) is None
         assert (
             await provider.get(
-                _generation_table_key(TABLE, newer), *TILE, cols_key="a,b"
+                _generation_table_key(TABLE, newer, 0), *TILE, cols_key="a,b"
             )
             is None
         )
@@ -167,7 +181,7 @@ async def test_invalidate_table_does_not_purge_a_prefix_sibling(kind):
     """`roads` must not evict `roads_2` — the suffix generate_table_name hands out."""
     async with _provider(kind) as provider:
         dataset_id = uuid.uuid4()
-        sibling = _generation_table_key("roads_2", dataset_id)
+        sibling = _generation_table_key("roads_2", dataset_id, 0)
 
         await provider.set(sibling, *TILE, b"x", ttl=300)
 
@@ -215,7 +229,7 @@ async def test_explicit_label_is_still_cardinality_bounded(kind):
     async with _provider(kind) as provider:
         other_before = _hits("_other")
 
-        key = _generation_table_key(TABLE, uuid.uuid4())
+        key = _generation_table_key(TABLE, uuid.uuid4(), 0)
         await provider.set(key, *TILE, b"tile", ttl=300)
         await provider.get(key, *TILE, label="Robert'); DROP TABLE--")
 

--- a/backend/tests/test_tile_cache_publication_key_2007.py
+++ b/backend/tests/test_tile_cache_publication_key_2007.py
@@ -1,0 +1,327 @@
+"""fix(#2007): a cached tile response is keyed on the publication version.
+
+#2005 retired outstanding signatures on a publication-status or visibility
+transition, which stops the application from serving a tile to the holder of an
+old template. It does not reach the caches in front of the application: an
+entry stored while the dataset was public and published stayed readable for its
+TTL afterwards, because the key carried the caller's own ``v`` and signature
+rather than the counter.
+
+The counter now keys both layers. The application's own vector and cluster tile
+keys are derived from the row, so an entry stored at version N is unreachable
+the moment the row moves to N+1. nginx keys ``$arg_pv``, and every raster
+template the product emits carries it, so a URL emitted after the transition
+addresses a different entry from one emitted before it.
+"""
+
+import gzip
+import re
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.core.tile_scope import TILE_PUBLICATION_VERSION_PARAM
+from app.modules.catalog.maps.style_json import build_maplibre_style
+
+from tests.test_maps_style_json import _layer, _map
+from tests.test_nginx_raster_stretch_cache_key_1778 import (
+    _PROXY_CACHE_KEY,
+    RASTER_TILES_LOCATION,
+    _conf,
+    _derive,
+    _location_block,
+    _nginx_arg,
+)
+from tests.test_tile_signature_revocation_1963 import (
+    _admin_id,
+    _drop_table,
+    _evict_tile_meta,
+    _make_raster,
+    _make_vector,
+    _mint,
+    _patch_dataset,
+    _set_status,
+)
+
+_SENTINEL = b"bytes stored while the dataset was public and published"
+
+
+def _nginx_cache_key(query: str) -> str:
+    """The raster_cache entry a request with ``query`` would address.
+
+    Renders frontend/nginx.conf's own ``proxy_cache_key`` rather than a copy of
+    it, so the pin fails if the directive stops holding the param.
+    """
+    conf = _conf()
+    match = _PROXY_CACHE_KEY.search(_location_block(conf, RASTER_TILES_LOCATION))
+    assert match, "expected a proxy_cache_key in the /raster-tiles/ location"
+    fixed = {
+        "dataset_id": "00000000-0000-0000-0000-0000000000ff",
+        "z": "1",
+        "x": "2",
+        "y": "3",
+        "fmt": "png",
+        "geolens_raster_pmin": _derive(conf, "pmin", query),
+        "geolens_raster_pmax": _derive(conf, "pmax", query),
+        "geolens_raster_sigma": _derive(conf, "sigma", query),
+    }
+
+    def _resolve(m: re.Match) -> str:
+        name = m.group(1)
+        if name.startswith("arg_"):
+            return _nginx_arg(query, name[len("arg_") :])
+        return fixed[name]
+
+    return re.sub(r"\$(\w+)", _resolve, match.group(1))
+
+
+async def _serve_with_cache(
+    client: AsyncClient, url: str, params: dict, stored: dict[str, bytes]
+) -> tuple[object, str]:
+    """Answer the route's one cache read from ``stored``; report the key it used."""
+    read_keys: list[str] = []
+
+    async def _get(key, z, x, y, cols_key="", label=None):
+        read_keys.append(key)
+        return stored.get(key)
+
+    cache = AsyncMock()
+    cache.get.side_effect = _get
+    with patch("app.processing.tiles.router.get_tile_cache", return_value=cache):
+        response = await client.get(url, params=params)
+    assert len(read_keys) == 1, read_keys
+    return response, read_keys[0]
+
+
+async def _publication_version(session, dataset_id) -> int:
+    row = await session.execute(
+        text("SELECT publication_version FROM catalog.datasets WHERE id = :id"),
+        {"id": dataset_id},
+    )
+    return row.scalar_one()
+
+
+async def _tile_cache_version(session, dataset_id) -> int:
+    row = await session.execute(
+        text("SELECT tile_cache_version FROM catalog.datasets WHERE id = :id"),
+        {"id": dataset_id},
+    )
+    return row.scalar_one()
+
+
+class TestTheEdgeKeyHoldsThePublicationVersion:
+    def test_the_raster_cache_key_holds_the_param_the_api_emits(self):
+        conf = _conf()
+        match = _PROXY_CACHE_KEY.search(_location_block(conf, RASTER_TILES_LOCATION))
+        assert match
+        assert f"$arg_{TILE_PUBLICATION_VERSION_PARAM}" in match.group(1), (
+            "the edge and the api must agree on one param name, or the key "
+            f"never moves: {match.group(1)!r}"
+        )
+
+    def test_two_publication_versions_address_different_entries(self):
+        assert _nginx_cache_key("v=4&pv=0") != _nginx_cache_key("v=4&pv=1")
+
+    def test_the_param_is_read_the_way_nginx_reads_it(self):
+        """nginx takes the FIRST occurrence and matches the name case-insensitively.
+
+        ``$arg_v`` must not resolve out of ``pv=``: nginx requires the byte
+        before a match to start the query string or be ``&``.
+        """
+        assert _nginx_arg("pv=7", "v") == ""
+        assert _nginx_arg("PV=7&pv=8", "pv") == "7"
+
+
+@pytest.mark.usefixtures("_init_tile_pool_for_tests")
+class TestTheApplicationKeyRollsWithThePublicationVersion:
+    async def test_a_vector_tile_cached_before_an_unpublish_is_not_served_after(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        dataset = await _make_vector(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+        url = f"/tiles/data.{dataset.table_name}/0/0/0.pbf"
+        try:
+            params = await _mint(client, dataset.id, admin_auth_header)
+            _, published_key = await _serve_with_cache(client, url, params, {})
+            stored = {published_key: gzip.compress(_SENTINEL)}
+
+            hit, _ = await _serve_with_cache(client, url, params, stored)
+            assert hit.content == _SENTINEL
+
+            await _set_status(client, dataset.id, admin_auth_header, "internal")
+            _evict_tile_meta()
+            fresh = await _mint(client, dataset.id, admin_auth_header)
+            after, unpublished_key = await _serve_with_cache(client, url, fresh, stored)
+
+            assert unpublished_key != published_key
+            assert after.content != _SENTINEL
+        finally:
+            await _drop_table(test_db_session, dataset.table_name)
+
+    async def test_a_cluster_tile_cached_before_a_move_to_private_is_not_served_after(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        dataset = await _make_vector(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+        url = f"/tiles/clusters/data.{dataset.table_name}/0/0/0.pbf"
+        try:
+            params = await _mint(client, dataset.id, admin_auth_header)
+            _, public_key = await _serve_with_cache(client, url, params, {})
+            stored = {public_key: gzip.compress(_SENTINEL)}
+
+            hit, _ = await _serve_with_cache(client, url, params, stored)
+            assert hit.content == _SENTINEL
+
+            await _patch_dataset(
+                client, dataset.id, admin_auth_header, {"visibility": "private"}
+            )
+            _evict_tile_meta()
+            fresh = await _mint(client, dataset.id, admin_auth_header)
+            after, private_key = await _serve_with_cache(client, url, fresh, stored)
+
+            assert private_key != public_key
+            assert after.content != _SENTINEL
+        finally:
+            await _drop_table(test_db_session, dataset.table_name)
+
+    async def test_the_key_carries_the_row_not_the_request(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """A supplied ``pv`` cannot address another row state's entry.
+
+        The vector key is derived from the row, which is what makes the old
+        entry unreachable rather than merely unaddressed by emitted URLs.
+        """
+        dataset = await _make_vector(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+        url = f"/tiles/data.{dataset.table_name}/0/0/0.pbf"
+        try:
+            params = await _mint(client, dataset.id, admin_auth_header)
+            _, honest_key = await _serve_with_cache(client, url, params, {})
+            _, claimed_key = await _serve_with_cache(
+                client, url, {**params, TILE_PUBLICATION_VERSION_PARAM: "9"}, {}
+            )
+            assert claimed_key == honest_key
+            assert honest_key.endswith(":p0")
+        finally:
+            await _drop_table(test_db_session, dataset.table_name)
+
+
+@pytest.mark.usefixtures("_init_tile_pool_for_tests")
+class TestTheSharedCacheIsRefusedToAMismatchedRequest:
+    """A response may only be stored under the state that produced it.
+
+    Without this the counter would be a way IN rather than out: a caller
+    supplying the version an unpublish is about to make current would fill that
+    key with bytes from before the transition.
+    """
+
+    async def _cache_status(self, client, dataset_id, params) -> str:
+        resp = await client.get(
+            "/tiles/raster-auth-check/",
+            params=[("dataset_id", str(dataset_id)), *params],
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.headers["X-GeoLens-Cache-Status"]
+
+    async def test_the_current_publication_version_is_publicly_cacheable(
+        self, client: AsyncClient, test_db_session
+    ):
+        dataset = await _make_raster(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+        version = await _tile_cache_version(test_db_session, dataset.id)
+        current = await _publication_version(test_db_session, dataset.id)
+
+        status_header = await self._cache_status(
+            client,
+            dataset.id,
+            [("v", str(version)), (TILE_PUBLICATION_VERSION_PARAM, str(current))],
+        )
+
+        assert status_header == "public"
+
+    async def test_a_publication_version_naming_another_state_is_not(
+        self, client: AsyncClient, test_db_session
+    ):
+        dataset = await _make_raster(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+        current = await _publication_version(test_db_session, dataset.id)
+
+        status_header = await self._cache_status(
+            client,
+            dataset.id,
+            [(TILE_PUBLICATION_VERSION_PARAM, str(current + 1))],
+        )
+
+        assert status_header == "private"
+
+    async def test_a_duplicated_publication_version_is_not(
+        self, client: AsyncClient, test_db_session
+    ):
+        """The two layers would read different occurrences of a repeated name."""
+        dataset = await _make_raster(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+        current = await _publication_version(test_db_session, dataset.id)
+
+        status_header = await self._cache_status(
+            client,
+            dataset.id,
+            [
+                (TILE_PUBLICATION_VERSION_PARAM, str(current)),
+                (TILE_PUBLICATION_VERSION_PARAM, str(current + 1)),
+            ],
+        )
+
+        assert status_header == "private"
+
+    async def test_an_absent_publication_version_keeps_the_old_behaviour(
+        self, client: AsyncClient, test_db_session
+    ):
+        """A copied connect URL keys on the empty segment, as it always has."""
+        dataset = await _make_raster(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+
+        assert await self._cache_status(client, dataset.id, []) == "public"
+
+
+@pytest.mark.usefixtures("_init_tile_pool_for_tests")
+class TestEmittedTemplatesCarryTheCurrentCounter:
+    async def test_the_raster_token_url_rolls_after_an_unpublish(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        dataset = await _make_raster(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+        before = await client.get(
+            f"/tiles/token/{dataset.id}/", headers=admin_auth_header
+        )
+        assert before.status_code == 200, before.text
+        assert f"&{TILE_PUBLICATION_VERSION_PARAM}=0" in before.json()["tile_url"]
+
+        await _set_status(client, dataset.id, admin_auth_header, "internal")
+        _evict_tile_meta()
+
+        after = await client.get(
+            f"/tiles/token/{dataset.id}/", headers=admin_auth_header
+        )
+        assert after.status_code == 200, after.text
+        assert f"&{TILE_PUBLICATION_VERSION_PARAM}=1" in after.json()["tile_url"]
+
+
+class TestTheStyleDocument:
+    def test_it_keys_a_vector_layer_on_its_signed_counter(self):
+        layer = _layer().model_copy(update={"publication_version": 5})
+        style = build_maplibre_style(_map(), [layer])
+        url = style["sources"][f"geolens-{layer.dataset_id}"]["tiles"][0]
+
+        assert f"{TILE_PUBLICATION_VERSION_PARAM}=5" in url
+        assert "%3Ap5" in url or ":p5" in url

--- a/backend/tests/test_tile_cache_publication_key_2007.py
+++ b/backend/tests/test_tile_cache_publication_key_2007.py
@@ -473,3 +473,66 @@ class TestTheRecordDocumentRepublishesAStoredTemplate:
             assert not any(u.endswith(".pbf?pv=0") for u in after), after
         finally:
             await _drop_table(test_db_session, dataset.table_name)
+
+
+@pytest.mark.usefixtures("_init_tile_pool_for_tests")
+class TestTheConnectEndpointRepublishesAStoredTemplate:
+    """The Connect panel copies its vector template out of this endpoint.
+
+    Versioning it is safe in a way the raster Connect template is not: a frozen
+    counter there would pin an edge entry, while the vector key is derived from
+    the row, so a stale one costs shared caching and never stale bytes.
+    """
+
+    async def _urls(
+        self, client: AsyncClient, record_id, admin_auth_header: dict
+    ) -> dict[str, str]:
+        resp = await client.get(
+            f"/records/{record_id}/distributions/", headers=admin_auth_header
+        )
+        assert resp.status_code == 200, resp.text
+        return {d["distribution_type"]: d["url"] for d in resp.json()["distributions"]}
+
+    async def test_it_rolls_after_an_unpublish(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        dataset = await _make_vector(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+        download_url = f"/datasets/{dataset.id}/export?format=gpkg"
+        try:
+            for row in (
+                RecordDistribution(
+                    record_id=dataset.record_id,
+                    distribution_type="vector_tiles",
+                    format="pbf",
+                    url=f"/tiles/data.{dataset.table_name}/{{z}}/{{x}}/{{y}}.pbf",
+                    title="Vector Tiles",
+                    media_type="application/vnd.mapbox-vector-tile",
+                    auto_generated=True,
+                ),
+                RecordDistribution(
+                    record_id=dataset.record_id,
+                    distribution_type="download",
+                    format="gpkg",
+                    url=download_url,
+                    title="Download as GPKG",
+                    media_type="application/geopackage+sqlite3",
+                    auto_generated=True,
+                ),
+            ):
+                test_db_session.add(row)
+            await test_db_session.commit()
+
+            before = await self._urls(client, dataset.record_id, admin_auth_header)
+            assert before["vector_tiles"].endswith(".pbf?pv=0"), before
+            assert before["download"] == download_url
+
+            await _set_status(client, dataset.id, admin_auth_header, "internal")
+            after = await self._urls(client, dataset.record_id, admin_auth_header)
+
+            assert after["vector_tiles"].endswith(".pbf?pv=1"), after
+            assert "pv=0" not in after["vector_tiles"]
+            assert after["download"] == download_url
+        finally:
+            await _drop_table(test_db_session, dataset.table_name)

--- a/backend/tests/test_tile_cache_publication_key_2007.py
+++ b/backend/tests/test_tile_cache_publication_key_2007.py
@@ -188,6 +188,34 @@ class TestTheApplicationKeyRollsWithThePublicationVersion:
         finally:
             await _drop_table(test_db_session, dataset.table_name)
 
+    async def test_the_metadata_snapshot_bounds_the_roll(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        """Without an eviction the pre-transition snapshot still keys the read.
+
+        The counter comes off the same 60 s snapshot that decides visibility
+        and record_status, so the key is never staler than the authorization
+        that admitted the request and both age out together. Pinned rather
+        than hidden: the cases around this one evict first so they assert the
+        key rather than this bound.
+        """
+        dataset = await _make_vector(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+        url = f"/tiles/data.{dataset.table_name}/0/0/0.pbf"
+        try:
+            params = await _mint(client, dataset.id, admin_auth_header)
+            _, published_key = await _serve_with_cache(client, url, params, {})
+            stored = {published_key: gzip.compress(_SENTINEL)}
+
+            await _set_status(client, dataset.id, admin_auth_header, "internal")
+            after, key = await _serve_with_cache(client, url, params, stored)
+
+            assert key == published_key
+            assert after.content == _SENTINEL
+        finally:
+            await _drop_table(test_db_session, dataset.table_name)
+
     async def test_the_key_carries_the_row_not_the_request(
         self, client: AsyncClient, admin_auth_header: dict, test_db_session
     ):

--- a/backend/tests/test_tile_cache_publication_key_2007.py
+++ b/backend/tests/test_tile_cache_publication_key_2007.py
@@ -16,14 +16,20 @@ addresses a different entry from one emitted before it.
 
 import gzip
 import re
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
 
-from app.core.tile_scope import TILE_PUBLICATION_VERSION_PARAM
+from app.core.tile_scope import (
+    TILE_PUBLICATION_VERSION_PARAM,
+    republished_tile_url,
+)
 from app.modules.catalog.maps.style_json import build_maplibre_style
+from app.modules.catalog.datasets.domain.models import RecordDistribution
+from app.standards.distributions import published_distributions
 
 from tests.test_maps_style_json import _layer, _map
 from tests.test_nginx_raster_stretch_cache_key_1778 import (
@@ -353,3 +359,117 @@ class TestTheStyleDocument:
 
         assert f"{TILE_PUBLICATION_VERSION_PARAM}=5" in url
         assert "%3Ap5" in url or ":p5" in url
+
+
+class TestAStoredTemplateIsRepublishedAtTheCurrentCounter:
+    """A ``record_distributions`` row is written once at ingest.
+
+    It predates every transition since, so a feed that passed it through as
+    stored would hand a consumer a URL addressing a pre-transition entry.
+    """
+
+    def test_the_auto_generated_vector_template_gains_the_counter(self):
+        url = republished_tile_url("/tiles/data.roads/{z}/{x}/{y}.pbf", 4)
+        assert url == "/tiles/data.roads/{z}/{x}/{y}.pbf?pv=4"
+
+    def test_a_cluster_template_gains_it_too(self):
+        url = republished_tile_url("/tiles/clusters/data.roads/{z}/{x}/{y}.pbf", 4)
+        assert url.endswith("?pv=4")
+
+    def test_a_stale_counter_on_the_row_is_replaced_not_repeated(self):
+        url = republished_tile_url("/tiles/data.roads/{z}/{x}/{y}.pbf?pv=1", 4)
+        assert url.count("pv=") == 1
+        assert url.endswith("pv=4")
+
+    def test_other_params_on_the_row_survive(self):
+        url = republished_tile_url("/tiles/data.roads/{z}/{x}/{y}.pbf?cols=name", 4)
+        assert "cols=name" in url
+        assert url.endswith("pv=4")
+
+    def test_a_link_to_another_service_is_untouched(self):
+        """Only our own tile routes are rewritten; an operator's URL is theirs."""
+        other = "https://tiles.example.org/roads/{z}/{x}/{y}.pbf"
+        assert republished_tile_url(other, 4) == other
+        assert republished_tile_url("/datasets/x/export?format=gpkg", 4) == (
+            "/datasets/x/export?format=gpkg"
+        )
+
+
+def _stored_vector_tiles_row(table_name: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        distribution_type="vector_tiles",
+        format="pbf",
+        url=f"/tiles/data.{table_name}/{{z}}/{{x}}/{{y}}.pbf",
+        title="Vector Tiles",
+        description=None,
+        media_type="application/vnd.mapbox-vector-tile",
+    )
+
+
+class TestTheDcatFeedRepublishesAStoredTemplate:
+    def test_the_published_distribution_carries_the_current_counter(self):
+        record = SimpleNamespace(
+            record_type="vector_dataset",
+            distributions=[_stored_vector_tiles_row("roads")],
+        )
+        dataset = SimpleNamespace(
+            id="00000000-0000-0000-0000-0000000000ff",
+            record=record,
+            tile_cache_version=1,
+            publication_version=4,
+        )
+
+        entries = published_distributions(
+            dataset,
+            api_base_url="https://api.example.org",
+            app_base_url="https://app.example.org",
+        )
+
+        assert [e.url for e in entries] == [
+            "https://api.example.org/tiles/data.roads/{z}/{x}/{y}.pbf?pv=4"
+        ]
+
+
+@pytest.mark.usefixtures("_init_tile_pool_for_tests")
+class TestTheRecordDocumentRepublishesAStoredTemplate:
+    async def _distribution_urls(
+        self, client: AsyncClient, dataset_id, admin_auth_header: dict
+    ) -> list[str]:
+        resp = await client.get(
+            f"/collections/datasets/items/{dataset_id}", headers=admin_auth_header
+        )
+        assert resp.status_code == 200, resp.text
+        return [d["url"] for d in resp.json()["properties"]["distributions"]]
+
+    async def test_it_rolls_after_an_unpublish(
+        self, client: AsyncClient, admin_auth_header: dict, test_db_session
+    ):
+        dataset = await _make_vector(
+            test_db_session, created_by=await _admin_id(test_db_session)
+        )
+        try:
+            test_db_session.add(
+                RecordDistribution(
+                    record_id=dataset.record_id,
+                    distribution_type="vector_tiles",
+                    format="pbf",
+                    url=f"/tiles/data.{dataset.table_name}/{{z}}/{{x}}/{{y}}.pbf",
+                    title="Vector Tiles",
+                    media_type="application/vnd.mapbox-vector-tile",
+                    auto_generated=True,
+                )
+            )
+            await test_db_session.commit()
+
+            before = await self._distribution_urls(
+                client, dataset.id, admin_auth_header
+            )
+            assert any(u.endswith(".pbf?pv=0") for u in before), before
+
+            await _set_status(client, dataset.id, admin_auth_header, "internal")
+            after = await self._distribution_urls(client, dataset.id, admin_auth_header)
+
+            assert any(u.endswith(".pbf?pv=1") for u in after), after
+            assert not any(u.endswith(".pbf?pv=0") for u in after), after
+        finally:
+            await _drop_table(test_db_session, dataset.table_name)

--- a/backend/tests/test_tiles.py
+++ b/backend/tests/test_tiles.py
@@ -365,8 +365,10 @@ class TestTileEndpoint:
         # fix(#1429): the dataset id sits between the table and the cluster
         # segments, so a reused table name cannot read the previous dataset's
         # cluster tiles, and `label` carries the bare table name for the metric.
+        # fix(#2007): the publication version follows the dataset id.
         mock_cache.get.assert_awaited_once_with(
-            f"{table_name}:ds{dataset.id.hex}:cluster:v3:r64:z12",
+            f"{table_name}:ds{dataset.id.hex}:p{dataset.publication_version}"
+            ":cluster:v3:r64:z12",
             0,
             0,
             0,

--- a/backend/tests/test_vrt_catalog_175.py
+++ b/backend/tests/test_vrt_catalog_175.py
@@ -83,6 +83,8 @@ def _make_mock_dataset(record_type: str, title: str = "Test Dataset") -> MagicMo
     ds.schema_drift_status = None
     # fix(#1372): _build_raster_metadata reads this into the tile URL's `v=`.
     ds.tile_cache_version = 1
+    # fix(#2007): and this into its `pv=`.
+    ds.publication_version = 0
 
     ds.record = MagicMock()
     ds.record.record_type = record_type

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -161,8 +161,10 @@ map $upstream_http_access_control_allow_origin $geolens_export_acao {
 # reachable through raster_cache's on-disk files and any backup of them,
 # even though access logging already strips query strings for exactly this
 # reason. proxy_cache_key must only ever be built from the sanitised
-# $geolens_raster_* variables (never raw $args, never any $arg_* directly),
-# so a non-canonical request is instead served UNCACHED: bypass skips the
+# $geolens_raster_* variables and the enumerated version/render names
+# $arg_v, $arg_pv, $arg_colormap_name and $arg_stretch, none of which can
+# name a credential (never raw $args, never an unenumerated $arg_*), so a
+# non-canonical request is instead served UNCACHED: bypass skips the
 # lookup, no_cache skips the store, and nothing about that request's
 # arguments -- credential included -- is ever written anywhere. The
 # per-parameter fallback above still matters independently: it is what
@@ -451,18 +453,22 @@ server {
         # maps declared above (fix(#1778): those maps blank the args a request's
         # stretch mode does not read, so an anonymous caller can no longer defeat
         # the cache by randomizing an arg that never touches the rendered bytes).
-        # The key is built ONLY from these sanitised variables -- fix(#1778 codex
-        # r6): it must never include raw $args or any single raw $arg_*, because
-        # this route accepts credentials on the query string (?api_key=, the
-        # deprecated lane _resolve_api_key still honours) and a raw value would
-        # write that credential into the cache key, reachable through
-        # raster_cache's on-disk files and any backup of them.
+        # The key is built ONLY from these sanitised variables and the
+        # enumerated names below -- fix(#1778 codex r6): it must never include
+        # raw $args or an unenumerated $arg_*, because this route accepts
+        # credentials on the query string (?api_key=, the deprecated lane
+        # _resolve_api_key still honours) and a raw value would write that
+        # credential into the cache key, reachable through raster_cache's
+        # on-disk files and any backup of them.
         # fix(#1372): $arg_v is the dataset's tile_cache_version, emitted by the
         # api in every raster tile URL — a raster replace bumps it, so the
         # shared cache rolls immediately instead of serving pre-replace bytes
         # for up to proxy_cache_valid. Unversioned clients (copied connect
         # URLs) key on the empty segment and keep the old bounded staleness.
-        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_v/$arg_colormap_name/$arg_stretch/$geolens_raster_pmin/$geolens_raster_pmax/$geolens_raster_sigma";
+        # fix(#2007): $arg_pv is the dataset's publication_version, in every
+        # tile URL the api emits. A status or visibility transition rolls it,
+        # so an emitted URL stops reading an entry stored before the change.
+        proxy_cache_key "$dataset_id/$z/$x/$y.$fmt/$arg_v/$arg_pv/$arg_colormap_name/$arg_stretch/$geolens_raster_pmin/$geolens_raster_pmax/$geolens_raster_sigma";
         # fix(#1778 codex r6): a non-canonical request (see the maps declared
         # near the top of this file) is served UNCACHED rather than keyed on
         # anything derived from its raw $args -- bypass skips the lookup,

--- a/frontend/src/components/maps/hooks/__tests__/use-map-layers.test.ts
+++ b/frontend/src/components/maps/hooks/__tests__/use-map-layers.test.ts
@@ -157,12 +157,25 @@ describe('useMapLayers raster tile source cache-busting', () => {
   // to a server-versioned URL.
   it('does not append a second v when the server URL already carries one', () => {
     const map = runRasterHook(
-      '/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png?v=7',
+      '/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png?v=7&pv=3',
       '2026-08-10T00:00:00Z',
     );
     const source = addedSourceConfig(map);
     expect(source?.tiles[0]).toBe(
-      `${window.location.origin}/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png?v=7`,
+      `${window.location.origin}/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png?v=7&pv=3`,
+    );
+  });
+
+  // fix(#2007): a legacy row with no tile_cache_version emits `?pv=` alone.
+  // A `?` appended onto that is a malformed URL, not a second version.
+  it('leaves a server URL carrying only the publication version alone', () => {
+    const map = runRasterHook(
+      '/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png?pv=3',
+      '2026-08-10T00:00:00Z',
+    );
+    const source = addedSourceConfig(map);
+    expect(source?.tiles[0]).toBe(
+      `${window.location.origin}/raster-tiles/dataset-1/tiles/{z}/{x}/{y}.png?pv=3`,
     );
   });
 });

--- a/frontend/src/components/maps/hooks/use-map-layers.ts
+++ b/frontend/src/components/maps/hooks/use-map-layers.ts
@@ -236,11 +236,11 @@ export function useMapLayers({
         // freshly re-added on remount. Bust that with tileVersion (the
         // dataset's updated_at) the same way the vector source already does
         // via buildSignedTileUrl.
-        // fix(#1372): the server now embeds `?v=<tile_cache_version>` in the
-        // raster tile URL (nginx's shared cache keys on it) — when present,
-        // it supersedes this client-side append; appending a second `v`
-        // would make nginx key on the wrong (first) value.
-        const hasServerVersion = /[?&]v=/.test(rasterTileUrl);
+        // fix(#1372, #2007): the server embeds `?v=<tile_cache_version>` and
+        // `pv=<publication_version>` (nginx's shared cache keys on both) — any
+        // server query supersedes this client-side append, which would both
+        // make nginx key on the wrong `v` and emit a second `?`.
+        const hasServerVersion = rasterTileUrl.includes('?');
         const versionedTileUrl =
           tileVersion && !hasServerVersion
             ? `${window.location.origin}${rasterTileUrl}?v=${encodeURIComponent(tileVersion)}`


### PR DESCRIPTION
## Summary

#2005 retires a dataset's tile signatures when its publication status or visibility changes, which stops the application from serving a tile to the holder of an old template. It does not reach the caches in front of the application. Both of those keyed on the caller's own `v` and signature and never on the counter, so an entry stored while the dataset was public and published stayed readable for its TTL after the owner unpublished it or made it private.

This is the issue's option 3. The publication counter now takes part in the cache key at both layers under one parameter name, `pv`, defined once in `backend/app/core/tile_scope.py` beside the signed scope that already binds it. It is added exactly the way `v` was added for the content version in #1372, which keeps one shape rather than two.

Where the counter comes from decides how complete the fix is on each layer, so both are stated plainly below rather than folded into one claim.

**The application's own vector and cluster tile cache is closed by construction.** Its key is derived from the row the request resolved, not from anything the caller sent, so once the counter rolls, the bytes stored under the previous one cannot be addressed by any request at all. `test_the_key_carries_the_row_not_the_request` pins that a supplied `pv` does not move the key.

**nginx and a CDN are keyed by the URL, so what changes there is which entry an emitted URL reads.** Every template the product emits after the transition carries the new counter and therefore addresses a different entry from one emitted before it, and the old entry expires on its own. A caller who kept the pre-transition URL still reads its entry until `proxy_cache_valid` elapses, because an nginx cache hit never reaches the application and nothing at that layer can consult the current counter. Closing that residual window means a purge or a revalidation policy, which is what #1928 and #1959 decided against and what the issue keeps out of option 3.

A CDN in front of nginx that keys on the full URL gets this behaviour for free, since the parameter is part of the URL. A CDN configured to strip query strings does not: it collapses every version onto one entry, exactly as it already collapses `v`.

**The parameter is not a way in.** A request whose `pv` names a row state other than the current one is refused the shared cache on all three routes and answered no-store, so it cannot fill the key that the next transition will make current with bytes from before it. An absent `pv` keeps the behaviour a copied connect URL has always had. Duplicates count as a mismatch, because nginx reads the first occurrence of a case-insensitively matched name while the api reads the last exact-case one, and the two layers must not key on different values.

The cache-scope rule from #1928 and #1959 is unchanged: a tile response is publicly cacheable only while the dataset is public and published.

## Changes

- `backend/app/core/tile_scope.py`: `TILE_PUBLICATION_VERSION_PARAM` and `tile_template_params` / `tile_template_query`, the one place the cache-key params are spelled.
- `frontend/nginx.conf`: `$arg_pv` joins the raster `proxy_cache_key`, beside `$arg_v` and read the same way. The rule about what may enter that key is restated as what it has always meant: the sanitised `$geolens_raster_*` values plus the enumerated names that cannot carry a credential, never raw `$args` and never an unenumerated `$arg_*`.
- `backend/app/processing/tiles/router.py`: one helper reads a cache-key param the way nginx resolves `$arg_`, one decides whether it disagrees with the row, and both `v` and `pv` go through them. The vector and cluster keys carry the counter through `_generation_table_key`, which keeps the `tile:{table}:*` invalidation patterns matching.
- Every emitted template carries the counter: the raster metadata and token URLs, the shared-map layer URLs, the style document, the STAC assets, and the DCAT and OGC tile links.
- `backend/app/core/tile_scope.py` also carries `republished_tile_url`: a `record_distributions` row is written once at ingest, so the vector template it stores predates every transition since. Both readers of that row, the record document and `published_distributions`, republish it at the dataset's current counter rather than as stored, which is the same reason the raster template is synthesized per request instead of persisted. Only our own tile routes are rewritten; an operator's link to another service is returned untouched, other params on the row survive, and a stale counter on it is replaced rather than repeated.
- `backend/app/modules/catalog/records/router.py`: the distributions endpoint the Connect panel reads republishes the same way, so copying the vector template off the dataset page no longer hands out the counter it had at ingest. Versioning this one is safe where the raster Connect template is not: a frozen counter there pins an edge entry, while the vector key comes off the row, so a stale one costs shared caching and never stale bytes.
- `frontend/src/components/maps/hooks/use-map-layers.ts`: the client-side `v` append yields to any server query string rather than to a `v=` match, so a row with no content version cannot produce a URL with two `?`.

## Area

- [x] Backend (API, services, models)
- [x] Frontend (UI, components, hooks)
- [x] Infrastructure (Docker, nginx)
- [x] Tiles / Rendering
- [x] OGC / Standards

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)

`backend/tests/test_tile_cache_publication_key_2007.py`, 21 cases. The nginx tests render the directive out of `frontend/nginx.conf` and resolve `$arg_` the way nginx does, reusing the harness #1778 built, so they fail if the directive stops holding the param rather than asserting a copy of it.

Counterfactuals, each observed with the fix reverted on this branch:

| Reverted | Failing cases |
| --- | --- |
| `pv` dropped from the vector/cluster key and from `proxy_cache_key` | 5, including both "cached before the transition, not served after" cases |
| the `pv` arm of the shared-cache guard | 2, the mismatched and the duplicated parameter |
| the stored-template rewrite reduced to a passthrough | 6, including both feed readers of the row |
| the Connect endpoint's rewrite dropped | 1, the reader-level pin |

Suites run green: the tile family (`test_tiles`, `test_raster_tiles`, `test_tile_signature_revocation_1963`, `test_tile_cache`, `test_tile_cache_generation_key_1429`, `test_tile_cache_scope_sec009`, `test_tile_signing`, `test_tile_signature_draft_parity_1928`, `test_tile_cached_authz_liveness_1451`, `test_perf002_raster_meta_cache`), maps and sharing, the three nginx config suites, the standards and distribution suites, `test_datasets`, `test_modality_assets` and `test_optional_auth_failure_mode_1518`. Also `test_layering.py`, `test_rule1_structural.py`, `test_rule2_structural.py`, `python3 backend/tests/finding_markers.py`, `ruff check` and `ruff format --check`.

Frontend: `npm run build`, `npm run lint`, `npm run typecheck` and `npm run test:coverage` (456 files, 6022 tests) all pass.

No route signature, docstring or schema description changed, so nothing regenerates.

## Deferred

Revocation is bounded by `_resolve_dataset_meta`'s snapshot, which holds `visibility`, `record_status` and the counter together for `_DATASET_CACHE_TTL`. Inside that window a worker admits the request on the pre-transition row, so the key it derives is stale for exactly as long as the decision that admitted it, and re-reading the counter alone would change nothing. That is the bound #2005 declared for the same caches; what this branch changes is the far side of it, from the tile TTL down to that window. `test_the_metadata_snapshot_bounds_the_roll` pins it with no eviction, so it is visible and fails loudly if it moves, rather than being evicted away by every case around it.

When a record carries no `vector_tiles` row at all, `dataset-access.ts` falls back to building the template client-side and that fallback stays unversioned. `generate_distributions` writes the row for every spatial vector dataset, so this only covers rows predating it, and versioning it would need `publication_version` on the dataset response plus an SDK regeneration. It is the same class as the raster Connect URL rather than a reader of the stored row.

Closing it exactly needs cross-worker invalidation of that snapshot: `notify_table_invalidated` is in-process, so wiring the transitions to it would refresh the writing worker and leave its siblings stale. That changes the authorization path rather than the cache key, so it belongs with #1963 and #2005 rather than here.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: no new user-facing strings
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [x] No migration needed (the column landed in #2005)
- [x] No secrets or credentials in the diff

`_MODULE_LOC_CAPS`: `processing/tiles/router.py` 2409 to 2475, `maps/style_json.py` 1590 to 1597, `search/router.py` 1380 to 1381, all exact.

Closes #2007
