### PR TITLE
fix(core,admin): redact credentials for any URL scheme; rate the backfill estimate on walked records

### DIFF
--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -249,24 +249,45 @@ def redact_url_credentials(url: str) -> str:
         # fix(#2044 review x3): scan the raw text for an embedded http(s) URL
         # AND any other scheme's userinfo, rather than trust urlsplit's parse
         # of the whole string — it can absorb unrelated text past either.
-        prefix = URL_LIKE_RE.sub(
-            lambda match: redact_url_credentials(match.group(0)),
-            url,
-        )
-        return _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", prefix)
+        return _scan_for_embedded_credentials(url)
     redacted_netloc = _redacted_netloc(parts)
-    if not parts.query:
-        if redacted_netloc == parts.netloc:
-            return url
-        return urlunsplit(
-            (parts.scheme, redacted_netloc, parts.path, parts.query, parts.fragment)
-        )
-    redacted_query = redact_query_credentials(parts.query)
-    if redacted_query == parts.query and redacted_netloc == parts.netloc:
+    redacted_query = (
+        redact_query_credentials(parts.query) if parts.query else parts.query
+    )
+    # fix(#2044 review x5): a clean http(s) URL's path/fragment can itself
+    # carry a second, differently-schemed credentialed URL (GDAL stderr
+    # appending text past the first) — scan them like free text too.
+    redacted_path = (
+        _scan_for_embedded_credentials(parts.path) if parts.path else parts.path
+    )
+    redacted_fragment = (
+        _scan_for_embedded_credentials(parts.fragment)
+        if parts.fragment
+        else parts.fragment
+    )
+    if (
+        redacted_netloc == parts.netloc
+        and redacted_query == parts.query
+        and redacted_path == parts.path
+        and redacted_fragment == parts.fragment
+    ):
         return url
     return urlunsplit(
-        (parts.scheme, redacted_netloc, parts.path, redacted_query, parts.fragment)
+        (
+            parts.scheme,
+            redacted_netloc,
+            redacted_path,
+            redacted_query,
+            redacted_fragment,
+        )
     )
+
+
+def _scan_for_embedded_credentials(text: str) -> str:
+    """Redact an embedded http(s) URL, fully and recursively, or any other
+    scheme's userinfo — wherever either sits in free text."""
+    text = URL_LIKE_RE.sub(lambda match: redact_url_credentials(match.group(0)), text)
+    return _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", text)
 
 
 def scrub_registered_credentials(text: str) -> str:

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -231,12 +231,19 @@ def redact_url_credentials(url: str) -> str:
     redacted = url
     is_http = parts.scheme.lower() in {"http", "https"}
     # fix(#2044 review x9/x10): trust this split's netloc only with a real
-    # /?# boundary, or at most one `@` — either way it has no OTHER `@` it
-    # could have reached past prose to, unlike review x9's two-`@` case.
+    # /?# boundary, or at most one `@` — either way there is no OTHER `@`
+    # it could have reached past prose to, unlike review x9's two-`@` case.
     has_boundary = bool(parts.path or parts.query or parts.fragment)
     unambiguous = has_boundary or parts.netloc.count("@") <= 1
-    if unambiguous and (is_http or parts.username or parts.password):
-        redacted = _redact_netloc_and_query(url, parts, is_http=is_http)
+    # fix(#2044 review x11): urlsplit splits off a "query" for a bare `?` in
+    # scheme-less free text too — trust a non-http query only alongside a
+    # real scheme+netloc; is_http alone is enough (fix #429's empty-host URL
+    # has no netloc but is still real, since "http(s)://" is unambiguous).
+    has_real_url = is_http or bool(parts.scheme and parts.netloc)
+    if has_real_url and (
+        is_http or parts.query or (unambiguous and (parts.username or parts.password))
+    ):
+        redacted = _redact_netloc_and_query(url, parts)
     # fix(#2044 review x7): also scan the RAW text — urlsplit's split can put
     # a second scheme's authority in the wrong component (reviews x1-x6).
     # Non-recursive, so chained input can't grow the call stack (review x5/x6).
@@ -247,18 +254,22 @@ def redact_url_credentials(url: str) -> str:
     return redacted if redacted != url else url
 
 
-def _redact_netloc_and_query(url: str, parts, *, is_http: bool) -> str:  # type: ignore[no-untyped-def]
-    """Redact one recognised URL's userinfo, and sensitive query params if
-    ``is_http``, from urlsplit's own split of ``url``.
+def _redact_netloc_and_query(url: str, parts) -> str:  # type: ignore[no-untyped-def]
+    """Redact one recognised URL's userinfo and sensitive query params,
+    from urlsplit's own split of ``url``.
 
     Slices ``parts.netloc`` at its last ``@`` rather than rebuilding through
     ``.hostname``/``.port`` — those normalise and silently drop a character
     (fix #2044 review x2) when netloc absorbed text that isn't really a host.
+
+    fix(#2044 review x11): query redaction applies to any scheme, not just
+    http — ``?password=`` is a connection-string convention, and
+    SENSITIVE_QUERY_PARAMS already names params no http service defines.
     """
     _, sep, host_part = parts.netloc.rpartition("@")
     redacted_netloc = f"{REDACTED_USERINFO}@{host_part}" if sep else parts.netloc
     redacted_query = parts.query
-    if is_http and parts.query:
+    if parts.query:
         # fix(#2044 review x6): scan BEFORE redact_query_credentials — once
         # any one param is sensitive it re-urlencodes every value, which
         # would percent-escape an embedded credential's "://" out of reach.
@@ -305,7 +316,7 @@ def _redact_http_span(span: str) -> str:
         parts = urlsplit(rest)
     except ValueError:
         return prefix + _redact_without_parsing(rest)
-    return prefix + _redact_netloc_and_query(rest, parts, is_http=True)
+    return prefix + _redact_netloc_and_query(rest, parts)
 
 
 def scrub_registered_credentials(text: str) -> str:

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -39,12 +39,10 @@ REDACTED_SECRET = "***"
 # O(n²) on GDAL stderr/VRT paths. A longer prefix still redacts correctly.
 URL_LIKE_RE = re.compile(r"(?:(?:[A-Za-z0-9_+.-]{1,64}:)?https?://)[^\s\"'<>]+")
 
-# fix(#2044 review x3/x4): matches "<scheme>://<userinfo>@" for ANY scheme
-# anywhere in a string. `@` allowed in the userinfo class so greedy
-# backtracking lands on the LAST one, as urlsplit itself resolves it.
-_ANY_SCHEME_USERINFO_RE = re.compile(
-    r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\s\"'<>/?#]*@"
-)
+# fix(#2044 review x3/x4/x8): matches "<scheme>://<userinfo>@" anywhere, for
+# ANY scheme, bounded like urlsplit's own authority (/?#) — NOT whitespace,
+# which can legally sit inside userinfo and truncated the match without it.
+_ANY_SCHEME_USERINFO_RE = re.compile(r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\"'<>/?#]*@")
 
 SENSITIVE_QUERY_PARAMS = frozenset(
     {
@@ -122,22 +120,6 @@ def _split_prefixed_url(value: str) -> tuple[str, str] | None:
     if rest.startswith(("http://", "https://")):
         return f"{prefix}:", rest
     return None
-
-
-def _redacted_netloc(parts) -> str:  # type: ignore[no-untyped-def]
-    if not (parts.username or parts.password):
-        return parts.netloc
-
-    host = parts.hostname or ""
-    if ":" in host and not host.startswith("["):
-        host = f"[{host}]"
-    try:
-        port = parts.port
-    except ValueError:
-        port = None
-    if port is not None:
-        host = f"{host}:{port}"
-    return f"{REDACTED_USERINFO}@{host}"
 
 
 def redact_query_credentials(query: str) -> str:
@@ -238,40 +220,38 @@ def redact_url_credentials(url: str) -> str:
         return prefix + redact_url_credentials(nested_url)
 
     try:
-        urlsplit(url)
+        parts = urlsplit(url)
     except ValueError:
         # fix(#1119): a malformed authority must not turn a redaction call into
         # a raise. A malformed http(s) SPAN inside free text is instead caught
         # by _redact_http_span below, without recursing back through here.
         return _redact_without_parsing(url)
-    # fix(#2044 review x7): scan the RAW text directly for every embedded
-    # credential — not urlsplit's split of the WHOLE string into components,
-    # which can separate a scheme from its own authority across a netloc/path
-    # boundary and hide the pattern from both regexes (reviews x1-x6 each hit
-    # a different shape of this). _redact_http_span never calls back into this
-    # function, so adversarial chained input (many URLs, no separator) cannot
-    # grow the call stack the way the review x5/x6 recursion did.
-    redacted = URL_LIKE_RE.sub(lambda match: _redact_http_span(match.group(0)), url)
+    redacted = url
+    if parts.scheme.lower() in {"http", "https"}:
+        # fix(#2044 review x8): urlsplit tolerates whitespace in userinfo/query
+        # (stops only at /?#); URL_LIKE_RE below does not — redact via
+        # urlsplit's OWN split of the whole string first, before that truncates.
+        redacted = _redact_netloc_and_query(url, parts)
+    # fix(#2044 review x7): also scan the RAW text — urlsplit's split can put
+    # a second scheme's authority in the wrong component (reviews x1-x6).
+    # Non-recursive, so chained input can't grow the call stack (review x5/x6).
+    redacted = URL_LIKE_RE.sub(
+        lambda match: _redact_http_span(match.group(0)), redacted
+    )
     redacted = _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", redacted)
     return redacted if redacted != url else url
 
 
-def _redact_http_span(span: str) -> str:
-    """Redact userinfo and sensitive query params in one http(s)-shaped span
-    matched by URL_LIKE_RE.
+def _redact_netloc_and_query(url: str, parts) -> str:  # type: ignore[no-untyped-def]
+    """Redact one recognised http(s) URL's userinfo and sensitive query
+    params, from urlsplit's own split of ``url``.
 
-    Never calls back into redact_url_credentials. A second credential
-    elsewhere in the text — a different scheme, or another http(s) URL
-    separated by whitespace from this one — is caught by the caller's own
-    two scans instead, which is what keeps this non-recursive.
+    Slices ``parts.netloc`` at its last ``@`` rather than rebuilding through
+    ``.hostname``/``.port`` — those normalise and silently drop a character
+    (fix #2044 review x2) when netloc absorbed text that isn't really a host.
     """
-    prefixed = _split_prefixed_url(span)
-    prefix, rest = prefixed if prefixed is not None else ("", span)
-    try:
-        parts = urlsplit(rest)
-    except ValueError:
-        return prefix + _redact_without_parsing(rest)
-    redacted_netloc = _redacted_netloc(parts)
+    _, sep, host_part = parts.netloc.rpartition("@")
+    redacted_netloc = f"{REDACTED_USERINFO}@{host_part}" if sep else parts.netloc
     # fix(#2044 review x6): scan BEFORE redact_query_credentials — once any
     # one param is sensitive it re-urlencodes every value, which would
     # percent-escape an embedded credential's "://" out of regex reach.
@@ -283,10 +263,27 @@ def _redact_http_span(span: str) -> str:
         else parts.query
     )
     if redacted_netloc == parts.netloc and redacted_query == parts.query:
-        return prefix + rest
-    return prefix + urlunsplit(
+        return url
+    return urlunsplit(
         (parts.scheme, redacted_netloc, parts.path, redacted_query, parts.fragment)
     )
+
+
+def _redact_http_span(span: str) -> str:
+    """Redact userinfo and sensitive query params in one http(s)-shaped span
+    matched by URL_LIKE_RE.
+
+    Never calls back into redact_url_credentials. A second credential
+    elsewhere in the text is caught by the caller's own two scans instead,
+    which is what keeps this non-recursive.
+    """
+    prefixed = _split_prefixed_url(span)
+    prefix, rest = prefixed if prefixed is not None else ("", span)
+    try:
+        parts = urlsplit(rest)
+    except ValueError:
+        return prefix + _redact_without_parsing(rest)
+    return prefix + _redact_netloc_and_query(rest, parts)
 
 
 def scrub_registered_credentials(text: str) -> str:

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -238,55 +238,55 @@ def redact_url_credentials(url: str) -> str:
         return prefix + redact_url_credentials(nested_url)
 
     try:
-        parts = urlsplit(url)
+        urlsplit(url)
     except ValueError:
-        # fix(#1119): a malformed authority must not turn a redaction call into a
-        # raise. Reached both directly and from the URL_LIKE_RE.sub callback
-        # below, which recurses here on each matched substring of free text.
+        # fix(#1119): a malformed authority must not turn a redaction call into
+        # a raise. A malformed http(s) SPAN inside free text is instead caught
+        # by _redact_http_span below, without recursing back through here.
         return _redact_without_parsing(url)
-    is_http = parts.scheme.lower() in {"http", "https"}
-    if not is_http:
-        # fix(#2044 review x3): scan the raw text for an embedded http(s) URL
-        # AND any other scheme's userinfo, rather than trust urlsplit's parse
-        # of the whole string — it can absorb unrelated text past either.
-        return _scan_for_embedded_credentials(url)
-    # fix(#2044 review x5/x6): query/path/fragment can each still carry a
-    # second, differently-schemed credentialed URL (a redirect-style query
-    # value, GDAL stderr appending text) — scan every one like free text too.
+    # fix(#2044 review x7): scan the RAW text directly for every embedded
+    # credential — not urlsplit's split of the WHOLE string into components,
+    # which can separate a scheme from its own authority across a netloc/path
+    # boundary and hide the pattern from both regexes (reviews x1-x6 each hit
+    # a different shape of this). _redact_http_span never calls back into this
+    # function, so adversarial chained input (many URLs, no separator) cannot
+    # grow the call stack the way the review x5/x6 recursion did.
+    redacted = URL_LIKE_RE.sub(lambda match: _redact_http_span(match.group(0)), url)
+    redacted = _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", redacted)
+    return redacted if redacted != url else url
+
+
+def _redact_http_span(span: str) -> str:
+    """Redact userinfo and sensitive query params in one http(s)-shaped span
+    matched by URL_LIKE_RE.
+
+    Never calls back into redact_url_credentials. A second credential
+    elsewhere in the text — a different scheme, or another http(s) URL
+    separated by whitespace from this one — is caught by the caller's own
+    two scans instead, which is what keeps this non-recursive.
+    """
+    prefixed = _split_prefixed_url(span)
+    prefix, rest = prefixed if prefixed is not None else ("", span)
+    try:
+        parts = urlsplit(rest)
+    except ValueError:
+        return prefix + _redact_without_parsing(rest)
     redacted_netloc = _redacted_netloc(parts)
-    # Scan BEFORE the named-param pass: a query with a genuinely sensitive
-    # param re-encodes every value, which percent-escapes an embedded URL's
-    # "://" past what these regexes match once it's no longer literal text.
+    # fix(#2044 review x6): scan BEFORE redact_query_credentials — once any
+    # one param is sensitive it re-urlencodes every value, which would
+    # percent-escape an embedded credential's "://" out of regex reach.
     redacted_query = (
-        redact_query_credentials(_scan_for_embedded_credentials(parts.query))
+        redact_query_credentials(
+            _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", parts.query)
+        )
         if parts.query
         else parts.query
     )
-    redacted_path = _scan_for_embedded_credentials(parts.path)
-    redacted_fragment = _scan_for_embedded_credentials(parts.fragment)
-    if (
-        redacted_netloc == parts.netloc
-        and redacted_query == parts.query
-        and redacted_path == parts.path
-        and redacted_fragment == parts.fragment
-    ):
-        return url
-    return urlunsplit(
-        (
-            parts.scheme,
-            redacted_netloc,
-            redacted_path,
-            redacted_query,
-            redacted_fragment,
-        )
+    if redacted_netloc == parts.netloc and redacted_query == parts.query:
+        return prefix + rest
+    return prefix + urlunsplit(
+        (parts.scheme, redacted_netloc, parts.path, redacted_query, parts.fragment)
     )
-
-
-def _scan_for_embedded_credentials(text: str) -> str:
-    """Redact an embedded http(s) URL, fully and recursively, or any other
-    scheme's userinfo — wherever either sits in free text."""
-    text = URL_LIKE_RE.sub(lambda match: redact_url_credentials(match.group(0)), text)
-    return _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", text)
 
 
 def scrub_registered_credentials(text: str) -> str:

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -250,21 +250,20 @@ def redact_url_credentials(url: str) -> str:
         # AND any other scheme's userinfo, rather than trust urlsplit's parse
         # of the whole string — it can absorb unrelated text past either.
         return _scan_for_embedded_credentials(url)
+    # fix(#2044 review x5/x6): query/path/fragment can each still carry a
+    # second, differently-schemed credentialed URL (a redirect-style query
+    # value, GDAL stderr appending text) — scan every one like free text too.
     redacted_netloc = _redacted_netloc(parts)
+    # Scan BEFORE the named-param pass: a query with a genuinely sensitive
+    # param re-encodes every value, which percent-escapes an embedded URL's
+    # "://" past what these regexes match once it's no longer literal text.
     redacted_query = (
-        redact_query_credentials(parts.query) if parts.query else parts.query
+        redact_query_credentials(_scan_for_embedded_credentials(parts.query))
+        if parts.query
+        else parts.query
     )
-    # fix(#2044 review x5): a clean http(s) URL's path/fragment can itself
-    # carry a second, differently-schemed credentialed URL (GDAL stderr
-    # appending text past the first) — scan them like free text too.
-    redacted_path = (
-        _scan_for_embedded_credentials(parts.path) if parts.path else parts.path
-    )
-    redacted_fragment = (
-        _scan_for_embedded_credentials(parts.fragment)
-        if parts.fragment
-        else parts.fragment
-    )
+    redacted_path = _scan_for_embedded_credentials(parts.path)
+    redacted_fragment = _scan_for_embedded_credentials(parts.fragment)
     if (
         redacted_netloc == parts.netloc
         and redacted_query == parts.query

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -230,11 +230,12 @@ def redact_url_credentials(url: str) -> str:
         return _redact_without_parsing(url)
     redacted = url
     is_http = parts.scheme.lower() in {"http", "https"}
-    # fix(#2044 review x9): only trust this split when it found a real /?#
-    # to stop netloc at — otherwise it ran to end of string and can equally
-    # absorb later prose up to a coincidental `@` (review x8 over-redacted).
+    # fix(#2044 review x9/x10): trust this split's netloc only with a real
+    # /?# boundary, or at most one `@` — either way it has no OTHER `@` it
+    # could have reached past prose to, unlike review x9's two-`@` case.
     has_boundary = bool(parts.path or parts.query or parts.fragment)
-    if has_boundary and (is_http or parts.username or parts.password):
+    unambiguous = has_boundary or parts.netloc.count("@") <= 1
+    if unambiguous and (is_http or parts.username or parts.password):
         redacted = _redact_netloc_and_query(url, parts, is_http=is_http)
     # fix(#2044 review x7): also scan the RAW text — urlsplit's split can put
     # a second scheme's authority in the wrong component (reviews x1-x6).
@@ -274,10 +275,9 @@ def _redact_netloc_and_query(url: str, parts, *, is_http: bool) -> str:  # type:
 def _scan_query_value_credentials(query: str) -> str:
     """Redact an embedded userinfo credential inside each query VALUE.
 
-    fix(#2044 review x9): scanning the raw query string let the match cross
-    an `&`-separated pair boundary (parse_qsl's own delimiter, absent from
-    _ANY_SCHEME_USERINFO_RE's class), swallowing a sibling param into the
-    "userinfo". Scanning each already-split value keeps the match inside it.
+    fix(#2044 review x9): scanning the raw query let a match cross the `&`
+    pair boundary, swallowing a sibling param as "userinfo" — scanning each
+    already-split value (parse_qsl) instead keeps the match inside it.
     """
     # fix(#1770): same reasoning as `query_has_credentials` above -- a
     # redactor must never raise on its own input.

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -235,15 +235,15 @@ def redact_url_credentials(url: str) -> str:
     # it could have reached past prose to, unlike review x9's two-`@` case.
     has_boundary = bool(parts.path or parts.query or parts.fragment)
     unambiguous = has_boundary or parts.netloc.count("@") <= 1
-    # fix(#2044 review x11): urlsplit splits off a "query" for a bare `?` in
-    # scheme-less free text too — trust a non-http query only alongside a
-    # real scheme+netloc; is_http alone is enough (fix #429's empty-host URL
-    # has no netloc but is still real, since "http(s)://" is unambiguous).
-    has_real_url = is_http or bool(parts.scheme and parts.netloc)
+    # fix(#2044 review x11/x12): urlsplit splits off a "query" for a bare `?`
+    # in scheme-less free text too (scheme='') — a genuinely recognised
+    # scheme is what distinguishes that from an opaque/no-authority URI
+    # (``myapp:/callback?code=``, scheme='myapp', no netloc, still real).
+    has_real_url = bool(parts.scheme)
     if has_real_url and (
         is_http or parts.query or (unambiguous and (parts.username or parts.password))
     ):
-        redacted = _redact_netloc_and_query(url, parts)
+        redacted = _redact_netloc_and_query(url, parts, scan_fragment=True)
     # fix(#2044 review x7): also scan the RAW text — urlsplit's split can put
     # a second scheme's authority in the wrong component (reviews x1-x6).
     # Non-recursive, so chained input can't grow the call stack (review x5/x6).
@@ -254,9 +254,11 @@ def redact_url_credentials(url: str) -> str:
     return redacted if redacted != url else url
 
 
-def _redact_netloc_and_query(url: str, parts) -> str:  # type: ignore[no-untyped-def]
-    """Redact one recognised URL's userinfo and sensitive query params,
-    from urlsplit's own split of ``url``.
+def _redact_netloc_and_query(  # type: ignore[no-untyped-def]
+    url: str, parts, *, scan_fragment: bool
+) -> str:
+    """Redact one recognised URL's userinfo, sensitive query params, and
+    (if ``scan_fragment``) a nested credential hiding in the fragment.
 
     Slices ``parts.netloc`` at its last ``@`` rather than rebuilding through
     ``.hostname``/``.port`` — those normalise and silently drop a character
@@ -276,10 +278,27 @@ def _redact_netloc_and_query(url: str, parts) -> str:  # type: ignore[no-untyped
         redacted_query = redact_query_credentials(
             _scan_query_value_credentials(parts.query)
         )
-    if redacted_netloc == parts.netloc and redacted_query == parts.query:
+    redacted_fragment = parts.fragment
+    if scan_fragment and parts.fragment:
+        # fix(#2044 review x12): a second http(s) URL, or another scheme's
+        # userinfo, can hide in the fragment with no whitespace to separate
+        # it — scan_fragment=False on the inner call bounds this to one
+        # extra level, so depth can't grow the way review x5/x6's did.
+        redacted_fragment = URL_LIKE_RE.sub(
+            lambda match: _redact_http_span(match.group(0), scan_fragment=False),
+            parts.fragment,
+        )
+        redacted_fragment = _ANY_SCHEME_USERINFO_RE.sub(
+            rf"\1{REDACTED_USERINFO}@", redacted_fragment
+        )
+    if (
+        redacted_netloc == parts.netloc
+        and redacted_query == parts.query
+        and redacted_fragment == parts.fragment
+    ):
         return url
     return urlunsplit(
-        (parts.scheme, redacted_netloc, parts.path, redacted_query, parts.fragment)
+        (parts.scheme, redacted_netloc, parts.path, redacted_query, redacted_fragment)
     )
 
 
@@ -302,13 +321,15 @@ def _scan_query_value_credentials(query: str) -> str:
     return query if scanned == pairs else urlencode(scanned)
 
 
-def _redact_http_span(span: str) -> str:
+def _redact_http_span(span: str, *, scan_fragment: bool = True) -> str:
     """Redact userinfo and sensitive query params in one http(s)-shaped span
     matched by URL_LIKE_RE.
 
-    Never calls back into redact_url_credentials. A second credential
-    elsewhere in the text is caught by the caller's own two scans instead,
-    which is what keeps this non-recursive.
+    Never calls back into redact_url_credentials or, with ``scan_fragment``
+    False, into a fragment scan of its own — see
+    ``_redact_netloc_and_query``'s ``scan_fragment`` for why that bounds the
+    depth. A second credential elsewhere in the text is caught by the
+    caller's own two scans instead.
     """
     prefixed = _split_prefixed_url(span)
     prefix, rest = prefixed if prefixed is not None else ("", span)
@@ -316,7 +337,7 @@ def _redact_http_span(span: str) -> str:
         parts = urlsplit(rest)
     except ValueError:
         return prefix + _redact_without_parsing(rest)
-    return prefix + _redact_netloc_and_query(rest, parts)
+    return prefix + _redact_netloc_and_query(rest, parts, scan_fragment=scan_fragment)
 
 
 def scrub_registered_credentials(text: str) -> str:

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -39,10 +39,12 @@ REDACTED_SECRET = "***"
 # O(n²) on GDAL stderr/VRT paths. A longer prefix still redacts correctly.
 URL_LIKE_RE = re.compile(r"(?:(?:[A-Za-z0-9_+.-]{1,64}:)?https?://)[^\s\"'<>]+")
 
-# fix(#2044 review x3/x4/x8): matches "<scheme>://<userinfo>@" anywhere, for
-# ANY scheme, bounded like urlsplit's own authority (/?#) — NOT whitespace,
-# which can legally sit inside userinfo and truncated the match without it.
-_ANY_SCHEME_USERINFO_RE = re.compile(r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\"'<>/?#]*@")
+# fix(#2044 review x3/x4/x9): matches "<scheme>://<userinfo>@" anywhere, for
+# ANY scheme. `\s` excluded on purpose: free text has no /?# to stop an
+# unbounded authority scan at, so allowing it swallows later unrelated prose.
+_ANY_SCHEME_USERINFO_RE = re.compile(
+    r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\s\"'<>/?#]*@"
+)
 
 SENSITIVE_QUERY_PARAMS = frozenset(
     {
@@ -227,11 +229,13 @@ def redact_url_credentials(url: str) -> str:
         # by _redact_http_span below, without recursing back through here.
         return _redact_without_parsing(url)
     redacted = url
-    if parts.scheme.lower() in {"http", "https"}:
-        # fix(#2044 review x8): urlsplit tolerates whitespace in userinfo/query
-        # (stops only at /?#); URL_LIKE_RE below does not — redact via
-        # urlsplit's OWN split of the whole string first, before that truncates.
-        redacted = _redact_netloc_and_query(url, parts)
+    is_http = parts.scheme.lower() in {"http", "https"}
+    # fix(#2044 review x9): only trust this split when it found a real /?#
+    # to stop netloc at — otherwise it ran to end of string and can equally
+    # absorb later prose up to a coincidental `@` (review x8 over-redacted).
+    has_boundary = bool(parts.path or parts.query or parts.fragment)
+    if has_boundary and (is_http or parts.username or parts.password):
+        redacted = _redact_netloc_and_query(url, parts, is_http=is_http)
     # fix(#2044 review x7): also scan the RAW text — urlsplit's split can put
     # a second scheme's authority in the wrong component (reviews x1-x6).
     # Non-recursive, so chained input can't grow the call stack (review x5/x6).
@@ -242,9 +246,9 @@ def redact_url_credentials(url: str) -> str:
     return redacted if redacted != url else url
 
 
-def _redact_netloc_and_query(url: str, parts) -> str:  # type: ignore[no-untyped-def]
-    """Redact one recognised http(s) URL's userinfo and sensitive query
-    params, from urlsplit's own split of ``url``.
+def _redact_netloc_and_query(url: str, parts, *, is_http: bool) -> str:  # type: ignore[no-untyped-def]
+    """Redact one recognised URL's userinfo, and sensitive query params if
+    ``is_http``, from urlsplit's own split of ``url``.
 
     Slices ``parts.netloc`` at its last ``@`` rather than rebuilding through
     ``.hostname``/``.port`` — those normalise and silently drop a character
@@ -252,21 +256,39 @@ def _redact_netloc_and_query(url: str, parts) -> str:  # type: ignore[no-untyped
     """
     _, sep, host_part = parts.netloc.rpartition("@")
     redacted_netloc = f"{REDACTED_USERINFO}@{host_part}" if sep else parts.netloc
-    # fix(#2044 review x6): scan BEFORE redact_query_credentials — once any
-    # one param is sensitive it re-urlencodes every value, which would
-    # percent-escape an embedded credential's "://" out of regex reach.
-    redacted_query = (
-        redact_query_credentials(
-            _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", parts.query)
+    redacted_query = parts.query
+    if is_http and parts.query:
+        # fix(#2044 review x6): scan BEFORE redact_query_credentials — once
+        # any one param is sensitive it re-urlencodes every value, which
+        # would percent-escape an embedded credential's "://" out of reach.
+        redacted_query = redact_query_credentials(
+            _scan_query_value_credentials(parts.query)
         )
-        if parts.query
-        else parts.query
-    )
     if redacted_netloc == parts.netloc and redacted_query == parts.query:
         return url
     return urlunsplit(
         (parts.scheme, redacted_netloc, parts.path, redacted_query, parts.fragment)
     )
+
+
+def _scan_query_value_credentials(query: str) -> str:
+    """Redact an embedded userinfo credential inside each query VALUE.
+
+    fix(#2044 review x9): scanning the raw query string let the match cross
+    an `&`-separated pair boundary (parse_qsl's own delimiter, absent from
+    _ANY_SCHEME_USERINFO_RE's class), swallowing a sibling param into the
+    "userinfo". Scanning each already-split value keeps the match inside it.
+    """
+    # fix(#1770): same reasoning as `query_has_credentials` above -- a
+    # redactor must never raise on its own input.
+    pairs = parse_qsl(query, keep_blank_values=True)  # parse_qs: unbounded
+    if not pairs:
+        return query
+    scanned = [
+        (key, _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", value))
+        for key, value in pairs
+    ]
+    return query if scanned == pairs else urlencode(scanned)
 
 
 def _redact_http_span(span: str) -> str:
@@ -283,7 +305,7 @@ def _redact_http_span(span: str) -> str:
         parts = urlsplit(rest)
     except ValueError:
         return prefix + _redact_without_parsing(rest)
-    return prefix + _redact_netloc_and_query(rest, parts)
+    return prefix + _redact_netloc_and_query(rest, parts, is_http=True)
 
 
 def scrub_registered_credentials(text: str) -> str:

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -238,18 +238,23 @@ def redact_url_credentials(url: str) -> str:
         # below, which recurses here on each matched substring of free text.
         return _redact_without_parsing(url)
     is_http = parts.scheme.lower() in {"http", "https"}
-    # fix(#2044): a non-http scheme WITH an authority (redis://user:pass@host) is
-    # a real URL to redact below, not free text — fix(#429) needs the fallback
-    # only for scheme-less/no-netloc text, else an empty-host http(s) URL recurses.
-    if not is_http and not parts.netloc:
+    redacted_netloc = _redacted_netloc(parts)
+    if not is_http:
+        # fix(#2044 review): urlsplit hands free text a netloc too ("redis://cache/0
+        # then https://user:pass@evil" parses netloc="cache"), so redact THIS
+        # scheme's userinfo, then still scan for an embedded http(s) URL below.
+        prefix = (
+            url
+            if redacted_netloc == parts.netloc
+            else urlunsplit(
+                (parts.scheme, redacted_netloc, parts.path, parts.query, parts.fragment)
+            )
+        )
         return URL_LIKE_RE.sub(
             lambda match: redact_url_credentials(match.group(0)),
-            url,
+            prefix,
         )
-    redacted_netloc = _redacted_netloc(parts)
-    # SENSITIVE_QUERY_PARAMS is an http(s) convention (token=, api_key=, ...); a
-    # non-http scheme only gets its userinfo redacted, same as no query below.
-    if not parts.query or not is_http:
+    if not parts.query:
         if redacted_netloc == parts.netloc:
             return url
         return urlunsplit(

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -39,11 +39,11 @@ REDACTED_SECRET = "***"
 # O(n²) on GDAL stderr/VRT paths. A longer prefix still redacts correctly.
 URL_LIKE_RE = re.compile(r"(?:(?:[A-Za-z0-9_+.-]{1,64}:)?https?://)[^\s\"'<>]+")
 
-# fix(#2044 review x3): matches "<scheme>://<userinfo>@" for ANY scheme
-# anywhere in a string, so leading prose can't hide it from urlsplit like
-# `redact_url_credentials` below. Scheme bounded to 64 chars, same as URL_LIKE_RE.
+# fix(#2044 review x3/x4): matches "<scheme>://<userinfo>@" for ANY scheme
+# anywhere in a string. `@` allowed in the userinfo class so greedy
+# backtracking lands on the LAST one, as urlsplit itself resolves it.
 _ANY_SCHEME_USERINFO_RE = re.compile(
-    r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\s\"'<>@/?#]*@"
+    r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\s\"'<>/?#]*@"
 )
 
 SENSITIVE_QUERY_PARAMS = frozenset(

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -46,12 +46,12 @@ _ANY_SCHEME_USERINFO_RE = re.compile(
     r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\s\"'<>/?#]*@"
 )
 
-# fix(#2044 review x13/x14/x15): "<scheme>:...?..." for any NON-http(s)
-# scheme with a `?`; `/{0,2}` admits an opaque/single-slash URI too. Body
-# excludes a nested `://` start (a length cap is itself a bypass, x15).
+# fix(#2044 review x13/x14): "<scheme>:...?..." for any NON-http(s) scheme
+# with a `?` (http(s) is URL_LIKE_RE's job). `/{0,2}` admits an opaque or
+# single-slash URI too, not just `://` ones. Bounded like URL_LIKE_RE.
 _ANY_SCHEME_QUERY_RE = re.compile(
     r"(?<![A-Za-z0-9+.-])(?!https?://)"
-    r"[A-Za-z][A-Za-z0-9+.-]{0,63}:/{0,2}(?:(?!://)[^\s\"'<>?])*\?[^\s\"'<>]*"
+    r"[A-Za-z][A-Za-z0-9+.-]{0,63}:/{0,2}[^\s\"'<>?]{0,2048}\?[^\s\"'<>]*"
 )
 
 SENSITIVE_QUERY_PARAMS = frozenset(
@@ -242,16 +242,7 @@ def redact_url_credentials(url: str) -> str:
     # boundary, or at most one `@` — either way no OTHER `@` it could have
     # reached past prose to (review x9's two-`@` case couldn't say that).
     has_boundary = bool(parts.path or parts.query or parts.fragment)
-    at_count = parts.netloc.count("@")
-    # fix(#2044 review x15): a further `@` is still trustworthy when only
-    # the password sits between it and the one before it -- review x9's
-    # prose case had space-separated WORDS there; a password does not.
-    middle_segments = parts.netloc.split("@")[1:-1]
-    unambiguous = (
-        has_boundary
-        or at_count <= 1
-        or not any(ch.isspace() for segment in middle_segments for ch in segment)
-    )
+    unambiguous = has_boundary or parts.netloc.count("@") <= 1
     # fix(#2044 review x11/x12): a genuinely recognised scheme is what tells
     # a real (if opaque/no-authority, e.g. myapp:/callback) URI apart from
     # the bare `?` urlsplit finds in scheme-less free text (scheme='') too.
@@ -267,11 +258,7 @@ def redact_url_credentials(url: str) -> str:
 # fix(#2044 review x14): review x12 bounded fragment nesting to exactly one
 # level, which a double-nested case got past — depth now counts down across
 # every hop (fragment or query value), capped regardless of input shape.
-#
-# fix(#2044 review x15): 10 was itself exceeded by an 11-level chain;
-# raised with headroom (~5 stack frames/hop, well under Python's default
-# limit) and backed by _looks_url_shaped so exceeding even this redacts.
-_MAX_NESTED_URL_DEPTH = 50
+_MAX_NESTED_URL_DEPTH = 10
 
 
 def _scan_embedded_url_credentials(text: str, *, depth: int) -> str:
@@ -318,19 +305,13 @@ def _redact_netloc_and_query(  # type: ignore[no-untyped-def]
             _scan_query_value_credentials(parts.query, depth=depth)
         )
     redacted_fragment = parts.fragment
-    if parts.fragment:
-        if depth > 0:
-            # fix(#2044 review x12/x14): a credential can hide in the fragment
-            # with no whitespace to separate it — depth-1 here bounds how
-            # many MORE such hops get followed (see _MAX_NESTED_URL_DEPTH).
-            redacted_fragment = _scan_embedded_url_credentials(
-                parts.fragment, depth=depth - 1
-            )
-        elif _looks_url_shaped(parts.fragment):
-            # fix(#2044 review x15): budget exhausted -- an unscanned
-            # remainder that still looks URL-shaped is redacted wholesale
-            # rather than leaked verbatim; see _looks_url_shaped.
-            redacted_fragment = REDACTED_QUERY_VALUE
+    if depth > 0 and parts.fragment:
+        # fix(#2044 review x12/x14): a credential can hide in the fragment
+        # with no whitespace to separate it — depth-1 here bounds how many
+        # MORE such hops get followed (see _MAX_NESTED_URL_DEPTH).
+        redacted_fragment = _scan_embedded_url_credentials(
+            parts.fragment, depth=depth - 1
+        )
     if (
         redacted_netloc == parts.netloc
         and redacted_query == parts.query
@@ -339,20 +320,6 @@ def _redact_netloc_and_query(  # type: ignore[no-untyped-def]
         return url
     return urlunsplit(
         (parts.scheme, redacted_netloc, parts.path, redacted_query, redacted_fragment)
-    )
-
-
-def _looks_url_shaped(text: str) -> bool:
-    """Return True if any of the three URL-detection regexes match ``text``.
-
-    fix(#2044 review x15): shared by the fragment and query-value paths
-    below -- a text with no match here wouldn't have yielded anything even
-    with full budget, so it's left alone; a match is redacted wholesale.
-    """
-    return bool(
-        URL_LIKE_RE.search(text)
-        or _ANY_SCHEME_QUERY_RE.search(text)
-        or _ANY_SCHEME_USERINFO_RE.search(text)
     )
 
 
@@ -369,17 +336,15 @@ def _scan_query_value_credentials(query: str, *, depth: int) -> str:
     pairs = parse_qsl(query, keep_blank_values=True)  # parse_qs: unbounded
     if not pairs:
         return query
-    scanned = []
-    for key, value in pairs:
-        if depth > 0:
-            new_value = _scan_embedded_url_credentials(value, depth=depth - 1)
-        elif _looks_url_shaped(value):
-            # fix(#2044 review x15): same reasoning as the fragment branch
-            # in _redact_netloc_and_query above.
-            new_value = REDACTED_QUERY_VALUE
-        else:
-            new_value = value
-        scanned.append((key, new_value))
+    scanned = [
+        (
+            key,
+            _scan_embedded_url_credentials(value, depth=depth - 1)
+            if depth > 0
+            else value,
+        )
+        for key, value in pairs
+    ]
     return query if scanned == pairs else urlencode(scanned)
 
 

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -46,12 +46,12 @@ _ANY_SCHEME_USERINFO_RE = re.compile(
     r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\s\"'<>/?#]*@"
 )
 
-# fix(#2044 review x13): "<scheme>://...?..." for any NON-http(s) scheme
-# with a `?` (http(s) is URL_LIKE_RE's job; re-matching its output here once
-# misread a truncated leftover as unredacted). Bounded like URL_LIKE_RE — can't exclude `/`, was quadratic without it.
+# fix(#2044 review x13/x14): "<scheme>:...?..." for any NON-http(s) scheme
+# with a `?` (http(s) is URL_LIKE_RE's job). `/{0,2}` admits an opaque or
+# single-slash URI too, not just `://` ones. Bounded like URL_LIKE_RE.
 _ANY_SCHEME_QUERY_RE = re.compile(
     r"(?<![A-Za-z0-9+.-])(?!https?://)"
-    r"[A-Za-z][A-Za-z0-9+.-]{0,63}://[^\s\"'<>?]{0,2048}\?[^\s\"'<>]*"
+    r"[A-Za-z][A-Za-z0-9+.-]{0,63}:/{0,2}[^\s\"'<>?]{0,2048}\?[^\s\"'<>]*"
 )
 
 SENSITIVE_QUERY_PARAMS = frozenset(
@@ -250,12 +250,18 @@ def redact_url_credentials(url: str) -> str:
     if has_real_url and (
         is_http or parts.query or (unambiguous and (parts.username or parts.password))
     ):
-        redacted = _redact_netloc_and_query(url, parts, scan_fragment=True)
-    redacted = _scan_embedded_url_credentials(redacted)
+        redacted = _redact_netloc_and_query(url, parts, depth=_MAX_NESTED_URL_DEPTH)
+    redacted = _scan_embedded_url_credentials(redacted, depth=_MAX_NESTED_URL_DEPTH)
     return redacted if redacted != url else url
 
 
-def _scan_embedded_url_credentials(text: str, *, scan_fragment: bool = True) -> str:
+# fix(#2044 review x14): review x12 bounded fragment nesting to exactly one
+# level, which a double-nested case got past — depth now counts down across
+# every hop (fragment or query value), capped regardless of input shape.
+_MAX_NESTED_URL_DEPTH = 10
+
+
+def _scan_embedded_url_credentials(text: str, *, depth: int) -> str:
     """Redact a credential in an EMBEDDED URL anywhere in ``text``: an
     http(s) URL (full treatment), any scheme with a query (full treatment,
     fix #2044 review x13), or any scheme's bare userinfo.
@@ -263,27 +269,22 @@ def _scan_embedded_url_credentials(text: str, *, scan_fragment: bool = True) -> 
     fix(#2044 review x7): urlsplit's split of the OUTER string can put a
     second scheme's authority in the wrong component (reviews x1-x6) — this
     scans the raw text instead.
-
-    ``scan_fragment`` threads the same bound as ``_redact_netloc_and_query``
-    (review x12) into each match's own redaction, so chained or nested
-    input can't grow the call stack either way (review x5/x6).
     """
     text = URL_LIKE_RE.sub(
-        lambda match: _redact_http_span(match.group(0), scan_fragment=scan_fragment),
-        text,
+        lambda match: _redact_http_span(match.group(0), depth=depth), text
     )
     text = _ANY_SCHEME_QUERY_RE.sub(
-        lambda match: _redact_http_span(match.group(0), scan_fragment=scan_fragment),
-        text,
+        lambda match: _redact_http_span(match.group(0), depth=depth), text
     )
     return _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", text)
 
 
 def _redact_netloc_and_query(  # type: ignore[no-untyped-def]
-    url: str, parts, *, scan_fragment: bool
+    url: str, parts, *, depth: int
 ) -> str:
     """Redact one recognised URL's userinfo, sensitive query params, and
-    (if ``scan_fragment``) a nested credential hiding in the fragment.
+    (while ``depth`` allows descending further) a nested credential hiding
+    in the fragment or in a query value.
 
     Slices ``parts.netloc`` at its last ``@`` rather than rebuilding through
     ``.hostname``/``.port`` — those normalise and silently drop a character
@@ -301,15 +302,15 @@ def _redact_netloc_and_query(  # type: ignore[no-untyped-def]
         # any one param is sensitive it re-urlencodes every value, which
         # would percent-escape an embedded credential's "://" out of reach.
         redacted_query = redact_query_credentials(
-            _scan_query_value_credentials(parts.query)
+            _scan_query_value_credentials(parts.query, depth=depth)
         )
     redacted_fragment = parts.fragment
-    if scan_fragment and parts.fragment:
-        # fix(#2044 review x12): a credential can hide in the fragment with
-        # no whitespace to separate it from this URL — scan_fragment=False
-        # here bounds it to one extra level (see _scan_embedded_url_credentials).
+    if depth > 0 and parts.fragment:
+        # fix(#2044 review x12/x14): a credential can hide in the fragment
+        # with no whitespace to separate it — depth-1 here bounds how many
+        # MORE such hops get followed (see _MAX_NESTED_URL_DEPTH).
         redacted_fragment = _scan_embedded_url_credentials(
-            parts.fragment, scan_fragment=False
+            parts.fragment, depth=depth - 1
         )
     if (
         redacted_netloc == parts.netloc
@@ -322,8 +323,9 @@ def _redact_netloc_and_query(  # type: ignore[no-untyped-def]
     )
 
 
-def _scan_query_value_credentials(query: str) -> str:
-    """Redact an embedded userinfo credential inside each query VALUE.
+def _scan_query_value_credentials(query: str, *, depth: int) -> str:
+    """Redact a credential — embedded userinfo, or (fix #2044 review x14) a
+    whole nested URL's own query — inside each query VALUE.
 
     fix(#2044 review x9): scanning the raw query let a match cross the `&`
     pair boundary, swallowing a sibling param as "userinfo" — scanning each
@@ -335,19 +337,24 @@ def _scan_query_value_credentials(query: str) -> str:
     if not pairs:
         return query
     scanned = [
-        (key, _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", value))
+        (
+            key,
+            _scan_embedded_url_credentials(value, depth=depth - 1)
+            if depth > 0
+            else value,
+        )
         for key, value in pairs
     ]
     return query if scanned == pairs else urlencode(scanned)
 
 
-def _redact_http_span(span: str, *, scan_fragment: bool = True) -> str:
+def _redact_http_span(span: str, *, depth: int) -> str:
     """Redact userinfo and sensitive query params in one URL-shaped span
     matched by ``_scan_embedded_url_credentials``'s two URL regexes.
 
-    Never calls back into ``redact_url_credentials``. ``scan_fragment``
-    just threads through to ``_redact_netloc_and_query`` — see its own
-    docstring for the depth bound this keeps.
+    Never calls back into ``redact_url_credentials``. ``depth`` just
+    threads through to ``_redact_netloc_and_query`` — see
+    ``_MAX_NESTED_URL_DEPTH`` for the bound this keeps.
     """
     prefixed = _split_prefixed_url(span)
     prefix, rest = prefixed if prefixed is not None else ("", span)
@@ -355,7 +362,7 @@ def _redact_http_span(span: str, *, scan_fragment: bool = True) -> str:
         parts = urlsplit(rest)
     except ValueError:
         return prefix + _redact_without_parsing(rest)
-    return prefix + _redact_netloc_and_query(rest, parts, scan_fragment=scan_fragment)
+    return prefix + _redact_netloc_and_query(rest, parts, depth=depth)
 
 
 def scrub_registered_credentials(text: str) -> str:

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -46,6 +46,14 @@ _ANY_SCHEME_USERINFO_RE = re.compile(
     r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\s\"'<>/?#]*@"
 )
 
+# fix(#2044 review x13): "<scheme>://...?..." for any NON-http(s) scheme
+# with a `?` (http(s) is URL_LIKE_RE's job; re-matching its output here once
+# misread a truncated leftover as unredacted). Bounded like URL_LIKE_RE — can't exclude `/`, was quadratic without it.
+_ANY_SCHEME_QUERY_RE = re.compile(
+    r"(?<![A-Za-z0-9+.-])(?!https?://)"
+    r"[A-Za-z][A-Za-z0-9+.-]{0,63}://[^\s\"'<>?]{0,2048}\?[^\s\"'<>]*"
+)
+
 SENSITIVE_QUERY_PARAMS = frozenset(
     {
         "access_token",
@@ -230,28 +238,45 @@ def redact_url_credentials(url: str) -> str:
         return _redact_without_parsing(url)
     redacted = url
     is_http = parts.scheme.lower() in {"http", "https"}
-    # fix(#2044 review x9/x10): trust this split's netloc only with a real
-    # /?# boundary, or at most one `@` — either way there is no OTHER `@`
-    # it could have reached past prose to, unlike review x9's two-`@` case.
+    # fix(#2044 review x9/x10): trust this split's netloc with a real /?#
+    # boundary, or at most one `@` — either way no OTHER `@` it could have
+    # reached past prose to (review x9's two-`@` case couldn't say that).
     has_boundary = bool(parts.path or parts.query or parts.fragment)
     unambiguous = has_boundary or parts.netloc.count("@") <= 1
-    # fix(#2044 review x11/x12): urlsplit splits off a "query" for a bare `?`
-    # in scheme-less free text too (scheme='') — a genuinely recognised
-    # scheme is what distinguishes that from an opaque/no-authority URI
-    # (``myapp:/callback?code=``, scheme='myapp', no netloc, still real).
+    # fix(#2044 review x11/x12): a genuinely recognised scheme is what tells
+    # a real (if opaque/no-authority, e.g. myapp:/callback) URI apart from
+    # the bare `?` urlsplit finds in scheme-less free text (scheme='') too.
     has_real_url = bool(parts.scheme)
     if has_real_url and (
         is_http or parts.query or (unambiguous and (parts.username or parts.password))
     ):
         redacted = _redact_netloc_and_query(url, parts, scan_fragment=True)
-    # fix(#2044 review x7): also scan the RAW text — urlsplit's split can put
-    # a second scheme's authority in the wrong component (reviews x1-x6).
-    # Non-recursive, so chained input can't grow the call stack (review x5/x6).
-    redacted = URL_LIKE_RE.sub(
-        lambda match: _redact_http_span(match.group(0)), redacted
-    )
-    redacted = _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", redacted)
+    redacted = _scan_embedded_url_credentials(redacted)
     return redacted if redacted != url else url
+
+
+def _scan_embedded_url_credentials(text: str, *, scan_fragment: bool = True) -> str:
+    """Redact a credential in an EMBEDDED URL anywhere in ``text``: an
+    http(s) URL (full treatment), any scheme with a query (full treatment,
+    fix #2044 review x13), or any scheme's bare userinfo.
+
+    fix(#2044 review x7): urlsplit's split of the OUTER string can put a
+    second scheme's authority in the wrong component (reviews x1-x6) — this
+    scans the raw text instead.
+
+    ``scan_fragment`` threads the same bound as ``_redact_netloc_and_query``
+    (review x12) into each match's own redaction, so chained or nested
+    input can't grow the call stack either way (review x5/x6).
+    """
+    text = URL_LIKE_RE.sub(
+        lambda match: _redact_http_span(match.group(0), scan_fragment=scan_fragment),
+        text,
+    )
+    text = _ANY_SCHEME_QUERY_RE.sub(
+        lambda match: _redact_http_span(match.group(0), scan_fragment=scan_fragment),
+        text,
+    )
+    return _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", text)
 
 
 def _redact_netloc_and_query(  # type: ignore[no-untyped-def]
@@ -280,16 +305,11 @@ def _redact_netloc_and_query(  # type: ignore[no-untyped-def]
         )
     redacted_fragment = parts.fragment
     if scan_fragment and parts.fragment:
-        # fix(#2044 review x12): a second http(s) URL, or another scheme's
-        # userinfo, can hide in the fragment with no whitespace to separate
-        # it — scan_fragment=False on the inner call bounds this to one
-        # extra level, so depth can't grow the way review x5/x6's did.
-        redacted_fragment = URL_LIKE_RE.sub(
-            lambda match: _redact_http_span(match.group(0), scan_fragment=False),
-            parts.fragment,
-        )
-        redacted_fragment = _ANY_SCHEME_USERINFO_RE.sub(
-            rf"\1{REDACTED_USERINFO}@", redacted_fragment
+        # fix(#2044 review x12): a credential can hide in the fragment with
+        # no whitespace to separate it from this URL — scan_fragment=False
+        # here bounds it to one extra level (see _scan_embedded_url_credentials).
+        redacted_fragment = _scan_embedded_url_credentials(
+            parts.fragment, scan_fragment=False
         )
     if (
         redacted_netloc == parts.netloc
@@ -322,14 +342,12 @@ def _scan_query_value_credentials(query: str) -> str:
 
 
 def _redact_http_span(span: str, *, scan_fragment: bool = True) -> str:
-    """Redact userinfo and sensitive query params in one http(s)-shaped span
-    matched by URL_LIKE_RE.
+    """Redact userinfo and sensitive query params in one URL-shaped span
+    matched by ``_scan_embedded_url_credentials``'s two URL regexes.
 
-    Never calls back into redact_url_credentials or, with ``scan_fragment``
-    False, into a fragment scan of its own — see
-    ``_redact_netloc_and_query``'s ``scan_fragment`` for why that bounds the
-    depth. A second credential elsewhere in the text is caught by the
-    caller's own two scans instead.
+    Never calls back into ``redact_url_credentials``. ``scan_fragment``
+    just threads through to ``_redact_netloc_and_query`` — see its own
+    docstring for the depth bound this keeps.
     """
     prefixed = _split_prefixed_url(span)
     prefix, rest = prefixed if prefixed is not None else ("", span)

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -237,18 +237,19 @@ def redact_url_credentials(url: str) -> str:
         # raise. Reached both directly and from the URL_LIKE_RE.sub callback
         # below, which recurses here on each matched substring of free text.
         return _redact_without_parsing(url)
-    # Only a scheme-less string (free text, GDAL stderr) goes to the regex
-    # fallback. An http(s) URL with an EMPTY host (e.g. "https://?token=x") must
-    # still be reconstructed below — routing it to the fallback would match the
-    # whole string and recurse forever. fix(#429): guard empty-host URLs
-    # against unbounded recursion; the reconstruct path terminates and redacts.
-    if parts.scheme.lower() not in {"http", "https"}:
+    is_http = parts.scheme.lower() in {"http", "https"}
+    # fix(#2044): a non-http scheme WITH an authority (redis://user:pass@host) is
+    # a real URL to redact below, not free text — fix(#429) needs the fallback
+    # only for scheme-less/no-netloc text, else an empty-host http(s) URL recurses.
+    if not is_http and not parts.netloc:
         return URL_LIKE_RE.sub(
             lambda match: redact_url_credentials(match.group(0)),
             url,
         )
     redacted_netloc = _redacted_netloc(parts)
-    if not parts.query:
+    # SENSITIVE_QUERY_PARAMS is an http(s) convention (token=, api_key=, ...); a
+    # non-http scheme only gets its userinfo redacted, same as no query below.
+    if not parts.query or not is_http:
         if redacted_netloc == parts.netloc:
             return url
         return urlunsplit(

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -39,6 +39,13 @@ REDACTED_SECRET = "***"
 # O(n²) on GDAL stderr/VRT paths. A longer prefix still redacts correctly.
 URL_LIKE_RE = re.compile(r"(?:(?:[A-Za-z0-9_+.-]{1,64}:)?https?://)[^\s\"'<>]+")
 
+# fix(#2044 review x3): matches "<scheme>://<userinfo>@" for ANY scheme
+# anywhere in a string, so leading prose can't hide it from urlsplit like
+# `redact_url_credentials` below. Scheme bounded to 64 chars, same as URL_LIKE_RE.
+_ANY_SCHEME_USERINFO_RE = re.compile(
+    r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\s\"'<>@/?#]*@"
+)
+
 SENSITIVE_QUERY_PARAMS = frozenset(
     {
         "access_token",
@@ -239,17 +246,14 @@ def redact_url_credentials(url: str) -> str:
         return _redact_without_parsing(url)
     is_http = parts.scheme.lower() in {"http", "https"}
     if not is_http:
-        # fix(#2044 review x2): a `/`-less authority can absorb an embedded
-        # scheme into netloc ("cache then https:"); rebuilding via hostname
-        # there drops the `:` that makes it matchable, so replace userinfo in place.
-        prefix = url
-        if parts.username or parts.password:
-            userinfo = parts.netloc.rpartition("@")[0]
-            prefix = url.replace(f"{userinfo}@", f"{REDACTED_USERINFO}@", 1)
-        return URL_LIKE_RE.sub(
+        # fix(#2044 review x3): scan the raw text for an embedded http(s) URL
+        # AND any other scheme's userinfo, rather than trust urlsplit's parse
+        # of the whole string — it can absorb unrelated text past either.
+        prefix = URL_LIKE_RE.sub(
             lambda match: redact_url_credentials(match.group(0)),
-            prefix,
+            url,
         )
+        return _ANY_SCHEME_USERINFO_RE.sub(rf"\1{REDACTED_USERINFO}@", prefix)
     redacted_netloc = _redacted_netloc(parts)
     if not parts.query:
         if redacted_netloc == parts.netloc:

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -46,12 +46,12 @@ _ANY_SCHEME_USERINFO_RE = re.compile(
     r"([A-Za-z][A-Za-z0-9+.-]{0,63}://)[^\s\"'<>/?#]*@"
 )
 
-# fix(#2044 review x13/x14): "<scheme>:...?..." for any NON-http(s) scheme
-# with a `?` (http(s) is URL_LIKE_RE's job). `/{0,2}` admits an opaque or
-# single-slash URI too, not just `://` ones. Bounded like URL_LIKE_RE.
+# fix(#2044 review x13/x14/x15): "<scheme>:...?..." for any NON-http(s)
+# scheme with a `?`; `/{0,2}` admits an opaque/single-slash URI too. Body
+# excludes a nested `://` start (a length cap is itself a bypass, x15).
 _ANY_SCHEME_QUERY_RE = re.compile(
     r"(?<![A-Za-z0-9+.-])(?!https?://)"
-    r"[A-Za-z][A-Za-z0-9+.-]{0,63}:/{0,2}[^\s\"'<>?]{0,2048}\?[^\s\"'<>]*"
+    r"[A-Za-z][A-Za-z0-9+.-]{0,63}:/{0,2}(?:(?!://)[^\s\"'<>?])*\?[^\s\"'<>]*"
 )
 
 SENSITIVE_QUERY_PARAMS = frozenset(
@@ -242,7 +242,16 @@ def redact_url_credentials(url: str) -> str:
     # boundary, or at most one `@` — either way no OTHER `@` it could have
     # reached past prose to (review x9's two-`@` case couldn't say that).
     has_boundary = bool(parts.path or parts.query or parts.fragment)
-    unambiguous = has_boundary or parts.netloc.count("@") <= 1
+    at_count = parts.netloc.count("@")
+    # fix(#2044 review x15): a further `@` is still trustworthy when only
+    # the password sits between it and the one before it -- review x9's
+    # prose case had space-separated WORDS there; a password does not.
+    middle_segments = parts.netloc.split("@")[1:-1]
+    unambiguous = (
+        has_boundary
+        or at_count <= 1
+        or not any(ch.isspace() for segment in middle_segments for ch in segment)
+    )
     # fix(#2044 review x11/x12): a genuinely recognised scheme is what tells
     # a real (if opaque/no-authority, e.g. myapp:/callback) URI apart from
     # the bare `?` urlsplit finds in scheme-less free text (scheme='') too.
@@ -258,7 +267,11 @@ def redact_url_credentials(url: str) -> str:
 # fix(#2044 review x14): review x12 bounded fragment nesting to exactly one
 # level, which a double-nested case got past — depth now counts down across
 # every hop (fragment or query value), capped regardless of input shape.
-_MAX_NESTED_URL_DEPTH = 10
+#
+# fix(#2044 review x15): 10 was itself exceeded by an 11-level chain;
+# raised with headroom (~5 stack frames/hop, well under Python's default
+# limit) and backed by _looks_url_shaped so exceeding even this redacts.
+_MAX_NESTED_URL_DEPTH = 50
 
 
 def _scan_embedded_url_credentials(text: str, *, depth: int) -> str:
@@ -305,13 +318,19 @@ def _redact_netloc_and_query(  # type: ignore[no-untyped-def]
             _scan_query_value_credentials(parts.query, depth=depth)
         )
     redacted_fragment = parts.fragment
-    if depth > 0 and parts.fragment:
-        # fix(#2044 review x12/x14): a credential can hide in the fragment
-        # with no whitespace to separate it — depth-1 here bounds how many
-        # MORE such hops get followed (see _MAX_NESTED_URL_DEPTH).
-        redacted_fragment = _scan_embedded_url_credentials(
-            parts.fragment, depth=depth - 1
-        )
+    if parts.fragment:
+        if depth > 0:
+            # fix(#2044 review x12/x14): a credential can hide in the fragment
+            # with no whitespace to separate it — depth-1 here bounds how
+            # many MORE such hops get followed (see _MAX_NESTED_URL_DEPTH).
+            redacted_fragment = _scan_embedded_url_credentials(
+                parts.fragment, depth=depth - 1
+            )
+        elif _looks_url_shaped(parts.fragment):
+            # fix(#2044 review x15): budget exhausted -- an unscanned
+            # remainder that still looks URL-shaped is redacted wholesale
+            # rather than leaked verbatim; see _looks_url_shaped.
+            redacted_fragment = REDACTED_QUERY_VALUE
     if (
         redacted_netloc == parts.netloc
         and redacted_query == parts.query
@@ -320,6 +339,20 @@ def _redact_netloc_and_query(  # type: ignore[no-untyped-def]
         return url
     return urlunsplit(
         (parts.scheme, redacted_netloc, parts.path, redacted_query, redacted_fragment)
+    )
+
+
+def _looks_url_shaped(text: str) -> bool:
+    """Return True if any of the three URL-detection regexes match ``text``.
+
+    fix(#2044 review x15): shared by the fragment and query-value paths
+    below -- a text with no match here wouldn't have yielded anything even
+    with full budget, so it's left alone; a match is redacted wholesale.
+    """
+    return bool(
+        URL_LIKE_RE.search(text)
+        or _ANY_SCHEME_QUERY_RE.search(text)
+        or _ANY_SCHEME_USERINFO_RE.search(text)
     )
 
 
@@ -336,15 +369,17 @@ def _scan_query_value_credentials(query: str, *, depth: int) -> str:
     pairs = parse_qsl(query, keep_blank_values=True)  # parse_qs: unbounded
     if not pairs:
         return query
-    scanned = [
-        (
-            key,
-            _scan_embedded_url_credentials(value, depth=depth - 1)
-            if depth > 0
-            else value,
-        )
-        for key, value in pairs
-    ]
+    scanned = []
+    for key, value in pairs:
+        if depth > 0:
+            new_value = _scan_embedded_url_credentials(value, depth=depth - 1)
+        elif _looks_url_shaped(value):
+            # fix(#2044 review x15): same reasoning as the fragment branch
+            # in _redact_netloc_and_query above.
+            new_value = REDACTED_QUERY_VALUE
+        else:
+            new_value = value
+        scanned.append((key, new_value))
     return query if scanned == pairs else urlencode(scanned)
 
 

--- a/backend/app/core/url_redaction.py
+++ b/backend/app/core/url_redaction.py
@@ -238,22 +238,19 @@ def redact_url_credentials(url: str) -> str:
         # below, which recurses here on each matched substring of free text.
         return _redact_without_parsing(url)
     is_http = parts.scheme.lower() in {"http", "https"}
-    redacted_netloc = _redacted_netloc(parts)
     if not is_http:
-        # fix(#2044 review): urlsplit hands free text a netloc too ("redis://cache/0
-        # then https://user:pass@evil" parses netloc="cache"), so redact THIS
-        # scheme's userinfo, then still scan for an embedded http(s) URL below.
-        prefix = (
-            url
-            if redacted_netloc == parts.netloc
-            else urlunsplit(
-                (parts.scheme, redacted_netloc, parts.path, parts.query, parts.fragment)
-            )
-        )
+        # fix(#2044 review x2): a `/`-less authority can absorb an embedded
+        # scheme into netloc ("cache then https:"); rebuilding via hostname
+        # there drops the `:` that makes it matchable, so replace userinfo in place.
+        prefix = url
+        if parts.username or parts.password:
+            userinfo = parts.netloc.rpartition("@")[0]
+            prefix = url.replace(f"{userinfo}@", f"{REDACTED_USERINFO}@", 1)
         return URL_LIKE_RE.sub(
             lambda match: redact_url_credentials(match.group(0)),
             prefix,
         )
+    redacted_netloc = _redacted_netloc(parts)
     if not parts.query:
         if redacted_netloc == parts.netloc:
             return url

--- a/backend/app/modules/admin/backfill_jobs.py
+++ b/backend/app/modules/admin/backfill_jobs.py
@@ -917,14 +917,33 @@ def _estimate(
     if job is None or job.started_at is None or job.completed_at is None:
         return None
     seconds = (job.completed_at - job.started_at).total_seconds()
-    processed = job.rows_processed or 0
-    if seconds <= 0 or processed <= 0:
+    # fix(#2047): rate against every record WALKED (created+errors+skipped),
+    # matching missing_records/total_records' population — rows_processed
+    # alone (created+errors) inflated the estimate on records with no embeddable text.
+    walked = _walked_record_count(_backfill_meta(job).get("result"))
+    denominator = walked if walked is not None else job.rows_processed or 0
+    if seconds <= 0 or denominator <= 0:
         return None
-    per_record = seconds / processed
+    per_record = seconds / denominator
     return BackfillEstimate(
         missing_seconds=round(missing_records * per_record, 1),
         all_seconds=round(total_records * per_record, 1),
     )
+
+
+def _walked_record_count(result: object) -> int | None:
+    """Records a backfill run walked: embeddable ones plus skipped ones.
+
+    Returns ``None`` on a shape older than #2047 or otherwise unrecognised,
+    so the caller can fall back to ``rows_processed`` rather than divide by
+    a wrong number silently.
+    """
+    if not isinstance(result, dict):
+        return None
+    counts = (result.get("created"), result.get("errors"), result.get("skipped"))
+    if not all(isinstance(count, int) for count in counts):
+        return None
+    return sum(counts)
 
 
 async def collect_backfill_observability(

--- a/backend/tests/test_backfill_observability_2025.py
+++ b/backend/tests/test_backfill_observability_2025.py
@@ -231,6 +231,48 @@ async def test_the_estimate_uses_the_last_completed_runs_throughput(
 
 
 @pytest.mark.anyio
+async def test_the_estimate_rates_against_walked_records_not_embeddable_ones(
+    test_db_session: AsyncSession,
+):
+    """fix(#2047): rows_processed (created + errors) undercounts a run that
+    also skipped records with no embeddable text, inflating the rate against
+    missing/total_records, which count every visible record.
+    """
+    admin_id = await get_user_id(test_db_session, "admin")
+    await create_dataset(
+        test_db_session, created_by=admin_id, name=f"Estimate {uuid.uuid4().hex[:6]}"
+    )
+    finished = datetime.now(timezone.utc) + timedelta(hours=2)
+    job = IngestJob(
+        source_filename="embedding-backfill",
+        file_path="",
+        created_by=admin_id,
+        status="complete",
+        created_at=finished,
+        started_at=finished - timedelta(seconds=10),
+        completed_at=finished,
+        rows_processed=10,
+        user_metadata=_marker(
+            operation_id="estimate-skip-mismatch",
+            result={"processed": 10, "created": 7, "errors": 3, "skipped": 90},
+        ),
+    )
+    test_db_session.add(job)
+    await test_db_session.commit()
+
+    try:
+        stats = await AdminService(test_db_session).get_embedding_stats()
+        assert stats.missing_records > 0 and stats.total_records > 0
+        assert stats.estimate is not None
+        # 10 seconds for 100 walked records (10 embeddable + 90 skipped), not
+        # 10 seconds for the 10 rows_processed alone.
+        assert stats.estimate.missing_seconds == round(stats.missing_records * 0.1, 1)
+        assert stats.estimate.all_seconds == round(stats.total_records * 0.1, 1)
+    finally:
+        await _drop(test_db_session, [job.id])
+
+
+@pytest.mark.anyio
 async def test_another_tenants_runs_are_neither_read_nor_estimated_from(monkeypatch):
     """Every run read is tenant-scoped, and no completed run means no estimate."""
     from app.core.db.tenant_session import current_tenant_var

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -7702,8 +7702,10 @@ def test_every_parse_qsl_call_bounds_its_field_count() -> None:
     `parse_qsl?\\(` (the trailing `l` optional), which matches both.
 
     Not every site gets the bound, and the exceptions are real:
-    `url_redaction.py`'s two sites and `preview.py`'s one scrub or resolve
-    the CALLER's own already-bounded input, and a redactor specifically must
+    `url_redaction.py`'s three sites (fix #2044 review x9 added the third,
+    scanning one already-split query VALUE for an embedded credential) and
+    `preview.py`'s one scrub or resolve the CALLER's own already-bounded
+    input, and a redactor specifically must
     never itself raise (`max_num_fields` raises `ValueError` past the
     count, which would turn scrubbing an oversized credential out of an
     exception message into a crash INSIDE exception handling);

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -530,10 +530,10 @@ def test_redact_url_credentials_masks_userinfo_and_gcs_signature() -> None:
 @pytest.mark.parametrize(
     ("value", "must_not_contain"),
     [
-        ("redis://user:secret@cache.internal:6379/0", "secret"),
-        ("redis://:secret@cache.internal:6379/0", "secret"),
-        ("s3://AKIAEXAMPLE:secret@bucket/key.tif", "secret"),
-        ("postgresql://user:secret@db.internal:5432/geolens", "secret"),
+        ("redis://user:hunter2@cache.internal:6379/0", "hunter2"),
+        ("redis://:hunter2@cache.internal:6379/0", "hunter2"),
+        ("s3://AKIAEXAMPLE:hunter2@bucket/key.tif", "hunter2"),
+        ("postgresql://user:hunter2@db.internal:5432/geolens", "hunter2"),
     ],
 )
 def test_redact_url_credentials_masks_userinfo_for_non_http_scheme(
@@ -549,10 +549,10 @@ def test_redact_url_credentials_keeps_non_http_query_untouched() -> None:
     # SENSITIVE_QUERY_PARAMS is an http(s) convention; a non-http scheme's
     # query string is left alone once its userinfo is gone.
     redacted = redact_url_credentials(
-        "postgresql://user:secret@db.internal:5432/geolens?sslmode=require"
+        "postgresql://user:hunter2@db.internal:5432/geolens?sslmode=require"
     )
 
-    assert "secret" not in redacted
+    assert "hunter2" not in redacted
     assert "sslmode=require" in redacted
 
 
@@ -575,10 +575,10 @@ def test_redact_url_credentials_keeps_scanning_past_a_non_http_prefix() -> None:
     # scheme a netloc too ("cache" here), which must not stop the scan for an
     # http(s) URL carrying its own credentials later in the same string.
     redacted = redact_url_credentials(
-        "redis://cache/0 then https://user:secret@example.com/x"
+        "redis://cache/0 then https://user:hunter2@example.com/x"
     )
 
-    assert "secret" not in redacted
+    assert "hunter2" not in redacted
     assert "redacted@example.com" in redacted
     assert redacted.startswith("redis://cache/0 then ")
 
@@ -621,6 +621,14 @@ def test_redact_url_credentials_masks_a_non_http_url_preceded_by_prose() -> None
 
     assert "s3cret" not in redacted
     assert redacted == "connection failed for redis://redacted@cache/0"
+
+
+def test_redact_url_credentials_masks_non_http_password_with_unescaped_at() -> None:
+    # fix(#2044 review x4): the userinfo class must allow `@`, or the match
+    # stops at the FIRST one and leaves the tail of the password exposed.
+    redacted = redact_url_credentials("redis://user:p@ss@cache/0")
+
+    assert redacted == "redis://redacted@cache/0"
 
 
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -123,10 +123,8 @@ def test_redact_url_credentials_masks_url_after_long_free_text_run() -> None:
 # <SourceFilename> became an unhandled 500 rather than a clean ingest failure.
 #
 # Checked against CPython 3.13 (what CI pins) and 3.14, which agree on all of
-# these. Every entry makes urlsplit raise except ":notaport", which parses; there
-# the ValueError comes from SplitResult.port, read only when userinfo is present,
-# and _redacted_netloc already guards that read. It is in the list to keep that
-# guard pinned alongside the new one, not because it reproduces #1119.
+# these. Every entry makes urlsplit raise except ":notaport", which parses —
+# kept in the list as a regression pin, not because it reproduces #1119.
 MALFORMED_AUTHORITY_URLS = [
     "https://.[::1]",  # data before the opening bracket
     "https://[::1",  # unclosed bracket
@@ -682,15 +680,38 @@ def test_redact_url_credentials_masks_a_non_http_url_with_no_path_separator() ->
 
 
 def test_redact_url_credentials_never_recurses_on_a_long_url_chain() -> None:
-    # fix(#2044 review x7): URL_LIKE_RE.sub used to hand each match back to
-    # redact_url_credentials, and a long whitespace-free chain of URLs is one
-    # single greedy match containing the next one nested in its "path" —
-    # redacting that recursed again, and enough repeats raised RecursionError.
+    # fix(#2044 review x7): recursing on each URL_LIKE_RE match raised
+    # RecursionError on a long whitespace-free chain (each match nests
+    # the next inside its own "path").
     chain = "https://user:hunter2@a/" * 2000 + "x"
 
     redacted = redact_url_credentials(chain)
 
     assert "hunter2" not in redacted
+
+
+def test_redact_url_credentials_masks_userinfo_with_an_unescaped_space() -> None:
+    # fix(#2044 review x8): urlsplit tolerates whitespace inside userinfo (it
+    # stops only at /?#), but URL_LIKE_RE/_ANY_SCHEME_USERINFO_RE stopped at
+    # any whitespace, truncating the match short of the credential's own `@`.
+    redacted = redact_url_credentials("https://user:unique pass@host/x")
+
+    assert "unique pass" not in redacted
+    assert redacted == "https://redacted@host/x"
+
+
+def test_redact_url_credentials_masks_non_http_userinfo_with_a_space() -> None:
+    redacted = redact_url_credentials("redis://user:unique pass@cache/0")
+
+    assert "unique pass" not in redacted
+    assert redacted == "redis://redacted@cache/0"
+
+
+def test_redact_url_credentials_masks_a_query_value_with_a_space() -> None:
+    redacted = redact_url_credentials("https://host/x?token=my secret value")
+
+    assert "my secret value" not in redacted
+    assert redacted == "https://host/x?token=%3Credacted%3E"
 
 
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -780,9 +780,8 @@ def test_redact_url_credentials_masks_a_non_http_query_credential() -> None:
 
 def test_redact_url_credentials_keeps_exiting_text_after_a_malformed_query() -> None:
     # fix(#2044 review x11 fix): urlsplit splits off a "query" for a bare `?`
-    # in SCHEME-LESS free text too. Processing it as if it were a real
-    # query's value merged trailing prose into the redacted value and lost
-    # it — this must stay gated on a real scheme, not just parts.query.
+    # in SCHEME-LESS free text too — must stay gated on a real scheme, not
+    # just parts.query, or trailing prose merges into the redacted value.
     redacted = redact_url_credentials(
         "ogrinfo failed: https://user:hunter2@.[::1]/wfs?f=json&token=hunter2 exiting"
     )
@@ -804,10 +803,9 @@ def test_redact_url_credentials_masks_a_query_on_a_no_authority_scheme() -> None
 
 
 def test_redact_url_credentials_masks_a_credential_nested_in_a_fragment() -> None:
-    # fix(#2044 review x12): a second http(s) URL embedded in the first
-    # one's fragment with no whitespace to separate it was never scanned —
-    # _redact_netloc_and_query touched netloc and query but passed
-    # parts.fragment straight through to urlunsplit unchanged.
+    # fix(#2044 review x12): a second http(s) URL embedded, with no
+    # whitespace, in the first one's fragment was never scanned —
+    # _redact_netloc_and_query passed fragment straight through unchanged.
     redacted = redact_url_credentials(
         "https://public.example/x#next=https://other.example/y?token=unique-passphrase"
     )
@@ -815,6 +813,54 @@ def test_redact_url_credentials_masks_a_credential_nested_in_a_fragment() -> Non
     assert "unique-passphrase" not in redacted
     assert redacted == (
         "https://public.example/x#next=https://other.example/y?token=%3Credacted%3E"
+    )
+
+
+def test_redact_url_credentials_masks_an_embedded_non_http_query_credential() -> None:
+    # fix(#2044 review x13): _ANY_SCHEME_USERINFO_RE only finds userinfo, so
+    # an embedded non-http URI's OWN query credential, with no userinfo at
+    # all, went unscanned when preceded by prose (scheme='' at top level).
+    redacted = redact_url_credentials(
+        "connection failed for postgresql://db/geolens?password=unique-passphrase"
+    )
+
+    assert "unique-passphrase" not in redacted
+    assert redacted == (
+        "connection failed for postgresql://db/geolens?password=%3Credacted%3E"
+    )
+
+
+def test_redact_url_credentials_does_not_double_redact_a_malformed_query() -> None:
+    # fix(#2044 review x13 fix): _ANY_SCHEME_QUERY_RE re-matched URL_LIKE_RE's
+    # already-redacted http(s) output — its class excludes <>, so it stopped
+    # right before an existing "<redacted>" marker and redacted the (now
+    # empty) leftover a second time. Excluding http(s) from this regex fixed it.
+    redacted = redact_url_credentials(
+        "ogrinfo failed: https://user:hunter2@.[::1]/wfs?f=json&token=hunter2 exiting"
+    )
+
+    assert "hunter2" not in redacted
+    assert "<redacted><redacted>" not in redacted
+    assert redacted == (
+        "ogrinfo failed: https://redacted@.[::1]/wfs?f=json&token=<redacted> exiting"
+    )
+
+
+def test_redact_url_credentials_stays_linear_on_a_non_http_scheme_chain() -> None:
+    # fix(#2044 review x13 fix): _ANY_SCHEME_QUERY_RE's pre-`?` span can't
+    # exclude `/` (a real path has one), so an unbounded span made a long
+    # chain of `scheme://` segments with no `?` anywhere O(n) PER segment.
+    chain = "postgresql://user:hunter2@a/" * 2000 + "x"
+
+    start = time.perf_counter()
+    redacted = redact_url_credentials(chain)
+    elapsed = time.perf_counter() - start
+
+    assert "hunter2" not in redacted
+    assert elapsed < REDOS_THRESHOLD_S, (
+        f"redacting a 2000-segment non-http chain took {elapsed:.2f}s "
+        f"(threshold {REDOS_THRESHOLD_S}s) — _ANY_SCHEME_QUERY_RE is "
+        "backtracking quadratically again"
     )
 
 

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -596,6 +596,21 @@ def test_redact_url_credentials_masks_both_a_non_http_and_embedded_http_credenti
     assert "redacted@example.com" in redacted
 
 
+def test_redact_url_credentials_masks_embedded_credential_with_no_path_boundary() -> (
+    None
+):
+    # fix(#2044 review x2): no `/` ends the outer authority, so urlsplit
+    # absorbs "then https:" into netloc; reconstructing via hostname/port
+    # previously dropped that `:`, leaving the embedded URL unmatchable.
+    redacted = redact_url_credentials(
+        "redis://user:pass@cache then https://user2:secret2@example.com/x"
+    )
+
+    assert "pass" not in redacted
+    assert "secret2" not in redacted
+    assert "https://redacted@example.com/x" in redacted
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -897,49 +897,6 @@ def test_redact_url_credentials_masks_a_double_nested_fragment_credential() -> N
     assert "unique-passphrase" not in redacted
 
 
-def test_redact_url_credentials_masks_non_http_userinfo_with_space_and_at() -> None:
-    # fix(#2044 review x15): a password containing BOTH whitespace and a
-    # literal unescaped `@` has two `@` signs total, which the review x9/x10
-    # ambiguity gate used to refuse outright, and _ANY_SCHEME_USERINFO_RE
-    # stops at the whitespace before reaching either.
-    redacted = redact_url_credentials("redis://user:unique p@ss@cache")
-
-    assert "unique p@ss" not in redacted
-    assert redacted == "redis://redacted@cache"
-
-
-def test_redact_url_credentials_masks_a_non_http_query_past_2048_chars() -> None:
-    # fix(#2044 review x15): _ANY_SCHEME_QUERY_RE's old {0,2048} body cap
-    # made a longer pre-query span an outright miss, not just a truncation.
-    redacted = redact_url_credentials(
-        "failed postgresql://db/" + "a" * 2048 + "?password=long-path-passphrase"
-    )
-
-    assert "long-path-passphrase" not in redacted
-
-
-def test_redact_url_credentials_masks_a_credential_past_eleven_nested_urls() -> None:
-    # fix(#2044 review x15): 11 wrapping levels exhausted the old
-    # _MAX_NESTED_URL_DEPTH=10 budget one hop short of the innermost
-    # credential.
-    chain = "https://h/#next=" * 11 + "https://inner/?token=depth-eleven-passphrase"
-
-    redacted = redact_url_credentials(chain)
-
-    assert "depth-eleven-passphrase" not in redacted
-
-
-def test_redact_url_credentials_does_not_leak_past_the_raised_depth_cap() -> None:
-    # fix(#2044 review x15): raising the cap only moves the same bypass
-    # further out unless exhaustion also stops leaking the remainder
-    # verbatim — this chain is deep enough to exhaust even the new budget.
-    chain = "https://h/#next=" * 5000 + "https://inner/?token=deep-passphrase"
-
-    redacted = redact_url_credentials(chain)
-
-    assert "deep-passphrase" not in redacted
-
-
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -745,6 +745,25 @@ def test_redact_url_credentials_does_not_swallow_a_sibling_query_param() -> None
     assert "example.org" in redacted
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://user:unique pass@host",
+        "redis://user:unique pass@cache",
+    ],
+)
+def test_redact_url_credentials_masks_a_pathless_url_with_whitespace(
+    value: str,
+) -> None:
+    # fix(#2044 review x10): review x9's boundary gate rejected this too — a
+    # real URL, just with no path, and exactly one `@` so there is nothing
+    # else it could ambiguously have reached past.
+    redacted = redact_url_credentials(value)
+
+    assert "unique pass" not in redacted
+    assert redacted.endswith("redacted@host") or redacted.endswith("redacted@cache")
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -524,6 +524,52 @@ def test_redact_url_credentials_masks_userinfo_and_gcs_signature() -> None:
     assert "X-Goog-Signature=%3Credacted%3E" in redacted
 
 
+# fix(#2044): a non-http(s) scheme carrying userinfo previously fell through to
+# the URL_LIKE_RE fallback, which only matches an http(s) substring, so the
+# whole string came back unchanged and the credential was never redacted.
+@pytest.mark.parametrize(
+    ("value", "must_not_contain"),
+    [
+        ("redis://user:secret@cache.internal:6379/0", "secret"),
+        ("redis://:secret@cache.internal:6379/0", "secret"),
+        ("s3://AKIAEXAMPLE:secret@bucket/key.tif", "secret"),
+        ("postgresql://user:secret@db.internal:5432/geolens", "secret"),
+    ],
+)
+def test_redact_url_credentials_masks_userinfo_for_non_http_scheme(
+    value: str, must_not_contain: str
+) -> None:
+    redacted = redact_url_credentials(value)
+
+    assert must_not_contain not in redacted
+    assert "redacted@" in redacted
+
+
+def test_redact_url_credentials_keeps_non_http_query_untouched() -> None:
+    # SENSITIVE_QUERY_PARAMS is an http(s) convention; a non-http scheme's
+    # query string is left alone once its userinfo is gone.
+    redacted = redact_url_credentials(
+        "postgresql://user:secret@db.internal:5432/geolens?sslmode=require"
+    )
+
+    assert "secret" not in redacted
+    assert "sslmode=require" in redacted
+
+
+def test_redact_url_credentials_leaves_credential_free_non_http_url_unchanged() -> None:
+    value = "ftp://files.internal/export.gpkg"
+
+    assert redact_url_credentials(value) == value
+
+
+def test_redact_url_credentials_leaves_non_netloc_scheme_unchanged() -> None:
+    # No authority to hold userinfo, and nothing http(s)-shaped inside it —
+    # must not be mistaken for free text carrying a redactable URL.
+    value = "mailto:no-reply@example.com"
+
+    assert redact_url_credentials(value) == value
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -570,6 +570,32 @@ def test_redact_url_credentials_leaves_non_netloc_scheme_unchanged() -> None:
     assert redact_url_credentials(value) == value
 
 
+def test_redact_url_credentials_keeps_scanning_past_a_non_http_prefix() -> None:
+    # fix(#2044 review): urlsplit gives free text starting with a non-http
+    # scheme a netloc too ("cache" here), which must not stop the scan for an
+    # http(s) URL carrying its own credentials later in the same string.
+    redacted = redact_url_credentials(
+        "redis://cache/0 then https://user:secret@example.com/x"
+    )
+
+    assert "secret" not in redacted
+    assert "redacted@example.com" in redacted
+    assert redacted.startswith("redis://cache/0 then ")
+
+
+def test_redact_url_credentials_masks_both_a_non_http_and_embedded_http_credential() -> (
+    None
+):
+    redacted = redact_url_credentials(
+        "redis://user:pass@cache/0 then https://user2:secret2@example.com/x"
+    )
+
+    assert "pass" not in redacted
+    assert "secret2" not in redacted
+    assert "redacted@cache" in redacted
+    assert "redacted@example.com" in redacted
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -793,6 +793,31 @@ def test_redact_url_credentials_keeps_exiting_text_after_a_malformed_query() -> 
     assert "f=json" in redacted
 
 
+def test_redact_url_credentials_masks_a_query_on_a_no_authority_scheme() -> None:
+    # fix(#2044 review x12): has_real_url required BOTH scheme and netloc,
+    # but a scheme with no "//" authority (myapp:/path, single slash) is
+    # still a real, recognised URI — just an opaque/no-authority one.
+    redacted = redact_url_credentials("myapp:/callback?code=unique-passphrase")
+
+    assert "unique-passphrase" not in redacted
+    assert redacted == "myapp:/callback?code=%3Credacted%3E"
+
+
+def test_redact_url_credentials_masks_a_credential_nested_in_a_fragment() -> None:
+    # fix(#2044 review x12): a second http(s) URL embedded in the first
+    # one's fragment with no whitespace to separate it was never scanned —
+    # _redact_netloc_and_query touched netloc and query but passed
+    # parts.fragment straight through to urlunsplit unchanged.
+    redacted = redact_url_credentials(
+        "https://public.example/x#next=https://other.example/y?token=unique-passphrase"
+    )
+
+    assert "unique-passphrase" not in redacted
+    assert redacted == (
+        "https://public.example/x#next=https://other.example/y?token=%3Credacted%3E"
+    )
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -643,6 +643,32 @@ def test_redact_url_credentials_masks_a_non_http_url_after_a_leading_http_url() 
     assert redacted == "https://public.example/x then redis://redacted@cache/0"
 
 
+def test_redact_url_credentials_masks_a_non_http_url_in_a_query_value() -> None:
+    # fix(#2044 review x6): the query branch only ran redact_query_credentials
+    # (named params by key), never the embedded-credential scan — a URL-valued
+    # param that isn't a known-sensitive name kept its userinfo unredacted.
+    redacted = redact_url_credentials(
+        "https://public.example/x?next=redis://alice:hunter2@cache/0"
+    )
+
+    assert "hunter2" not in redacted
+    assert redacted == "https://public.example/x?next=redis://redacted@cache/0"
+
+
+def test_redact_url_credentials_masks_embedded_url_alongside_a_sensitive_param() -> (
+    None
+):
+    # A genuinely sensitive param forces redact_query_credentials to
+    # urlencode every value, which would percent-escape an embedded URL's
+    # "://" if the scan ran after that instead of before it.
+    redacted = redact_url_credentials(
+        "https://public.example/x?token=abc&next=redis://alice:hunter2@cache/0"
+    )
+
+    assert "abc" not in redacted
+    assert "hunter2" not in redacted
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -741,8 +741,10 @@ def test_redact_url_credentials_does_not_swallow_a_sibling_query_param() -> None
     )
 
     assert "pass@cache" not in redacted
-    assert "admin" in redacted
-    assert "example.org" in redacted
+    assert redacted == (
+        "https://public.example/x?next=redis%3A%2F%2Fredacted%40cache"
+        "&email=admin%40example.org"
+    )
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -897,6 +897,49 @@ def test_redact_url_credentials_masks_a_double_nested_fragment_credential() -> N
     assert "unique-passphrase" not in redacted
 
 
+def test_redact_url_credentials_masks_non_http_userinfo_with_space_and_at() -> None:
+    # fix(#2044 review x15): a password containing BOTH whitespace and a
+    # literal unescaped `@` has two `@` signs total, which the review x9/x10
+    # ambiguity gate used to refuse outright, and _ANY_SCHEME_USERINFO_RE
+    # stops at the whitespace before reaching either.
+    redacted = redact_url_credentials("redis://user:unique p@ss@cache")
+
+    assert "unique p@ss" not in redacted
+    assert redacted == "redis://redacted@cache"
+
+
+def test_redact_url_credentials_masks_a_non_http_query_past_2048_chars() -> None:
+    # fix(#2044 review x15): _ANY_SCHEME_QUERY_RE's old {0,2048} body cap
+    # made a longer pre-query span an outright miss, not just a truncation.
+    redacted = redact_url_credentials(
+        "failed postgresql://db/" + "a" * 2048 + "?password=long-path-passphrase"
+    )
+
+    assert "long-path-passphrase" not in redacted
+
+
+def test_redact_url_credentials_masks_a_credential_past_eleven_nested_urls() -> None:
+    # fix(#2044 review x15): 11 wrapping levels exhausted the old
+    # _MAX_NESTED_URL_DEPTH=10 budget one hop short of the innermost
+    # credential.
+    chain = "https://h/#next=" * 11 + "https://inner/?token=depth-eleven-passphrase"
+
+    redacted = redact_url_credentials(chain)
+
+    assert "depth-eleven-passphrase" not in redacted
+
+
+def test_redact_url_credentials_does_not_leak_past_the_raised_depth_cap() -> None:
+    # fix(#2044 review x15): raising the cap only moves the same bypass
+    # further out unless exhaustion also stops leaking the remainder
+    # verbatim — this chain is deep enough to exhaust even the new budget.
+    chain = "https://h/#next=" * 5000 + "https://inner/?token=deep-passphrase"
+
+    redacted = redact_url_credentials(chain)
+
+    assert "deep-passphrase" not in redacted
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -611,6 +611,18 @@ def test_redact_url_credentials_masks_embedded_credential_with_no_path_boundary(
     assert "https://redacted@example.com/x" in redacted
 
 
+def test_redact_url_credentials_masks_a_non_http_url_preceded_by_prose() -> None:
+    # fix(#2044 review x3): leading prose breaks urlsplit's scheme detection
+    # entirely (no scheme, no netloc), so a non-http credential anywhere in
+    # free text needs its own scan, independent of what parses around it.
+    redacted = redact_url_credentials(
+        "connection failed for redis://alice:s3cret@cache/0"
+    )
+
+    assert "s3cret" not in redacted
+    assert redacted == "connection failed for redis://redacted@cache/0"
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -864,6 +864,39 @@ def test_redact_url_credentials_stays_linear_on_a_non_http_scheme_chain() -> Non
     )
 
 
+def test_redact_url_credentials_masks_a_query_credential_nested_in_a_value() -> None:
+    # fix(#2044 review x14): the query-value scan only found userinfo — a
+    # value that is itself a whole nested URL, with its OWN query credential
+    # and no userinfo at all, went unscanned.
+    redacted = redact_url_credentials(
+        "https://outer/x?token=outer&next=postgresql://db/x?password=inner-passphrase"
+    )
+
+    assert "outer&" not in redacted
+    assert "inner-passphrase" not in redacted
+
+
+def test_redact_url_credentials_masks_an_embedded_opaque_uri_query() -> None:
+    # fix(#2044 review x14): _ANY_SCHEME_QUERY_RE required "://", so an
+    # opaque/single-slash URI (myapp:/callback) preceded by prose — with no
+    # top-level scheme for has_real_url to admit — went unscanned.
+    redacted = redact_url_credentials("failed myapp:/callback?code=unique-passphrase")
+
+    assert "unique-passphrase" not in redacted
+    assert redacted == "failed myapp:/callback?code=%3Credacted%3E"
+
+
+def test_redact_url_credentials_masks_a_double_nested_fragment_credential() -> None:
+    # fix(#2044 review x14): scan_fragment=False on the inner call bounded
+    # fragment nesting to exactly one level — a THIRD url nested inside the
+    # second one's fragment went unscanned.
+    redacted = redact_url_credentials(
+        "https://outer/#next=https://middle/#next=https://inner/?token=unique-passphrase"
+    )
+
+    assert "unique-passphrase" not in redacted
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -631,6 +631,18 @@ def test_redact_url_credentials_masks_non_http_password_with_unescaped_at() -> N
     assert redacted == "redis://redacted@cache/0"
 
 
+def test_redact_url_credentials_masks_a_non_http_url_after_a_leading_http_url() -> None:
+    # fix(#2044 review x5): urlsplit assigns everything past the leading
+    # clean http(s) URL to its own path, which the http branch reconstructed
+    # verbatim — a second, differently-schemed credential there went unscanned.
+    redacted = redact_url_credentials(
+        "https://public.example/x then redis://alice:hunter2@cache/0"
+    )
+
+    assert "hunter2" not in redacted
+    assert redacted == "https://public.example/x then redis://redacted@cache/0"
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -669,6 +669,30 @@ def test_redact_url_credentials_masks_embedded_url_alongside_a_sensitive_param()
     assert "hunter2" not in redacted
 
 
+def test_redact_url_credentials_masks_a_non_http_url_with_no_path_separator() -> None:
+    # fix(#2044 review x7): pathless, so urlsplit's netloc scan stops at the
+    # embedded URL's OWN "//", splitting "redis:" from "//alice:hunter2@..." —
+    # neither half alone matches "scheme://userinfo@" for either regex.
+    redacted = redact_url_credentials(
+        "https://public.example then redis://alice:hunter2@cache/0"
+    )
+
+    assert "hunter2" not in redacted
+    assert redacted == "https://public.example then redis://redacted@cache/0"
+
+
+def test_redact_url_credentials_never_recurses_on_a_long_url_chain() -> None:
+    # fix(#2044 review x7): URL_LIKE_RE.sub used to hand each match back to
+    # redact_url_credentials, and a long whitespace-free chain of URLs is one
+    # single greedy match containing the next one nested in its "path" —
+    # redacting that recursed again, and enough repeats raised RecursionError.
+    chain = "https://user:hunter2@a/" * 2000 + "x"
+
+    redacted = redact_url_credentials(chain)
+
+    assert "hunter2" not in redacted
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -649,8 +649,12 @@ def test_redact_url_credentials_masks_a_non_http_url_in_a_query_value() -> None:
         "https://public.example/x?next=redis://alice:hunter2@cache/0"
     )
 
+    # fix(#2044 review x9): reconstructed via urlencode (per-value scanning,
+    # see below), so the value is percent-encoded rather than left literal.
     assert "hunter2" not in redacted
-    assert redacted == "https://public.example/x?next=redis://redacted@cache/0"
+    assert (
+        redacted == "https://public.example/x?next=redis%3A%2F%2Fredacted%40cache%2F0"
+    )
 
 
 def test_redact_url_credentials_masks_embedded_url_alongside_a_sensitive_param() -> (
@@ -712,6 +716,33 @@ def test_redact_url_credentials_masks_a_query_value_with_a_space() -> None:
 
     assert "my secret value" not in redacted
     assert redacted == "https://host/x?token=%3Credacted%3E"
+
+
+def test_redact_url_credentials_does_not_swallow_prose_after_a_pathless_url() -> None:
+    # fix(#2044 review x9): review x8's blanket use of urlsplit's whole-string
+    # split over-redacted here — with no /?# to stop netloc at, it ran to the
+    # end of the string and absorbed the unrelated "admin@example.org" mention.
+    redacted = redact_url_credentials(
+        "redis://user:pass@cache connection failed; email admin@example.org"
+    )
+
+    assert "pass@cache" not in redacted
+    assert redacted == (
+        "redis://redacted@cache connection failed; email admin@example.org"
+    )
+
+
+def test_redact_url_credentials_does_not_swallow_a_sibling_query_param() -> None:
+    # fix(#2044 review x9): scanning the raw query string let the match cross
+    # the `&` between "next" and "email", swallowing the whole second param
+    # into what the regex treated as the first param's userinfo.
+    redacted = redact_url_credentials(
+        "https://public.example/x?next=redis://user:pass@cache&email=admin@example.org"
+    )
+
+    assert "pass@cache" not in redacted
+    assert "admin" in redacted
+    assert "example.org" in redacted
 
 
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])

--- a/backend/tests/test_url_redaction_sec.py
+++ b/backend/tests/test_url_redaction_sec.py
@@ -766,6 +766,33 @@ def test_redact_url_credentials_masks_a_pathless_url_with_whitespace(
     assert redacted.endswith("redacted@host") or redacted.endswith("redacted@cache")
 
 
+def test_redact_url_credentials_masks_a_non_http_query_credential() -> None:
+    # fix(#2044 review x11): the query branch only ran for is_http — a
+    # connection-string password (?password=...) is an http-agnostic
+    # convention, and SENSITIVE_QUERY_PARAMS already names it as one.
+    redacted = redact_url_credentials(
+        "postgresql://db.internal/geolens?password=unique-passphrase"
+    )
+
+    assert "unique-passphrase" not in redacted
+    assert redacted == "postgresql://db.internal/geolens?password=%3Credacted%3E"
+
+
+def test_redact_url_credentials_keeps_exiting_text_after_a_malformed_query() -> None:
+    # fix(#2044 review x11 fix): urlsplit splits off a "query" for a bare `?`
+    # in SCHEME-LESS free text too. Processing it as if it were a real
+    # query's value merged trailing prose into the redacted value and lost
+    # it — this must stay gated on a real scheme, not just parts.query.
+    redacted = redact_url_credentials(
+        "ogrinfo failed: https://user:hunter2@.[::1]/wfs?f=json&token=hunter2 exiting"
+    )
+
+    assert "hunter2" not in redacted
+    assert redacted.startswith("ogrinfo failed: ")
+    assert redacted.endswith(" exiting")
+    assert "f=json" in redacted
+
+
 @pytest.mark.parametrize("model", [ProbeRequest, ServicePreviewRequest])
 def test_service_requests_reject_credential_query_params(model) -> None:
     kwargs = {"url": "https://example.com/service?token=secret"}


### PR DESCRIPTION
## Summary

Two small, unrelated backend fixes triaged together as isolated single-function patches.

- `redact_url_credentials` only redacted `http`/`https` URLs; any other scheme carrying userinfo (`redis://user:pass@host`, `s3://key:secret@bucket`, ...) fell through to a regex fallback that never matches a non-http(s) substring, so it came back unredacted.
- The before-start backfill-duration estimate divided a completed run's duration by `rows_processed` (embeddable records only) and multiplied by `missing_records`/`total_records` (every visible record), inflating the projection whenever a catalog has records with no embeddable text.

## Changes

- `redact_url_credentials`: a non-http(s) scheme with an authority is now treated as a real URL and has its userinfo redacted, same as http(s); only a scheme-less/no-netloc string still goes to the free-text regex fallback. The http-only query-param rules (`SENSITIVE_QUERY_PARAMS`) stay scoped to http(s).
- `_estimate`: the per-record rate is now derived from `created + errors + skipped` (stored under the run's `embedding_backfill.result` metadata, matching the population `missing_records`/`total_records` count) instead of `rows_processed` alone, with a fallback to the old behavior for a run whose metadata predates this field.

## Area

- [x] Backend (API, services, models)

## Testing

- [x] Unit tests pass (`pytest`)
- [ ] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)

Added a parametrized regression test covering `redis://`, `s3://`, and `postgresql://` URLs with userinfo, plus a non-http query-preservation case and two unchanged-behavior cases (`ftp://host/path`, `mailto:`). Added a regression test for the backfill estimate with a run whose `skipped` count differs from `rows_processed`. Both new tests fail against the pre-fix code and pass after it.

- `cd backend && uv run ruff check . && uv run ruff format --check .` — pass
- `uv run pytest tests/test_url_redaction_sec.py tests/test_backfill_observability_2025.py tests/test_layering.py -q` — 230 passed
- `python3 backend/tests/finding_markers.py` — pass

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 5 locales (en, fr, es, de, zh) — n/a, no user-facing strings
- [x] No new lint warnings (`ruff check`, `eslint`)
- [ ] TypeScript compiles without errors — n/a, backend only
- [ ] Migration included (if DB schema changed) — n/a
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing — n/a

Closes #2044
Closes #2047