### PR TITLE
fix(auth): stop a transient refresh failure signing out every session

### DIFF
--- a/frontend/src/api/__tests__/client.session-expiry.test.ts
+++ b/frontend/src/api/__tests__/client.session-expiry.test.ts
@@ -1,4 +1,4 @@
-import { apiFetch, ApiError, onSessionExpired } from '@/api/client';
+import { abortInflightRefresh, apiFetch, ApiError, onSessionExpired } from '@/api/client';
 import { useAuthStore } from '@/stores/auth-store';
 import { refreshAccessToken, logoutSession } from '@/api/auth';
 import type { TokenResponse } from '@/types/api';
@@ -65,6 +65,8 @@ describe('session-expiry notification (fix #628)', () => {
   afterEach(() => {
     unregister();
     useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+    // fix(#2038): the transient refresh back-off is module state; end signed out.
+    abortInflightRefresh();
   });
 
   // fix(#2038): a rate-limited refresh in one client used to revoke every
@@ -82,12 +84,13 @@ describe('session-expiry notification (fix #628)', () => {
     expect(useAuthStore.getState().token).toBe(live);
   });
 
-  // fix(#2038): a dropped connection is no evidence the credential is dead.
+  // fix(#2038): refreshAccessToken issues a bare fetch, so a real offline
+  // failure arrives as a TypeError, not an ApiError.
   it('keeps the session and revokes nothing when the refresh cannot reach the server', async () => {
     signIn();
     const live = useAuthStore.getState().token;
     mockFetch.mockResolvedValue(errorResponse(401));
-    vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('network error', 0));
+    vi.mocked(refreshAccessToken).mockRejectedValue(new TypeError('Failed to fetch'));
 
     await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401 });
 
@@ -101,6 +104,20 @@ describe('session-expiry notification (fix #628)', () => {
     signIn();
     mockFetch.mockResolvedValue(errorResponse(401));
     vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('unauthorized', 401));
+
+    await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401 });
+
+    expect(logoutSession).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  // fix(#2038): 403 on refresh is a rejection too, and ends the session the
+  // same way 401 does.
+  it('clears local state and prompts when the refresh is answered 403', async () => {
+    signIn();
+    mockFetch.mockResolvedValue(errorResponse(401));
+    vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('forbidden', 403));
 
     await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401 });
 

--- a/frontend/src/api/__tests__/client.session-expiry.test.ts
+++ b/frontend/src/api/__tests__/client.session-expiry.test.ts
@@ -77,7 +77,9 @@ describe('session-expiry notification (fix #628)', () => {
     mockFetch.mockResolvedValue(errorResponse(401));
     vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('rate limited', 429));
 
-    await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401 });
+    // fix(#2038): flagged unconfirmed so a sign-in catch downstream cannot read
+    // it as a rejected credential and revoke every session.
+    await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401, unconfirmed: true });
 
     expect(logoutSession).not.toHaveBeenCalled();
     expect(handler).not.toHaveBeenCalled();
@@ -105,7 +107,9 @@ describe('session-expiry notification (fix #628)', () => {
     mockFetch.mockResolvedValue(errorResponse(401));
     vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('unauthorized', 401));
 
-    await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401 });
+    const err = await apiFetch('/a/').catch((e: unknown) => e);
+    expect(err).toMatchObject({ status: 401 });
+    expect((err as ApiError).unconfirmed).toBeUndefined();
 
     expect(logoutSession).not.toHaveBeenCalled();
     expect(handler).toHaveBeenCalledTimes(1);

--- a/frontend/src/api/__tests__/client.session-expiry.test.ts
+++ b/frontend/src/api/__tests__/client.session-expiry.test.ts
@@ -67,18 +67,44 @@ describe('session-expiry notification (fix #628)', () => {
     useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
   });
 
-  // fix(#1446): the refresh may have failed transiently (429, 5xx, dropped
-  // connection), leaving a perfectly valid httpOnly refresh cookie behind a UI
-  // that says "signed out". Clearing the store cannot reach that credential,
-  // so revocation is dispatched on the way out.
-  it('revokes server-side when the refresh failed transiently rather than definitively', async () => {
+  // fix(#2038): a rate-limited refresh in one client used to revoke every
+  // session of the user, so every other client then revoked in turn.
+  it('keeps the session and revokes nothing when the refresh is rate-limited', async () => {
     signIn();
+    const live = useAuthStore.getState().token;
     mockFetch.mockResolvedValue(errorResponse(401));
     vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('rate limited', 429));
 
     await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401 });
 
-    expect(logoutSession).toHaveBeenCalledTimes(1);
+    expect(logoutSession).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().token).toBe(live);
+  });
+
+  // fix(#2038): a dropped connection is no evidence the credential is dead.
+  it('keeps the session and revokes nothing when the refresh cannot reach the server', async () => {
+    signIn();
+    const live = useAuthStore.getState().token;
+    mockFetch.mockResolvedValue(errorResponse(401));
+    vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('network error', 0));
+
+    await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401 });
+
+    expect(logoutSession).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().token).toBe(live);
+  });
+
+  // fix(#2038): a rejected refresh row has nothing left to revoke server-side.
+  it('clears local state without a server revocation when the refresh is rejected', async () => {
+    signIn();
+    mockFetch.mockResolvedValue(errorResponse(401));
+    vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('unauthorized', 401));
+
+    await expect(apiFetch('/a/')).rejects.toMatchObject({ status: 401 });
+
+    expect(logoutSession).not.toHaveBeenCalled();
     expect(handler).toHaveBeenCalledTimes(1);
     expect(useAuthStore.getState().token).toBeNull();
   });

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { apiFetch, ApiError, tryRefresh } from '@/api/client';
+import { abortInflightRefresh, apiFetch, ApiError, tryRefresh } from '@/api/client';
 import { useAuthStore } from '@/stores/auth-store';
 import type { TokenResponse } from '@/types/api';
 
