### PR TITLE
style(ingest): trim the unable-to-open comment to three lines

### DIFF
--- a/backend/app/processing/ingest/ogr.py
+++ b/backend/app/processing/ingest/ogr.py
@@ -49,11 +49,9 @@ from app.processing.raster.vrt import gdal_service_safe_env, gdal_vector_safe_en
 # group is optional since some GDAL builds emit bare driver names.
 _OGR_DRIVER_LIST_LINE_RE = re.compile(r"^\s*->\s*'[^']+'\s*(\([^)]*\))?\s*$")
 
-# When no driver can open the source, ogr2ogr prints this line ahead of GDAL's
-# full driver enumeration (100+ lines) — raw text a demo visitor once saw in
-# the job UI. fix(#2036): ogrinfo says it in one line of its own naming the
-# staging path, which the first alternative never matched. Both are anchored
-# tightly so no other failure class (bad SRS, permission denied) matches.
+# fix(#2036): both wordings for a source no driver can open, either of which
+# reaches the job UI raw: ogr2ogr's, ahead of its 100+ line driver enumeration,
+# and ogrinfo's one line naming the staging path. Anchored so nothing else matches.
 _OGR_UNABLE_TO_OPEN_RE = re.compile(
     r"Unable to open datasource `[^']*' with the following drivers\."
     r"|ogrinfo failed - unable to open '[^']*'"

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -5013,10 +5013,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # recognises the class first and composes the reason from the fields that
     # class may carry, since a driver names the source inside its own prose.
     # Cap 1307 -> 1341, exact.
-    # fix(#2036): +2. The unable-to-open pattern gains ogrinfo's own one-line
-    # wording, which ogr2ogr's driver enumeration never matched.
-    # Cap 1341 -> 1343, exact.
-    "backend/app/processing/ingest/ogr.py": 1343,
+    # fix(#2036): net zero. The pattern gained ogrinfo's wording (+2 in #2042)
+    # and the comment above it gives two lines back. Cap 1343 -> 1341, exact.
+    "backend/app/processing/ingest/ogr.py": 1341,
     # fix(#1846, GHSA-hrf5-v3cq-frx5): first entry. This module crossed the
     # 1000-line threshold when the content check landed: the SQLite schema
     # reader, the archive member walk that identifies members by their bytes


### PR DESCRIPTION
## Summary

Follow-up to #2042. The comment above `_OGR_UNABLE_TO_OPEN_RE` grew to five lines there; the
repository convention caps a comment block at three. This trims it back, keeping the `fix(#2036)`
anchor and the two facts that matter: ogr2ogr's wording precedes its driver enumeration, and
ogrinfo's one line names the staging path.

Comment only. The pattern, the code and every test are untouched.

## Changes

- Three-line comment above `_OGR_UNABLE_TO_OPEN_RE` in place of the five-line one.
- `ogr.py` returns to exactly 1341 lines, so its `_MODULE_LOC_CAPS` entry ratchets back down from
  the 1343 #2042 set, with a note recording the round trip.

## Area

- [x] Backend (API, services, models)
- [x] Import / Ingestion

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)

```
pytest tests/test_ingest_ogr_pure.py tests/test_ingest_open_failure_message.py   132 passed
pytest tests/test_layering.py   50 passed
ruff check . && ruff format --check .   clean
python3 backend/tests/finding_markers.py   clean
```

The two suites above are the ones that exercise the pattern this comment describes, including the
real-binaries ogrinfo case added in #2042.

## Checklist

- [x] Code follows existing project conventions
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] No secrets or credentials in the diff

No changelog entry: #2042 already describes the behavior, and nothing here changes it.
