### PR TITLE
fix(reupload): answer 422 for a file the preview cannot read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,10 @@ and releases use semantic versioning.
   An unrecognised local-file failure records the tool and its exit status, with the driver's full
   output kept in the structured logs. The CLI job views and the ingest-failure notification
   render the same sentence the web app shows, instead of the stored code. (#2010)
+- Replacing a dataset with a file the server cannot read now answers the same 422 and the
+  same message the import preview gives, instead of a generic server error. The reason
+  recorded for such a file names the file that was uploaded, rather than reporting only the
+  tool and its exit status. (#2036)
 
 ## [1.18.1] - 2026-09-05
 

--- a/backend/app/modules/catalog/datasets/api/router_reupload.py
+++ b/backend/app/modules/catalog/datasets/api/router_reupload.py
@@ -633,6 +633,14 @@ async def reupload_preview(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(exc),
         ) from exc
+    except Exception as exc:  # broad: GDAL subprocess can raise various errors on unsupported/malformed files
+        # fix(#2036): the 422 the import preview answers for the same failure.
+        # A malformed file's IngestionError escaped this door as a 500.
+        logger.exception("ogrinfo_preview failed", job_id=str(job_id), error=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Unable to preview file. The file may be malformed or unsupported.",
+        ) from exc
     finally:
         if downloaded_preview_path is not None:
             downloaded_preview_path.unlink(missing_ok=True)

--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -49,12 +49,14 @@ from app.processing.raster.vrt import gdal_service_safe_env, gdal_vector_safe_en
 # group is optional since some GDAL builds emit bare driver names.
 _OGR_DRIVER_LIST_LINE_RE = re.compile(r"^\s*->\s*'[^']+'\s*(\([^)]*\))?\s*$")
 
-# When no driver can open the source, ogr2ogr/ogrinfo print this line
-# followed by GDAL's full driver enumeration (100+ lines) — raw text a demo
-# visitor once saw verbatim in the job UI. Anchored tightly so no other
-# failure class (bad SRS, permission denied, disk full) matches.
+# When no driver can open the source, ogr2ogr prints this line ahead of GDAL's
+# full driver enumeration (100+ lines) — raw text a demo visitor once saw in
+# the job UI. fix(#2036): ogrinfo says it in one line of its own naming the
+# staging path, which the first alternative never matched. Both are anchored
+# tightly so no other failure class (bad SRS, permission denied) matches.
 _OGR_UNABLE_TO_OPEN_RE = re.compile(
     r"Unable to open datasource `[^']*' with the following drivers\."
+    r"|ogrinfo failed - unable to open '[^']*'"
 )
 
 # A second shape: a driver DOES claim the source (e.g. GPKG is SQLite) but
@@ -73,9 +75,9 @@ _SQLITE_DISK_IMAGE_MALFORMED_RE = re.compile(r"database disk image is malformed"
 def _is_unopenable_source_stderr(stderr_text: str) -> bool:
     """True when ``stderr_text`` matches a known "can't open this source" shape.
 
-    The three patterns all mean the same thing to the uploader — GDAL
-    couldn't read it as a spatial dataset — so they map to one friendly
-    message; see ``_friendly_open_failure_message``.
+    The patterns all mean the same thing to the uploader — GDAL couldn't
+    read it as a spatial dataset — so they map to one friendly message;
+    see ``_friendly_open_failure_message``.
     """
     return bool(
         _OGR_UNABLE_TO_OPEN_RE.search(stderr_text)

--- a/backend/tests/test_ingest_ogr_pure.py
+++ b/backend/tests/test_ingest_ogr_pure.py
@@ -12,9 +12,11 @@ import pytest
 
 from app.processing.ingest.metadata import _sql_quote_ident
 from app.processing.ingest.ogr import (
+    IngestionError,
     _extract_common_layer_metadata,
     _friendly_open_failure_message,
     _is_unopenable_source_stderr,
+    _raise_gdal_failure,
     _sanitize_authorization_token,
     _strip_ogr_driver_list,
     extract_srid_from_json,
@@ -1015,6 +1017,39 @@ class TestIsUnopenableSourceStderr:
 
     def test_empty_string_does_not_match(self):
         assert _is_unopenable_source_stderr("") is False
+
+
+class TestOgrinfoOneLineOpenFailure:
+    """fix(#2036): ogrinfo reports an unopenable source in one line of its
+    own rather than ogr2ogr's driver enumeration, so the reason for it is
+    the friendly sentence and not ``ogrinfo failed (exit 1)``.
+    """
+
+    _STDERR = (
+        "ERROR 4: `/app/staging/7c3d-uuid_march.gpkg' not recognized as being "
+        "in a supported file format.\n"
+        "ogrinfo failed - unable to open '/app/staging/7c3d-uuid_march.gpkg'.\n"
+    )
+
+    def test_the_one_line_wording_is_an_open_failure(self):
+        assert _is_unopenable_source_stderr(self._STDERR) is True
+
+    def test_the_reason_names_the_source_and_not_the_staging_path(self):
+        with pytest.raises(IngestionError) as exc_info:
+            _raise_gdal_failure("ogrinfo", 1, self._STDERR, "march.gpkg")
+        reason = str(exc_info.value)
+        assert reason == (
+            "Could not open 'march.gpkg' as a spatial dataset — the file "
+            "may be corrupt, incomplete, or not a valid GeoPackage (.gpkg) "
+            "file."
+        )
+        assert "/app/staging" not in reason
+        assert "7c3d-uuid_march.gpkg" not in reason
+
+    def test_a_layer_that_is_not_in_the_source_is_not_an_open_failure(self):
+        """The other ogrinfo exit-1 shape keeps its own class (#2010)."""
+        stderr = "ERROR 1: Couldn't fetch requested layer parcels.\n"
+        assert _is_unopenable_source_stderr(stderr) is False
 
 
 class TestFriendlyOpenFailureMessage:

--- a/backend/tests/test_ingest_open_failure_message.py
+++ b/backend/tests/test_ingest_open_failure_message.py
@@ -14,11 +14,12 @@ fixture files built in ``tmp_path`` and assert:
   2. The full raw stderr (driver list / SQLite diagnostics) still reaches
      structured logs at error level, so the diagnostic is not lost.
 
-Three corrupt-file shapes are covered, matching the three stderr patterns
+Three corrupt-file shapes are covered, matching the stderr patterns
 GDAL/SQLite actually produce for this failure class:
 
-  - No driver recognizes the source at all (plain garbage bytes) → GDAL's
-    "Unable to open datasource ... with the following drivers." enumeration.
+  - No driver recognizes the source at all (plain garbage bytes) → ogr2ogr's
+    "Unable to open datasource ... with the following drivers." enumeration,
+    and ogrinfo's one-line "ogrinfo failed - unable to open '<path>'".
   - The SQLite/GPKG magic header itself doesn't parse (a truncated/
     garbage-filled GPKG whose first bytes claim to be SQLite but the header
     fields are junk) → SQLite's own "file is not a database" diagnostics.
@@ -132,18 +133,23 @@ def _write_malformed_page_gpkg(tmp_path) -> str:
 
 
 class TestRunOgrinfoFriendlyOpenFailure:
-    """ogrinfo runs before ogr2ogr in the ingest_file task (CRS detection), so
-    for the realistic corrupt-upload case — content-sniffing at upload time
-    already rejects a file with no recognizable magic header at all — this is
-    the function that actually raises. Empirically (GDAL 3.13 on this host,
-    matching the orchestrator's live dev-stack reproduction), ogrinfo's
-    "no driver at all" failure is a short one-liner without a driver
-    enumeration (a distinct, out-of-scope leak noted in the PR description),
-    so only the two SQLite-diagnostic shapes (corrupt header, corrupt page)
-    are exercised against ogrinfo here; the driver-enumeration shape is
-    exercised against ogr2ogr below, which is where the original march.gpkg
-    incident's exact stderr came from.
+    """ogrinfo runs before ogr2ogr in the ingest task (CRS detection), so it
+    is the function that raises for a corrupt upload. Its own one-line
+    "unable to open" wording maps to the same friendly message the two
+    SQLite diagnostics do (#2036).
     """
+
+    async def test_no_driver_case_raises_friendly_message(self, tmp_path):
+        source = _write_no_driver_gpkg(tmp_path)
+        with pytest.raises(IngestionError) as exc_info:
+            await run_ogrinfo(source, original_filename="march.gpkg")
+        message = str(exc_info.value)
+        assert message == (
+            "Could not open 'march.gpkg' as a spatial dataset — the file "
+            "may be corrupt, incomplete, or not a valid GeoPackage (.gpkg) "
+            "file."
+        )
+        assert str(tmp_path) not in message
 
     async def test_sqlite_corrupt_content_case_raises_friendly_message(self, tmp_path):
         source = _write_sqlite_magic_corrupt_gpkg(tmp_path)

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4574,7 +4574,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # service_queue verdict, its parameter and the configure() branch. Cap 1506 -> 1488, exact.
     # fix(#1953): +1 — the import of the one redactor every failure writer
     # in this module now goes through. Cap 1427 -> 1428, exact.
-    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1428,
+    # fix(#2036): +8. The re-upload preview maps an unreadable file to the
+    # import preview's 422 instead of letting it escape as a 500.
+    # Cap 1428 -> 1436, exact.
+    "backend/app/modules/catalog/datasets/api/router_reupload.py": 1436,
     # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
     # other creation path, so a post-migration VRT does not report null while
     # a backfilled one carries a timestamp, with a note on why it is a Python
@@ -5010,7 +5013,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # recognises the class first and composes the reason from the fields that
     # class may carry, since a driver names the source inside its own prose.
     # Cap 1307 -> 1341, exact.
-    "backend/app/processing/ingest/ogr.py": 1341,
+    # fix(#2036): +2. The unable-to-open pattern gains ogrinfo's own one-line
+    # wording, which ogr2ogr's driver enumeration never matched.
+    # Cap 1341 -> 1343, exact.
+    "backend/app/processing/ingest/ogr.py": 1343,
     # fix(#1846, GHSA-hrf5-v3cq-frx5): first entry. This module crossed the
     # 1000-line threshold when the content check landed: the SQLite schema
     # reader, the archive member walk that identifies members by their bytes

--- a/backend/tests/test_reupload.py
+++ b/backend/tests/test_reupload.py
@@ -673,6 +673,55 @@ class TestReuploadPreview:
         assert resp.status_code == 200, resp.text
         assert not downloaded.exists()
 
+    async def test_unreadable_file_answers_422_and_removes_the_download(
+        self,
+        client: AsyncClient,
+        admin_auth_header: dict,
+        test_db_session,
+        mock_reupload_catalog_port,
+        mock_ogrinfo_preview,
+        tmp_path,
+    ):
+        """A file ogrinfo cannot read answers the import preview's 422 (#2036)."""
+        admin_id = await get_user_id(test_db_session, "admin")
+        dataset = await _create_dataset(test_db_session, created_by=admin_id)
+        job = IngestJob(
+            dataset_id=dataset.id,
+            source_filename="replacement.geojson",
+            file_path=f"staging/{uuid.uuid4()}/replacement.geojson",
+            created_by=admin_id,
+            status="pending",
+            user_metadata={
+                "reupload": True,
+                "dataset_id": str(dataset.id),
+            },
+        )
+        test_db_session.add(job)
+        await test_db_session.commit()
+
+        downloaded = tmp_path / "downloaded-preview.geojson"
+        downloaded.write_text('{"type":"FeatureCollection","features":[')
+        mock_ogrinfo_preview.side_effect = router_reupload.IngestionError(
+            "Could not open 'replacement.geojson' as a spatial dataset — the "
+            "file may be corrupt, incomplete, or not a valid GeoJSON "
+            "(.geojson) file."
+        )
+        with patch.object(
+            mock_reupload_catalog_port,
+            "resolve_file_path",
+            new=AsyncMock(return_value=str(downloaded)),
+        ):
+            resp = await client.post(
+                f"/datasets/{dataset.id}/reupload/{job.id}/preview",
+                headers=admin_auth_header,
+            )
+
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"] == (
+            "Unable to preview file. The file may be malformed or unsupported."
+        )
+        assert not downloaded.exists()
+
 
 class TestReuploadJobBinding:
     async def test_ordinary_unbound_job_is_hidden_from_all_reupload_consumers(


### PR DESCRIPTION
## Summary

`POST /api/datasets/{id}/reupload/{job}/preview` returned 500 for a file GDAL cannot read. The
handler caught only `UnsafeUploadError` around its ogrinfo call, so the `IngestionError` a
malformed file raises escaped unhandled. The import preview answers 422 for the identical file.
The CLI's `geolens replace <dataset> <file> --wait` hits the same door.

Secondary, same path: the reason stored for an unopenable vector file was `ogrinfo failed
(exit 1)`. The unable-to-open pattern matched ogr2ogr's driver enumeration but not the one-line
wording ogrinfo prints for the same failure, so the sentence #2028 intended was never reached.

## Changes

- The re-upload preview maps every non-`UnsafeUploadError` failure from the preview call to the
  import preview's 422 and detail text, with the same `logger.exception` record. The
  `UnsafeUploadError` branch from #1846 still answers first with its own message, and the
  staged-download unlink still runs on the way out.
- The unable-to-open pattern gains ogrinfo's `ogrinfo failed - unable to open '<path>'` wording,
  so both tools reach the sentence built from the source filename alone, through the same
  `core/failure_reason` door as before. Confirmed against ogrinfo on GDAL 3.13.
- The re-upload service preview was checked and left alone. It maps `IngestionError` to 502,
  which is the right answer for a remote service, and every typed refusal below it already
  arrives as a finished `HTTPException`.

## Area

- [x] Backend (API, services, models)
- [x] Import / Ingestion

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)

Run from the worktree with `.env.test` sourced:

```
pytest tests/test_reupload.py tests/test_ingest_ogr_pure.py tests/test_ingest_open_failure_message.py   177 passed
pytest tests/test_gdal_driver_clamp_1846.py tests/test_rule1_structural.py tests/test_pooled_connection_release_1848.py   113 passed
pytest tests/test_rule2_structural.py tests/test_stored_failure_reason_1953.py tests/test_failure_reason_readers_2010.py   152 passed
pytest tests/test_reupload_idor.py tests/test_reupload_service.py   12 passed
pytest tests/test_layering.py   50 passed
ruff check . && ruff format --check .   clean
python3 backend/tests/finding_markers.py   clean
make public-surface-check   passed
```

Counterfactuals, each observed with the fix reverted:

- With the broad handler removed, the new preview test gets an unhandled `IngestionError` and a
  500 from the route.
- With the ogrinfo alternative removed from the pattern, both new pattern tests and the new
  real-binaries ogrinfo test report `ogrinfo failed (exit 1)` instead of the friendly sentence.

`_MODULE_LOC_CAPS` re-measured for both changed modules: `router_reupload.py` 1428 to 1436,
`ogr.py` 1341 to 1343, both exact.

## Checklist

- [x] Code follows existing project conventions
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] No secrets or credentials in the diff

No API schema change: no route docstring or field description was touched, so no SDK or type
regeneration is needed. No new user-facing string: the 422 detail is the one the import preview
already returns.

## Deferred

A `.parquet` re-upload that exceeds the ingest ceiling now answers the generic 422 rather than
the ceiling message the import preview keeps for that class. It answered 500 before, so nothing
regresses; matching the import door would need the budget error class on the catalog port.

Closes #2036