@@ -36,6 +36,8 @@ describe('apiFetch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+    // fix(#2038): the transient refresh back-off is module state; start signed out.
+    abortInflightRefresh();
   });
 
   it('makes a GET request to the correct URL', async () => {
@@ -393,6 +395,30 @@ describe('apiFetch', () => {
       expect(useAuthStore.getState().token).toBe('peer-rotated-token');
     });
 
+    // fix(#2038): without the back-off, an auth outage let every 401'd surface
+    // in every tab re-ask forever against a rate-limited endpoint.
+    it('stops asking until the back-off expires after a transient failure', async () => {
+      vi.useFakeTimers();
+      try {
+        const { refreshAccessToken } = await import('@/api/auth');
+        vi.mocked(refreshAccessToken).mockRejectedValue(new ApiError('unavailable', 503));
+
+        useAuthStore.setState({ token: 'live-token-2038', refreshToken: 'r' });
+
+        await expect(tryRefresh()).resolves.toBe(false);
+        expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+
+        await expect(tryRefresh()).resolves.toBe(false);
+        expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(30_000);
+        await expect(tryRefresh()).resolves.toBe(false);
+        expect(refreshAccessToken).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('still returns false when the token is unchanged after a failed refresh', async () => {
       const { refreshAccessToken } = await import('@/api/auth');
       vi.mocked(refreshAccessToken).mockRejectedValueOnce(new Error('boom'));
@@ -509,8 +535,9 @@ describe('apiFetch', () => {
       const { refreshAccessToken } = await import('@/api/auth');
       const mockRefresh = vi.mocked(refreshAccessToken);
 
-      // First refresh attempt fails
-      mockRefresh.mockRejectedValueOnce(new Error('boom'));
+      // fix(#2038): a REJECTED credential, so no transient back-off is armed
+      // and the second wave below is free to ask again immediately.
+      mockRefresh.mockRejectedValueOnce(new ApiError('unauthorized', 401));
       useAuthStore.setState({ token: 'expired', refreshToken: 'r' });
       // fix(#1849): a failed refresh no longer retries with the dead token —
       // one queued response, not two.

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -4,9 +4,6 @@ import type { TokenResponse } from '@/types/api';
 
 vi.mock('@/api/auth', () => ({
   refreshAccessToken: vi.fn(),
-  // fix(#1446): the 401 path now dispatches a best-effort server revocation,
-  // because a transiently-failed refresh leaves a live httpOnly cookie that
-  // clearing the store cannot reach.
   logoutSession: vi.fn(() => Promise.resolve()),
 }));
 
@@ -270,7 +267,8 @@ describe('apiFetch', () => {
   // attempt a refresh. Only when that refresh also fails is the session dead.
   it('still attempts a cookie refresh on 401 with no stored refresh token', async () => {
     const { refreshAccessToken } = await import('@/api/auth');
-    vi.mocked(refreshAccessToken).mockRejectedValueOnce(new Error('refresh failed'));
+    // fix(#2038): 401 is what makes the session dead rather than merely stalled.
+    vi.mocked(refreshAccessToken).mockRejectedValueOnce(new ApiError('unauthorized', 401));
 
     useAuthStore.setState({ token: 'cookie-session-token', refreshToken: null });
     // fix(#1849): a failed refresh no longer retries with the dead token, so
@@ -293,9 +291,9 @@ describe('apiFetch', () => {
     expect(refreshAccessToken).not.toHaveBeenCalled();
   });
 
-  it('logs out and throws on 401 when refresh fails', async () => {
+  it('logs out and throws on 401 when the refresh credential is rejected', async () => {
     const { refreshAccessToken } = await import('@/api/auth');
-    vi.mocked(refreshAccessToken).mockRejectedValueOnce(new Error('refresh failed'));
+    vi.mocked(refreshAccessToken).mockRejectedValueOnce(new ApiError('unauthorized', 401));
 
     // A distinct access token per test: the session-death latch dedupes on it,
     // and real sessions never reuse one (every JWT carries a fresh jti).
@@ -358,7 +356,8 @@ describe('apiFetch', () => {
 
         expect(result).toBeInstanceOf(ApiError);
         expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(useAuthStore.getState().token).toBeNull();
+        // fix(#2038): rate-limited is transient, so the session survives it.
+        expect(useAuthStore.getState().token).toBe('expired-token-1849c');
       } finally {
         vi.useRealTimers();
       }

--- a/frontend/src/api/__tests__/ingest-session-expiry-1446.test.ts
+++ b/frontend/src/api/__tests__/ingest-session-expiry-1446.test.ts
@@ -1,15 +1,14 @@
 import { useAuthStore } from '@/stores/auth-store';
-import { onSessionExpired } from '@/api/client';
+import { ApiError, onSessionExpired } from '@/api/client';
 
-// fix(#1446): the XHR upload path cleared the store directly on a terminal
-// 401. Since the refresh credential became an httpOnly cookie, that leaves it
-// and its server-side row alive while the client considers the user signed
-// out. It also skipped the signed-out prompt every other surface shows
-// (fix(#628)). It now routes through notifySessionExpired.
+// fix(#1446): the XHR upload path cleared the store directly on a terminal 401,
+// skipping the single signed-out prompt every other surface shows (fix(#628)).
+// It now routes through notifySessionExpired.
 
 const mockLogoutSession = vi.fn<() => Promise<void>>();
+const mockRefresh = vi.fn<() => Promise<never>>();
 vi.mock('@/api/auth', () => ({
-  refreshAccessToken: vi.fn(() => Promise.reject(new Error('rate limited'))),
+  refreshAccessToken: () => mockRefresh(),
   logoutSession: () => mockLogoutSession(),
 }));
 
@@ -36,6 +35,7 @@ describe('upload auth failure (fix #1446)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLogoutSession.mockResolvedValue(undefined);
+    mockRefresh.mockRejectedValue(new ApiError('unauthorized', 401));
     handler = vi.fn<() => void>();
     unregister = onSessionExpired(handler);
     (globalThis as unknown as { XMLHttpRequest: unknown }).XMLHttpRequest = FakeXHR;
@@ -46,10 +46,9 @@ describe('upload auth failure (fix #1446)', () => {
     useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
   });
 
-  it('revokes server-side and prompts once when an upload 401s terminally', async () => {
+  it('clears local state and prompts once when an upload 401s terminally', async () => {
     const { uploadFile } = await import('@/api/ingest');
-    // Both the original attempt and the post-refresh retry return 401.
-    FakeXHR.queue = [401, 401];
+    FakeXHR.queue = [401];
     useAuthStore.setState({
       token: 'stale-access',
       refreshToken: null,
@@ -60,9 +59,31 @@ describe('upload auth failure (fix #1446)', () => {
       uploadFile(new File(['x'], 'a.geojson')),
     ).rejects.toMatchObject({ status: 401 });
 
-    expect(mockLogoutSession).toHaveBeenCalledTimes(1);
+    // fix(#2038): local teardown only — /auth/logout/ revokes every device.
+    expect(mockLogoutSession).not.toHaveBeenCalled();
     expect(handler).toHaveBeenCalledTimes(1);
     expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  // fix(#2038): the upload door shares the rule — only a rejected refresh
+  // credential ends the session.
+  it('keeps the session when the upload 401s but the refresh failed transiently', async () => {
+    const { uploadFile } = await import('@/api/ingest');
+    mockRefresh.mockRejectedValue(new ApiError('service unavailable', 503));
+    FakeXHR.queue = [401];
+    useAuthStore.setState({
+      token: 'live-access',
+      refreshToken: null,
+      expiresAt: Date.now() + 120_000,
+    });
+
+    await expect(
+      uploadFile(new File(['x'], 'a.geojson')),
+    ).rejects.toMatchObject({ status: 401 });
+
+    expect(mockLogoutSession).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().token).toBe('live-access');
   });
 
   it('does not revoke on an anonymous upload 401 (no session to end)', async () => {

--- a/frontend/src/api/__tests__/ingest-session-expiry-1446.test.ts
+++ b/frontend/src/api/__tests__/ingest-session-expiry-1446.test.ts
@@ -1,5 +1,5 @@
 import { useAuthStore } from '@/stores/auth-store';
-import { ApiError, onSessionExpired } from '@/api/client';
+import { abortInflightRefresh, ApiError, onSessionExpired } from '@/api/client';
 
 // fix(#1446): the XHR upload path cleared the store directly on a terminal 401,
 // skipping the single signed-out prompt every other surface shows (fix(#628)).
@@ -44,6 +44,8 @@ describe('upload auth failure (fix #1446)', () => {
   afterEach(() => {
     unregister();
     useAuthStore.setState({ token: null, refreshToken: null, expiresAt: null, user: null });
+    // fix(#2038): the transient refresh back-off is module state; end signed out.
+    abortInflightRefresh();
   });
 
   it('clears local state and prompts once when an upload 401s terminally', async () => {

--- a/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
+++ b/frontend/src/api/__tests__/refresh-cookie-1302.test.ts
@@ -115,39 +115,25 @@ describe('browser refresh transport', () => {
     });
   });
 
-  // fix(#1446): a 2xx whose body fails to parse still installed the cookies,
-  // so bailing out without revoking reports a failed sign-in over a live
-  // server-side session.
-  it('revokes when a successful login response fails to parse', async () => {
+  // fix(#2038): a 2xx whose body fails to parse leaves a live session behind a
+  // failed sign-in, but /auth/logout/ revokes EVERY session of the user and a
+  // malformed body is no evidence the credential was rejected.
+  it('does not revoke every session when a successful login response fails to parse', async () => {
     document.cookie = 'geolens_csrf=csrf-abc; path=/';
     useAuthStore.setState({ token: null });
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
-        headers: new Headers(),
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 204,
-        statusText: 'No Content',
-        json: () => Promise.reject(new Error('no body')),
-        headers: new Headers(),
-      } as Response);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+      headers: new Headers(),
+    } as Response);
 
     await expect(login('someone', 'secret')).rejects.toThrow(SyntaxError);
 
-    const logoutCall = mockFetch.mock.calls.find(
-      ([url]) => (url as string) === '/api/auth/logout/',
-    );
-    expect(logoutCall).toBeDefined();
-    // The freshly-set cookie is what authenticates it — no bearer token was
-    // ever stored.
-    expect((logoutCall?.[1] as RequestInit).headers).toMatchObject({
-      'X-CSRF-Token': 'csrf-abc',
-    });
+    expect(
+      mockFetch.mock.calls.find(([url]) => (url as string) === '/api/auth/logout/'),
+    ).toBeUndefined();
   });
 
   // fix(#1446): logout revokes EVERY refresh token for the user and deletes

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,7 +1,7 @@
 import { API_BASE } from '@/lib/constants';
 import { cookieAuthAvailable, cookieAuthHeaders } from '@/lib/auth-transport';
 import { useAuthStore } from '@/stores/auth-store';
-import { apiFetch, safeFetch, ApiError } from './client';
+import { apiFetch, isCredentialRejected, safeFetch, ApiError } from './client';
 import { translateApiErrorDetail } from '@/lib/error-map';
 import type { TokenResponse, UserResponse, AuthConfigResponse, MessageResponse, SignupResponse, MyApiKeyResponse, ApiKeyCreateResponse, ApiKeyScope, OAuthProviderPublic, UserQuotaUsage } from '@/types/api';
 
@@ -42,11 +42,10 @@ export async function login(
   try {
     return (await response.json()) as TokenResponse;
   } catch (err) {
-    // fix(#1446): the response was 2xx, so the browser has already applied the
-    // refresh and CSRF cookies. Failing here without revoking would report a
-    // failed sign-in over a live server-side session. The bearer token was
-    // never stored, but the freshly-set cookie authenticates the revocation.
-    void logoutSession().catch(() => {});
+    // fix(#1446): the 2xx already applied the refresh and CSRF cookies, so
+    // bailing out leaves a live session behind a failed sign-in. fix(#2038): but
+    // /auth/logout/ revokes EVERY session, so only a rejection earns that call.
+    if (isCredentialRejected(err)) void logoutSession().catch(() => {});
     throw err;
   }
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,12 @@ import { useAuthStore } from '@/stores/auth-store';
 import { refreshAccessToken } from './auth';
 import i18n from '@/i18n/i18n';
 
+/** fix(#2038): true when the server REJECTED the credential — the only evidence
+ * that earns POST /auth/logout/, which revokes EVERY session of the user. */
+export function isCredentialRejected(err: unknown): boolean {
+  return err instanceof ApiError && (err.status === 401 || err.status === 403);
+}
+
 // fix(#438): DATA-04 — a request whose socket hangs used to spin forever and
 // stall the polling loop that issued it. 30s comfortably covers a slow catalog
 // query while still freeing a wedged loop. Applied to apiFetch (JSON) only;
@@ -31,6 +37,13 @@ export class ApiError extends Error {
 let inflightRefresh: Promise<RefreshOutcome> | null = null;
 let inflightRefreshAbort: AbortController | null = null;
 
+// fix(#2038): how long to stop asking after a transient refresh failure. Without
+// it an auth outage — or a shared egress IP over the endpoint's per-IP limit —
+// turns every 401'd surface in every tab into an unbounded refresh loop.
+const TRANSIENT_COOLDOWN_MS = 30_000;
+let transientUntil = 0;
+let transientToken: string | null = null;
+
 /**
  * fix(#1446): abandon any refresh still in flight, so its response — and the
  * `Set-Cookie` riding on it — is never processed. Called when the session ends
@@ -40,6 +53,9 @@ let inflightRefreshAbort: AbortController | null = null;
 export function abortInflightRefresh(): void {
   inflightRefreshAbort?.abort();
   inflightRefreshAbort = null;
+  // fix(#2038): a deliberate session end must not leave the next session inside
+  // the previous one's refresh back-off.
+  transientUntil = 0;
 }
 
 // fix(#628): once a request 401s AND the follow-up refresh cannot produce a
@@ -97,6 +113,13 @@ export async function attemptRefresh(): Promise<RefreshOutcome> {
   //
   // fix(#2038): nothing to refresh WITH, so this session cannot come back.
   if (!refreshToken && !(token && cookieAuthAvailable())) return 'rejected';
+
+  if (Date.now() < transientUntil) {
+    // fix(#2038): inside the back-off, so answer from it rather than issue
+    // another request — unless a peer tab rotated the token while we waited,
+    // which is the same live-session evidence the catch below trusts.
+    return token && token !== transientToken ? 'refreshed' : 'transient';
+  }
 
   // fix(#1849): the outcome of the in-flight refresh IS the answer here, not
   // whatever token happens to be sitting in the store — see the fix note on
@@ -166,10 +189,9 @@ export async function attemptRefresh(): Promise<RefreshOutcome> {
       if (currentToken && currentToken !== token) {
         return 'refreshed';
       }
-      // fix(#2038): 401/403 is the server rejecting the credential; anything
-      // else (429, 5xx, a dropped connection, an abort) left it alive.
-      const rejected = err instanceof ApiError && (err.status === 401 || err.status === 403);
-      return rejected ? 'rejected' : 'transient';
+      // fix(#2038): anything but a rejection (429, 5xx, a dropped connection,
+      // an abort) left the credential alive.
+      return isCredentialRejected(err) ? 'rejected' : 'transient';
     } finally {
       inflightRefresh = null;
       if (inflightRefreshAbort === controller) inflightRefreshAbort = null;
@@ -177,7 +199,12 @@ export async function attemptRefresh(): Promise<RefreshOutcome> {
   })();
   inflightRefresh = promise;
 
-  return await promise;
+  const outcome = await promise;
+  // fix(#2038): one place to arm the back-off and record the token it applies
+  // to; it clears as soon as the endpoint answers either way again.
+  transientUntil = outcome === 'transient' ? Date.now() + TRANSIENT_COOLDOWN_MS : 0;
+  transientToken = useAuthStore.getState().token;
+  return outcome;
 }
 
 /**

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,7 +3,7 @@ import { cookieAuthAvailable } from '@/lib/auth-transport';
 import { isEmbedViewer } from '@/lib/embed-context';
 import { translateApiErrorDetail } from '@/lib/error-map';
 import { useAuthStore } from '@/stores/auth-store';
-import { logoutSession, refreshAccessToken } from './auth';
+import { refreshAccessToken } from './auth';
 import i18n from '@/i18n/i18n';
 
 // fix(#438): DATA-04 — a request whose socket hangs used to spin forever and
@@ -28,7 +28,7 @@ export class ApiError extends Error {
 // timer in use-auth.ts (which now also calls tryRefresh) collapse to one
 // /auth/refresh/ POST per refresh cycle. Cleared in finally so the next
 // expiration starts fresh.
-let inflightRefresh: Promise<boolean> | null = null;
+let inflightRefresh: Promise<RefreshOutcome> | null = null;
 let inflightRefreshAbort: AbortController | null = null;
 
 /**
@@ -69,27 +69,34 @@ export function onSessionExpired(handler: () => void): () => void {
 export function notifySessionExpired(deadSessionKey: string): void {
   if (deadSessionKey === lastNotifiedSessionKey) return;
   lastNotifiedSessionKey = deadSessionKey;
-  // fix(#1446): the refresh that got us here may have failed transiently — a
-  // 429, a 5xx, a dropped connection — in which case the refresh cookie and
-  // its server-side row are still perfectly valid behind a UI that now says
-  // "signed out". Since fix(#1302) that credential is httpOnly, so clearing
-  // the store cannot touch it. Dispatch a best-effort revocation on the way
-  // out. logoutSession issues a plain fetch, so this cannot recurse back
-  // through the 401 interceptor that called us.
+  // fix(#2038): clear locally only. /auth/logout/ revokes EVERY refresh row
+  // of the user, so revoking a dead session here signed the account out on
+  // every other device, each of which then failed its own refresh and revoked.
   abortInflightRefresh();
-  void logoutSession().catch(() => {});
   useAuthStore.getState().logout();
   sessionExpiredHandler?.();
 }
 
+/** fix(#2038): only a REJECTED refresh credential (401/403) means the session
+ * is over; a 429, a 5xx or a dropped connection leaves it alive. */
+export type RefreshOutcome = 'refreshed' | 'rejected' | 'transient';
+
+/** True when this attempt stored a new access token. */
 export async function tryRefresh(): Promise<boolean> {
+  return (await attemptRefresh()) === 'refreshed';
+}
+
+/** As tryRefresh, but also reports WHY a failure happened. */
+export async function attemptRefresh(): Promise<RefreshOutcome> {
   const { refreshToken, token } = useAuthStore.getState();
   // fix(#1302): in cookie mode the credential is invisible to JS, so a stored
   // refresh token is no longer proof a session exists — an access token is.
   // `refreshToken` is still consulted because a pre-GH-1302 session carries one
   // for exactly one migrating refresh, and because cross-origin deployments
   // never leave cookie mode's starting gate.
-  if (!refreshToken && !(token && cookieAuthAvailable())) return false;
+  //
+  // fix(#2038): nothing to refresh WITH, so this session cannot come back.
+  if (!refreshToken && !(token && cookieAuthAvailable())) return 'rejected';
 
   // fix(#1849): the outcome of the in-flight refresh IS the answer here, not
   // whatever token happens to be sitting in the store — see the fix note on
@@ -130,10 +137,12 @@ export async function tryRefresh(): Promise<boolean> {
   // new token into this tab's store while this attempt is still in flight —
   // most easily during the 429 backoff wait. `token` is that pre-attempt
   // value from the destructure above.
-  const promise = (async (): Promise<boolean> => {
+  const promise = (async (): Promise<RefreshOutcome> => {
     try {
       const tokens = await refreshAccessToken(refreshToken, controller.signal);
-      if (useAuthStore.getState().sessionEpoch !== epochAtStart) return false;
+      // fix(#2038): the rotation landed, we just refuse to store it — the
+      // credential is alive, so this is not session death.
+      if (useAuthStore.getState().sessionEpoch !== epochAtStart) return 'transient';
       // fix(#1302): null in cookie mode, which also clears the legacy
       // localStorage token once the migrating refresh has spent it.
       useAuthStore.getState().setTokens(
@@ -141,7 +150,7 @@ export async function tryRefresh(): Promise<boolean> {
         tokens.refresh_token ?? null,
         tokens.expires_in,
       );
-      return true;
+      return 'refreshed';
     } catch (err) {
       // If rate-limited, wait before giving up so the next attempt isn't also blocked
       if (err instanceof ApiError && err.status === 429) {
@@ -155,10 +164,12 @@ export async function tryRefresh(): Promise<boolean> {
       // that tab just refreshed.
       const currentToken = useAuthStore.getState().token;
       if (currentToken && currentToken !== token) {
-        return true;
+        return 'refreshed';
       }
-      // Refresh failed -- will fall through to logout
-      return false;
+      // fix(#2038): 401/403 is the server rejecting the credential; anything
+      // else (429, 5xx, a dropped connection, an abort) left it alive.
+      const rejected = err instanceof ApiError && (err.status === 401 || err.status === 403);
+      return rejected ? 'rejected' : 'transient';
     } finally {
       inflightRefresh = null;
       if (inflightRefreshAbort === controller) inflightRefreshAbort = null;
@@ -256,8 +267,8 @@ export async function authenticatedRawFetch(
     // fix(#1302): keyed on the access token now that the refresh token is a
     // cookie. Every real session has one, and it is cleared on logout.
     const deadSessionKey = useAuthStore.getState().token;
-    const refreshed = await tryRefresh();
-    if (refreshed) {
+    const outcome = await attemptRefresh();
+    if (outcome === 'refreshed') {
       const retry = await safeFetch(target, {
         ...options,
         headers: buildHeaders(),
@@ -268,10 +279,14 @@ export async function authenticatedRawFetch(
       // a spurious logout.
       if (retry.status !== 401) return retry;
     }
-    if (deadSessionKey) {
-      notifySessionExpired(deadSessionKey);
-    } else {
-      useAuthStore.getState().logout();
+    // fix(#2038): a transiently-failed refresh leaves the session alive, so keep
+    // it and let the caller see the 401 instead of tearing the session down.
+    if (outcome !== 'transient') {
+      if (deadSessionKey) {
+        notifySessionExpired(deadSessionKey);
+      } else {
+        useAuthStore.getState().logout();
+      }
     }
     // fix(#438): UX-10 — was hardcoded English.
     throw new ApiError(i18n.t('common:errors.unauthorized'), 401);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,7 +9,8 @@ import i18n from '@/i18n/i18n';
 /** fix(#2038): true when the server REJECTED the credential — the only evidence
  * that earns POST /auth/logout/, which revokes EVERY session of the user. */
 export function isCredentialRejected(err: unknown): boolean {
-  return err instanceof ApiError && (err.status === 401 || err.status === 403);
+  if (!(err instanceof ApiError) || err.unconfirmed) return false;
+  return err.status === 401 || err.status === 403;
 }
 
 // fix(#438): DATA-04 — a request whose socket hangs used to spin forever and
@@ -21,6 +22,9 @@ const REQUEST_TIMEOUT_MS = 30_000;
 export class ApiError extends Error {
   status: number;
   body?: unknown;
+  /** fix(#2038): a 401 the client could NOT confirm — the refresh behind it
+   * failed transiently, so nothing here says the credential was rejected. */
+  unconfirmed?: boolean;
 
   constructor(message: string, status: number, body?: unknown) {
     super(message);
@@ -307,13 +311,17 @@ export async function authenticatedRawFetch(
       if (retry.status !== 401) return retry;
     }
     // fix(#2038): a transiently-failed refresh leaves the session alive, so keep
-    // it and let the caller see the 401 instead of tearing the session down.
-    if (outcome !== 'transient') {
-      if (deadSessionKey) {
-        notifySessionExpired(deadSessionKey);
-      } else {
-        useAuthStore.getState().logout();
-      }
+    // it and hand the caller a 401 flagged as unconfirmed, which the sign-in
+    // catches must not read as a rejected credential.
+    if (outcome === 'transient') {
+      const unverified = new ApiError(i18n.t('common:errors.unauthorized'), 401);
+      unverified.unconfirmed = true;
+      throw unverified;
+    }
+    if (deadSessionKey) {
+      notifySessionExpired(deadSessionKey);
+    } else {
+      useAuthStore.getState().logout();
     }
     // fix(#438): UX-10 — was hardcoded English.
     throw new ApiError(i18n.t('common:errors.unauthorized'), 401);

--- a/frontend/src/api/ingest.ts
+++ b/frontend/src/api/ingest.ts
@@ -1,4 +1,4 @@
-import { apiFetch, ApiError, notifySessionExpired, tryRefresh } from './client';
+import { apiFetch, ApiError, attemptRefresh, notifySessionExpired, tryRefresh, type RefreshOutcome } from './client';
 import { uploadChunks } from './_presignedUpload';
 import { API_BASE } from '@/lib/constants';
 import { translateApiErrorDetail } from '@/lib/error-map';
@@ -84,9 +84,11 @@ async function xhrUpload<T>(
   // authenticatedRawFetch — every concurrent failure then keys the
   // notification latch on the same value.
   let deadSessionKey: string | null = null;
+  let refreshOutcome: RefreshOutcome | null = null;
   if (res.status === 401) {
     deadSessionKey = useAuthStore.getState().token;
-    if (await tryRefresh()) {
+    refreshOutcome = await attemptRefresh();
+    if (refreshOutcome === 'refreshed') {
       try {
         res = await attempt();
       } catch (err) {
@@ -105,13 +107,10 @@ async function xhrUpload<T>(
       // Non-JSON failures use the localized status category below.
     }
     reportNetworkError({ status: res.status, url: reportUrl, detail });
-    // fix(#1446): route terminal auth failure through the shared path instead
-    // of clearing the store directly. Since the refresh credential became an
-    // httpOnly cookie, a store-only logout leaves it and its server-side row
-    // alive; notifySessionExpired dispatches the revocation. It also gives
-    // uploads the same single signed-out prompt every other surface shows
-    // (fix(#628)), which this call site never had.
-    if (res.status === 401) {
+    // fix(#1446): route terminal auth failure through the shared path, so
+    // uploads get the same single signed-out prompt every other surface shows.
+    // fix(#2038): and only when the refresh credential was actually rejected.
+    if (res.status === 401 && refreshOutcome !== 'transient') {
       if (deadSessionKey) {
         notifySessionExpired(deadSessionKey);
       } else {

--- a/frontend/src/api/ingest.ts
+++ b/frontend/src/api/ingest.ts
@@ -117,7 +117,11 @@ async function xhrUpload<T>(
         useAuthStore.getState().logout();
       }
     }
-    throw new ApiError(translateApiErrorDetail(detail, res.status), res.status, detail);
+    const failure = new ApiError(translateApiErrorDetail(detail, res.status), res.status, detail);
+    // fix(#2038): same flag as authenticatedRawFetch — a 401 whose refresh only
+    // failed transiently is no evidence the credential was rejected.
+    if (res.status === 401 && refreshOutcome === 'transient') failure.unconfirmed = true;
+    throw failure;
   }
 
   // codex on #1660: a 2xx response whose body isn't valid JSON (empty,

--- a/frontend/src/hooks/__tests__/use-auth.test.tsx
+++ b/frontend/src/hooks/__tests__/use-auth.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, act, waitFor } from '@/test/test-utils';
 import { useAuth } from '@/hooks/use-auth';
 import { useAuthStore } from '@/stores/auth-store';
+import { ApiError } from '@/api/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query-keys';
 import { MemoryRouter } from 'react-router';
@@ -97,11 +98,9 @@ describe('useAuth', () => {
     ).rejects.toThrow('Invalid credentials');
   });
 
-  // fix(#1446): login installs the refresh cookie before getMe() runs, so a
-  // failure there must revoke server-side — a store reset cannot reach the
-  // httpOnly cookie, and the UI would claim the sign-in failed while the
-  // credential stayed live.
-  it('revokes the session when getMe fails after a successful login', async () => {
+  // fix(#2038): /auth/me/ answering 500 after a good sign-in used to revoke
+  // every session of the user, signing them out on every other device.
+  it('keeps the other sessions when getMe fails transiently after a login', async () => {
     mockLogin.mockResolvedValueOnce({
       access_token: 'abc',
       refresh_token: null,
@@ -110,7 +109,7 @@ describe('useAuth', () => {
     });
     // Not `...Once`: the hook's own meQuery also calls getMe once the token is
     // set, and would otherwise eat the single rejection.
-    mockGetMe.mockRejectedValue(new Error('me failed'));
+    mockGetMe.mockRejectedValue(new ApiError('server error', 500));
 
     const { result } = renderHook(() => useAuth());
 
@@ -118,7 +117,30 @@ describe('useAuth', () => {
       act(async () => {
         await result.current.login('user', 'pass');
       }),
-    ).rejects.toThrow('me failed');
+    ).rejects.toThrow('server error');
+
+    expect(mockLogoutSession).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  // fix(#1446): login installs the refresh cookie before getMe() runs, so a
+  // rejected credential must be revoked — a store reset cannot reach it.
+  it('revokes the session when getMe rejects the credential after a login', async () => {
+    mockLogin.mockResolvedValueOnce({
+      access_token: 'abc',
+      refresh_token: null,
+      token_type: 'bearer',
+      expires_in: 900,
+    });
+    mockGetMe.mockRejectedValue(new ApiError('unauthorized', 401));
+
+    const { result } = renderHook(() => useAuth());
+
+    await expect(
+      act(async () => {
+        await result.current.login('user', 'pass');
+      }),
+    ).rejects.toThrow('unauthorized');
 
     expect(mockLogoutSession).toHaveBeenCalledTimes(1);
     expect(useAuthStore.getState().token).toBeNull();

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/stores/auth-store';
 import { login as apiLogin, getMe, logoutSession } from '@/api/auth';
-import { abortInflightRefresh, tryRefresh } from '@/api/client';
+import { abortInflightRefresh, isCredentialRejected, tryRefresh } from '@/api/client';
 
 export function useAuth() {
   const navigate = useNavigate();
@@ -73,11 +73,10 @@ export function useAuth() {
       try {
         userResponse = await getMe();
       } catch (err) {
-        // fix(#1446): login already installed the refresh cookie. Bailing out
-        // with only a store reset would leave that credential live while the
-        // UI reports a failed sign-in, so revoke it before surfacing the error.
-        // Dispatched, not awaited — same reasoning as logout below.
-        void logoutSession().catch(() => {});
+        // fix(#1446): login already installed the refresh cookie, so a store
+        // reset alone leaves it live. fix(#2038): but /auth/logout/ revokes EVERY
+        // session, so a 500 or a dropped socket here must not end the others.
+        if (isCredentialRejected(err)) void logoutSession().catch(() => {});
         useAuthStore.getState().logout();
         throw err;
       }

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -230,9 +230,9 @@ export function useVisibleTileTokenRefresh(
         // races the refresh, and a raster descriptor does not change across
         // one, so nothing in the token→setTiles plumbing retries the tiles that
         // 401'd. Reload them explicitly, but only once the token has ACTUALLY
-        // rotated: `tryRefresh` resolves false on a transient failure (offline,
-        // 429), and reloading against the same stale Bearer would just 401
-        // again. `recover`'s own mint collapses into this same refresh (the
+        // rotated.
+        // fix(#2038): compares token VALUES; the reload needs the new token, not just a refresh's success.
+        // `recover`'s own mint collapses into this same refresh (the
         // in-flight singleton in api/client.ts), so this costs no extra request
         // — and when our attempt is the one that fails, that mint's later
         // rotation is what the store subscription below picks up.

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -230,9 +230,9 @@ export function useVisibleTileTokenRefresh(
         // races the refresh, and a raster descriptor does not change across
         // one, so nothing in the token→setTiles plumbing retries the tiles that
         // 401'd. Reload them explicitly, but only once the token has ACTUALLY
-        // rotated.
-        // fix(#2038): compares token VALUES; the reload needs the new token, not just a refresh's success.
-        // `recover`'s own mint collapses into this same refresh (the
+        // rotated: `tryRefresh` resolves false on a transient failure (offline,
+        // 429), and reloading against the same stale Bearer would just 401
+        // again. `recover`'s own mint collapses into this same refresh (the
         // in-flight singleton in api/client.ts), so this costs no extra request
         // — and when our attempt is the one that fails, that mint's later
         // rotation is what the store subscription below picks up.

--- a/frontend/src/hooks/use-tile-auth-recovery.ts
+++ b/frontend/src/hooks/use-tile-auth-recovery.ts
@@ -144,11 +144,8 @@ const RENEWAL_WATCH_MS = 30_000;
  * our own refresh produced the new one, otherwise on the first store change a
  * concurrent mint's refresh writes, and never if neither happens.
  *
- * The token comparison is the ONLY evidence used. `tryRefresh` resolves
- * `!!useAuthStore.getState().token` (api/client.ts), so it answers "is there
- * still a token", not "did it rotate" — it comes back true for a transient
- * failure that left the stale one in place, and reloading on that would just
- * 401 against the same Bearer. */
+ * fix(#2038): compares token VALUES; the reload needs the new token, not just a
+ * refresh's success. */
 function reloadOnTokenRotation(reload: () => void): void {
   const tokenBefore = useAuthStore.getState().token;
   renewalInFlight = true;

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -43,13 +43,9 @@ export function OAuthCallbackPage() {
     window.history.replaceState({}, '', '/oauth/callback');
 
     if (!token || !expiresIn || (!refreshToken && !cookieMode)) {
-      // fix(#1446): a truncated or malformed fragment still arrived on a
-      // response that installed the cookies, so bailing out here without
-      // revoking leaves a live credential behind a UI reporting failure. The
-      // freshly-set CSRF cookie authenticates it; there is no bearer token to
-      // send. Unconditional — on the legacy fragment path there is no cookie,
-      // so the call simply 401s and costs nothing.
-      void logoutSession().catch(() => {});
+      // fix(#2038): the response that redirected here did install the cookies,
+      // but /auth/logout/ revokes EVERY session of the user and a fragment too
+      // short to finish sign-in is no evidence the credential was rejected.
       useAuthStore.getState().logout();
       navigate('/login', { replace: true });
       return;

--- a/frontend/src/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/OAuthCallbackPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/auth-store';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 import { getMe, logoutSession } from '@/api/auth';
+import { isCredentialRejected } from '@/api/client';
 import { readSessionStorage, removeSessionStorage } from '@/lib/storage';
 import { Loader2 } from 'lucide-react';
 
@@ -69,13 +70,11 @@ export function OAuthCallbackPage() {
         const target = redirect && redirect.startsWith('/') ? redirect : '/';
         navigate(target, { replace: true });
       })
-      .catch(() => {
-        // fix(#1446): the backend already installed the refresh cookie before
-        // redirecting here, so clearing the store alone would strand a
-        // replayable credential the UI claims is gone. logoutSession captures
-        // the temporary bearer token synchronously, so dispatching it here
-        // sends a fully-formed request before the store is cleared below.
-        void logoutSession().catch(() => {});
+      .catch((err: unknown) => {
+        // fix(#1446): the redirect already installed the refresh cookie, so a
+        // store reset alone strands a replayable credential. fix(#2038): but
+        // /auth/logout/ revokes EVERY session — a 500 here must not end them.
+        if (isCredentialRejected(err)) void logoutSession().catch(() => {});
         useAuthStore.getState().logout();
         navigate('/login', { replace: true });
       });

--- a/frontend/src/pages/__tests__/OAuthCallbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/OAuthCallbackPage.test.tsx
@@ -71,6 +71,23 @@ describe('OAuthCallbackPage', () => {
     expect(useAuthStore.getState().token).toBeNull();
   });
 
+  // fix(#2038): a 401 the client could not confirm — its refresh only failed
+  // transiently — is not a rejection, so it must not revoke either.
+  it('keeps the other sessions when getMe answers an unconfirmed 401', async () => {
+    const unconfirmed = new ApiError('unauthorized', 401);
+    unconfirmed.unconfirmed = true;
+    mockGetMe.mockRejectedValueOnce(unconfirmed);
+    setHash('#token=access-1&expires_in=900&auth_mode=cookie');
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true }),
+    );
+    expect(mockLogoutSession).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
   // fix(#1446): the cookie is already installed by the time this page runs, so a
   // rejected credential must be revoked — clearing the store cannot reach it.
   it('revokes the session when getMe rejects the credential', async () => {
@@ -86,10 +103,9 @@ describe('OAuthCallbackPage', () => {
     );
   });
 
-  // fix(#1446): the cookies were installed by the response that redirected
-  // here, so a fragment too incomplete to finish sign-in still leaves a live
-  // credential unless it is revoked.
-  it('revokes before sending an incomplete fragment back to /login', async () => {
+  // fix(#2038): a fragment too incomplete to finish sign-in is no evidence the
+  // credential was rejected, and revoking would end every other session.
+  it('does not revoke when an incomplete fragment goes back to /login', async () => {
     setHash('#expires_in=900&auth_mode=cookie');
 
     render(<OAuthCallbackPage />);
@@ -98,7 +114,7 @@ describe('OAuthCallbackPage', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true }),
     );
     expect(mockGetMe).not.toHaveBeenCalled();
-    expect(mockLogoutSession).toHaveBeenCalledTimes(1);
+    expect(mockLogoutSession).not.toHaveBeenCalled();
   });
 
   /**

--- a/frontend/src/pages/__tests__/OAuthCallbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/OAuthCallbackPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, waitFor } from '@/test/test-utils';
+import { ApiError } from '@/api/client';
 import { OAuthCallbackPage } from '@/pages/OAuthCallbackPage';
 import { useAuthStore } from '@/stores/auth-store';
 import { denySessionStorage } from '@/test/deny-storage';
@@ -55,12 +56,25 @@ describe('OAuthCallbackPage', () => {
     expect(useAuthStore.getState().refreshToken).toBe('legacy-r1');
   });
 
-  // fix(#1446): the cookie is already installed by the time this page runs, so
-  // a failed setup must revoke server-side — clearing the store cannot reach an
-  // httpOnly cookie, and the UI would send the user to /login while the
-  // credential stayed replayable.
-  it('revokes the session when getMe fails after the cookie was installed', async () => {
-    mockGetMe.mockRejectedValueOnce(new Error('me failed'));
+  // fix(#2038): SSO completes on a new device, /auth/me/ answers 500 or the
+  // socket drops — revoking here would have ended every other session.
+  it('keeps the other sessions when getMe fails transiently after sign-in', async () => {
+    mockGetMe.mockRejectedValueOnce(new ApiError('server error', 500));
+    setHash('#token=access-1&expires_in=900&auth_mode=cookie');
+
+    render(<OAuthCallbackPage />);
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true }),
+    );
+    expect(mockLogoutSession).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  // fix(#1446): the cookie is already installed by the time this page runs, so a
+  // rejected credential must be revoked — clearing the store cannot reach it.
+  it('revokes the session when getMe rejects the credential', async () => {
+    mockGetMe.mockRejectedValueOnce(new ApiError('unauthorized', 401));
     setHash('#token=access-1&expires_in=900&auth_mode=cookie');
 
     render(<OAuthCallbackPage />);


### PR DESCRIPTION
## Summary

A transient refresh failure in one browser client signed the user out of every
session. `frontend/src/api/client.ts` treated "401, and the follow-up refresh
also failed" as session death regardless of *why* the refresh failed, and its
dead-session path dispatched a best-effort `POST /auth/logout/` (#1446). That
endpoint calls `revoke_all_tokens`, so it invalidates every refresh row and
bumps `token_version` for the whole user. Every other client of that user then
started 401ing, failed its own refresh, and dispatched its own revocation — the
cascade observed on 2026-09-09 as six logouts in three minutes with nobody
logging out.

The rule this PR establishes: a client asks the server to revoke only on
evidence the server rejected the credential — a 401 or 403 — because
`/auth/logout/` is user-wide, not session-scoped. Everything else (a 429, a
5xx, a dropped connection, an abort, a malformed body) clears local state and
sends the user to `/login` without touching anyone else's session.

Client-side only. `revoke_all_tokens` keeps its semantics, no endpoint was
added, and explicit user logout still signs out everywhere as before.

## Changes

- `notifySessionExpired` no longer dispatches `logoutSession()`. It still
  aborts any in-flight refresh (so a late `Set-Cookie` cannot land on a later
  session, per #1446) and still clears the store and raises the single
  signed-out prompt.
- `tryRefresh`'s classification is split out as `attemptRefresh(): RefreshOutcome`
  (`refreshed` / `rejected` / `transient`). `tryRefresh` stays a boolean wrapper,
  so its existing call sites and their tests are untouched. Both 401 doors — the
  shared fetch core and the XHR upload path in `api/ingest.ts` — end the session
  only for a `rejected` credential.
- The three catches that revoked on *any* failure now gate on the same rule:
  the OAuth callback's `getMe` catch, the login `getMe` catch in `use-auth.ts`,
  and login's body-parse catch in `api/auth.ts`. Without this, SSO completing on
  a new device while `/auth/me/` answered 500 revoked every session.
- One shared predicate, `isCredentialRejected`, is the single definition of
  "the server rejected this credential", used by both the refresh
  classification and the three catches.
- A 401 raised because the refresh failed transiently carries `unconfirmed: true`,
  and `isCredentialRejected` refuses a flagged error. Without it a transient failure
  inside `getMe` surfaced as a 401 that the sign-in catches read as a rejection and
  revoked every session for. One boolean on `ApiError`, set in the two 401 doors that can
  produce an unverified 401, read only by the predicate.
- The OAuth callback's malformed-fragment bail-out no longer revokes either. A fragment
  too short to finish sign-in says nothing about the credential.
- A `transient` outcome arms a 30s back-off before the next attempt. Without
  one, an auth outage or a shared egress IP over the refresh endpoint's per-IP
  limit turned every 401'd surface in every tab into an unbounded refresh loop.
  The back-off yields to a peer tab's rotation — the same live-session evidence
  the failure path already trusts — and clears on a deliberate session end.

## Area

- [x] Frontend (UI, components, hooks)
- [x] Auth / Permissions

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)
- [ ] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)

Twelve tests fail on `origin/main` and pass here, verified by restoring the
source files from `origin/main` and re-running:

- `client.session-expiry.test.ts` — a rate-limited refresh keeps the session and
  issues no revocation; so does a refresh the client cannot deliver at all
  (a `TypeError`, which is what `refreshAccessToken`'s bare `fetch` throws); a
  rejected refresh clears local state without a revocation; and 403 ends the
  session exactly as 401 does. The rate-limit case is the scenario the issue
  asks for: no `POST /auth/logout/` is issued, which is the only thing that
  could have invalidated another client's tokens.
- `ingest-session-expiry-1446.test.ts` — the upload door does the same, with a
  transient (503) case alongside the terminal one.
- `OAuthCallbackPage.test.tsx` and `use-auth.test.tsx` — a 500 from `/auth/me/`
  after a good sign-in keeps the user's other sessions; a 401 still revokes.
- `refresh-cookie-1302.test.ts` — a login response with an unparseable body no
  longer revokes every session.
- `client.test.ts` — after a transient failure the client stops asking until the
  back-off expires, then asks again (fake timers).
- The transient 401 carries `unconfirmed: true` and the rejected one does not; the OAuth
  callback keeps the user's other sessions when `getMe` answers an unconfirmed 401; an
  incomplete fragment no longer revokes.

Gates run from `frontend/`, all green: `npm run build`, `npm run lint`,
`npm run typecheck`, `npm run test:coverage` (460 files, 6116 tests).

No API schema, docstring or config change, so no `make sdks` / `types:generate`.
No new user-facing strings, so no locale change.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: no new user-facing strings
- [x] No new lint warnings (`ruff check`, `eslint`)
- [x] TypeScript compiles without errors
- [x] Migration included (if DB schema changed) — n/a
- [x] No secrets or credentials in the diff

## Notes for review

Two residuals are deliberate, both consequences of `/auth/logout/` being user-wide
with no per-session alternative.

1. When a refresh *succeeds* and the retry is still 401, the freshly rotated
   refresh row stays alive server-side while the client signs out locally.
   That case implies the server is rejecting a token it just minted, so the
   credential chain is invalid anyway.
2. At login's body-parse catch the rejection predicate is unreachable — the
   `try` only covers a 2xx, so the sole error it can see is a malformed body.
   That site therefore no longer revokes at all. A bad response body is no
   evidence of a rejected credential, and revoking on it ends the user's other
   devices.

Refresh rotation has no reuse detection, so with server-side revocation gone
from the dead-session path, a refresh credential someone else rotated stays
valid until an explicit logout or a password change. Closing that needs a
revoke-this-session endpoint and reuse detection on the backend, which is out
of scope here.

Closes #2038
