### PR TITLE
fix(gate): match the renamed cloud guide; count five locales

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -140,7 +140,7 @@ v5, Tailwind, and shadcn/ui primitives in `components/ui/`.
 | Add an admin setting | `backend/app/modules/settings/` + `frontend/src/components/admin/settings/` |
 | Add optional runtime behavior | Extend a Protocol in `backend/app/platform/extensions/`; keep core behavior in default implementations |
 | Add a DB column or table | New migration in `backend/alembic/versions/` + the domain's `models.py`; apply with `alembic upgrade heads` |
-| Add UI text | The component + **all 4** `frontend/src/i18n/locales/` files |
+| Add UI text | The component + **all 5** `frontend/src/i18n/locales/` files |
 
 ---
 

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -120,8 +120,8 @@ v5, Tailwind, and shadcn/ui primitives in `components/ui/`.
 - **Routes:** `pages/` (admin sub-pages in `pages/admin/`).
 - **Map builder:** `components/builder/` + `src/builder/` + `lib/builder/`.
 - **Public viewer:** `components/viewer/`. **Map plugins/widgets:** `components/map-plugins/`.
-- **i18n:** new user-facing strings must be added to **all 4 locales** in
-  `i18n/locales/` (`en`/`fr`/`es`/`de`) or the CI "Locale parity" check fails.
+- **i18n:** new user-facing strings must be added to **all 5 locales** in
+  `i18n/locales/` (`en`/`fr`/`es`/`de`/`zh`) or the CI "Locale parity" check fails.
 
 ---
 
@@ -149,6 +149,6 @@ v5, Tailwind, and shadcn/ui primitives in `components/ui/`.
 - **Migrations use `heads` (plural):** `alembic upgrade heads` — the chain can carry multiple heads. Baseline is squashed (`0001_baseline` + `0002_procrastinate`).
 - **Trailing slashes matter:** the app runs with `redirect_slashes=False`; some routes 404 on a trailing slash.
 - **Don't import split service internals across domains** — go through the domain facade (enforced by `test_layering.py`).
-- **Locale parity is a CI gate** — a new `t()` key needs all 4 locale files, not just a `defaultValue`.
+- **Locale parity is a CI gate** — a new `t()` key needs all 5 locale files, not just a `defaultValue`.
 - **The worker is Postgres-backed** (procrastinate) — no Redis/RabbitMQ broker to run.
 - **Tests run in the container:** `make test` for the backend (a bare `docker compose exec api pytest` fails against the container's read-only uv cache — CONTRIBUTING.md has the filtered-run recipe) / `docker compose exec frontend npm test`. E2E (Playwright): `e2e:smoke:core` gates PRs that touch the stack; the full matrix runs nightly (see CONTRIBUTING.md's End-to-end section).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -157,7 +157,7 @@ If a PR template exists at `.github/PULL_REQUEST_TEMPLATE.md`, your PR descripti
 - Keep PRs focused -- one feature or fix per PR.
 - Include tests for new functionality.
 - Update documentation if your change affects user-facing behavior.
-- Add locale strings to all 4 language files if you introduce new UI text.
+- Add locale strings to all 5 language files if you introduce new UI text.
 
 ## Project Structure
 
@@ -226,7 +226,7 @@ geolens/
 │       │   ├── ui/             # Reusable primitives (shadcn/ui)
 │       │   └── viewer/         # Public map viewer components
 │       ├── hooks/              # React hooks (one per feature domain)
-│       ├── i18n/               # i18next config & locale files (en/fr/es/de)
+│       ├── i18n/               # i18next config & locale files (en/fr/es/de/zh)
 │       ├── lib/                # Pure utility functions & constants
 │       ├── pages/              # Top-level route pages
 │       │   └── admin/          # Admin sub-pages

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Code style is enforced by linters and formatters. Run them before submitting a P
 
 - **Backend:** `ruff check` and `ruff format` (configured in `pyproject.toml`)
 - **Frontend:** ESLint (configured in `frontend/eslint.config.js`)
-- **All user-facing strings** must be added to all 4 locale files (en, fr, es, de) under `frontend/src/i18n/locales/`
+- **All user-facing strings** must be added to all 5 locale files (en, fr, es, de, zh) under `frontend/src/i18n/locales/`
 
 Check both before committing:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@
 ## Checklist
 
 - [ ] Code follows existing project conventions
-- [ ] i18n: new user-facing strings added to all 4 locales (en, fr, es, de)
+- [ ] i18n: new user-facing strings added to all 5 locales (en, fr, es, de, zh)
 - [ ] No new lint warnings (`ruff check`, `eslint`)
 - [ ] TypeScript compiles without errors
 - [ ] Migration included (if DB schema changed)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Frontend change: from the worktree run `cd frontend && API_PROXY_TARGET=http://l
 
 - API schema changes, including published route docstrings/Pydantic field descriptions, require `make sdks` (refreshes OpenAPI and both SDKs), then `cd frontend && npm run types:generate`. Frontend drift gate: `npm run types:check`. Commit generated changes only when source changes require them.
 - Never hand-edit generated SDK code or `frontend/src/types/api.generated.ts`. SDK auth/entry wrappers (`auth.py`, `__init__.py`, `auth.ts`, `index.ts`) are hand-maintained; CLI and MCP wrap the SDK.
-- New UI strings use `t()` with keys in all four locales (en/es/fr/de); run `cd frontend && npm run test:i18n`. `defaultValue` is insufficient. Keep plural suffixes consistent; `_many` does not fall back to `_other`. French count 0 uses `_one`, so interpolate `{{count}}` instead of hardcoding 1.
+- New UI strings use `t()` with keys in all five locales (en/es/fr/de/zh); run `cd frontend && npm run test:i18n`. `defaultValue` is insufficient. Keep plural suffixes consistent; `_many` does not fall back to `_other`. French count 0 uses `_one`, so interpolate `{{count}}` instead of hardcoding 1.
 - Comments explain non-obvious reasons/traps; docstrings state contracts. Avoid narration/history. Review references need an issue/PR anchor plus the invariant, at most three lines: `// fix(#1234): suppress basemap row click during multi-selection`. Bare private tracker IDs fail finding-marker checks. Outside `backend/app/`, `no-agent-tag-markers` needs the `fix(#issue)` anchor on the same line as the tag; a bare tag fails there too.
 - Put `# broad: <reason>` on the same line as every `except Exception`. Follow CodeQL marker placement below.
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ see [RUNBOOK.md §4](RUNBOOK.md#4-monitoring) for the setup steps.
 | [Upgrade Guide](https://docs.getgeolens.com/guides/quickstart/upgrade/) | Upgrading between versions with rollback procedures |
 | [Configuration Reference](https://docs.getgeolens.com/guides/quickstart/configuration/) | All environment variables and their defaults |
 | [Admin Guide](https://docs.getgeolens.com/guides/admin/) | User management, datasets, system health |
-| [Self-host on AWS, GCP, or DigitalOcean](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | Managed database, object storage, and cache deployment guides |
+| [Self-host on managed cloud services](https://docs.getgeolens.com/guides/quickstart/cloud-deployment/) | Managed database, object storage, and cache deployment guides |
 | [CLI & Manifests](https://docs.getgeolens.com/guides/cli/) | Publish files and manage catalogs with the `geolens` CLI |
 | [API Reference](https://docs.getgeolens.com/guides/api/) | Auto-generated reference at docs.getgeolens.com; development-mode stacks also serve Swagger UI at `/api/docs` (disabled in production) |
 | [Manifest examples](examples/manifests/) | Template `geolens.yaml` manifests to adapt: public-cog (remote COG), url-source, s3-source, publication-states |

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -135,7 +135,7 @@ async def _load_mask_dataset(
     fix(#955): shared with select_by_location, which takes its selection
     geometry from the same mask pair; both ceilings apply unchanged. The
     over-limit message still says "to clip with" -- reads slightly off for
-    a selection, but is wired through error-map.ts and five locales.
+    a selection, but is wired through error-map.ts and four locales.
     """
     dataset = await _load_vector_dataset(db, mask_dataset_id, user)
     if (dataset.geometry_type or "").upper() not in _POLYGONAL_TYPES:

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -135,7 +135,7 @@ async def _load_mask_dataset(
     fix(#955): shared with select_by_location, which takes its selection
     geometry from the same mask pair; both ceilings apply unchanged. The
     over-limit message still says "to clip with" -- reads slightly off for
-    a selection, but is wired through error-map.ts and four locales.
+    a selection, but is wired through error-map.ts and five locales.
     """
     dataset = await _load_vector_dataset(db, mask_dataset_id, user)
     if (dataset.geometry_type or "").upper() not in _POLYGONAL_TYPES:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,7 +23,7 @@ npm run build      # Production build (tsc -b && vite build)
 - `src/api/`: typed API client wrappers around the auto-generated `@geolens/sdk`.
 - `src/hooks/`: TanStack Query hooks and store subscriptions.
 - `src/stores/`: global Zustand stores (auth, theme, search, drawing).
-- `src/i18n/`: translation files (en/es/fr/de).
+- `src/i18n/`: translation files (en/es/fr/de/zh).
 - `src/lib/`: utilities (basemap helpers, formatting, validation).
 
 ## Documentation

--- a/scripts/deployed_surface_gate.json
+++ b/scripts/deployed_surface_gate.json
@@ -58,7 +58,7 @@
         },
         {
           "id": "provider_guide_link",
-          "pattern": "Self-host\\s+on\\s+AWS,\\s+GCP,\\s+or\\s+DigitalOcean",
+          "pattern": "Self-host\\s+on\\s+managed\\s+cloud\\s+services",
           "flags": "i",
           "reason": "Install guide should expose self-hosted provider guidance."
         },
@@ -158,7 +158,7 @@
       "required": [
         {
           "id": "provider_title",
-          "pattern": "Self-host\\s+on\\s+AWS,\\s+GCP,\\s+or\\s+DigitalOcean",
+          "pattern": "Self-host\\s+on\\s+managed\\s+cloud\\s+services",
           "flags": "i",
           "reason": "Provider guide should be deployed."
         },

--- a/tests/test_check_deployed_surface.py
+++ b/tests/test_check_deployed_surface.py
@@ -364,7 +364,7 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                         "i",
                     ),
                     ("backup_guide_link", "Backups\\s+&\\s+Restore", "i"),
-                    ("provider_guide_link", "Self-host\\s+on\\s+AWS,\\s+GCP,\\s+or\\s+DigitalOcean", "i"),
+                    ("provider_guide_link", "Self-host\\s+on\\s+managed\\s+cloud\\s+services", "i"),
                     ("provider_notes_link", "Self-hosted\\s+Provider\\s+Notes", "i"),
                 ],
                 "forbidden": [
@@ -392,7 +392,7 @@ class DeployedSurfaceGateTest(unittest.TestCase):
             "docs_cloud_deployment": {
                 "url": "https://docs.getgeolens.com/guides/quickstart/cloud-deployment/",
                 "required": [
-                    ("provider_title", "Self-host\\s+on\\s+AWS,\\s+GCP,\\s+or\\s+DigitalOcean", "i"),
+                    ("provider_title", "Self-host\\s+on\\s+managed\\s+cloud\\s+services", "i"),
                     ("managed_database", "\\bmanaged\\s+database\\b", "i"),
                     ("object_storage", "\\bobject\\s+storage\\b", "i"),
                     ("docker_compose_comparison", "\\bDocker\\s+Compose\\b", "i"),
@@ -522,14 +522,14 @@ class DeployedSurfaceGateTest(unittest.TestCase):
             "docs_install": (
                 "curl -fsSL https://getgeolens.com/install.sh | sh "
                 "OGC API clients should connect through the reverse-proxy path at http://localhost:8080/api/ "
-                "Backups & Restore Self-host on AWS, GCP, or DigitalOcean Self-hosted Provider Notes"
+                "Backups & Restore Self-host on managed cloud services Self-hosted Provider Notes"
             ),
             "docs_backups": (
                 "Backups & Restore Automated backups are on by default. "
                 "The backup service uses BACKUP_S3_ENABLED for off-site upload."
             ),
             "docs_cloud_deployment": (
-                "Self-host on AWS, GCP, or DigitalOcean with managed database, object storage, "
+                "Self-host on managed cloud services with managed database, object storage, "
                 "and Docker Compose comparison notes."
             ),
             "docs_provider_notes": "Self-hosted Provider Notes",
@@ -568,7 +568,7 @@ class DeployedSurfaceGateTest(unittest.TestCase):
                 "docs_install",
                 "curl -fsSL https://getgeolens.com/install.sh | sh "
                 "OGC API clients should connect through the reverse-proxy path at http://localhost:8080/api/ "
-                "Backups & Restore Self-host on AWS, GCP, or DigitalOcean Self-hosted Provider Notes "
+                "Backups & Restore Self-host on managed cloud services Self-hosted Provider Notes "
                 "Get Enterprise Only Tabs",
                 "stale_strategy_label",
             ),


### PR DESCRIPTION
## Summary

Two small fixes to keep contributor-facing docs and the release gate accurate. The deployed-surface gate's cloud-provider-guide assertions still matched the docs site's old page title, so `make deployed-surface-check` fails against the live site. Separately, several repo docs still told contributors that new UI strings go in four locales, but 1.19.0 shipped a Simplified Chinese locale and the i18n parity test now enforces five.

## Changes

- `scripts/deployed_surface_gate.json`: update `docs_install.provider_guide_link` and `docs_cloud_deployment.provider_title` to match the docs site's renamed guide title, "Self-host on managed cloud services" (the docs repo retitled this page in a PR merged 2026-09-09).
- `tests/test_check_deployed_surface.py`: update the matching expected-assertion lists and offline HTML fixtures so the unit tests stay in sync with the gate config.
- `AGENTS.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/CONTRIBUTING.md`, `.github/ARCHITECTURE.md` (two spots), `frontend/README.md`: "four locales (en/es/fr/de)" -> "five locales (en/es/fr/de/zh)".
- `backend/app/modules/catalog/datasets/api/router_analysis.py`: one code comment that referenced "four locales" for the same reason.

No schema/API/config impact.

## Area

- [x] Docs / Config

## Testing

- [x] Unit tests pass (`pytest` / `npm test`): `python3 -m unittest tests/test_check_deployed_surface.py -q` -> `OK` (20 tests).
- [x] Manual testing (describe below):
  - `python3 scripts/check_deployed_surface.py` against the live sites -> `deployed-surface gate passed (13 deployed page(s) scanned)`.
  - `make public-surface-check` -> `public-surface gate passed (73 tracked file(s) scanned)`.
  - `git diff --check` -> clean.
- [x] Release/docs deploys: ran `make deployed-surface-check` (via the equivalent direct invocation above) against the already-deployed docs site and confirmed it now passes.

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 5 locales (en, fr, es, de, zh) — N/A, no new user-facing strings added
- [x] No new lint warnings (`ruff check`, `eslint`) — pre-commit ran `ruff check` / `ruff format --check`; no JS/TS files changed
- [ ] TypeScript compiles without errors — N/A, no TypeScript changes
- [ ] Migration included (if DB schema changed) — N/A
- [x] No secrets or credentials in the diff
- [x] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing
