### PR TITLE
fix(ratelimit): share rate-limit buckets and the facets claim registry (#2018)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -731,6 +731,13 @@ FRONTEND_PORT=8080
 # never reaches the server-side cache key (the raster route does, which is why
 # raster does not have this behaviour). Set REDIS_URL for any deployment that
 # runs more than one uvicorn worker and edits features.
+# fix(#2018): this also decides where rate-limit buckets are counted. With it
+# unset, every per-IP and per-user limit is counted per uvicorn worker, so the
+# cap you configure is really that cap times UVICORN_WORKERS. With it set, the
+# buckets are one counter the whole cluster shares, and a store outage falls
+# back to per-worker counting rather than dropping the limit. Only redis:// and
+# rediss:// URLs can hold the buckets; any other scheme keeps them per worker
+# and says so once at startup.
 # Type: string | No default
 # Example: redis://redis:6379/0
 # REDIS_URL=

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -50,7 +50,7 @@ from app.platform.extensions.bootstrap import (
 )
 from app.modules.auth.models import Role, User, UserRole
 from app.modules.auth.providers.local import hash_password
-from app.platform.ratelimit import limiter
+from app.platform.ratelimit import emit_startup_notices, limiter
 from app.processing.ingest.tasks import task_app
 from app.api.middleware.body_limit import RequestBodyLimitMiddleware
 from app.api.middleware.cors import DynamicCORSMiddleware
@@ -379,6 +379,11 @@ async def lifespan(app: FastAPI):
 
     # SEC-08 / M-72: surface unset CORS_ALLOWED_ORIGINS in production once.
     _warn_if_cors_unset(settings, logger)
+
+    # fix(#2018): the rate-limit storage decision is made at import, before
+    # setup_logging() above, so its notices are queued rather than logged
+    # there and flushed here into the configured stream.
+    emit_startup_notices()
 
     # WORK-01: shared bootstrap — extension load, enterprise-overlay-requested check,
     # edition init, extension router include, storage + S3 health probe, billing

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -21,6 +21,7 @@ from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.search.service_filters import SearchFilters
 from app.platform.cache import tenant_cache_context_available, tenant_cache_key
 from app.platform.extensions import get_catalog_port
+from app.platform.ratelimit_claims import get_shared_claim_store
 
 logger = structlog.stdlib.get_logger(__name__)
 EmbeddingUnavailableError = get_catalog_port().embedding_unavailable_error_class()
@@ -80,7 +81,8 @@ def _embedding_cache_clear() -> None:
 
 # fix(#1903): coordinates the SPA's unordered results/facets pair so only
 # one request pays the SEC-S11 token; keyed on (client, tenant, text),
-# single-use, bounded by TTL + LRU (cross-worker sharing tracked at #2018).
+# single-use, bounded by TTL + LRU. fix(#2018): a configured shared store
+# answers first, so this is the fallback for one that does not answer.
 _QUERY_CLAIM_TTL_SECONDS = 5.0
 _QUERY_CLAIM_MAX_SIZE = 256
 _query_claims: "OrderedDict[tuple[str, str], tuple[str, float]]" = OrderedDict()
@@ -113,6 +115,11 @@ def consume_paired_query_claim(client_key: str, text: str, route: str) -> bool:
     key = _query_claim_key(client_key, text)
     if key is None:
         return False
+    store = get_shared_claim_store()
+    if store is not None:
+        shared = store.consume(key, route)
+        if shared is not None:
+            return shared
     claimed = _query_claims.get(key)
     if claimed is None:
         return False
@@ -127,6 +134,9 @@ def record_paired_query_claim(client_key: str, text: str, route: str) -> None:
     """Claim (client, text) for *route*. Call only once a request is admitted."""
     key = _query_claim_key(client_key, text)
     if key is None:
+        return
+    store = get_shared_claim_store()
+    if store is not None and store.record(key, route) is not None:
         return
     _query_claims[key] = (route, time.monotonic() + _QUERY_CLAIM_TTL_SECONDS)
     _query_claims.move_to_end(key)

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -117,13 +117,14 @@ def consume_paired_query_claim(client_key: str, text: str, route: str) -> bool:
     if key is None:
         return False
     store = get_shared_claim_store()
-    if store is not None:
-        shared = store.consume(key, route)
-        if shared is not None:
-            # fix(#2018): the store answered, so drop the local mirror with it
-            # -- a later outage must not re-serve a claim already redeemed.
-            _query_claims.pop(key, None)
-            return shared
+    if store is not None and store.consume(key, route):
+        # fix(#2018): a redeemed claim takes any local entry with it, so one
+        # left over from an earlier outage cannot fund a second exemption.
+        _query_claims.pop(key, None)
+        return True
+    # fix(#2018): a store "no key" is not authoritative over a claim the
+    # fallback wrote while the store was unreachable: that claim can outlive
+    # the cooldown, and it was never published for the store to answer for.
     claimed = _query_claims.get(key)
     if claimed is None:
         return False
@@ -140,11 +141,8 @@ def record_paired_query_claim(client_key: str, text: str, route: str) -> None:
     if key is None:
         return
     store = get_shared_claim_store()
-    # fix(#2018): mirror every claim locally even when the store took it. A
-    # store that accepts SET but refuses GETDEL (older server, narrow ACL)
-    # would otherwise leave the sibling nothing to fall back to.
-    if store is not None:
-        store.record(key, route)
+    if store is not None and store.record(key, route) is not None:
+        return
     _query_claims[key] = (route, time.monotonic() + _QUERY_CLAIM_TTL_SECONDS)
     _query_claims.move_to_end(key)
     while len(_query_claims) > _QUERY_CLAIM_MAX_SIZE:

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -21,7 +21,7 @@ from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.search.service_filters import SearchFilters
 from app.platform.cache import tenant_cache_context_available, tenant_cache_key
 from app.platform.extensions import get_catalog_port
-from app.platform.ratelimit_claims import get_shared_claim_store
+from app.platform.ratelimit_claims import CLAIM_TTL_SECONDS, get_shared_claim_store
 
 logger = structlog.stdlib.get_logger(__name__)
 EmbeddingUnavailableError = get_catalog_port().embedding_unavailable_error_class()
@@ -82,8 +82,9 @@ def _embedding_cache_clear() -> None:
 # fix(#1903): coordinates the SPA's unordered results/facets pair so only
 # one request pays the SEC-S11 token; keyed on (client, tenant, text),
 # single-use, bounded by TTL + LRU. fix(#2018): a configured shared store
-# answers first, so this is the fallback for one that does not answer.
-_QUERY_CLAIM_TTL_SECONDS = 5.0
+# answers first, so this is the fallback for one that does not answer, and
+# the pairing window is that store's, not a second copy of it.
+_QUERY_CLAIM_TTL_SECONDS = float(CLAIM_TTL_SECONDS)
 _QUERY_CLAIM_MAX_SIZE = 256
 _query_claims: "OrderedDict[tuple[str, str], tuple[str, float]]" = OrderedDict()
 

--- a/backend/app/modules/catalog/search/service_semantic.py
+++ b/backend/app/modules/catalog/search/service_semantic.py
@@ -120,6 +120,9 @@ def consume_paired_query_claim(client_key: str, text: str, route: str) -> bool:
     if store is not None:
         shared = store.consume(key, route)
         if shared is not None:
+            # fix(#2018): the store answered, so drop the local mirror with it
+            # -- a later outage must not re-serve a claim already redeemed.
+            _query_claims.pop(key, None)
             return shared
     claimed = _query_claims.get(key)
     if claimed is None:
@@ -137,8 +140,11 @@ def record_paired_query_claim(client_key: str, text: str, route: str) -> None:
     if key is None:
         return
     store = get_shared_claim_store()
-    if store is not None and store.record(key, route) is not None:
-        return
+    # fix(#2018): mirror every claim locally even when the store took it. A
+    # store that accepts SET but refuses GETDEL (older server, narrow ACL)
+    # would otherwise leave the sibling nothing to fall back to.
+    if store is not None:
+        store.record(key, route)
     _query_claims[key] = (route, time.monotonic() + _QUERY_CLAIM_TTL_SECONDS)
     _query_claims.move_to_end(key)
     while len(_query_claims) > _QUERY_CLAIM_MAX_SIZE:

--- a/backend/app/platform/ratelimit.py
+++ b/backend/app/platform/ratelimit.py
@@ -24,7 +24,7 @@ pre-#2018 behaviour, rather than to no limit or a 500 per request.
 from __future__ import annotations
 
 from functools import cache
-from urllib.parse import urlsplit
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import structlog
 from fastapi import Request
@@ -45,6 +45,33 @@ _SHARED_STORAGE_SCHEMES = frozenset({"redis", "rediss"})
 # so a hung store has to fail into the in-memory fallback fast.
 STORAGE_SOCKET_TIMEOUT_SECONDS = 0.25
 
+# fix(#2018): redis-py parses these from the URL and lets the querystring win
+# over the keyword arguments, so a raised value there would hold the event
+# loop for that long. The bound above is not the operator's to widen.
+_PINNED_TIMEOUT_PARAMS = frozenset({"socket_timeout", "socket_connect_timeout"})
+
+
+def _pin_socket_timeouts(url: str) -> str:
+    """Return *url* without any socket-timeout query parameter."""
+    parts = urlsplit(url)
+    if not parts.query:
+        return url
+    # fix(#2018): REDIS_URL is an operator-supplied boot-time value parsed
+    # once at import, the same class as config.py's DATABASE_URL_OVERRIDE
+    # sites; a raise here would fail boot rather than refuse a request.
+    pairs = parse_qsl(parts.query, keep_blank_values=True)  # parse_qs: unbounded
+    kept = [(k, v) for k, v in pairs if k.lower() not in _PINNED_TIMEOUT_PARAMS]
+    if len(kept) == len(pairs):
+        return url
+    logger.warning(
+        "rate_limit_storage_socket_timeout_override_ignored",
+        parameters=sorted({k.lower() for k, _ in pairs} & _PINNED_TIMEOUT_PARAMS),
+        consequence="the store is held to the built-in socket timeout",
+    )
+    return urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, urlencode(kept), parts.fragment)
+    )
+
 
 @cache
 def shared_storage_uri() -> str | None:
@@ -55,13 +82,18 @@ def shared_storage_uri() -> str | None:
     """
     url = settings.redis_url
     if not url:
+        logger.warning(
+            "rate_limit_storage_not_configured",
+            consequence="rate-limit buckets count per uvicorn worker",
+            remediation="set REDIS_URL when running more than one uvicorn worker",
+        )
         return None
     try:
         scheme = urlsplit(url).scheme.lower()
     except ValueError:
         scheme = ""
     if scheme in _SHARED_STORAGE_SCHEMES:
-        return url
+        return _pin_socket_timeouts(url)
     # fix(#2018): the scheme, never the URL -- REDIS_URL commonly carries a
     # password in its userinfo, and redact_url_credentials only rewrites
     # http(s), so it would hand a credential straight to the log.

--- a/backend/app/platform/ratelimit.py
+++ b/backend/app/platform/ratelimit.py
@@ -24,6 +24,7 @@ pre-#2018 behaviour, rather than to no limit or a 500 per request.
 from __future__ import annotations
 
 from functools import cache
+from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import structlog
@@ -35,6 +36,24 @@ from app.core.config import settings
 from app.core.persistent_config import get_cached_global_rate_limit
 
 logger = structlog.stdlib.get_logger(__name__)
+
+# fix(#2018): the storage decision is made while this module is imported,
+# which `app/api/main.py` does before it calls `setup_logging`. Logging there
+# renders console-formatted lines outside the JSON stream an operator greps,
+# so the notices queue here and the app flushes them once logging is up.
+_startup_notices: list[tuple[str, dict[str, Any]]] = []
+
+
+def _notice(event: str, **fields: Any) -> None:
+    _startup_notices.append((event, fields))
+
+
+def emit_startup_notices() -> None:
+    """Log every queued storage notice. Call once, after logging is set up."""
+    while _startup_notices:
+        event, fields = _startup_notices.pop(0)
+        logger.warning(event, **fields)
+
 
 # fix(#2018): the schemes BOTH limits' sync storage and redis-py accept.
 # `redis_url` reaches redis-py directly in `platform/cache`, so a scheme
@@ -66,7 +85,7 @@ def _pin_call_duration(url: str) -> str:
     kept = [(k, v) for k, v in pairs if k.lower() not in _PINNED_CLIENT_PARAMS]
     if len(kept) == len(pairs):
         return url
-    logger.warning(
+    _notice(
         "rate_limit_storage_call_duration_override_ignored",
         parameters=sorted({k.lower() for k, _ in pairs} & _PINNED_CLIENT_PARAMS),
         consequence="the store is held to the built-in socket timeout",
@@ -85,7 +104,7 @@ def shared_storage_uri() -> str | None:
     """
     url = settings.redis_url
     if not url:
