### PR TITLE
fix(ingest): map coded failure reasons in the CLI and notifications, compose GDAL reasons by class (#2010)

### DIFF
--- a/backend/app/core/failure_reason.py
+++ b/backend/app/core/failure_reason.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import re
 
 from app.core.url_redaction import (
+    REDACTED_QUERY_VALUE,
     redact_filesystem_paths,
     redact_libpq_credentials,
     redact_url_credentials,
@@ -25,6 +26,16 @@ MAX_REASON_CHARS = 2000
 # A code rather than prose, so a reader (`ReuploadDialog.tsx`) can localize
 # it and no driver text can hide behind it.
 INTERNAL_FAILURE_REASON = "internal_error"
+
+# fix(#2010): the sentence each code stands for, for a reader that cannot
+# localize one itself. Same vocabulary as `frontend/src/lib/failure-reason.ts`
+# and `cli/geolens_cli/refresh.py`, which map it for their own readers.
+FAILURE_REASON_SENTENCES: dict[str, str] = {
+    INTERNAL_FAILURE_REASON: (
+        "The job failed for a reason the server could not report safely. "
+        "The details are in the server log for this job."
+    ),
+}
 
 _OWN_EXCEPTION_ROOT = "app."
 
@@ -87,6 +98,12 @@ def _drop_subprocess_output(summary: str) -> str:
     return summary[: match.start()].rstrip(" :-") if match else summary
 
 
+# fix(#2010): a stored reason has no use for a query string, and a signing
+# parameter need not be named in SENSITIVE_QUERY_PARAMS to be one. `[^\s=]*`
+# excludes its own delimiter, so each match has a single path through.
+_QUERY_TAIL_RE = re.compile(r"\?[^\s=]*=\S*")
+
+
 def _scrub(text: str) -> str:
     """Every shape Decision 3 keeps out of a reason, masked.
 
@@ -96,7 +113,11 @@ def _scrub(text: str) -> str:
     """
     return redact_filesystem_paths(
         redact_libpq_credentials(
-            scrub_registered_credentials(redact_url_credentials(text))
+            scrub_registered_credentials(
+                _QUERY_TAIL_RE.sub(
+                    f"?{REDACTED_QUERY_VALUE}", redact_url_credentials(text)
+                )
+            )
         )
     )
 
@@ -131,3 +152,8 @@ def coded_failure_reason(prefix: str, exc: BaseException) -> str:
     credential, so it survives Decision 3 where ``str(exc)`` does not.
     """
     return f"{prefix} ({type(exc).__name__})"
+
+
+def describe_failure_reason(reason: str) -> str:
+    """The stored reason, or the sentence it stands for when it is a code."""
+    return FAILURE_REASON_SENTENCES.get(reason, reason)

--- a/backend/app/core/failure_reason.py
+++ b/backend/app/core/failure_reason.py
@@ -99,9 +99,10 @@ def _drop_subprocess_output(summary: str) -> str:
 
 
 # fix(#2010): a stored reason has no use for a query string, and a signing
-# parameter need not be named in SENSITIVE_QUERY_PARAMS to be one. `[^\s=]*`
-# excludes its own delimiter, so each match has a single path through.
-_QUERY_TAIL_RE = re.compile(r"\?[^\s=]*=\S*")
+# parameter need not be named in SENSITIVE_QUERY_PARAMS to be one. The name
+# class excludes `?` as well as `=`, so a run of them cannot be rescanned
+# from every position; GDAL stderr reaches this uncapped.
+_QUERY_TAIL_RE = re.compile(r"\?[^\s=?]*=\S*")
 
 
 def _scrub(text: str) -> str:

--- a/backend/app/platform/notifications/events.py
+++ b/backend/app/platform/notifications/events.py
@@ -65,16 +65,23 @@ def build_event_notification(
     may be None) in ``data["to"]``. *reason* (EVENT-03 failure path) is
     appended to *body* and placed in ``data["reason"]`` — it's the job's
     error_message surfaced to the dataset owner, not a secret (T-1230-01).
+    A reason the door stored as a code becomes the sentence it stands for.
     *extra* is merged into ``data`` last for structured context (job_id,
     dataset name, etc.).
     """
     # Deferred import — Phase 214 discipline.
     from app.core.config import settings as app_settings
+    from app.core.failure_reason import describe_failure_reason
     from app.platform.extensions.protocols import Notification
 
     recipient: str | None = getattr(
         app_settings, "notification_admin_email", None
     ) or getattr(app_settings, "smtp_from_address", None)
+
+    # fix(#2010): mail is a reader like the web app, and a code is not a
+    # sentence. Mapped here rather than at each call site, so a new event
+    # that carries a reason cannot reintroduce the raw identifier.
+    reason = describe_failure_reason(reason) if reason else reason
 
     final_body = body
     if reason:

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -6,7 +6,7 @@ import os
 import re
 import time
 from collections.abc import Callable
-from typing import TypedDict
+from typing import NoReturn, TypedDict
 
 import structlog
 
@@ -84,6 +84,26 @@ def _is_unopenable_source_stderr(stderr_text: str) -> bool:
     )
 
 
+# fix(#2010): the failure classes a stored reason may name, and the only
+# field any of them takes out of GDAL's text. A driver names the source
+# inside its own prose ("unable to open 'GPKG:/app/staging/x.gpkg'"), which
+# no cut over that text can be relied on to reach.
+_GDAL_FAILURE_CLASSES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"HTTP (?:error )?(?:code|response)\s*:?\s*(\d{3})"),
+        "the source service answered HTTP {}",
+    ),
+    (
+        re.compile(r"(?i)couldn't fetch requested layer"),
+        "the requested layer is not in the source",
+    ),
+    (
+        re.compile(r"Failed to process SRS definition"),
+        "the coordinate reference system could not be resolved",
+    ),
+)
+
+
 # Human-readable label per uploaded extension, used only to phrase the
 # friendly "could not open" message below. Unknown/missing extensions fall
 # back to a generic "spatial data" phrasing.
@@ -121,6 +141,35 @@ def _friendly_open_failure_message(original_filename: "str | None") -> str:
         "Could not open the uploaded file as a spatial dataset — it may be "
         "corrupt, incomplete, or not a valid spatial data file."
     )
+
+
+def _raise_gdal_failure(
+    tool: str,
+    returncode: int,
+    stderr_text: str,
+    original_filename: "str | None",
+) -> NoReturn:
+    """Raise the reason ``stderr_text``'s failure class allows, having logged it.
+
+    The message carries the tool, the exit status and the fields the matched
+    class permits, never the driver's own prose. Full stderr is diagnostic
+    gold for us and noise for the job UI, so it stays in the log.
+    """
+    structlog.get_logger().error(
+        f"{tool} failed",
+        exit_code=returncode,
+        stderr=stderr_text,
+        original_filename=original_filename,
+    )
+    if _is_unopenable_source_stderr(stderr_text):
+        raise IngestionError(_friendly_open_failure_message(original_filename))
+    for pattern, sentence in _GDAL_FAILURE_CLASSES:
+        match = pattern.search(stderr_text)
+        if match:
+            raise IngestionError(
+                f"{tool} failed (exit {returncode}): {sentence.format(*match.groups())}"
+            )
+    raise IngestionError(f"{tool} failed (exit {returncode})")
 
 
 # fix(#1746): the worker's own refusals, as constants rather than composed
@@ -762,18 +811,9 @@ async def run_ogrinfo(
     )
 
     if proc.returncode != 0:
-        stderr_text = stderr.decode().strip()
-        if _is_unopenable_source_stderr(stderr_text):
-            # Full stderr is diagnostic gold for us but noise (plus a leaked
-            # staging path) for the job UI — log it here, raise a friendly message.
-            structlog.get_logger().error(
-                "ogrinfo could not open source file",
-                exit_code=proc.returncode,
-                stderr=stderr_text,
-                original_filename=original_filename,
-            )
-            raise IngestionError(_friendly_open_failure_message(original_filename))
-        raise IngestionError(f"ogrinfo failed (exit {proc.returncode}): {stderr_text}")
+        _raise_gdal_failure(
+            "ogrinfo", proc.returncode, stderr.decode().strip(), original_filename
+        )
 
     result = _parse_text_ogrinfo(stdout.decode())
     # Text-fallback parse doesn't extract field definitions, so the DBF
@@ -1005,17 +1045,9 @@ async def run_ogr2ogr(
     )
 
     if proc.returncode != 0:
-        stderr_text = stderr.decode().strip()
-        if _is_unopenable_source_stderr(stderr_text):
-            # Same rationale as run_ogrinfo above.
-            structlog.get_logger().error(
-                "ogr2ogr could not open source file",
-                exit_code=proc.returncode,
-                stderr=stderr_text,
-                original_filename=original_filename,
-            )
-            raise IngestionError(_friendly_open_failure_message(original_filename))
-        raise IngestionError(f"ogr2ogr failed (exit {proc.returncode}): {stderr_text}")
+        _raise_gdal_failure(
+            "ogr2ogr", proc.returncode, stderr.decode().strip(), original_filename
+        )
 
 
 async def run_ogr2ogr_service(
@@ -1295,6 +1327,8 @@ async def run_ogr2ogr_service(
         stripped = _strip_ogr_driver_list(
             stderr.decode()
         )  # SEED-04: strip driver list noise
+        # fix(#2010): the service path keeps GDAL's text: its source is the
+        # caller's own URL, and `_looks_like_auth_error` reads this message.
         # fix(#1277): redact BEFORE the text becomes an exception. For
         # ArcGIS the credential rides in the ESRIJSON source URL query
         # string (only WFS/OGC API get the header-file treatment above),

--- a/backend/app/processing/ingest/tasks_raster.py
+++ b/backend/app/processing/ingest/tasks_raster.py
@@ -208,7 +208,7 @@ async def ingest_raster(
                 # EVENT-03: notify on ingest failed (non-fatal, after commit — deferred import).
                 # status="failed" is already committed so a notification error cannot
                 # roll back or alter the terminal job write (T-1230-09 fail-safe).
-                _early_reason = str(exc)
+                _early_reason = redact_failure_reason(exc)
                 _early_job_id = str(job_uuid)
                 from app.platform.notifications.events import (
                     build_event_notification,
@@ -806,7 +806,7 @@ async def ingest_raster(
         # notification error cannot roll back or alter the terminal job write
         # (T-1230-09 fail-safe).  Placed BEFORE the re-raise so the notification
         # fires on the terminal write without suppressing the re-raise (T-1230-10).
-        _late_reason = str(exc)
+        _late_reason = redact_failure_reason(exc)
         _late_job_id = job_id
         from app.platform.notifications.events import (
             build_event_notification,

--- a/backend/tests/test_failure_reason_readers_2010.py
+++ b/backend/tests/test_failure_reason_readers_2010.py
@@ -8,6 +8,7 @@ carrying a signing parameter `SENSITIVE_QUERY_PARAMS` does not list.
 from __future__ import annotations
 
 import ast
+import time
 from pathlib import Path
 
 import pytest
@@ -164,6 +165,18 @@ class TestTheDoorDropsAQueryTail:
         assert "abcdef123456" not in reason
         assert "sig2" not in reason
         assert reason.endswith("timed out")
+
+    def test_a_run_of_question_marks_is_not_rescanned_from_each_one(self) -> None:
+        """The tail pass is reached with uncapped GDAL stderr.
+
+        A name class that admitted `?` retried from every one of them, which
+        measured 3.7s over 40k characters before the reason cap applies.
+        """
+        started = time.perf_counter()
+        redact_failure_reason("ERROR 1: " + "?" * 40_000)
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < 1.0, elapsed
 
     def test_prose_and_a_query_free_url_are_left_alone(self) -> None:
         assert redact_failure_reason("Is this a GeoPackage? Probably not") == (

--- a/backend/tests/test_failure_reason_readers_2010.py
+++ b/backend/tests/test_failure_reason_readers_2010.py
@@ -1,0 +1,237 @@
+"""The readers of a stored failure reason, and what may become one (#2010).
+
+Three follow-ups to #2004 (#1953): a reader that renders the door's code, a
+GDAL driver that names the source inside its own prose, and a query tail
+carrying a signing parameter `SENSITIVE_QUERY_PARAMS` does not list.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from app.core import failure_reason as door
+from app.core.failure_reason import (
+    FAILURE_REASON_SENTENCES,
+    INTERNAL_FAILURE_REASON,
+    describe_failure_reason,
+    redact_failure_reason,
+)
+from app.platform.notifications.events import build_event_notification
+from app.processing.ingest.ogr import IngestionError, _raise_gdal_failure
+
+_APP = Path(__file__).resolve().parents[1] / "app"
+
+# The source GDAL echoes for a zipped upload, and the first stderr line it
+# puts that source in. `redact_filesystem_paths` cannot mask this one: its
+# lookbehind refuses a run preceded by `/`, which `/vsizip/` supplies.
+_STAGED_SOURCE = "/vsizip//app/staging/9f2c1a3e_march.zip"
+_PROSE_PATH_LINE = (
+    f"ERROR 4: `{_STAGED_SOURCE}' does not exist in the file system, "
+    "and is not recognized as a supported dataset name."
+)
+
+
+class TestEveryCodeTheDoorCanEmitHasASentence:
+    def test_every_code_constant_is_mapped(self) -> None:
+        codes = {
+            value
+            for name, value in vars(door).items()
+            if name.endswith("_FAILURE_REASON") and isinstance(value, str)
+        }
+
+        assert codes, "the enumeration found no code to check"
+        assert codes <= set(FAILURE_REASON_SENTENCES)
+        for code in codes:
+            assert describe_failure_reason(code) != code
+
+    def test_a_composed_reason_is_left_alone(self) -> None:
+        composed = "Layer 'parcels' has no geometry column"
+        assert describe_failure_reason(composed) == composed
+
+
+class TestTheIngestFailureMailRendersTheSentence:
+    def test_a_coded_reason_becomes_its_sentence(self) -> None:
+        notification = build_event_notification(
+            "ingest_failed",
+            subject="Ingest failed",
+            body="Ingest job failed.",
+            reason=INTERNAL_FAILURE_REASON,
+        )
+
+        assert (
+            notification.data["reason"]
+            == (FAILURE_REASON_SENTENCES[INTERNAL_FAILURE_REASON])
+        )
+        assert INTERNAL_FAILURE_REASON not in notification.body
+
+    def test_a_composed_reason_reaches_the_reader_unchanged(self) -> None:
+        notification = build_event_notification(
+            "ingest_failed",
+            subject="Ingest failed",
+            body="Ingest job failed.",
+            reason="Layer 'parcels' has no geometry column",
+        )
+
+        assert notification.data["reason"] == "Layer 'parcels' has no geometry column"
+
+    def test_no_call_site_hands_the_mail_an_unredacted_reason(self) -> None:
+        offenders: list[str] = []
+        for module in sorted(_APP.rglob("*.py")):
+            tree = ast.parse(module.read_text())
+            safe = _redacted_locals(tree)
+            for value in _notification_reasons(tree):
+                if _is_safe_reason(value, safe):
+                    continue
+                offenders.append(
+                    f"{module.relative_to(_APP)}:{value.lineno} "
+                    f"{ast.unparse(value)[:60]}"
+                )
+        assert not offenders, offenders
+
+    def test_the_gate_above_can_see_a_violation(self) -> None:
+        tree = ast.parse("build_event_notification('ingest_failed', reason=str(exc))\n")
+        values = _notification_reasons(tree)
+
+        assert len(values) == 1
+        assert not _is_safe_reason(values[0], _redacted_locals(tree))
+
+
+class TestAGdalReasonIsComposedFromItsFailureClass:
+    @pytest.mark.parametrize(
+        ("stderr_text", "expected"),
+        [
+            pytest.param(
+                f"ERROR 1: Couldn't fetch requested layer roads.\n{_PROSE_PATH_LINE}",
+                "ogrinfo failed (exit 1): the requested layer is not in the source",
+                id="missing_layer",
+            ),
+            pytest.param(
+                f"ERROR 1: HTTP error code : 502\n{_PROSE_PATH_LINE}",
+                "ogrinfo failed (exit 1): the source service answered HTTP 502",
+                id="http_status",
+            ),
+            pytest.param(
+                f"ERROR 1: Failed to process SRS definition: EPSG:999999\n"
+                f"{_PROSE_PATH_LINE}",
+                "ogrinfo failed (exit 1): "
+                "the coordinate reference system could not be resolved",
+                id="unresolved_srs",
+            ),
+            pytest.param(
+                f"{_PROSE_PATH_LINE}\nERROR 6: Unsupported field type",
+                "ogrinfo failed (exit 1)",
+                id="unrecognised",
+            ),
+        ],
+    )
+    def test_the_class_composes_the_reason_and_the_source_is_absent(
+        self, stderr_text: str, expected: str
+    ) -> None:
+        with pytest.raises(IngestionError) as exc_info:
+            _raise_gdal_failure("ogrinfo", 1, stderr_text, "march.zip")
+
+        assert str(exc_info.value) == expected
+        assert _STAGED_SOURCE not in str(exc_info.value)
+        assert redact_failure_reason(exc_info.value) == expected
+
+    def test_trimming_the_driver_text_would_have_kept_the_source(self) -> None:
+        """The counterfactual: the reason this cut is composition, not a cut."""
+        trimmed = redact_failure_reason(
+            IngestionError(f"ogrinfo failed (exit 1): {_PROSE_PATH_LINE}")
+        )
+
+        assert _STAGED_SOURCE in trimmed
+
+    def test_an_unopenable_source_still_gets_the_friendly_message(self) -> None:
+        with pytest.raises(IngestionError) as exc_info:
+            _raise_gdal_failure(
+                "ogr2ogr", 1, "ERROR 1: file is not a database", "march.gpkg"
+            )
+
+        assert str(exc_info.value).startswith("Could not open 'march.gpkg'")
+
+
+class TestTheDoorDropsAQueryTail:
+    def test_a_signing_parameter_no_list_names_is_dropped(self) -> None:
+        reason = redact_failure_reason(
+            "Failed to download manifest source: "
+            "https://example.com/a/b.gpkg?sig2=abcdef123456 timed out"
+        )
+
+        assert "abcdef123456" not in reason
+        assert "sig2" not in reason
+        assert reason.endswith("timed out")
+
+    def test_prose_and_a_query_free_url_are_left_alone(self) -> None:
+        assert redact_failure_reason("Is this a GeoPackage? Probably not") == (
+            "Is this a GeoPackage? Probably not"
+        )
+        assert redact_failure_reason(
+            "Failed to download manifest source: https://example.com/a/b.gpkg timed out"
+        ) == (
+            "Failed to download manifest source: https://example.com/a/b.gpkg timed out"
+        )
+
+
+_SANCTIONED_REDACTORS = frozenset(
+    {"redact_failure_reason", "prefixed_failure_reason", "coded_failure_reason"}
+)
+
+
+def _call_names(node: ast.AST) -> set[str]:
+    return {
+        call.func.id
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+
+
+def _redacted_locals(tree: ast.AST) -> set[str]:
+    """Names bound from a sanctioned redactor, directly or through an alias.
+
+    The failure tails bind the redacted text once and re-bind it under a
+    lambda-safe name at the emit site, so a one-hop rule would miss them.
+    """
+    assigns = [
+        (target.id, node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    ]
+    names: set[str] = set()
+    growing = True
+    while growing:
+        growing = False
+        for name, value in assigns:
+            if name in names:
+                continue
+            if _call_names(value) & _SANCTIONED_REDACTORS or (
+                isinstance(value, ast.Name) and value.id in names
+            ):
+                names.add(name)
+                growing = True
+    return names
+
+
+def _notification_reasons(tree: ast.AST) -> list[ast.expr]:
+    return [
+        keyword.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "build_event_notification"
+        for keyword in node.keywords
+        if keyword.arg == "reason"
+    ]
+
+
+def _is_safe_reason(value: ast.expr, redacted: set[str]) -> bool:
+    if _call_names(value) & _SANCTIONED_REDACTORS:
+        return True
+    if isinstance(value, ast.Constant):
+        return True
+    return isinstance(value, ast.Name) and value.id in redacted

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4964,7 +4964,11 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # file. Cap 1428 -> 1433, exact.
     # fix(#1828): +6. `run_ogr2ogr_service` refuses a credentialed WFS that
     # names no layer before the origin check and the spawn. Cap 1433 -> 1439.
-    "backend/app/processing/ingest/ogr.py": 1307,
+    # fix(#2010): +34. The two local-file spawners share one failure exit that
+    # recognises the class first and composes the reason from the fields that
+    # class may carry, since a driver names the source inside its own prose.
+    # Cap 1307 -> 1341, exact.
+    "backend/app/processing/ingest/ogr.py": 1341,
     # fix(#1846, GHSA-hrf5-v3cq-frx5): first entry. This module crossed the
     # 1000-line threshold when the content check landed: the SQLite schema
     # reader, the archive member walk that identifies members by their bytes

--- a/cli/geolens_cli/refresh.py
+++ b/cli/geolens_cli/refresh.py
@@ -90,6 +90,24 @@ _REFUSAL_MESSAGES: dict[str, str] = {
 }
 
 
+# The code the server stores instead of a failure it did not compose
+# (`backend/app/core/failure_reason.py`). Same vocabulary as
+# `frontend/src/lib/failure-reason.ts`.
+INTERNAL_FAILURE_REASON = "internal_error"
+
+FAILURE_REASON_MESSAGES: dict[str, str] = {
+    INTERNAL_FAILURE_REASON: (
+        "The job failed for a reason the server could not report safely. "
+        "Ask an operator to check the server log for this job."
+    ),
+}
+
+
+def describe_failure_reason(reason: str) -> str:
+    """The stored reason, or the sentence it stands for when it is a code."""
+    return FAILURE_REASON_MESSAGES.get(reason, reason)
+
+
 def start_refresh(client: Any, dataset_id: UUID, token: str | None = None) -> Any:
     """Dispatch a refresh through the generated SDK.
 
@@ -256,9 +274,16 @@ def wait_for_refresh(
                 return RefreshPollResult(status=status)
             if status in {"failed", "cancelled"}:
                 error = getattr(job, "error_message", None)
+                # fix(#2010): the one point a stored reason enters the CLI, so
+                # the human views and the JSON payload cannot disagree about
+                # whether a coded reason reads as an identifier or a sentence.
                 return RefreshPollResult(
                     status=status,
-                    error_message=_redact_secret(str(error), token) if error else None,
+                    error_message=(
+                        describe_failure_reason(_redact_secret(str(error), token))
+                        if error
+                        else None
+                    ),
                 )
             if deadline is None:
                 sleep(interval)

--- a/cli/tests/test_refresh.py
+++ b/cli/tests/test_refresh.py
@@ -1638,3 +1638,64 @@ class TestUnreadableMemberNeverDeletesOrRefreshes:
             # (round 27/30), so the refresh proceeds normally.
             assert result.exit_code == 0, result.output
             assert refresh_calls["count"] == 1, member
+
+
+class TestCodedFailureReasonsRenderAsSentences:
+    def test_every_code_the_door_can_emit_is_mapped(self) -> None:
+        from geolens_cli.refresh import (
+            FAILURE_REASON_MESSAGES,
+            INTERNAL_FAILURE_REASON,
+            describe_failure_reason,
+        )
+
+        assert INTERNAL_FAILURE_REASON in FAILURE_REASON_MESSAGES
+        for code, sentence in FAILURE_REASON_MESSAGES.items():
+            assert describe_failure_reason(code) == sentence
+            assert sentence != code
+
+    def test_a_composed_reason_is_left_alone(self) -> None:
+        from geolens_cli.refresh import describe_failure_reason
+
+        composed = "Layer 'parcels' has no geometry column"
+        assert describe_failure_reason(composed) == composed
+
+    def test_the_refresh_view_prints_the_sentence_and_not_the_code(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+        from geolens_cli.refresh import (
+            FAILURE_REASON_MESSAGES,
+            INTERNAL_FAILURE_REASON,
+        )
+
+        _seed_login(mock_keyring)
+        _patch_refresh_endpoint(monkeypatch, _accepted())
+        _patch_job(monkeypatch, status="failed", error_message=INTERNAL_FAILURE_REASON)
+
+        result = runner.invoke(app, ["refresh", str(DATASET_ID), "--wait"])
+
+        assert result.exit_code == 1
+        assert INTERNAL_FAILURE_REASON not in result.output
+        assert FAILURE_REASON_MESSAGES[INTERNAL_FAILURE_REASON].split(".")[0] in (
+            " ".join(result.output.split())
+        )
+
+    def test_the_json_payload_carries_the_same_sentence(
+        self, runner, tmp_xdg_home, mock_keyring, monkeypatch
+    ) -> None:
+        from geolens_cli.main import app
+        from geolens_cli.refresh import (
+            FAILURE_REASON_MESSAGES,
+            INTERNAL_FAILURE_REASON,
+        )
+
+        _seed_login(mock_keyring)
+        _patch_refresh_endpoint(monkeypatch, _accepted())
+        _patch_job(monkeypatch, status="failed", error_message=INTERNAL_FAILURE_REASON)
+
+        result = runner.invoke(app, ["--json", "refresh", str(DATASET_ID), "--wait"])
+
+        assert result.exit_code == 1
+        assert json.loads(result.output)["error_message"] == (
+            FAILURE_REASON_MESSAGES[INTERNAL_FAILURE_REASON]
+        )


### PR DESCRIPTION
## Summary

Three follow-ups deferred from #2004 (#1953), which made `backend/app/core/failure_reason.py` the single door every stored `error_message` passes through.

The CLI job views and the ingest-failure mail printed the door's code verbatim, so an operator saw `internal_error` where the web app shows a sentence. A GDAL driver can still name the source inside its own prose, which the door's cut over the invocation does not reach. And `_scrub` had no query-tail pass, so a signing parameter the redaction list does not name survived in a stored reason.

Closes #2010.

## Changes

- `describe_failure_reason()` beside the door maps a stored code to the sentence it stands for. `build_event_notification()` applies it, so the mapping sits at the reader rather than at each emit site and a new event that carries a reason cannot reintroduce the identifier.
- The CLI maps the same vocabulary in `cli/geolens_cli/refresh.py`, at the point a stored reason enters `RefreshPollResult`. The human view and the `--json` payload therefore agree. The CLI keeps its own copy because it wraps the generated SDK and must not import `app.`.
- `processing/ingest/ogr.py` recognises the failure class before it composes a reason. The two local-file spawners share one exit that logs the driver's full stderr, then raises a message built from the tool, the exit status and the fields the matched class may carry. Classes today: the source cannot be opened, the origin answered an HTTP status, the requested layer is not in the source, the CRS could not be resolved. Anything else stores the tool and the exit status alone.
- The service spawner keeps GDAL's text. Its source is the caller's own URL, and `_looks_like_auth_error` reads that message to turn a 401 into retry guidance.
- `_scrub` drops any `?name=value` run, the pass `core/logging_config.py` already applies on the logging path. Motivation: `SENSITIVE_QUERY_PARAMS` is a list of names, and a signing parameter need not be on it.
- The two raster notification tails passed `str(exc)` rather than the redacted reason. Both now go through the door, and a tree-wide AST gate pins every `build_event_notification(reason=...)` to a sanctioned redactor.

## Area

- [x] Backend (API, services, models)
- [ ] Frontend (UI, components, hooks)
- [ ] Infrastructure (Docker, nginx)
- [ ] Tiles / Rendering
- [ ] Auth / Permissions
- [x] Import / Ingestion
- [ ] OGC / Standards
- [ ] Docs / Config

## Testing

New `backend/tests/test_failure_reason_readers_2010.py` and a new class in `cli/tests/test_refresh.py`. Each carries its counterfactual:

- The composed reason omits the staged source that the pre-fix trimming kept. `test_trimming_the_driver_text_would_have_kept_the_source` asserts the old route still leaks it, because `redact_filesystem_paths` refuses a run preceded by `/`, which `/vsizip/` supplies. The prose line in the fixture is real GDAL output for a zipped upload.
- The AST gate flags the pre-fix raster tails. Re-parsed with `str(exc)` restored, it reports `_early_reason` and `_late_reason`.
- The query tail: `?sig2=<value>` survived a stored reason before this change and is gone after.
- The CLI test drives `geolens refresh --wait` against a failed job whose `error_message` is the code, and asserts the code is absent from both the text output and the JSON payload.

Ran on the host: `test_failure_reason_readers_2010.py`, `test_layering.py`, `test_stored_failure_reason_1953.py`, `test_rule2_structural.py`, `test_ingest_open_failure_message.py` (against the real GDAL binaries), `test_ingest_ogr_pure.py`, `test_ogr_subprocess_env.py`, `test_ogr_communicate_cancellation.py`, `test_ingest_vector_failure_tails.py`, `test_event_ingest.py`, `test_service_token_redaction_1277.py`, `test_reupload_service.py`, `test_ingest.py`, `test_ingest_tier1_formats.py`, `test_ingest_layer_name_guard.py`, `test_raster_ingest.py`, `test_service_auth_transport_1746.py`, `test_url_redaction_sec.py`, `test_phase_273_log_redaction.py`, `test_1746_stdlib_log_redaction.py`, `test_dataset_history_redaction.py`, `test_failed_job_token_purge_1746.py`. Plus the whole CLI unit suite, `ruff check`, `ruff format --check`, and `finding_markers.py`.

- [x] Unit tests pass (`pytest` / `npm test`)
- [ ] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)

## Note on the trade

An unrecognised local-file failure now stores the tool and the exit status instead of GDAL's first stderr line. The full stderr still reaches structured logs at error level, which is where it already went for the unopenable class. Recovering a diagnostic for the job UI means adding the class, not widening the cut. The four classes here are grounded in output from the GDAL the image ships.

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [ ] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing
