### PR TITLE
chore(release): 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-09-09
+
 ### Added
 
 - A STAC catalog behind an API key can be imported and refreshed. The import and refresh dialogs
@@ -17,6 +19,14 @@ and releases use semantic versioning.
   when none is supplied, rather than dispatched to collect a 401. Tiles are still rendered by
   fetching the asset URL without a credential, so an asset that needs one of its own cannot yet
   be tiled, and a refresh reports it as inaccessible. (#1764)
+- Simplified Chinese (zh) interface locale, contributed by @cloader, with the STAC-credential,
+  URL-import and dataset-distribution strings brought to parity with the other locales. Browser
+  language detection maps Simplified Chinese tags such as `zh-CN`, `zh-SG` and `zh-MY` to the new
+  bundle by script, while Traditional Chinese tags keep the English fallback. (#1829)
+- The admin AI settings panel shows an embedding backfill's progress while it runs, the last five
+  runs with their outcome and record counts, and an estimate of how long a run will take before you
+  start one, taken from the throughput of the last completed run. Both backfill buttons stay
+  disabled while any run is in flight, including one another operator started. (#2025)
 
 ### Changed
 
@@ -214,6 +224,12 @@ and releases use semantic versioning.
   same message the import preview gives, instead of a generic server error. The reason
   recorded for such a file names the file that was uploaded, rather than reporting only the
   tool and its exit status. (#2036)
+- Rate limits are counted in one store the whole deployment shares when `REDIS_URL` is set, instead
+  of once per API worker, so a configured per-IP or per-user cap is the cap you get rather than that
+  cap times the worker count. The paired search request the catalog page makes on every query change
+  coordinates through the same store, so it spends one token whichever worker each half lands on. If
+  the store becomes unreachable, limits fall back to per-worker counting rather than switching off,
+  and a startup log names a deployment that runs several workers without a shared store. (#2018)
 
 ## [1.18.1] - 2026-09-05
 
@@ -3831,7 +3847,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.18.1...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.19.0...HEAD
+[1.19.0]: https://github.com/geolens-io/geolens/compare/v1.18.1...v1.19.0
 [1.18.1]: https://github.com/geolens-io/geolens/compare/v1.18.0...v1.18.1
 [1.18.0]: https://github.com/geolens-io/geolens/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/geolens-io/geolens/compare/v1.16.1...v1.17.0

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -752,7 +752,7 @@ _is_production = settings.is_production
 # Fallback below covers running from a source checkout with no `uv pip
 # install -e .` (no metadata to read); keep it in lockstep with
 # pyproject.toml — `make bump` rewrites it.
-_FALLBACK_APP_VERSION = "1.18.1"
+_FALLBACK_APP_VERSION = "1.19.0"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -19263,7 +19263,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.18.1"
+    "version": "1.19.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.18.1"
+version = "1.19.0"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.18.1"
+version = "1.19.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.18.1"
+version = "1.19.0"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.18.1",
+      "version": "1.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.18.1",
+  "version": "1.19.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.18.1"
+version = "1.19.0"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.geolens-io/geolens",
   "title": "GeoLens",
   "description": "Read-only access to a self-hosted GeoLens spatial catalog: datasets, features, maps, sandboxed SQL.",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "websiteUrl": "https://docs.getgeolens.com/",
   "repository": {
     "url": "https://github.com/geolens-io/geolens",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "geolens-mcp",
-      "version": "1.18.1",
+      "version": "1.19.0",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.18.1"
+version = "1.19.0"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.18.1"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.18.1",
+      "version": "1.19.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.18.1
+package_version_override: 1.19.0
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.18.1"
+version = "1.19.0"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.18.1",
+      "version": "1.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
## Summary
Release 1.19.0: the 2026-09-08/09 fold-in waves (about thirty lane PRs), the Simplified Chinese locale (#1829), shared rate-limit storage (#2018), the embedding backfill panel (#2025) and the re-upload preview 422 fix (#2036), on top of the earlier September fold-ins already recorded under Unreleased.

## Changes
- `make bump VERSION=1.19.0`: all 21 version sites, lockfiles and the CHANGELOG compare links.
- CHANGELOG: `Unreleased` becomes `[1.19.0] - 2026-09-09`; three entries added for PRs that landed without one (#1829, #2018, #2025); a fresh empty `Unreleased` section.

## Area
- [x] Docs / Config

## Testing
- [x] `make version-check` (21 sites agree), `make openapi-check`, `make public-surface-check`, `git diff --check`, pre-commit.
- [x] Manual testing: pre-tag smoke on the dev stack at the final main, all rows PASS (tiles publication-version revocation, public map render, upload/strict_cog/retry/fan-out, URL import async job, re-upload preview 422 and failure reasons, search + facets rate limit, STAC request-only auth, service import, manifest apply, builder export credit line, es/fr/zh locale switch, shared rate-limit storage startup notice). Follow-ups filed: #2031–#2036, #2038, #2039, #2041, #2043–#2045, #2047, #2048.

## Checklist
- [x] Code follows existing project conventions
- [x] No secrets or credentials in the diff
- [x] Migration included (if DB schema changed): 0060 (`publication_version`) shipped in #2005; no new migration here.

Notes for operators: migration 0060 runs on upgrade; a dataset's old signed tile URLs stop serving within a minute of an unpublish or a visibility change; set `REDIS_URL` when running more than one API worker so rate limits are counted once per deployment (the API logs a notice otherwise, see #2041).