-        logger.warning(
+        _notice(
             "rate_limit_storage_not_configured",
             consequence="rate-limit buckets count per uvicorn worker",
             remediation="set REDIS_URL when running more than one uvicorn worker",
@@ -100,7 +119,7 @@ def shared_storage_uri() -> str | None:
     # fix(#2018): the scheme, never the URL -- REDIS_URL commonly carries a
     # password in its userinfo, and redact_url_credentials only rewrites
     # http(s), so it would hand a credential straight to the log.
-    logger.warning(
+    _notice(
         "rate_limit_storage_scheme_unsupported",
         scheme=scheme or "none",
         consequence="rate-limit buckets stay per uvicorn worker",

--- a/backend/app/platform/ratelimit.py
+++ b/backend/app/platform/ratelimit.py
@@ -45,14 +45,17 @@ _SHARED_STORAGE_SCHEMES = frozenset({"redis", "rediss"})
 # so a hung store has to fail into the in-memory fallback fast.
 STORAGE_SOCKET_TIMEOUT_SECONDS = 0.25
 
-# fix(#2018): redis-py parses these from the URL and lets the querystring win
-# over the keyword arguments, so a raised value there would hold the event
-# loop for that long. The bound above is not the operator's to widen.
-_PINNED_TIMEOUT_PARAMS = frozenset({"socket_timeout", "socket_connect_timeout"})
+# fix(#2018): every URL parameter that can widen how long ONE call holds the
+# event loop. redis-py parses each from the URL and lets the querystring win
+# over the keyword arguments; either retry flag also lifts retries 0 -> 1,
+# doubling the bound. That bound is not the operator's to widen.
+_PINNED_CLIENT_PARAMS = frozenset(
+    {"socket_timeout", "socket_connect_timeout", "retry_on_timeout", "retry_on_error"}
+)
 
 
-def _pin_socket_timeouts(url: str) -> str:
-    """Return *url* without any socket-timeout query parameter."""
+def _pin_call_duration(url: str) -> str:
+    """Return *url* without any query parameter that lengthens one call."""
     parts = urlsplit(url)
     if not parts.query:
         return url
@@ -60,12 +63,12 @@ def _pin_socket_timeouts(url: str) -> str:
     # once at import, the same class as config.py's DATABASE_URL_OVERRIDE
     # sites; a raise here would fail boot rather than refuse a request.
     pairs = parse_qsl(parts.query, keep_blank_values=True)  # parse_qs: unbounded
-    kept = [(k, v) for k, v in pairs if k.lower() not in _PINNED_TIMEOUT_PARAMS]
+    kept = [(k, v) for k, v in pairs if k.lower() not in _PINNED_CLIENT_PARAMS]
     if len(kept) == len(pairs):
         return url
     logger.warning(
-        "rate_limit_storage_socket_timeout_override_ignored",
-        parameters=sorted({k.lower() for k, _ in pairs} & _PINNED_TIMEOUT_PARAMS),
+        "rate_limit_storage_call_duration_override_ignored",
+        parameters=sorted({k.lower() for k, _ in pairs} & _PINNED_CLIENT_PARAMS),
         consequence="the store is held to the built-in socket timeout",
     )
     return urlunsplit(
@@ -93,7 +96,7 @@ def shared_storage_uri() -> str | None:
     except ValueError:
         scheme = ""
     if scheme in _SHARED_STORAGE_SCHEMES:
-        return _pin_socket_timeouts(url)
+        return _pin_call_duration(url)
     # fix(#2018): the scheme, never the URL -- REDIS_URL commonly carries a
     # password in its userinfo, and redact_url_credentials only rewrites
     # http(s), so it would hand a credential straight to the log.

--- a/backend/app/platform/ratelimit.py
+++ b/backend/app/platform/ratelimit.py
@@ -13,21 +13,105 @@ rather than (client IP, path), slowapi's default. Otherwise a
 path-parameterised route hands one IP a fresh budget per dataset id or per
 z/x/y, multiplying the configured cap for free. See
 ``tests/test_admin_rate_limit.py``.
+
+fix(#2018): with ``REDIS_URL`` set every bucket is one counter the whole
+cluster shares, instead of one per uvicorn worker (the bundled prod compose
+runs two, so each configured cap was really twice that). ``in_memory_
+fallback_enabled`` keeps an outage degrading to per-worker counting, the
+pre-#2018 behaviour, rather than to no limit or a 500 per request.
 """
 
+from __future__ import annotations
+
+from functools import cache
+from urllib.parse import urlsplit
+
+import structlog
 from fastapi import Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+from app.core.config import settings
 from app.core.persistent_config import get_cached_global_rate_limit
+
+logger = structlog.stdlib.get_logger(__name__)
+
+# fix(#2018): the schemes BOTH limits' sync storage and redis-py accept.
+# `redis_url` reaches redis-py directly in `platform/cache`, so a scheme
+# outside this set cannot be a working deployment's value anyway.
+_SHARED_STORAGE_SCHEMES = frozenset({"redis", "rediss"})
+
+# fix(#2018): limits' sync storage blocks the event loop for its round trip,
+# so a hung store has to fail into the in-memory fallback fast.
+STORAGE_SOCKET_TIMEOUT_SECONDS = 0.25
+
+
+@cache
+def shared_storage_uri() -> str | None:
+    """The cluster-wide rate-limit store URL, or None to count per process.
+
+    Cached so both readers (this limiter and the claim store) resolve one
+    answer and a refused scheme is reported once per process.
+    """
+    url = settings.redis_url
+    if not url:
+        return None
+    try:
+        scheme = urlsplit(url).scheme.lower()
+    except ValueError:
+        scheme = ""
+    if scheme in _SHARED_STORAGE_SCHEMES:
+        return url
+    # fix(#2018): the scheme, never the URL -- REDIS_URL commonly carries a
+    # password in its userinfo, and redact_url_credentials only rewrites
+    # http(s), so it would hand a credential straight to the log.
+    logger.warning(
+        "rate_limit_storage_scheme_unsupported",
+        scheme=scheme or "none",
+        consequence="rate-limit buckets stay per uvicorn worker",
+        remediation="set REDIS_URL to a redis:// or rediss:// URL",
+    )
+    return None
 
 
 def _global_rate_limit(_request: Request | None = None) -> str:
     return f"{get_cached_global_rate_limit()}/second"
 
 
-limiter = Limiter(
+class _FallbackAnnouncingLimiter(Limiter):
+    """A Limiter that announces losing and regaining its shared store."""
+
+    _storage_dead_state = False
+
+    @property
+    def _storage_dead(self) -> bool:
+        return self._storage_dead_state
+
+    @_storage_dead.setter
+    def _storage_dead(self, dead: bool) -> None:
+        # fix(#2018): slowapi flips this once per outage, on the first failed
+        # check and again on recovery, so hooking the transition logs once
+        # rather than once per rejected request.
+        if dead == self._storage_dead_state:
+            return
+        self._storage_dead_state = dead
+        if dead:
+            logger.warning(
+                "rate_limit_storage_unreachable",
+                consequence="buckets count per uvicorn worker until it recovers",
+            )
+        else:
+            logger.info("rate_limit_storage_recovered")
+
+
+limiter = _FallbackAnnouncingLimiter(
     key_func=get_remote_address,
     default_limits=[_global_rate_limit],
     key_style="endpoint",
+    storage_uri=shared_storage_uri(),
+    storage_options={
+        "socket_timeout": STORAGE_SOCKET_TIMEOUT_SECONDS,
+        "socket_connect_timeout": STORAGE_SOCKET_TIMEOUT_SECONDS,
+    },
+    in_memory_fallback_enabled=True,
 )

--- a/backend/app/platform/ratelimit_claims.py
+++ b/backend/app/platform/ratelimit_claims.py
@@ -70,7 +70,14 @@ class SharedClaimStore:
             self._degraded("consume")
             return None
         self._unavailable_logged = False
-        return claimant is not None and claimant != route
+        if claimant is None:
+            return False
+        # fix(#2018): decode here rather than trusting the client's
+        # decode_responses. Comparing bytes to str is never equal, so a client
+        # built without it would exempt a same-route repeat.
+        if isinstance(claimant, bytes):
+            claimant = claimant.decode("utf-8", "replace")
+        return claimant != route
 
     def _degraded(self, operation: str) -> None:
         if self._unavailable_logged:

--- a/backend/app/platform/ratelimit_claims.py
+++ b/backend/app/platform/ratelimit_claims.py
@@ -10,6 +10,7 @@ before this module existed; "exempt" is never the fallback.
 from __future__ import annotations
 
 import hashlib
+import time
 from typing import Any
 
 import structlog
@@ -35,10 +36,26 @@ def claim_key(parts: tuple[str, ...]) -> str:
 
 
 class SharedClaimStore:
-    """``SET NX EX`` to record a claim, ``GETDEL`` to consume it once."""
+    """``SET NX EX`` to record a claim, ``GETDEL`` to consume it once.
 
-    def __init__(self, client: Any) -> None:
+    fix(#2018): a failure arms a cooldown, during which every call answers
+    ``None`` without touching the client. Both search routes are ``async
+    def``, so slowapi runs ``exempt_when`` inline on the event loop, and a
+    store that drops packets rather than refusing them would otherwise stall
+    the worker for the socket timeout on every request. slowapi's own limiter
+    backs off after one failure for the same reason.
+
+    The cooldown is the claim's own lifetime, so the store is never consulted
+    again while a claim the local registry recorded in its place is still
+    redeemable.
+    """
+
+    def __init__(
+        self, client: Any, cooldown_seconds: float = CLAIM_TTL_SECONDS
+    ) -> None:
         self._client = client
+        self._cooldown_seconds = cooldown_seconds
+        self._retry_after = 0.0
         self._unavailable_logged = False
 
     def record(self, parts: tuple[str, ...], route: str) -> bool | None:
@@ -48,12 +65,14 @@ class SharedClaimStore:
         route and deadline: a second writer must not extend someone else's
         window.
         """
+        if self._blocked():
+            return None
         try:
             self._client.set(claim_key(parts), route, nx=True, ex=CLAIM_TTL_SECONDS)
         except Exception:  # broad: any client or transport error must degrade
             self._degraded("record")
             return None
-        self._unavailable_logged = False
+        self._recovered()
         return True
 
     def consume(self, parts: tuple[str, ...], route: str) -> bool | None:
@@ -64,12 +83,14 @@ class SharedClaimStore:
         the process-local registry would leave it standing; that can only cost
         an exemption the sibling would have had, never grant an extra one.
         """
+        if self._blocked():
+            return None
         try:
             claimant = self._client.getdel(claim_key(parts))
         except Exception:  # broad: any client or transport error must degrade
             self._degraded("consume")
             return None
-        self._unavailable_logged = False
+        self._recovered()
         if claimant is None:
             return False
         # fix(#2018): decode here rather than trusting the client's
@@ -79,7 +100,11 @@ class SharedClaimStore:
             claimant = claimant.decode("utf-8", "replace")
         return claimant != route
 
+    def _blocked(self) -> bool:
+        return time.monotonic() < self._retry_after
+
     def _degraded(self, operation: str) -> None:
+        self._retry_after = time.monotonic() + self._cooldown_seconds
         if self._unavailable_logged:
             return
         self._unavailable_logged = True
@@ -89,6 +114,13 @@ class SharedClaimStore:
             consequence="paired search requests each spend their own token",
             exc_info=True,
         )
+
+    def _recovered(self) -> None:
+        if not self._unavailable_logged:
+            return
+        self._unavailable_logged = False
+        self._retry_after = 0.0
+        logger.info("paired_claim_store_recovered")
 
 
 _store: SharedClaimStore | None = None

--- a/backend/app/platform/ratelimit_claims.py
+++ b/backend/app/platform/ratelimit_claims.py
@@ -45,9 +45,11 @@ class SharedClaimStore:
     the worker for the socket timeout on every request. slowapi's own limiter
     backs off after one failure for the same reason.
 
-    The cooldown is the claim's own lifetime, so the store is never consulted
-    again while a claim the local registry recorded in its place is still
-    redeemable.
+    The cooldown is one claim lifetime. That bounds how long the store goes
+    unprobed; it does NOT bound the fallback claims written during it, whose
+    own TTL starts when they are written, so a claim recorded late in a
+    cooldown outlives it. ``consume_paired_query_claim`` is what covers that,
+    by reading the local registry whenever this store does not say "yes".
     """
 
     def __init__(

--- a/backend/app/platform/ratelimit_claims.py
+++ b/backend/app/platform/ratelimit_claims.py
@@ -1,0 +1,120 @@
+"""Single-use paired-request claims, shared across workers when a store exists.
+
+fix(#2018): the claim a paired request redeems is consumed inside slowapi's
+SYNCHRONOUS ``exempt_when``, so this is a sync client with a short timeout
+rather than the async cache provider. Every store error answers ``None`` so
+the caller falls back to its process-local registry, which is the behaviour
+before this module existed; "exempt" is never the fallback.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import structlog
+
+from app.platform.ratelimit import STORAGE_SOCKET_TIMEOUT_SECONDS, shared_storage_uri
+
+logger = structlog.stdlib.get_logger(__name__)
+
+CLAIM_TTL_SECONDS = 5
+_KEY_PREFIX = "geolens:paired-claim:"
+
+
+def claim_key(parts: tuple[str, ...]) -> str:
+    """Hash a length-prefixed join of *parts* into one store key.
+
+    fix(#2018): length-prefixed, because a component is an IPv6 address and
+    another is caller-supplied text, so a plain separator lets a /64 holder
+    pick low bits that shift the split and collide with a neighbour's key.
+    """
+    joined = "".join(f"{len(part)}:{part}" for part in parts)
+    digest = hashlib.blake2s(joined.encode("utf-8"), digest_size=16).hexdigest()
+    return f"{_KEY_PREFIX}{digest}"
+
+
+class SharedClaimStore:
+    """``SET NX EX`` to record a claim, ``GETDEL`` to consume it once."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+        self._unavailable_logged = False
+
+    def record(self, parts: tuple[str, ...], route: str) -> bool | None:
+        """Claim *parts* for *route*. None means the store did not answer.
+
+        ``NX`` so a claim already standing for these *parts* keeps its own
+        route and deadline: a second writer must not extend someone else's
+        window.
+        """
+        try:
+            self._client.set(claim_key(parts), route, nx=True, ex=CLAIM_TTL_SECONDS)
+        except Exception:  # broad: any client or transport error must degrade
+            self._degraded("record")
+            return None
+        self._unavailable_logged = False
+        return True
+
+    def consume(self, parts: tuple[str, ...], route: str) -> bool | None:
+        """True when ANOTHER route holds the claim, consuming it. None: no answer.
+
+        ``GETDEL`` is one round trip, so two workers cannot both redeem one
+        claim. A same-route caller reads its own claim and destroys it, where
+        the process-local registry would leave it standing; that can only cost
+        an exemption the sibling would have had, never grant an extra one.
+        """
+        try:
+            claimant = self._client.getdel(claim_key(parts))
+        except Exception:  # broad: any client or transport error must degrade
+            self._degraded("consume")
+            return None
+        self._unavailable_logged = False
+        return claimant is not None and claimant != route
+
+    def _degraded(self, operation: str) -> None:
+        if self._unavailable_logged:
+            return
+        self._unavailable_logged = True
+        logger.warning(
+            "paired_claim_store_unavailable",
+            operation=operation,
+            consequence="paired search requests each spend their own token",
+            exc_info=True,
+        )
+
+
+_store: SharedClaimStore | None = None
+_store_resolved = False
+
+
+def get_shared_claim_store() -> SharedClaimStore | None:
+    """The process's claim store, or None when no shared store is configured."""
+    global _store, _store_resolved
+    if not _store_resolved:
+        _store = _build_store()
+        _store_resolved = True
+    return _store
+
+
+def _build_store() -> SharedClaimStore | None:
+    uri = shared_storage_uri()
+    if uri is None:
+        return None
+    import redis
+
+    try:
+        client = redis.Redis.from_url(
+            uri,
+            decode_responses=True,
+            socket_timeout=STORAGE_SOCKET_TIMEOUT_SECONDS,
+            socket_connect_timeout=STORAGE_SOCKET_TIMEOUT_SECONDS,
+        )
+    except Exception:  # broad: a URL the client rejects must not fail boot
+        logger.warning(
+            "paired_claim_store_unconfigurable",
+            consequence="paired search requests each spend their own token",
+            exc_info=True,
+        )
+        return None
+    return SharedClaimStore(client)

--- a/backend/app/processing/ai/query_router.py
+++ b/backend/app/processing/ai/query_router.py
@@ -166,13 +166,13 @@ _capacity_bound = capacity_bound
 _query_slots = query_slots
 
 # Module-level so tests can lower them; slowapi evaluates callables per
-# request. These reuse the app-wide in-memory ``limiter``, so the per-user/
-# per-IP counters are per-uvicorn-worker, not shared (fix(#565)); a
-# Valkey-backed limiter is a tracked app-wide change, not forked here. It's
-# a secondary bound anyway: the sandbox's per-user advisory lock is a
-# Postgres xact lock (GLOBAL across workers), already serializing each user
-# to ONE in-flight query at a 5 s statement timeout — the per-worker counter
-# only caps request FREQUENCY loosely.
+# request. These reuse the app-wide ``limiter``, so fix(#2018): the
+# per-user/per-IP counters are cluster-wide wherever REDIS_URL is set and
+# per-uvicorn-worker otherwise (fix(#565)). Either way it's a secondary
+# bound: the sandbox's per-user advisory lock is a Postgres xact lock
+# (GLOBAL across workers), already serializing each user to ONE in-flight
+# query at a 5 s statement timeout, so the counter only caps request
+# FREQUENCY loosely.
 _QUERY_PER_USER_LIMIT = "30/minute"
 _QUERY_PER_IP_LIMIT = "60/minute"
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1807,11 +1807,12 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # call (gated on the same fully-pinned predicate the provider's own
         # session-read check uses) so an exemption can never fund two paid
         # calls. Cap 398 -> 466, exact.
-        # fix(#2018): +10. Both claim functions consult the shared store
+        # fix(#2018): +11. Both claim functions consult the shared store
         # first, so the pair coordinates across uvicorn workers; the local
-        # registry is the fallback for a store that does not answer.
-        # Cap 466 -> 476, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 476,
+        # registry is the fallback for a store that does not answer, and the
+        # pairing window is derived from that store rather than copied.
+        # Cap 466 -> 477, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 477,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -7697,6 +7698,10 @@ def test_every_parse_qsl_call_bounds_its_field_count() -> None:
     `MAX_QUERY_FIELDS` across a layering boundary `config.py` cannot import
     across (it has no `app.*` imports at all, and importing `platform.
     service_endpoints` into it would very likely create an import cycle).
+
+    fix(#2018): `platform/ratelimit.py`'s one site is that same class --
+    `REDIS_URL`, read once at import, where a raise would fail boot rather
+    than refuse a request.
 
     fix(#1770 round 47c): `adapters/wfs.py::build_capabilities_url` and
     `service_endpoints.py::_capabilities_url` moved from the BOUND list to

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1811,8 +1811,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # first, so the pair coordinates across uvicorn workers; the local
         # registry is the fallback for a store that does not answer, and the
         # pairing window is derived from that store rather than copied.
-        # Cap 466 -> 477, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 477,
+        # fix(#2018 codex r1): +6. Every claim is mirrored locally and the
+        # mirror is dropped on the store's own verdict, so a store that takes
+        # a SET but refuses GETDEL still leaves the sibling a fallback.
+        # Cap 477 -> 483, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 483,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1811,11 +1811,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # first, so the pair coordinates across uvicorn workers; the local
         # registry is the fallback for a store that does not answer, and the
         # pairing window is derived from that store rather than copied.
-        # fix(#2018 codex r1): +6. Every claim is mirrored locally and the
-        # mirror is dropped on the store's own verdict, so a store that takes
-        # a SET but refuses GETDEL still leaves the sibling a fallback.
-        # Cap 477 -> 483, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 483,
+        # fix(#2018 review r2): +4. A store "no key" no longer short-circuits
+        # the local registry: a claim the fallback wrote can outlive the
+        # cooldown, and the store was never given it to answer for.
+        # Cap 477 -> 481, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 481,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
@@ -3015,7 +3015,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # 1903 -> 1912, exact.
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1962, exact.
     # fix(#1847): the handler docstring states its contract. Cap 1962 -> 1959.
-    "backend/app/api/main.py": 1716,
+    # fix(#2018): +5. The rate-limit storage decision is made at import,
+    # before setup_logging, so the lifespan flushes its queued notices into
+    # the configured stream. Cap 1716 -> 1721, exact.
+    "backend/app/api/main.py": 1721,
     # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
     # thumbnail cache version split out of updated_at. Ratchet stays exact.
     # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1807,7 +1807,11 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         # call (gated on the same fully-pinned predicate the provider's own
         # session-read check uses) so an exemption can never fund two paid
         # calls. Cap 398 -> 466, exact.
-        "backend/app/modules/catalog/search/service_semantic.py": 466,
+        # fix(#2018): +10. Both claim functions consult the shared store
+        # first, so the pair coordinates across uvicorn workers; the local
+        # registry is the fallback for a store that does not answer.
+        # Cap 466 -> 476, exact.
+        "backend/app/modules/catalog/search/service_semantic.py": 476,
         # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
         # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
         # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).

--- a/backend/tests/test_paired_claim_store_2018.py
+++ b/backend/tests/test_paired_claim_store_2018.py
@@ -46,6 +46,19 @@ def test_a_same_route_repeat_is_never_exempt_and_takes_the_claim_with_it(
     assert store.consume(_PARTS, "datasets") is False
 
 
+def test_a_client_that_returns_bytes_still_refuses_a_same_route_repeat():
+    """The route comparison must not depend on ``decode_responses``.
+
+    Bytes never compare equal to a str, so a client built without it would
+    read a same-route caller's own claim as the sibling's and exempt it.
+    """
+    store = SharedClaimStore(fakeredis.FakeStrictRedis())
+
+    store.record(_PARTS, "facets")
+
+    assert store.consume(_PARTS, "facets") is False
+
+
 def test_a_second_writer_does_not_extend_a_standing_claim():
     """``NX``: whoever claimed first keeps the route and the deadline."""
     client = fakeredis.FakeStrictRedis(decode_responses=True)

--- a/backend/tests/test_paired_claim_store_2018.py
+++ b/backend/tests/test_paired_claim_store_2018.py
@@ -1,0 +1,121 @@
+"""Pin #2018's shared claim store: the #1903 semantics, on a store two workers share.
+
+The counting invariant these back is exercised end to end against both
+backends in test_rate_limits.py; this file pins the store primitives that
+invariant rests on.
+"""
+
+import fakeredis
+import pytest
+import structlog
+
+from app.platform.ratelimit_claims import (
+    CLAIM_TTL_SECONDS,
+    SharedClaimStore,
+    claim_key,
+)
+
+_PARTS = ("203.0.113.7", "tenant:cities")
+
+
+@pytest.fixture
+def store() -> SharedClaimStore:
+    return SharedClaimStore(fakeredis.FakeStrictRedis(decode_responses=True))
+
+
+def test_a_claim_is_single_use_and_only_the_other_route_redeems_it(
+    store: SharedClaimStore,
+):
+    assert store.record(_PARTS, "datasets") is True
+    assert store.consume(_PARTS, "facets") is True
+    assert store.consume(_PARTS, "facets") is False
+
+
+def test_a_same_route_repeat_is_never_exempt_and_takes_the_claim_with_it(
+    store: SharedClaimStore,
+):
+    """A burst against one route still pays per request.
+
+    ``GETDEL`` is one round trip, which is what stops two workers redeeming
+    one claim, and the price is the only divergence from the process-local
+    registry: a same-route caller reads its own claim and destroys it. That
+    can cost the sibling an exemption, never grant an extra one.
+    """
+    store.record(_PARTS, "facets")
+    assert store.consume(_PARTS, "facets") is False
+    assert store.consume(_PARTS, "datasets") is False
+
+
+def test_a_second_writer_does_not_extend_a_standing_claim():
+    """``NX``: whoever claimed first keeps the route and the deadline."""
+    client = fakeredis.FakeStrictRedis(decode_responses=True)
+    store = SharedClaimStore(client)
+
+    store.record(_PARTS, "datasets")
+    store.record(_PARTS, "facets")
+
+    assert client.get(claim_key(_PARTS)) == "datasets"
+
+
+def test_a_claim_carries_the_pairing_window_as_its_ttl():
+    client = fakeredis.FakeStrictRedis(decode_responses=True)
+    SharedClaimStore(client).record(_PARTS, "datasets")
+    assert client.ttl(claim_key(_PARTS)) == CLAIM_TTL_SECONDS
+
+
+def test_an_ipv6_client_cannot_shift_the_key_onto_a_neighbours(
+    store: SharedClaimStore,
+):
+    """The key is length-prefixed before it is hashed.
+
+    Both components contain ``:`` -- one is an IPv6 address, the other is
+    caller-supplied text -- so a plain join would let a /64 holder pick low
+    bits that move the split and land on a neighbour's key.
+    """
+    mine = ("2001:db8::1", "ab")
+    neighbours = ("2001:db8::1a", "b")
+
+    assert claim_key(mine) != claim_key(neighbours)
+    store.record(mine, "datasets")
+    assert store.consume(neighbours, "facets") is False
+
+
+def test_a_store_error_answers_none_rather_than_exempt():
+    """None is the signal to fall back; True would be a free exemption."""
+
+    class _DeadClient:
+        def set(self, *_args, **_kwargs):
+            raise ConnectionError("claim store unreachable")
+
+        def getdel(self, *_args, **_kwargs):
+            raise ConnectionError("claim store unreachable")
+
+    dead = SharedClaimStore(_DeadClient())
+    assert dead.record(_PARTS, "datasets") is None
+    assert dead.consume(_PARTS, "facets") is None
+
+
+def test_an_outage_is_logged_once_per_outage_not_once_per_request():
+    """This runs inside ``exempt_when``, so per-call logging is per request."""
+
+    class _FlakyClient:
+        healthy = False
+
+        def getdel(self, *_args, **_kwargs):
+            if not self.healthy:
+                raise ConnectionError("claim store unreachable")
+            return None
+
+    client = _FlakyClient()
+    flaky = SharedClaimStore(client)
+
+    with structlog.testing.capture_logs() as captured:
+        for _ in range(3):
+            flaky.consume(_PARTS, "facets")
+        client.healthy = True
+        flaky.consume(_PARTS, "facets")
+        client.healthy = False
+        flaky.consume(_PARTS, "facets")
+
+    outages = [e for e in captured if e["event"] == "paired_claim_store_unavailable"]
+    assert len(outages) == 2, [e["event"] for e in captured]

--- a/backend/tests/test_paired_claim_store_2018.py
+++ b/backend/tests/test_paired_claim_store_2018.py
@@ -108,8 +108,61 @@ def test_a_store_error_answers_none_rather_than_exempt():
     assert dead.consume(_PARTS, "facets") is None
 
 
+class _CountingDeadClient:
+    """A store that drops every call, and counts the ones that reach it."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def set(self, *_args, **_kwargs):
+        self.calls += 1
+        raise ConnectionError("claim store unreachable")
+
+    def getdel(self, *_args, **_kwargs):
+        self.calls += 1
+        raise ConnectionError("claim store unreachable")
+
+
+def test_an_outage_stops_touching_the_client_until_the_cooldown_lifts():
+    """A dead store must be skipped, not retried, for the whole cooldown.
+
+    Both search routes are ``async def``, so slowapi runs ``exempt_when``
+    inline on the event loop. Without this, a store that drops packets
+    stalls the worker for the socket timeout on every single request, where
+    slowapi's own limiter would have backed off after the first failure.
+    """
+    client = _CountingDeadClient()
+    store = SharedClaimStore(client)
+
+    for _ in range(50):
+        assert store.consume(_PARTS, "facets") is None
+        assert store.record(_PARTS, "datasets") is None
+
+    assert client.calls == 1, (
+        f"100 calls during one outage reached the client {client.calls} times; "
+        "the cooldown must skip them all after the first failure"
+    )
+
+
+def test_the_cooldown_covers_the_whole_life_of_a_fallback_claim():
+    """Why the cooldown is the claim TTL and not an arbitrary number.
+
+    A claim written to the process-local registry during an outage is
+    invisible to the store. If the store were consulted again inside that
+    claim's 5s life, its definite "no key" would shadow the local one and
+    the pair would pay twice.
+    """
+    from app.platform.ratelimit_claims import CLAIM_TTL_SECONDS as ttl
+
+    assert SharedClaimStore(_CountingDeadClient())._cooldown_seconds >= ttl
+
+
 def test_an_outage_is_logged_once_per_outage_not_once_per_request():
-    """This runs inside ``exempt_when``, so per-call logging is per request."""
+    """This runs inside ``exempt_when``, so per-call logging is per request.
+
+    Built with the cooldown disarmed so every call reaches the client, which
+    isolates the log gate from the skip gate above.
+    """
 
     class _FlakyClient:
         healthy = False
@@ -120,7 +173,7 @@ def test_an_outage_is_logged_once_per_outage_not_once_per_request():
             return None
 
     client = _FlakyClient()
-    flaky = SharedClaimStore(client)
+    flaky = SharedClaimStore(client, cooldown_seconds=0)
 
     with structlog.testing.capture_logs() as captured:
         for _ in range(3):
@@ -130,5 +183,11 @@ def test_an_outage_is_logged_once_per_outage_not_once_per_request():
         client.healthy = False
         flaky.consume(_PARTS, "facets")
 
-    outages = [e for e in captured if e["event"] == "paired_claim_store_unavailable"]
-    assert len(outages) == 2, [e["event"] for e in captured]
+    events = [
+        e["event"] for e in captured if e["event"].startswith("paired_claim_store_")
+    ]
+    assert events == [
+        "paired_claim_store_unavailable",
+        "paired_claim_store_recovered",
+        "paired_claim_store_unavailable",
+    ], events

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -531,7 +531,9 @@ async def test_a_claim_store_outage_falls_back_to_the_process_local_registry(
     Both halves of one pair run against a store whose every call raises. The
     pair still coordinates, because the local registry is still there; a
     request for a novel query still pays, because the fallback is the
-    pre-#2018 behaviour and not a blanket exemption.
+    pre-#2018 behaviour and not a blanket exemption. The store's cooldown is
+    the claim's own lifetime, which is what keeps a recovering store from
+    shadowing a claim the local registry holds and it cannot see.
     """
 
     class _DeadClient:

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -22,6 +22,7 @@ Per-test pattern:
 
 import uuid
 
+import fakeredis
 import pytest
 from httpx import AsyncClient
 
@@ -33,6 +34,7 @@ from app.core.persistent_config import (
     get_cached_basemap_proxy_rate_limit,
 )
 from app.modules.catalog.search import service_semantic
+from app.platform import ratelimit_claims
 from app.platform.ratelimit import limiter
 
 pytestmark = pytest.mark.anyio
@@ -73,6 +75,35 @@ def _set_cache_limit(key: str, value: int) -> None:
 
 def _clear_cache_limit(key: str) -> None:
     _sync_rate_limit_cache.pop(key, None)
+
+
+def _worker_claim_store(
+    server: fakeredis.FakeServer,
+) -> ratelimit_claims.SharedClaimStore:
+    """One worker's view of a shared store: its own client, the same server."""
+    return ratelimit_claims.SharedClaimStore(
+        fakeredis.FakeStrictRedis(server=server, decode_responses=True)
+    )
+
+
+@pytest.fixture(params=["process_local", "shared_store"])
+def claim_backend(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    """Run a #1903 counting test against both claim backends.
+
+    fix(#2018): the shared arm runs on fakeredis rather than a live Valkey.
+    What the port has to preserve is the counting invariant, and that is
+    decided by SET NX EX and GETDEL semantics, which fakeredis implements.
+    """
+    store = (
+        _worker_claim_store(fakeredis.FakeServer())
+        if request.param == "shared_store"
+        else None
+    )
+    monkeypatch.setattr(ratelimit_claims, "_store", store)
+    monkeypatch.setattr(ratelimit_claims, "_store_resolved", True)
+    return request.param
 
 
 def _reset_limiter_storage() -> None:
@@ -188,7 +219,7 @@ async def test_search_datasets_and_facets_share_one_bucket(
 
 @pytest.mark.parametrize("first_route", ["/search/datasets/", "/search/facets/"])
 async def test_paired_query_claims_the_bucket_once_whichever_route_is_first(
-    client: AsyncClient, first_route: str
+    client: AsyncClient, first_route: str, claim_backend: str
 ):
     """fix(#1903): the SPA's unordered paired request spends one token, not two.
 
@@ -237,7 +268,7 @@ async def test_paired_query_claims_the_bucket_once_whichever_route_is_first(
 
 
 async def test_same_route_repeat_does_not_ride_a_cross_route_claim(
-    client: AsyncClient,
+    client: AsyncClient, claim_backend: str
 ):
     """fix(#1903): a same-route burst still pays per request.
 
@@ -279,7 +310,9 @@ async def test_same_route_repeat_does_not_ride_a_cross_route_claim(
         service_semantic._query_claims_clear()
 
 
-async def test_rejected_request_does_not_seed_a_claim(client: AsyncClient):
+async def test_rejected_request_does_not_seed_a_claim(
+    client: AsyncClient, claim_backend: str
+):
     """fix(#1903): a 429'd request must not create an exemption.
 
     exempt_when runs before the limiter's own admit/reject check, so it
@@ -319,7 +352,9 @@ async def test_rejected_request_does_not_seed_a_claim(client: AsyncClient):
         service_semantic._query_claims_clear()
 
 
-async def test_claim_is_scoped_to_the_requesting_client(client: AsyncClient):
+async def test_claim_is_scoped_to_the_requesting_client(
+    client: AsyncClient, claim_backend: str
+):
     """fix(#1903): a claim is scoped to the client that made it.
 
     The SEC-S11 bucket is per-IP, so two different clients requesting the
@@ -370,7 +405,7 @@ async def test_claim_is_scoped_to_the_requesting_client(client: AsyncClient):
 
 
 async def test_claim_functions_degrade_without_crashing_when_tenant_unscoped(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, claim_backend: str
 ):
     """fix(#1903): an unscoped multi-tenant request must not 500.
 
@@ -405,7 +440,7 @@ async def test_claim_functions_degrade_without_crashing_when_tenant_unscoped(
 
 
 async def test_four_request_chain_for_one_query_spends_exactly_two_tokens(
-    client: AsyncClient,
+    client: AsyncClient, claim_backend: str
 ):
     """fix(#1903): datasets, facets, datasets, facets for one q spends
     exactly two tokens -- an exempted request never records a claim, so it
@@ -438,6 +473,98 @@ async def test_four_request_chain_for_one_query_spends_exactly_two_tokens(
         fifth = await client.get(f"/search/datasets/?q={q}")
         assert fifth.status_code == 429, (
             f"the chain must have spent exactly two tokens, got {fifth.status_code}"
+        )
+    finally:
+        limiter.enabled = False
+        _clear_cache_limit("semantic_search_rate_limit")
+        _reset_limiter_storage()
+        service_semantic._query_claims_clear()
+
+
+async def test_a_pair_split_across_two_workers_still_spends_one_token(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    """fix(#2018): the exemption survives the pair landing on two workers.
+
+    A second uvicorn process cannot be built in-process, so the boundary is
+    modelled the way the code meets it: the sibling has its own client on the
+    same store and an EMPTY process-local registry. Clearing that registry is
+    also the counterfactual -- before #2018 the claim lived nowhere else, so
+    the facets call below was a 429 against the spent bucket.
+    """
+    server = fakeredis.FakeServer()
+    q = f"sec-2018-split-{uuid.uuid4().hex}"
+    _set_cache_limit("semantic_search_rate_limit", 1)
+    limiter.enabled = True
+    _reset_limiter_storage()
+    service_semantic._query_claims_clear()
+    monkeypatch.setattr(ratelimit_claims, "_store_resolved", True)
+    monkeypatch.setattr(ratelimit_claims, "_store", _worker_claim_store(server))
+
+    try:
+        first = await client.get(f"/search/datasets/?q={q}")
+        assert first.status_code == 200, (
+            f"expected worker A's call to spend the shared bucket, "
+            f"got {first.status_code}"
+        )
+
+        monkeypatch.setattr(ratelimit_claims, "_store", _worker_claim_store(server))
+        service_semantic._query_claims_clear()
+
+        second = await client.get(f"/search/facets/?q={q}")
+        assert second.status_code == 200, (
+            "worker B holds no local claim and must redeem worker A's from the "
+            f"shared store, got {second.status_code}"
+        )
+    finally:
+        limiter.enabled = False
+        _clear_cache_limit("semantic_search_rate_limit")
+        _reset_limiter_storage()
+        service_semantic._query_claims_clear()
+
+
+async def test_a_claim_store_outage_falls_back_to_the_process_local_registry(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    """fix(#2018): a store that answers nothing must not answer "exempt".
+
+    Both halves of one pair run against a store whose every call raises. The
+    pair still coordinates, because the local registry is still there; a
+    request for a novel query still pays, because the fallback is the
+    pre-#2018 behaviour and not a blanket exemption.
+    """
+
+    class _DeadClient:
+        def set(self, *_args, **_kwargs):
+            raise ConnectionError("claim store unreachable")
+
+        def getdel(self, *_args, **_kwargs):
+            raise ConnectionError("claim store unreachable")
+
+    q = f"sec-2018-outage-{uuid.uuid4().hex}"
+    _set_cache_limit("semantic_search_rate_limit", 1)
+    limiter.enabled = True
+    _reset_limiter_storage()
+    service_semantic._query_claims_clear()
+    monkeypatch.setattr(ratelimit_claims, "_store_resolved", True)
+    monkeypatch.setattr(
+        ratelimit_claims, "_store", ratelimit_claims.SharedClaimStore(_DeadClient())
+    )
+
+    try:
+        first = await client.get(f"/search/datasets/?q={q}")
+        assert first.status_code == 200, first.status_code
+
+        second = await client.get(f"/search/facets/?q={q}")
+        assert second.status_code == 200, (
+            "the local registry still coordinates the pair when the store is "
+            f"unreachable, got {second.status_code}"
+        )
+
+        novel = await client.get(f"/search/facets/?q=sec-2018-novel-{uuid.uuid4().hex}")
+        assert novel.status_code == 429, (
+            "an unreachable store must not exempt an unclaimed query, "
+            f"got {novel.status_code}"
         )
     finally:
         limiter.enabled = False

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -533,6 +533,64 @@ class _FrozenClock:
         return self.now
 
 
+class _DeadClaimClient:
+    """A store client whose every call fails."""
+
+    def set(self, *_args, **_kwargs):
+        raise ConnectionError("claim store unreachable")
+
+    def getdel(self, *_args, **_kwargs):
+        raise ConnectionError("claim store unreachable")
+
+
+def test_a_claim_another_worker_redeemed_is_not_re_served_locally(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """fix(#2018): one charged token must never fund two exemptions.
+
+    Worker A records into the shared store and worker B redeems it there, so
+    A never sees that consume and cannot drop a local copy of the claim. A
+    copy kept alongside the store one would therefore survive A's whole
+    window, and A would serve it again the moment its own store call failed.
+    That is why a claim the store accepted is not written locally at all.
+    """
+    server = fakeredis.FakeServer()
+    monkeypatch.setattr(ratelimit_claims, "_store_resolved", True)
+
+    monkeypatch.setattr(ratelimit_claims, "_store", _worker_claim_store(server))
+    service_semantic._query_claims_clear()
+    service_semantic.record_paired_query_claim("203.0.113.11", "shared q", "datasets")
+    worker_a_registry = dict(service_semantic._query_claims)
+    assert worker_a_registry == {}, (
+        "a claim the store accepted must not also be kept in the local registry"
+    )
+
+    monkeypatch.setattr(ratelimit_claims, "_store", _worker_claim_store(server))
+    service_semantic._query_claims_clear()
+    assert (
+        service_semantic.consume_paired_query_claim(
+            "203.0.113.11", "shared q", "facets"
+        )
+        is True
+    ), "worker B must redeem the claim from the shared store"
+
+    service_semantic._query_claims.update(worker_a_registry)
+    monkeypatch.setattr(
+        ratelimit_claims,
+        "_store",
+        ratelimit_claims.SharedClaimStore(_DeadClaimClient()),
+    )
+    try:
+        assert (
+            service_semantic.consume_paired_query_claim(
+                "203.0.113.11", "shared q", "facets"
+            )
+            is False
+        ), "a claim another worker already redeemed must not be served again here"
+    finally:
+        service_semantic._query_claims_clear()
+
+
 def test_a_fallback_claim_outliving_the_cooldown_is_still_redeemed(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -523,6 +523,53 @@ async def test_a_pair_split_across_two_workers_still_spends_one_token(
         service_semantic._query_claims_clear()
 
 
+def test_a_recorded_claim_is_mirrored_locally_even_when_the_store_takes_it(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """fix(#2018): the local fallback must not depend on call ordering.
+
+    A store that accepts SET but refuses GETDEL (older server, narrow ACL)
+    leaves the sibling nothing if the claim lives only in the store. The
+    cooldown happens to cover that, since consume always runs first and arms
+    it, but the mirror removes the dependence on that argument. The store's
+    own verdict still drops the mirror, so a later outage cannot re-serve a
+    claim already redeemed.
+    """
+    server = fakeredis.FakeServer()
+    monkeypatch.setattr(ratelimit_claims, "_store_resolved", True)
+    monkeypatch.setattr(ratelimit_claims, "_store", _worker_claim_store(server))
+    service_semantic._query_claims_clear()
+
+    service_semantic.record_paired_query_claim(
+        "203.0.113.9", "mirror probe", "datasets"
+    )
+    assert service_semantic._query_claims, (
+        "a claim the store accepted must also be in the local registry"
+    )
+
+    assert (
+        service_semantic.consume_paired_query_claim(
+            "203.0.113.9", "mirror probe", "facets"
+        )
+        is True
+    )
+    assert not service_semantic._query_claims, (
+        "the store's verdict must take the mirror with it"
+    )
+
+    service_semantic.record_paired_query_claim(
+        "203.0.113.9", "mirror probe", "datasets"
+    )
+    monkeypatch.setattr(ratelimit_claims, "_store", None)
+    assert (
+        service_semantic.consume_paired_query_claim(
+            "203.0.113.9", "mirror probe", "facets"
+        )
+        is True
+    ), "with the store gone the mirror is what the sibling redeems"
+    service_semantic._query_claims_clear()
+
+
 async def test_a_claim_store_outage_falls_back_to_the_process_local_registry(
     client: AsyncClient, monkeypatch: pytest.MonkeyPatch
 ):

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -523,51 +523,72 @@ async def test_a_pair_split_across_two_workers_still_spends_one_token(
         service_semantic._query_claims_clear()
 
 
-def test_a_recorded_claim_is_mirrored_locally_even_when_the_store_takes_it(
+class _FrozenClock:
+    """A monotonic clock the test moves by hand."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+def test_a_fallback_claim_outliving_the_cooldown_is_still_redeemed(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """fix(#2018): the local fallback must not depend on call ordering.
+    """fix(#2018): a store "no key" is not authoritative over a local claim.
 
-    A store that accepts SET but refuses GETDEL (older server, narrow ACL)
-    leaves the sibling nothing if the claim lives only in the store. The
-    cooldown happens to cover that, since consume always runs first and arms
-    it, but the mirror removes the dependence on that argument. The store's
-    own verdict still drops the mirror, so a later outage cannot re-serve a
-    claim already redeemed.
+    The cooldown bounds how long the store goes unprobed, not the life of
+    the claims written while it is armed: a record skipped at t=4.9 lives
+    locally until t=9.9, and the store unblocks at t=5.0. In that window the
+    store answers "no key" for a claim it was never given, which used to
+    short-circuit the local registry and make the pair pay twice.
     """
-    server = fakeredis.FakeServer()
+
+    class _RecoveringClient:
+        """Refuses the first call, then behaves like an empty store."""
+
+        def __init__(self) -> None:
+            self.healthy = False
+
+        def getdel(self, *_args, **_kwargs):
+            if not self.healthy:
+                raise ConnectionError("claim store unreachable")
+            return None
+
+        def set(self, *_args, **_kwargs):
+            if not self.healthy:
+                raise ConnectionError("claim store unreachable")
+            return True
+
+    clock = _FrozenClock()
+    monkeypatch.setattr(ratelimit_claims, "time", clock)
+    monkeypatch.setattr(service_semantic, "time", clock)
+    client = _RecoveringClient()
     monkeypatch.setattr(ratelimit_claims, "_store_resolved", True)
-    monkeypatch.setattr(ratelimit_claims, "_store", _worker_claim_store(server))
+    monkeypatch.setattr(
+        ratelimit_claims, "_store", ratelimit_claims.SharedClaimStore(client)
+    )
     service_semantic._query_claims_clear()
 
-    service_semantic.record_paired_query_claim(
-        "203.0.113.9", "mirror probe", "datasets"
-    )
-    assert service_semantic._query_claims, (
-        "a claim the store accepted must also be in the local registry"
-    )
-
-    assert (
-        service_semantic.consume_paired_query_claim(
-            "203.0.113.9", "mirror probe", "facets"
+    try:
+        assert (
+            service_semantic.consume_paired_query_claim("203.0.113.9", "q", "datasets")
+            is False
         )
-        is True
-    )
-    assert not service_semantic._query_claims, (
-        "the store's verdict must take the mirror with it"
-    )
 
-    service_semantic.record_paired_query_claim(
-        "203.0.113.9", "mirror probe", "datasets"
-    )
-    monkeypatch.setattr(ratelimit_claims, "_store", None)
-    assert (
-        service_semantic.consume_paired_query_claim(
-            "203.0.113.9", "mirror probe", "facets"
-        )
-        is True
-    ), "with the store gone the mirror is what the sibling redeems"
-    service_semantic._query_claims_clear()
+        clock.now = 1004.9
+        service_semantic.record_paired_query_claim("203.0.113.9", "q", "datasets")
+        assert service_semantic._query_claims, "the fallback must hold the claim"
+
+        clock.now = 1005.01
+        client.healthy = True
+        assert (
+            service_semantic.consume_paired_query_claim("203.0.113.9", "q", "facets")
+            is True
+        ), "the recovered store's 'no key' must not shadow the local claim"
+    finally:
+        service_semantic._query_claims_clear()
 
 
 async def test_a_claim_store_outage_falls_back_to_the_process_local_registry(

--- a/backend/tests/test_ratelimit_shared_storage_2018.py
+++ b/backend/tests/test_ratelimit_shared_storage_2018.py
@@ -1,0 +1,187 @@
+"""Pin #2018: rate-limit buckets count in a shared store, and degrade safely.
+
+The bundled prod compose runs two uvicorn workers, so slowapi's default
+in-memory storage made every configured cap really N caps. These tests cover
+the storage selection, the outage transition and the invariants the switch
+must not disturb. The cross-worker claim tests live in test_rate_limits.py.
+"""
+
+import inspect
+
+import pytest
+import structlog
+from httpx import AsyncClient
+
+from app.core.config import settings
+from app.modules.catalog.search.router import (
+    search_datasets_endpoint,
+    search_facets_endpoint,
+)
+from app.platform import ratelimit_claims
+from app.platform.ratelimit import (
+    _FallbackAnnouncingLimiter,
+    limiter,
+    shared_storage_uri,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def uncached_storage_uri():
+    """Drop the process-wide memo around a test that changes ``redis_url``."""
+    shared_storage_uri.cache_clear()
+    yield
+    shared_storage_uri.cache_clear()
+
+
+def test_no_configured_store_keeps_counting_per_process(
+    monkeypatch: pytest.MonkeyPatch, uncached_storage_uri
+):
+    monkeypatch.setattr(settings, "redis_url", None)
+    assert shared_storage_uri() is None
+    assert ratelimit_claims._build_store() is None
+
+
+@pytest.mark.parametrize("url", ["redis://valkey:6379/0", "rediss://valkey:6379/1"])
+def test_a_redis_url_becomes_the_storage_uri_unchanged(
+    monkeypatch: pytest.MonkeyPatch, uncached_storage_uri, url: str
+):
+    """The storage URL is derived from REDIS_URL, never a second copy of it."""
+    monkeypatch.setattr(settings, "redis_url", url)
+    assert shared_storage_uri() == url
+    assert ratelimit_claims._build_store() is not None
+
+
+def test_a_scheme_the_limiter_cannot_use_is_refused_not_raised(
+    monkeypatch: pytest.MonkeyPatch, uncached_storage_uri
+):
+    """``limits`` raises ConfigurationError on an unknown scheme.
+
+    That would be raised while building the module-level limiter, so an
+    otherwise-working deployment could not boot. Refusing the scheme keeps
+    per-process counting and says so once.
+    """
+    monkeypatch.setattr(settings, "redis_url", "unix:///run/valkey/valkey.sock")
+
+    with structlog.testing.capture_logs() as captured:
+        assert shared_storage_uri() is None
+
+    refusals = [
+        e for e in captured if e["event"] == "rate_limit_storage_scheme_unsupported"
+    ]
+    assert len(refusals) == 1, captured
+    assert refusals[0]["scheme"] == "unix"
+
+
+def test_the_configured_url_never_reaches_the_log(
+    monkeypatch: pytest.MonkeyPatch, uncached_storage_uri
+):
+    """REDIS_URL routinely carries a password in its userinfo.
+
+    ``redact_url_credentials`` rewrites http(s) only, so a redis:// URL would
+    pass through it unchanged; the refusal names the scheme instead.
+    """
+    monkeypatch.setattr(
+        settings,
+        "redis_url",
+        "unix://storeuser:redaction-sentinel@valkey-host/valkey.sock",
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        assert shared_storage_uri() is None
+
+    refusal = [
+        e for e in captured if e["event"] == "rate_limit_storage_scheme_unsupported"
+    ][0]
+    assert refusal["scheme"] == "unix"
+    for value in refusal.values():
+        assert "redaction-sentinel" not in str(value)
+        assert "storeuser" not in str(value)
+
+
+def test_the_limiter_keeps_its_strategy_key_function_and_style():
+    """#2018 changes where the counters live, nothing about how they are keyed."""
+    from slowapi.util import get_remote_address
+
+    assert isinstance(limiter, _FallbackAnnouncingLimiter)
+    assert limiter._key_func is get_remote_address
+    assert limiter._key_style == "endpoint"
+    assert limiter._strategy is None
+    assert type(limiter._limiter).__name__ == "FixedWindowRateLimiter"
+
+
+def test_an_outage_falls_back_to_per_process_limiting_not_to_none():
+    """The fallback limiter exists and re-evaluates the SAME limits.
+
+    ``in_memory_fallback`` is deliberately empty: slowapi swaps only the
+    storage, so a store outage keeps every configured cap and merely stops
+    sharing it, which is the pre-#2018 behaviour rather than no limit.
+    """
+    assert limiter._in_memory_fallback_enabled is True
+    assert limiter._fallback_limiter is not None
+    assert limiter._fallback_limiter is not limiter._limiter
+    assert limiter._in_memory_fallback == []
+
+
+@pytest.mark.parametrize("endpoint", [search_datasets_endpoint, search_facets_endpoint])
+def test_the_claim_gate_stays_a_synchronous_callable(endpoint):
+    """An async ``exempt_when`` returns a truthy coroutine for every request.
+
+    slowapi calls it without awaiting, so the limit would be skipped
+    unconditionally. #2018 puts a store round trip behind this callable,
+    which is the change most likely to tempt someone into making it async.
+    """
+    key = f"{endpoint.__module__}.{endpoint.__name__}"
+    groups = limiter._dynamic_route_limits[key]
+    assert groups
+    for group in groups:
+        assert group.exempt_when is not None
+        assert not inspect.iscoroutinefunction(group.exempt_when)
+
+
+async def test_a_dead_store_degrades_the_request_and_is_announced_once(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    """A store that fails every call must not 500, and must not log per request.
+
+    Fails both the counter write and the health probe, which is what an
+    unreachable Valkey looks like: with only the write failing, slowapi's own
+    recovery probe would flap the flag once per request.
+    """
+
+    def _unreachable(*_args, **_kwargs):
+        raise ConnectionError("rate-limit store unreachable")
+
+    monkeypatch.setattr(limiter._limiter, "hit", _unreachable)
+    monkeypatch.setattr(limiter._storage, "check", lambda: False)
+    limiter._fallback_storage.reset()
+    limiter.enabled = True
+    try:
+        with structlog.testing.capture_logs() as captured:
+            statuses = [
+                (
+                    await client.get(f"/search/datasets/?q=sec-2018-outage-{i}")
+                ).status_code
+                for i in range(3)
+            ]
+    finally:
+        limiter.enabled = False
+        limiter._storage_dead = False
+
+    assert statuses == [200, 200, 200], statuses
+    outages = [e for e in captured if e["event"] == "rate_limit_storage_unreachable"]
+    assert len(outages) == 1, [e["event"] for e in captured]
+
+
+def test_recovery_is_announced_once_too():
+    """The transition hook is symmetric, so an outage is not sticky in the log."""
+    limiter._storage_dead = False
+    with structlog.testing.capture_logs() as captured:
+        limiter._storage_dead = True
+        limiter._storage_dead = True
+        limiter._storage_dead = False
+        limiter._storage_dead = False
+
+    events = [e["event"] for e in captured]
+    assert events == ["rate_limit_storage_unreachable", "rate_limit_storage_recovered"]

--- a/backend/tests/test_ratelimit_shared_storage_2018.py
+++ b/backend/tests/test_ratelimit_shared_storage_2018.py
@@ -7,10 +7,15 @@ must not disturb. The cross-worker claim tests live in test_rate_limits.py.
 """
 
 import inspect
+import uuid
 
 import pytest
+import slowapi.extension
 import structlog
 from httpx import AsyncClient
+from limits import RateLimitItemPerMinute
+from limits.storage import MemoryStorage
+from slowapi.util import get_remote_address
 
 from app.core.config import settings
 from app.modules.catalog.search.router import (
@@ -20,6 +25,7 @@ from app.modules.catalog.search.router import (
 from app.platform import ratelimit_claims
 from app.platform.ratelimit import (
     _FallbackAnnouncingLimiter,
+    _global_rate_limit,
     limiter,
     shared_storage_uri,
 )
@@ -35,12 +41,59 @@ def uncached_storage_uri():
     shared_storage_uri.cache_clear()
 
 
-def test_no_configured_store_keeps_counting_per_process(
+def test_no_configured_store_keeps_counting_per_process_and_says_so(
     monkeypatch: pytest.MonkeyPatch, uncached_storage_uri
 ):
+    """The one configuration where limiting is not cluster-wide announces itself.
+
+    Every other degradation in this module logs; a silent one here would be
+    the only way to end up with per-worker buckets and no trace of it.
+    """
     monkeypatch.setattr(settings, "redis_url", None)
-    assert shared_storage_uri() is None
+
+    with structlog.testing.capture_logs() as captured:
+        assert shared_storage_uri() is None
+
+    assert [e["event"] for e in captured] == ["rate_limit_storage_not_configured"]
     assert ratelimit_claims._build_store() is None
+
+
+def test_a_socket_timeout_raised_in_the_url_is_dropped(
+    monkeypatch: pytest.MonkeyPatch, uncached_storage_uri
+):
+    """redis-py lets the querystring beat the keyword arguments.
+
+    Measured: ``from_url(..?socket_timeout=30, socket_timeout=0.25)`` leaves
+    30 in effect, on both the claim client and the limits storage. The call
+    runs on the event loop, so that bound is not the operator's to widen.
+    """
+    monkeypatch.setattr(
+        settings,
+        "redis_url",
+        "redis://valkey/0?socket_timeout=30&socket_connect_timeout=30&db=2",
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        resolved = shared_storage_uri()
+
+    assert resolved == "redis://valkey/0?db=2"
+    overrides = [
+        e
+        for e in captured
+        if e["event"] == "rate_limit_storage_socket_timeout_override_ignored"
+    ]
+    assert len(overrides) == 1, captured
+    assert overrides[0]["parameters"] == ["socket_connect_timeout", "socket_timeout"]
+
+
+def test_a_url_without_timeout_overrides_is_passed_through_untouched(
+    monkeypatch: pytest.MonkeyPatch, uncached_storage_uri
+):
+    """Only the case being fixed is rewritten; nothing else is re-encoded."""
+    url = "redis://valkey/0?db=2&client_name=geolens%2Fapi"
+    monkeypatch.setattr(settings, "redis_url", url)
+
+    assert shared_storage_uri() == url
 
 
 @pytest.mark.parametrize("url", ["redis://valkey:6379/0", "rediss://valkey:6379/1"])
@@ -122,6 +175,54 @@ def test_an_outage_falls_back_to_per_process_limiting_not_to_none():
     assert limiter._fallback_limiter is not None
     assert limiter._fallback_limiter is not limiter._limiter
     assert limiter._in_memory_fallback == []
+
+
+def test_two_workers_on_one_store_count_into_one_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The subject of #2018, pinned behaviourally rather than structurally.
+
+    Two limiters built the way the app builds its own stand in for two
+    uvicorn workers. The second arm is the bug: with a store each, the
+    second worker gets a whole fresh budget for the same caller. The first
+    arm also guards a hazard this PR introduces, since an always-present
+    in-memory fallback storage must never become the counting path while the
+    shared store is healthy.
+    """
+    item = RateLimitItemPerMinute(2)
+    key = f"sec-2018-bucket-{uuid.uuid4().hex}"
+
+    def _two_workers(*, shared: bool) -> list[_FallbackAnnouncingLimiter]:
+        one = MemoryStorage()
+        monkeypatch.setattr(
+            slowapi.extension,
+            "storage_from_string",
+            lambda _uri, **_options: one if shared else MemoryStorage(),
+        )
+        return [
+            _FallbackAnnouncingLimiter(
+                key_func=get_remote_address,
+                default_limits=[_global_rate_limit],
+                key_style="endpoint",
+                storage_uri="redis://stand-in",
+                in_memory_fallback_enabled=True,
+            )
+            for _ in range(2)
+        ]
+
+    worker_a, worker_b = _two_workers(shared=True)
+    assert [
+        worker_a.limiter.hit(item, key),
+        worker_b.limiter.hit(item, key),
+        worker_b.limiter.hit(item, key),
+    ] == [True, True, False], "two workers on one store must share one budget of 2"
+
+    worker_c, worker_d = _two_workers(shared=False)
+    assert [
+        worker_c.limiter.hit(item, key),
+        worker_d.limiter.hit(item, key),
+        worker_d.limiter.hit(item, key),
+    ] == [True, True, True], "a store each is the pre-#2018 bug: 2 per worker"
 
 
 @pytest.mark.parametrize("endpoint", [search_datasets_endpoint, search_facets_endpoint])

--- a/backend/tests/test_ratelimit_shared_storage_2018.py
+++ b/backend/tests/test_ratelimit_shared_storage_2018.py
@@ -58,19 +58,21 @@ def test_no_configured_store_keeps_counting_per_process_and_says_so(
     assert ratelimit_claims._build_store() is None
 
 
-def test_a_socket_timeout_raised_in_the_url_is_dropped(
+def test_url_parameters_that_lengthen_one_call_are_dropped(
     monkeypatch: pytest.MonkeyPatch, uncached_storage_uri
 ):
     """redis-py lets the querystring beat the keyword arguments.
 
-    Measured: ``from_url(..?socket_timeout=30, socket_timeout=0.25)`` leaves
-    30 in effect, on both the claim client and the limits storage. The call
-    runs on the event loop, so that bound is not the operator's to widen.
+    Measured on redis-py 7.4.1: a URL ``socket_timeout=30`` leaves 30 in
+    effect over the code's 0.25, on the limits storage as well, and either
+    retry flag lifts retries 0 to 1, doubling the bound again. The call runs
+    on the event loop, so that bound is not the operator's to widen.
     """
     monkeypatch.setattr(
         settings,
         "redis_url",
-        "redis://valkey/0?socket_timeout=30&socket_connect_timeout=30&db=2",
+        "redis://valkey/0?socket_timeout=30&socket_connect_timeout=30"
+        "&retry_on_timeout=true&retry_on_error=ConnectionError&db=2",
     )
 
     with structlog.testing.capture_logs() as captured:
@@ -80,10 +82,15 @@ def test_a_socket_timeout_raised_in_the_url_is_dropped(
     overrides = [
         e
         for e in captured
-        if e["event"] == "rate_limit_storage_socket_timeout_override_ignored"
+        if e["event"] == "rate_limit_storage_call_duration_override_ignored"
     ]
     assert len(overrides) == 1, captured
-    assert overrides[0]["parameters"] == ["socket_connect_timeout", "socket_timeout"]
+    assert overrides[0]["parameters"] == [
+        "retry_on_error",
+        "retry_on_timeout",
+        "socket_connect_timeout",
+        "socket_timeout",
+    ]
 
 
 def test_a_url_without_timeout_overrides_is_passed_through_untouched(

--- a/backend/tests/test_ratelimit_shared_storage_2018.py
+++ b/backend/tests/test_ratelimit_shared_storage_2018.py
@@ -7,6 +7,7 @@ must not disturb. The cross-worker claim tests live in test_rate_limits.py.
 """
 
 import inspect
+import pathlib
 import uuid
 
 import pytest
@@ -22,10 +23,11 @@ from app.modules.catalog.search.router import (
     search_datasets_endpoint,
     search_facets_endpoint,
 )
-from app.platform import ratelimit_claims
+from app.platform import ratelimit, ratelimit_claims
 from app.platform.ratelimit import (
     _FallbackAnnouncingLimiter,
     _global_rate_limit,
+    emit_startup_notices,
     limiter,
     shared_storage_uri,
 )
@@ -35,10 +37,17 @@ pytestmark = pytest.mark.anyio
 
 @pytest.fixture
 def uncached_storage_uri():
-    """Drop the process-wide memo around a test that changes ``redis_url``."""
+    """Drop the process-wide memo and the queued notices from importing.
+
+    The module queues its notice while it is imported, and in the app that
+    queue is drained once at startup; here each test needs to see only what
+    its own call queued.
+    """
     shared_storage_uri.cache_clear()
+    ratelimit._startup_notices.clear()
     yield
     shared_storage_uri.cache_clear()
+    ratelimit._startup_notices.clear()
 
 
 def test_no_configured_store_keeps_counting_per_process_and_says_so(
@@ -53,6 +62,8 @@ def test_no_configured_store_keeps_counting_per_process_and_says_so(
 
     with structlog.testing.capture_logs() as captured:
         assert shared_storage_uri() is None
+        assert captured == [], "the decision is made before logging is configured"
+        emit_startup_notices()
 
     assert [e["event"] for e in captured] == ["rate_limit_storage_not_configured"]
     assert ratelimit_claims._build_store() is None
@@ -77,6 +88,7 @@ def test_url_parameters_that_lengthen_one_call_are_dropped(
 
     with structlog.testing.capture_logs() as captured:
         resolved = shared_storage_uri()
+        emit_startup_notices()
 
     assert resolved == "redis://valkey/0?db=2"
     overrides = [
@@ -126,6 +138,7 @@ def test_a_scheme_the_limiter_cannot_use_is_refused_not_raised(
 
     with structlog.testing.capture_logs() as captured:
         assert shared_storage_uri() is None
+        emit_startup_notices()
 
     refusals = [
         e for e in captured if e["event"] == "rate_limit_storage_scheme_unsupported"
@@ -150,6 +163,7 @@ def test_the_configured_url_never_reaches_the_log(
 
     with structlog.testing.capture_logs() as captured:
         assert shared_storage_uri() is None
+        emit_startup_notices()
 
     refusal = [
         e for e in captured if e["event"] == "rate_limit_storage_scheme_unsupported"
@@ -248,48 +262,72 @@ def test_the_claim_gate_stays_a_synchronous_callable(endpoint):
         assert not inspect.iscoroutinefunction(group.exempt_when)
 
 
-async def test_a_dead_store_degrades_the_request_and_is_announced_once(
-    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+def test_the_app_drains_the_queue_after_it_configures_logging():
+    """Queueing the notices is only worth anything if something flushes them.
+
+    Deferring them and never draining would trade a badly formatted line for
+    no line at all, which is the silent disable the queue exists to avoid.
+    """
+    import app.api.main as api_main
+
+    source = pathlib.Path(api_main.__file__).read_text()
+
+    assert "emit_startup_notices()" in source, (
+        "nothing drains the queued rate-limit storage notices"
+    )
+    assert source.index("setup_logging(") < source.index("emit_startup_notices()"), (
+        "the flush must come after logging is configured, not before"
+    )
+
+
+async def test_a_dead_store_degrades_the_request_and_both_edges_are_announced(
+    client: AsyncClient,
 ):
     """A store that fails every call must not 500, and must not log per request.
 
-    Fails both the counter write and the health probe, which is what an
-    unreachable Valkey looks like: with only the write failing, slowapi's own
-    recovery probe would flap the flag once per request.
+    Both edges are driven through slowapi's own writes to ``_storage_dead``
+    rather than assigned here, so a rename in slowapi leaves this test
+    failing instead of quietly passing against a property nothing calls.
     """
 
     def _unreachable(*_args, **_kwargs):
         raise ConnectionError("rate-limit store unreachable")
 
-    monkeypatch.setattr(limiter._limiter, "hit", _unreachable)
-    monkeypatch.setattr(limiter._storage, "check", lambda: False)
+    live_hit = limiter._limiter.hit
+    live_check = limiter._storage.check
+    limiter._limiter.hit = _unreachable
+    limiter._storage.check = lambda: False
     limiter._fallback_storage.reset()
     limiter.enabled = True
     try:
-        with structlog.testing.capture_logs() as captured:
+        with structlog.testing.capture_logs() as outage:
             statuses = [
                 (
                     await client.get(f"/search/datasets/?q=sec-2018-outage-{i}")
                 ).status_code
                 for i in range(3)
             ]
+
+        assert statuses == [200, 200, 200], statuses
+        assert [
+            e["event"] for e in outage if e["event"].startswith("rate_limit_storage_")
+        ] == ["rate_limit_storage_unreachable"]
+
+        limiter._limiter.hit = live_hit
+        limiter._storage.check = live_check
+        # slowapi probes the backend on an exponential delay; zeroing the last
+        # probe time lets the next request take the recovery branch now.
+        limiter._Limiter__last_check_backend = 0.0
+
+        with structlog.testing.capture_logs() as recovery:
+            healed = await client.get("/search/datasets/?q=sec-2018-healed")
+
+        assert healed.status_code == 200, healed.status_code
+        assert [
+            e["event"] for e in recovery if e["event"].startswith("rate_limit_storage_")
+        ] == ["rate_limit_storage_recovered"]
     finally:
+        limiter._limiter.hit = live_hit
+        limiter._storage.check = live_check
         limiter.enabled = False
         limiter._storage_dead = False
-
-    assert statuses == [200, 200, 200], statuses
-    outages = [e for e in captured if e["event"] == "rate_limit_storage_unreachable"]
-    assert len(outages) == 1, [e["event"] for e in captured]
-
-
-def test_recovery_is_announced_once_too():
-    """The transition hook is symmetric, so an outage is not sticky in the log."""
-    limiter._storage_dead = False
-    with structlog.testing.capture_logs() as captured:
-        limiter._storage_dead = True
-        limiter._storage_dead = True
-        limiter._storage_dead = False
-        limiter._storage_dead = False
-
-    events = [e["event"] for e in captured]
-    assert events == ["rate_limit_storage_unreachable", "rate_limit_storage_recovered"]


### PR DESCRIPTION
## Summary

The app-wide slowapi `Limiter` was built with no `storage_uri`, so it used the library's in-memory storage and every per-IP and per-user bucket it backs was one bucket per uvicorn worker. The bundled `docker-compose.prod.yml` runs two workers by default, so every configured cap was really that cap times `UVICORN_WORKERS`. The paired-request claim registry added in #1903 had the same shape: a `/search/datasets/` and `/search/facets/` pair that landed on two different workers found no claim, so it spent two SEC-S11 tokens instead of one.

Both now use the store `REDIS_URL` already names, and both keep their old behaviour as the fallback rather than losing the limit.

Closes #2018. One caveat worth stating plainly: the bundled `docker-compose.prod.yml` still ships two API workers with `REDIS_URL` empty and its valkey service behind the `cloud-dev` profile, so a default `up` of that file gets the mechanism but not a shared store, and its buckets are still counted per worker. Changing that default is #2041. What this PR adds for that case is a startup warning naming the consequence, so the one configuration where limiting is not cluster-wide is no longer the only silent one.

## Changes

- `platform/ratelimit.py` derives the limiter's `storage_uri` from `settings.redis_url` (no new setting, no second copy of the URL) and passes `in_memory_fallback_enabled=True`. `in_memory_fallback` is left empty on purpose: slowapi then swaps only the storage on an outage and re-evaluates the same limits, so a dead store degrades to per-worker counting instead of dropping the limit or raising a 500 per request. The strategy, `key_func` and `key_style="endpoint"` are untouched.
- A scheme the limiter cannot use is refused rather than raised. `limits` raises `ConfigurationError` on an unknown scheme, and that would fire while building the module-level limiter, so an otherwise working deployment could not boot. The refusal logs the scheme, never the URL: `REDIS_URL` routinely carries a password in its userinfo, and `redact_url_credentials` only rewrites http(s), so passing the URL through it would hand the credential straight to the log.
- The store-outage transition is announced once per outage, and once again on recovery, by hooking the flag slowapi flips rather than logging from the request path.
- The three startup notices are queued rather than logged where they are decided. That decision happens while this module is imported, which `api/main.py` does before it calls `setup_logging`, so logging there would render console-formatted lines outside the JSON stream an operator greps. The lifespan drains the queue next to the existing CORS warning.
- `platform/ratelimit_claims.py` is the shared claim store: `SET key route NX EX 5` to record, `GETDEL` to consume. It is a synchronous client with a 0.25s socket timeout, because the consume happens inside slowapi's synchronous `exempt_when`. Any store error answers `None`, which sends the caller back to the process-local registry, the behaviour before this PR. "Exempt" is never the fallback.
- The claim key is a hash of a length-prefixed join of the same tuple #1903 introduced, so the property that tuple existed for survives the string form: one component is an IPv6 address and the other is caller-supplied text, and a plain separator would let a /64 holder pick low bits that shift the split onto a neighbour's key.
- A failed store call arms a cooldown, during which every call answers `None` without touching the client. Both search routes are `async def`, so slowapi runs `exempt_when` inline on the event loop with no threadpool, and a store that drops packets rather than refusing them would otherwise stall the whole worker for the socket timeout on every request. slowapi's own limiter backs off exponentially after one failure for the same reason; this was the one path that would have kept hammering. The cooldown is one claim lifetime, which bounds how long the store goes unprobed. It does not bound the claims written while it is armed, whose own TTL starts when they are written, so a claim recorded late in a cooldown outlives it.
- That gap is closed on the read side instead: a store answering "no key" no longer short-circuits the local registry. The store can only speak for claims it was given, and one the fallback wrote during an outage was never published to it. In steady state the local registry is empty, so this costs a dictionary lookup and nothing else; a claim the store does redeem takes any local entry with it, so a leftover cannot fund a second exemption.
- Every URL query parameter that can lengthen one store call is stripped before the URL reaches either client: `socket_timeout`, `socket_connect_timeout`, `retry_on_timeout`, `retry_on_error`. redis-py parses all four and lets the querystring beat the keyword arguments, measured on 7.4.1: `from_url("redis://host/0?socket_timeout=30", socket_timeout=0.25)` leaves 30 in effect, on the `limits` storage as well, and either retry flag lifts the retry count from 0 to 1, doubling the bound again. The bound exists because the call runs on the event loop, so it is not the operator's to widen; the removal is logged once, naming the parameters and not the URL.
- `service_semantic.py`'s two claim functions consult the store first and fall back to the local `OrderedDict`, which stays the default when no store is configured. The pairing window is now one constant, derived from the store's rather than copied beside it.
- `query_router.py`'s `fix(#565)` note said a Valkey-backed limiter was tracked but not forked there. It is now accurate about both configurations.

## Why `GETDEL` and not a script

`GETDEL` is one round trip, which is what stops two workers redeeming one claim. The price is the only divergence from the process-local registry: a same-route caller reads its own claim and takes it with it, where the local registry leaves it standing. That can cost the sibling an exemption it would have had; it can never grant an extra one, and the worst case is the pre-#1903 behaviour of one token per request. `test_paired_claim_store_2018.py` pins that divergence rather than leaving it for a reader to discover.

That "never grants an extra one" is true of the shipped code, not of every commit on the branch. Until the bytes decode landed, `consume` compared the store's return value to a `str`, so a client built without `decode_responses` would have compared bytes to str, never found them equal, and handed an exemption to any standing claim including the caller's own. The only constructor here passes `decode_responses=True` and it cannot be flipped through `REDIS_URL`, so it was latent rather than live, but the invariant dates from that commit.

## Config impact

No new environment variable. `REDIS_URL` now also decides where rate-limit buckets are counted, and `.env.example` says so under the existing entry. Only `redis://` and `rediss://` URLs can hold the buckets; those are the schemes both `limits` and redis-py accept, and `platform/cache` already hands `REDIS_URL` to redis-py, so a working deployment cannot have another scheme. Anything else keeps per-worker counting and says so once at startup.

Every existing `@limiter.limit` surface becomes cross-worker with no per-call-site change: the login throttle, the AI generate and metadata limits, the SQL sandbox per-user and per-IP limits, the OGC filtered-items limit, the basemap proxy limit, the admin and settings limits, and the outer layer of the ArcGIS sign-in guard.

## Audit of the remaining per-process state

Swept `backend/app/`, `cli/` and `mcp/` for rate-limiting, throttling, quota, single-flight, dedup, lock and circuit-breaker state. Nothing below is fixed here.

Still per-process, worth tracking:

- `processing/ai/sandbox_bounds.py` `query_slots`. Sized against this worker's own SQLAlchemy pool, which is correct, except on the `db_use_external_pooler` branch where the bound is a flat 4 against a pooler budget every worker shares. N workers admit 4N concurrent sandbox queries there.
- `catalog/search/service_semantic.py` `_embedding_inflight`. The single-flight that keeps one paid embed per query is per worker, so a pair split across workers can still make two provider calls under one charged token. Cost and latency only, never incorrect.
- `platform/cache/memory.py` `InMemoryCacheProvider`, selected as the only cache when `REDIS_URL` is unset. With two workers a revoke written in one is invisible to the other until the TTL expires. The remedy is the setting itself, and `platform/cache/revocation.py` reads a transactional database counter on every validation as the backstop.
- `platform/cache/redis.py` circuit breaker and authoritative-write replay queue. Per worker by construction, documented as such, backstopped by the same revocation counter.
- `processing/tiles/router.py` `_dataset_cache` and `_raster_meta_cache`. These 60s snapshots carry visibility and ownership, and the explicit eviction only reaches the acting worker, so another worker can serve an unpublished dataset until the TTL runs out. Bounded and already documented in that file.
- `api/main.py` health-alert cooldown and `modules/auth/dependencies.py` `_query_lane_log_last`. Both are log and notification dedup, so the effect is N copies rather than one. Noise only.

Per-process and acceptable: the embedding, sprite, schema, metadata, collection-meta and band-stats caches, and the in-memory tile cache, since every one is a memo whose miss is cheap and whose key makes a stale hit impossible; `_preview_slots`, sized against the same per-worker pool; the request-scoped fan-out semaphores in the ArcGIS and STAC adapters; the GC reference sets for in-flight tasks; the extension registry, which every worker loads identically; `persistent_config._sync_rate_limit_cache`, which mirrors limit values rather than counters; the metrics bookkeeping sets and the staging-reconcile cursors, both already serialised by Postgres advisory locks.

Already cluster-wide, no action: the ArcGIS sign-in ledger (`ArcGISSignInAttempt` plus two advisory locks), the revocation generations (`catalog.security_revocation_generation`), the AI token budget (a live window read over `catalog.ai_token_usage`), the upload and dataset quotas, the sandbox per-user advisory lock, and `platform/catalog_locks.py`.

## Deferred

- The cross-worker bucket test shares a `MemoryStorage` through slowapi's own storage factory rather than a fake Redis. `limits`' Redis storage counts through a Lua script, and fakeredis only runs Lua with its optional `lupa` extra, which I did not add for a test. The arm that matters is the counterfactual one, which shows a store each giving the second worker a whole fresh budget.
- `redact_url_credentials` returns non-http URLs unchanged, so it cannot redact a `redis://user:pass@host` URL. No current caller passes one, and this PR avoids the question by logging the scheme, but the helper's name promises more than it does.
- The limiter's store calls are synchronous and run on the event loop thread. That is inherent to slowapi's design, not something this PR introduces. The 0.25s socket timeout bounds a black-holed socket, and on redis-py 7.4.1 a connection pool built this way carries `retries=0` with `NoBackoff`, measured at 3ms to raise against a closed port, so there is no retry multiplier on top of that timeout. A future redis-py that changes that default would widen the stall, which is the assumption to recheck on a bump.

## Area

- [x] Backend (API, services, models)

## Testing

- [x] Unit tests pass (`pytest`)

`test_ratelimit_shared_storage_2018.py`, new, 14 tests: storage selection for an unset, a `redis://`, a `rediss://` and a refused scheme; that the refused URL never reaches the log; that the strategy, key function and key style are unchanged; that the fallback limiter exists and is distinct; that both search routes' `exempt_when` is still a plain function, since an async one returns a truthy coroutine slowapi never awaits and would skip the limit unconditionally; that a store failing both its counter write and its health probe leaves three requests at 200 with exactly one warning logged; and that recovery is announced too, both edges driven through slowapi's own writes to that flag rather than assigned by the test, so a rename in slowapi fails here instead of quietly passing against a property nothing calls. Plus four from review: that no configured store logs rather than degrading silently, that the URL parameters which lengthen a call are dropped and logged while a URL without them is passed through byte-identical, that two limiters on one store count into one bucket where two limiters on a store each do not, and that the app drains the queued notices after it configures logging rather than deferring them into silence.

`test_paired_claim_store_2018.py`, new, 10 tests: single-use and cross-route only; a same-route repeat is never exempt and takes the claim with it; a client that returns bytes still refuses a same-route repeat, since the route comparison must not depend on `decode_responses`; `NX` does not let a second writer extend a standing claim; the TTL is the pairing window; an IPv6 client cannot shift the key onto a neighbour's; a store error answers `None` rather than "exempt"; an outage logs once per outage, not once per call; 50 request pairs against a dead store reach the client once rather than 100 times; and the cooldown is at least the claim lifetime, which is the reason it is that number.

`test_rate_limits.py`: all six #1903 counting tests now run against both backends through a `claim_backend` fixture, and three are new. One drives a real paired request through the routes, then wipes the process-local registry and swaps in a second client on the same store to model the sibling worker, and asserts the facets call is still exempt. One runs both halves of a pair against a store whose every call raises and asserts the local registry still coordinates them while a novel query still pays. One drives a frozen clock through the sequence that made the cooldown insufficient on its own: a store failure at t=0 arms it to t=5, a record skipped at t=4.9 leaves a local claim living to t=9.9, and at t=5.01 the recovered store answers "no key" for a claim it was never given. The sibling must still be exempt.

Counterfactuals, each observed:

- Cross-worker exemption: with the store removed at the worker boundary, the facets call is a 429 against the spent bucket. That is the bug this PR closes.
- `in_memory_fallback_enabled`: with the flag off, a dead store raises `ConnectionError` out of the middleware and slowapi's handler fails on `exc.detail`, so every request is a 500.
- The bytes decode: `fakeredis` without `decode_responses` returns `b"facets"`, and `b"facets" != "facets"` is `True`, so the pre-fix comparison exempted a same-route repeat. That is the fail-open direction, which is why the decode is in the store rather than left to the constructor.
- The shared arm of the ported tests fails identically to the local arm when the invariant is broken, since both run the same assertions.

The shared arm runs on `fakeredis`, already a dev dependency in `backend/pyproject.toml`. No dependency was added. What the port has to preserve is the counting invariant, and that is decided by `SET NX EX` and `GETDEL` semantics, which fakeredis implements.

Also run: `test_layering.py` (the `service_semantic.py` budget re-measured to 476, exact), `test_rule1_structural.py`, `test_rule2_structural.py`, `test_semantic_search_rate_limit_1778.py` (the `override_defaults` invariant still holds), `test_search_embedding_cache.py`, `test_search_facets.py`, `test_search_facets_input_cap.py`, `test_hybrid_search.py`, `test_admin_rate_limit.py`, `test_global_rate_limit_envelope_1778.py`, `test_ogc_features_filter.py`, `test_sandbox_query_endpoint_565.py`, `test_config.py`, `test_environment_posture_sec005.py`, `test_phase_274_caches_and_pool.py`, `finding_markers.py`, `ruff check` and `ruff format --check`.

No route signature, query parameter or published description changed, so no OpenAPI or SDK regeneration is needed.

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [ ] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing
