### PR TITLE
fix(import,admin,i18n): fan-out count, jobs-list refetch, internal_error parity

### DIFF
--- a/frontend/src/components/admin/JobList.tsx
+++ b/frontend/src/components/admin/JobList.tsx
@@ -440,7 +440,7 @@ export function JobList() {
                                   <pre className="whitespace-pre-wrap overflow-x-auto text-xs">
                                     {describeFailureReason(
                                       job.error_message,
-                                      t('common:errors.unexpected'),
+                                      t('common:errors.internalFailureReason'),
                                     )}
                                   </pre>
                                 </div>

--- a/frontend/src/components/admin/__tests__/JobList.internalErrorReason.test.tsx
+++ b/frontend/src/components/admin/__tests__/JobList.internalErrorReason.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { JobList } from '../JobList';
+
+// fix(#2035): a stored 'internal_error' must read the same operator-facing
+// sentence as the CLI (cli/geolens_cli/refresh.py), not the generic fallback.
+
+const { mockUseAdminJobs } = vi.hoisted(() => ({ mockUseAdminJobs: vi.fn() }));
+
+vi.mock('@/hooks/use-admin', () => ({
+  useAdminJobs: (...args: unknown[]) => mockUseAdminJobs(...args),
+  useUserNames: () => ({ data: [] }),
+  useRetryAdminJob: () => ({ mutate: vi.fn(), isPending: false }),
+  useCancelAdminJob: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+function failedJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'job-1',
+    status: 'failed',
+    source_filename: 'roads.geojson',
+    dataset_id: null,
+    error_message: 'internal_error',
+    can_retry: true,
+    retry_reason: null,
+    user_metadata: null,
+    created_by: 'user-1',
+    username: 'editor',
+    started_at: '2026-07-12T12:00:00Z',
+    completed_at: '2026-07-12T12:01:00Z',
+    created_at: '2026-07-12T11:59:00Z',
+    ...overrides,
+  };
+}
+
+describe('JobList internal_error reason', () => {
+  it('renders the CLI-matching sentence instead of the generic fallback', async () => {
+    mockUseAdminJobs.mockReturnValue({
+      data: { jobs: [failedJob()], total: 1 },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const user = userEvent.setup();
+
+    render(<JobList />);
+    await user.click(screen.getByTestId('job-details-toggle'));
+
+    expect(
+      screen.getByText(
+        'The job failed for a reason the server could not report safely. Ask an operator to check the server log for this job.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('An unexpected error occurred')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dataset/SourcePanel.tsx
+++ b/frontend/src/components/dataset/SourcePanel.tsx
@@ -376,7 +376,7 @@ function RefreshRunHistory({ dataset, canEdit }: { dataset: DatasetResponse; can
                 <p className="mt-1 text-xs text-destructive">
                   {describeFailureReason(
                     run.error_message,
-                    t('common:errors.unexpected'),
+                    t('common:errors.internalFailureReason'),
                   )}
                 </p>
               )}

--- a/frontend/src/components/dataset/__tests__/SourcePanel.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SourcePanel.test.tsx
@@ -689,4 +689,46 @@ describe('SourcePanel', () => {
     expect(screen.getByText('Outdated')).toBeInTheDocument();
     expect(screen.queryByText(/memberHealth\.stale/)).not.toBeInTheDocument();
   });
+
+  // fix(#2035): a stored 'internal_error' must read the same operator-facing
+  // sentence as the CLI (cli/geolens_cli/refresh.py), not the generic fallback.
+  it('renders the CLI-matching sentence for a failed run stored as internal_error', () => {
+    vi.mocked(useDatasetRefreshRuns).mockReturnValue({
+      data: {
+        runs: [
+          {
+            id: 'run-1',
+            dataset_id: 'dataset-1',
+            dataset_version_id: null,
+            ingest_job_id: 'job-1',
+            origin_kind: 'service',
+            trigger: 'api',
+            status: 'failed',
+            triggered_by: 'user-1',
+            triggered_by_username: 'jdoe',
+            started_at: '2026-08-05T00:00:00Z',
+            claimed_at: '2026-08-05T00:00:01Z',
+            finished_at: '2026-08-05T00:01:00Z',
+            feature_count_before: 1200,
+            feature_count_after: null,
+            schema_diff: null,
+            error_code: null,
+            error_message: 'internal_error',
+          },
+        ],
+        total: 1,
+      } satisfies { runs: DatasetRefreshRunResponse[]; total: number },
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useDatasetRefreshRuns>);
+
+    render(<SourcePanel dataset={makeDataset()} />);
+
+    expect(
+      screen.getByText(
+        'The job failed for a reason the server could not report safely. Ask an operator to check the server log for this job.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('An unexpected error occurred')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/import/JobProgress.tsx
+++ b/frontend/src/components/import/JobProgress.tsx
@@ -318,7 +318,7 @@ export function JobProgress({ jobId, onReset, isRasterEntry = false }: JobProgre
           <div className="space-y-3">
             {job.error_message && (
               <p className="text-sm text-destructive">
-                {describeFailureReason(job.error_message, t('common:errors.unexpected'))}
+                {describeFailureReason(job.error_message, t('common:errors.internalFailureReason'))}
               </p>
             )}
             {job.retry_reason && (

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { commitImport } from '@/api/ingest';
-import { commitFanOut } from '@/api/datasets';
+import { commitFanOut, type FanOutLayerResult } from '@/api/datasets';
 import {
   startUploadEntry,
   startLayerPreview,
@@ -558,6 +558,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     const fileBase = stripExtension(entry.previewData.source_filename ?? entry.fileName) || 'Untitled';
 
     let results: FanOutResult[];
+    let queuedLayers: (FanOutLayerResult & { new_job_id: string })[] = [];
     try {
       // Single HTTP call — backend fans out N tasks from this one request.
       const response = await commitFanOut(
@@ -568,6 +569,9 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
         })),
       );
 
+      queuedLayers = response.results.filter(
+        (r): r is FanOutLayerResult & { new_job_id: string } => r.status === 'queued' && !!r.new_job_id,
+      );
       results = response.results.map((r) => ({
         layerName: r.layer_name,
         status: r.status === 'queued' ? ('fulfilled' as const) : ('rejected' as const),
@@ -585,9 +589,26 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     const succeededCount = results.filter((r) => r.status === 'fulfilled').length;
     const failedCount = results.length - succeededCount;
 
-    // Update entry status based on outcome.
+    // fix(#2034): on full success, replace the parent with one tracked entry
+    // per queued layer (own jobId). The parent job itself settles
+    // 'fanned_out' with no dataset_id, so BulkTrackingList's completedEntries
+    // never counted it — children complete (and count) like a normal import.
     if (failedCount === 0) {
-      updateEntry(entryId, { status: 'tracking' });
+      setEntries((prev) => [
+        ...prev.filter((e) => e.id !== entryId),
+        ...queuedLayers.map((layer) => ({
+          id: crypto.randomUUID(),
+          file: null,
+          fileName: `${fileBase}: ${layer.layer_name}`,
+          status: 'tracking' as const,
+          jobId: layer.new_job_id,
+          previewData: null,
+          error: null,
+          submittedTitle: `${fileBase}: ${layer.layer_name}`,
+          submittedVisibility: 'private',
+          submittedKind: 'vector' as const,
+        })),
+      ]);
       toast.success(t('upload.multiLayerSuccess', { count: succeededCount }));
     } else if (succeededCount === 0) {
       updateEntry(entryId, {

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -297,11 +297,13 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
           e.status === 'commit-failed',
       );
       const hasTracking = entries.some((e) => e.status === 'tracking');
-      if (allTerminal && hasTracking) {
+      // fix(#2034): a partial-failure fan-out modal (real 'rejected' results) holds the reviewing phase open — the queued layers it also tracked would otherwise hide it before it's read. A full-success modal never blocks, matching prior behavior.
+      const fanOutHasFailure = fanOutResults?.results.some((r) => r.status === 'rejected') ?? false;
+      if (allTerminal && hasTracking && !fanOutHasFailure) {
         setPhase('tracking');
       }
     }
-  }, [entries, phase, setPhase]);
+  }, [entries, phase, setPhase, fanOutResults]);
 
   const processFiles = useCallback(async (files: File[]) => {
     if (phase !== 'idle') return;
@@ -590,23 +592,25 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     const failedCount = results.length - succeededCount;
 
     // fix(#2034): track each queued layer by its own entry/jobId — the parent job settles 'fanned_out' with no dataset_id, so it's never counted.
+    // fix(#2034): every layer takes the previewed layer's kind (best proxy available) — a mixed container needs per-layer geometry_type on LayerPreview to do better.
+    const previewedLayerKind = entry.previewData.geometry_type ? ('vector' as const) : ('table' as const);
+    const queuedEntries = queuedLayers.map((layer) => ({
+      id: crypto.randomUUID(),
+      file: null,
+      fileName: `${fileBase}: ${layer.layer_name}`,
+      status: 'tracking' as const,
+      jobId: layer.new_job_id,
+      previewData: null,
+      error: null,
+      submittedTitle: `${fileBase}: ${layer.layer_name}`,
+      submittedVisibility: 'private',
+      submittedKind: previewedLayerKind,
+    }));
+
     if (failedCount === 0) {
-      // fix(#2034): every layer takes the previewed layer's kind (best proxy available) — a mixed container needs per-layer geometry_type on LayerPreview to do better.
-      const previewedLayerKind = entry.previewData.geometry_type ? ('vector' as const) : ('table' as const);
       setEntries((prev) => [
         ...prev.filter((e) => e.id !== entryId),
-        ...queuedLayers.map((layer) => ({
-          id: crypto.randomUUID(),
-          file: null,
-          fileName: `${fileBase}: ${layer.layer_name}`,
-          status: 'tracking' as const,
-          jobId: layer.new_job_id,
-          previewData: null,
-          error: null,
-          submittedTitle: `${fileBase}: ${layer.layer_name}`,
-          submittedVisibility: 'private',
-          submittedKind: previewedLayerKind,
-        })),
+        ...queuedEntries,
       ]);
       toast.success(t('upload.multiLayerSuccess', { count: succeededCount }));
     } else if (succeededCount === 0) {
@@ -619,6 +623,8 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
         status: 'commit-failed',
         error: t('upload.multiLayerPartialFailed', { succeeded: succeededCount, failed: failedCount }),
       });
+      // fix(#2034): the layers that DID queue still get tracked — only the parent shows the partial-failure error.
+      setEntries((prev) => [...prev, ...queuedEntries]);
     }
 
     setFanOutResults({ entryId, results });

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -591,6 +591,9 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
 
     // fix(#2034): track each queued layer by its own entry/jobId — the parent job settles 'fanned_out' with no dataset_id, so it's never counted.
     if (failedCount === 0) {
+      // fix(#2054): only the previewed layer's geometry_type is known — every other layer has no per-layer signal, so it defaults to 'table'.
+      const previewedLayerName = entry.previewData.layer_name;
+      const previewedLayerKind = entry.previewData.geometry_type ? ('vector' as const) : ('table' as const);
       setEntries((prev) => [
         ...prev.filter((e) => e.id !== entryId),
         ...queuedLayers.map((layer) => ({
@@ -603,7 +606,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
           error: null,
           submittedTitle: `${fileBase}: ${layer.layer_name}`,
           submittedVisibility: 'private',
-          submittedKind: 'vector' as const,
+          submittedKind: layer.layer_name === previewedLayerName ? previewedLayerKind : ('table' as const),
         })),
       ]);
       toast.success(t('upload.multiLayerSuccess', { count: succeededCount }));

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -591,8 +591,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
 
     // fix(#2034): track each queued layer by its own entry/jobId — the parent job settles 'fanned_out' with no dataset_id, so it's never counted.
     if (failedCount === 0) {
-      // fix(#2054): only the previewed layer's geometry_type is known — every other layer has no per-layer signal, so it defaults to 'table'.
-      const previewedLayerName = entry.previewData.layer_name;
+      // fix(#2034): every layer takes the previewed layer's kind (best proxy available) — a mixed container needs per-layer geometry_type on LayerPreview to do better.
       const previewedLayerKind = entry.previewData.geometry_type ? ('vector' as const) : ('table' as const);
       setEntries((prev) => [
         ...prev.filter((e) => e.id !== entryId),
@@ -606,7 +605,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
           error: null,
           submittedTitle: `${fileBase}: ${layer.layer_name}`,
           submittedVisibility: 'private',
-          submittedKind: layer.layer_name === previewedLayerName ? previewedLayerKind : ('table' as const),
+          submittedKind: previewedLayerKind,
         })),
       ]);
       toast.success(t('upload.multiLayerSuccess', { count: succeededCount }));

--- a/frontend/src/components/import/UploadForm.tsx
+++ b/frontend/src/components/import/UploadForm.tsx
@@ -589,10 +589,7 @@ export function UploadForm({ onPhaseChange }: UploadFormProps) {
     const succeededCount = results.filter((r) => r.status === 'fulfilled').length;
     const failedCount = results.length - succeededCount;
 
-    // fix(#2034): on full success, replace the parent with one tracked entry
-    // per queued layer (own jobId). The parent job itself settles
-    // 'fanned_out' with no dataset_id, so BulkTrackingList's completedEntries
-    // never counted it — children complete (and count) like a normal import.
+    // fix(#2034): track each queued layer by its own entry/jobId — the parent job settles 'fanned_out' with no dataset_id, so it's never counted.
     if (failedCount === 0) {
       setEntries((prev) => [
         ...prev.filter((e) => e.id !== entryId),

--- a/frontend/src/components/import/__tests__/JobProgress.test.tsx
+++ b/frontend/src/components/import/__tests__/JobProgress.test.tsx
@@ -108,6 +108,30 @@ describe('JobProgress retry capability', () => {
   });
 });
 
+// fix(#2035): a stored 'internal_error' must read the same operator-facing
+// sentence as the CLI (cli/geolens_cli/refresh.py), not the generic fallback.
+describe('JobProgress internal_error reason', () => {
+  beforeEach(() => {
+    mockUseJobStatus.mockReset();
+  });
+
+  it('renders the CLI-matching sentence instead of the generic fallback', () => {
+    mockUseJobStatus.mockReturnValue({
+      data: failedJob({ error_message: 'internal_error' }),
+      isLoading: false,
+    });
+
+    render(<JobProgress jobId="job-1" onReset={vi.fn()} />);
+
+    expect(
+      screen.getByText(
+        'The job failed for a reason the server could not report safely. Ask an operator to check the server log for this job.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('An unexpected error occurred')).not.toBeInTheDocument();
+  });
+});
+
 // fix(#1778): #1709 granted job-creator cancel server-side, but JobProgress —
 // the terminal render for every import path — offered no way to reach it.
 describe('JobProgress owner cancel', () => {

--- a/frontend/src/components/import/__tests__/UploadForm.multiLayerFanOut.test.tsx
+++ b/frontend/src/components/import/__tests__/UploadForm.multiLayerFanOut.test.tsx
@@ -116,7 +116,13 @@ vi.mock('../BulkReviewList', () => ({
 }));
 
 vi.mock('../BulkTrackingList', () => ({
-  BulkTrackingList: () => <div data-testid="bulk-tracking-list" />,
+  BulkTrackingList: ({ entries }: { entries: Array<{ id: string; jobId: string | null }> }) => (
+    <div data-testid="bulk-tracking-list">
+      {entries.map((e) => (
+        <div key={e.id} data-testid={`tracked-${e.jobId}`} />
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock('sonner', () => ({
@@ -334,6 +340,37 @@ describe('UploadForm — multi-layer fan-out via commitFanOut (GPKG-03 Phase 105
     await waitFor(() => {
       expect(screen.getByTestId('bulk-tracking-list')).toBeInTheDocument();
     });
+  });
+
+  it('(f) full success replaces the parent with one tracked entry per queued layer (#2034)', async () => {
+    mockCommitFanOut.mockResolvedValue(
+      makeFanOutResponse([
+        { layer_name: 'layer_a', status: 'queued' },
+        { layer_name: 'layer_b', status: 'queued' },
+        { layer_name: 'layer_c', status: 'queued' },
+      ]) as never,
+    );
+
+    await driveToReview(makeMultiLayerPreview(3));
+
+    const entries = screen.getAllByTestId(/^entry-/);
+    const entryId = entries[0].getAttribute('data-testid')!.replace('entry-', '');
+
+    await act(async () => {
+      screen.getByTestId(`ingest-all-${entryId}`).click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('bulk-tracking-list')).toBeInTheDocument();
+    });
+
+    // BulkTrackingList must track each layer's OWN new_job_id, not the
+    // parent job — the parent settles 'fanned_out' with no dataset_id, which
+    // is why the batch summary previously stayed at 0 (#2034).
+    expect(screen.queryByTestId('tracked-job-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tracked-new-layer_a')).toBeInTheDocument();
+    expect(screen.getByTestId('tracked-new-layer_b')).toBeInTheDocument();
+    expect(screen.getByTestId('tracked-new-layer_c')).toBeInTheDocument();
   });
 
   it('(e) network failure in commitFanOut → all layers shown as failed in modal', async () => {

--- a/frontend/src/components/import/__tests__/UploadForm.multiLayerFanOut.test.tsx
+++ b/frontend/src/components/import/__tests__/UploadForm.multiLayerFanOut.test.tsx
@@ -316,6 +316,17 @@ describe('UploadForm — multi-layer fan-out via commitFanOut (GPKG-03 Phase 105
 
     // Error message for the failed layer
     expect(screen.getByText('Dispatch failed')).toBeInTheDocument();
+
+    // #2054 P2 (round 4): the layer that DID queue (layer_a) must still get
+    // its own tracked entry — closing the modal (the parent stays visible
+    // with the partial-failure error until then) reveals it.
+    await act(async () => {
+      screen.getByRole('button', { name: 'Close' }).click();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('bulk-tracking-list')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('tracked-new-layer_a')).toHaveAttribute('data-kind', 'vector');
   });
 
   it('(d) entry transitions to tracking on full success; toast fires', async () => {

--- a/frontend/src/components/import/__tests__/UploadForm.multiLayerFanOut.test.tsx
+++ b/frontend/src/components/import/__tests__/UploadForm.multiLayerFanOut.test.tsx
@@ -154,7 +154,7 @@ function makeMultiLayerPreview(layerCount: number = 2) {
     source_filename: 'test.gpkg',
     columns: [],
     row_count: 0,
-    geometry_type: 'Point',
+    geometry_type: 'Point' as string | null,
     crs: null,
     latlon_candidates: null,
     layer_name: 'layer_a',
@@ -346,7 +346,7 @@ describe('UploadForm — multi-layer fan-out via commitFanOut (GPKG-03 Phase 105
     });
   });
 
-  it('(f) full success replaces the parent with one tracked entry per queued layer (#2034), deriving kind only for the previewed layer (#2054 P2)', async () => {
+  it('(f) full success replaces the parent with one tracked entry per queued layer (#2034), every layer taking the previewed layer\'s kind', async () => {
     mockCommitFanOut.mockResolvedValue(
       makeFanOutResponse([
         { layer_name: 'layer_a', status: 'queued' },
@@ -355,9 +355,8 @@ describe('UploadForm — multi-layer fan-out via commitFanOut (GPKG-03 Phase 105
       ]) as never,
     );
 
-    // makeMultiLayerPreview previews layer_a with geometry_type 'Point';
-    // layer_b/layer_c (a non-spatial GPKG table or Excel sheet, say) carry
-    // no per-layer geometry signal at all.
+    // makeMultiLayerPreview previews layer_a with geometry_type 'Point' — no
+    // per-layer signal exists for layer_b/layer_c, so all three take that.
     await driveToReview(makeMultiLayerPreview(3));
 
     const entries = screen.getAllByTestId(/^entry-/);
@@ -379,10 +378,38 @@ describe('UploadForm — multi-layer fan-out via commitFanOut (GPKG-03 Phase 105
     expect(screen.getByTestId('tracked-new-layer_b')).toBeInTheDocument();
     expect(screen.getByTestId('tracked-new-layer_c')).toBeInTheDocument();
 
-    // #2054 P2: kind must not be blanket-hardcoded to 'vector'. Only the
-    // previewed layer (layer_a) has a real geometry signal; the others have
-    // none and must fall back to 'table', not silently inherit 'vector'.
+    // A spatial previewed layer (layer_a, geometry_type 'Point') is the best
+    // available proxy for the others — every layer takes its kind.
     expect(screen.getByTestId('tracked-new-layer_a')).toHaveAttribute('data-kind', 'vector');
+    expect(screen.getByTestId('tracked-new-layer_b')).toHaveAttribute('data-kind', 'vector');
+    expect(screen.getByTestId('tracked-new-layer_c')).toHaveAttribute('data-kind', 'vector');
+  });
+
+  it('(g) a non-spatial previewed layer makes every fanned-out layer table', async () => {
+    mockCommitFanOut.mockResolvedValue(
+      makeFanOutResponse([
+        { layer_name: 'layer_a', status: 'queued' },
+        { layer_name: 'layer_b', status: 'queued' },
+        { layer_name: 'layer_c', status: 'queued' },
+      ]) as never,
+    );
+
+    // layer_a (previewed) has no geometry_type — an Excel workbook sheet or
+    // a GPKG attributes table — so every layer proxies off it as 'table'.
+    await driveToReview({ ...makeMultiLayerPreview(3), geometry_type: null });
+
+    const entries = screen.getAllByTestId(/^entry-/);
+    const entryId = entries[0].getAttribute('data-testid')!.replace('entry-', '');
+
+    await act(async () => {
+      screen.getByTestId(`ingest-all-${entryId}`).click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('bulk-tracking-list')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('tracked-new-layer_a')).toHaveAttribute('data-kind', 'table');
     expect(screen.getByTestId('tracked-new-layer_b')).toHaveAttribute('data-kind', 'table');
     expect(screen.getByTestId('tracked-new-layer_c')).toHaveAttribute('data-kind', 'table');
   });

--- a/frontend/src/components/import/__tests__/UploadForm.multiLayerFanOut.test.tsx
+++ b/frontend/src/components/import/__tests__/UploadForm.multiLayerFanOut.test.tsx
@@ -116,10 +116,14 @@ vi.mock('../BulkReviewList', () => ({
 }));
 
 vi.mock('../BulkTrackingList', () => ({
-  BulkTrackingList: ({ entries }: { entries: Array<{ id: string; jobId: string | null }> }) => (
+  BulkTrackingList: ({
+    entries,
+  }: {
+    entries: Array<{ id: string; jobId: string | null; submittedKind?: string | null }>;
+  }) => (
     <div data-testid="bulk-tracking-list">
       {entries.map((e) => (
-        <div key={e.id} data-testid={`tracked-${e.jobId}`} />
+        <div key={e.id} data-testid={`tracked-${e.jobId}`} data-kind={e.submittedKind} />
       ))}
     </div>
   ),
@@ -342,7 +346,7 @@ describe('UploadForm — multi-layer fan-out via commitFanOut (GPKG-03 Phase 105
     });
   });
 
-  it('(f) full success replaces the parent with one tracked entry per queued layer (#2034)', async () => {
+  it('(f) full success replaces the parent with one tracked entry per queued layer (#2034), deriving kind only for the previewed layer (#2054 P2)', async () => {
     mockCommitFanOut.mockResolvedValue(
       makeFanOutResponse([
         { layer_name: 'layer_a', status: 'queued' },
@@ -351,6 +355,9 @@ describe('UploadForm — multi-layer fan-out via commitFanOut (GPKG-03 Phase 105
       ]) as never,
     );
 
+    // makeMultiLayerPreview previews layer_a with geometry_type 'Point';
+    // layer_b/layer_c (a non-spatial GPKG table or Excel sheet, say) carry
+    // no per-layer geometry signal at all.
     await driveToReview(makeMultiLayerPreview(3));
 
     const entries = screen.getAllByTestId(/^entry-/);
@@ -371,6 +378,13 @@ describe('UploadForm — multi-layer fan-out via commitFanOut (GPKG-03 Phase 105
     expect(screen.getByTestId('tracked-new-layer_a')).toBeInTheDocument();
     expect(screen.getByTestId('tracked-new-layer_b')).toBeInTheDocument();
     expect(screen.getByTestId('tracked-new-layer_c')).toBeInTheDocument();
+
+    // #2054 P2: kind must not be blanket-hardcoded to 'vector'. Only the
+    // previewed layer (layer_a) has a real geometry signal; the others have
+    // none and must fall back to 'table', not silently inherit 'vector'.
+    expect(screen.getByTestId('tracked-new-layer_a')).toHaveAttribute('data-kind', 'vector');
+    expect(screen.getByTestId('tracked-new-layer_b')).toHaveAttribute('data-kind', 'table');
+    expect(screen.getByTestId('tracked-new-layer_c')).toHaveAttribute('data-kind', 'table');
   });
 
   it('(e) network failure in commitFanOut → all layers shown as failed in modal', async () => {

--- a/frontend/src/hooks/__tests__/use-admin.jobsRefetch.test.tsx
+++ b/frontend/src/hooks/__tests__/use-admin.jobsRefetch.test.tsx
@@ -1,0 +1,80 @@
+// fix(#2033): useAdminJobs had no refetchInterval, so a retried job kept
+// showing its pre-retry status until the page was reloaded.
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import { useAdminJobs } from '@/hooks/use-admin';
+import type { AdminJobListResponse } from '@/types/api';
+
+const mockListAdminJobs = vi.fn();
+vi.mock('@/api/admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/admin')>();
+  return { ...actual, listAdminJobs: (...args: unknown[]) => mockListAdminJobs(...args) };
+});
+
+function makeJob(status: string): AdminJobListResponse['jobs'][number] {
+  return {
+    id: 'job-1',
+    status,
+    source_filename: 'a.gpkg',
+    dataset_id: null,
+    error_message: null,
+    can_retry: status === 'failed',
+    retry_reason: null,
+    user_metadata: null,
+    created_by: null,
+    username: null,
+    started_at: null,
+    completed_at: null,
+    created_at: '2026-09-09T00:00:00Z',
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useAdminJobs polling (#2033)', () => {
+  beforeEach(() => {
+    mockListAdminJobs.mockReset();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps polling a non-terminal row and picks up its settled status without a manual refetch', async () => {
+    mockListAdminJobs
+      .mockResolvedValueOnce({ jobs: [makeJob('running')], total: 1 })
+      .mockResolvedValueOnce({ jobs: [makeJob('complete')], total: 1 });
+
+    const { result } = renderHook(() => useAdminJobs({}), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.data?.jobs[0].status).toBe('running'));
+    expect(mockListAdminJobs).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await waitFor(() => expect(result.current.data?.jobs[0].status).toBe('complete'));
+    expect(mockListAdminJobs).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops polling once every row is terminal', async () => {
+    mockListAdminJobs.mockResolvedValue({ jobs: [makeJob('complete')], total: 1 });
+
+    const { result } = renderHook(() => useAdminJobs({}), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.data?.jobs[0].status).toBe('complete'));
+    expect(mockListAdminJobs).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // No further fetches — nothing left to watch.
+    expect(mockListAdminJobs).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -113,6 +113,15 @@ export function useAdminJobs(params: {
     queryKey: queryKeys.admin.jobs(params),
     queryFn: () => listAdminJobs(params),
     placeholderData: keepPreviousData,
+    // fix(#2033): a retried job can settle within a second — poll while the
+    // current page still has a pending/running row instead of relying on the
+    // retry mutation's one-shot invalidate.
+    refetchInterval: (q) => {
+      const jobs = q.state.data?.jobs ?? [];
+      const hasActive = jobs.some((j) => j.status === 'pending' || j.status === 'running');
+      return hasActive ? 3_000 : false;
+    },
+    refetchIntervalInBackground: false,
   });
 }
 

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -141,6 +141,7 @@
   },
   "errors": {
     "unexpected": "Ein unerwarteter Fehler ist aufgetreten",
+    "internalFailureReason": "Der Auftrag ist aus einem Grund fehlgeschlagen, den der Server nicht sicher melden konnte. Bitten Sie einen Betreiber, das Server-Protokoll für diesen Auftrag zu prüfen.",
     "requestFailed": "Die Anfrage konnte nicht abgeschlossen werden. Versuchen Sie es erneut.",
     "badRequest": "Die Anfrage konnte nicht abgeschlossen werden. Prüfen Sie Ihre Eingaben.",
     "resourceNotFound": "Die angeforderte Ressource wurde nicht gefunden.",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -266,6 +266,7 @@
   "unknown": "Unknown",
   "errors": {
     "unexpected": "An unexpected error occurred",
+    "internalFailureReason": "The job failed for a reason the server could not report safely. Ask an operator to check the server log for this job.",
     "requestFailed": "The request could not be completed. Try again.",
     "badRequest": "The request could not be completed. Check your input.",
     "resourceNotFound": "The requested resource was not found.",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -141,6 +141,7 @@
   },
   "errors": {
     "unexpected": "Ocurrió un error inesperado",
+    "internalFailureReason": "El trabajo falló por un motivo que el servidor no pudo comunicar de forma segura. Pide a un operador que revise el registro del servidor para este trabajo.",
     "requestFailed": "No se pudo completar la solicitud. Inténtalo de nuevo.",
     "badRequest": "No se pudo completar la solicitud. Comprueba los datos introducidos.",
     "resourceNotFound": "No se encontró el recurso solicitado.",

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -141,6 +141,7 @@
   },
   "errors": {
     "unexpected": "Une erreur inattendue s'est produite",
+    "internalFailureReason": "La tâche a échoué pour une raison que le serveur n'a pas pu signaler en toute sécurité. Demandez à un opérateur de consulter le journal du serveur pour cette tâche.",
     "requestFailed": "La requête n'a pas pu aboutir. Réessayez.",
     "badRequest": "La requête n'a pas pu aboutir. Vérifiez les données saisies.",
     "resourceNotFound": "La ressource demandée est introuvable.",

--- a/frontend/src/i18n/locales/zh/common.json
+++ b/frontend/src/i18n/locales/zh/common.json
@@ -266,6 +266,7 @@
   "unknown": "未知",
   "errors": {
     "unexpected": "发生意外错误",
+    "internalFailureReason": "该任务失败的原因服务器无法安全报告。请让运维人员检查此任务的服务器日志。",
     "requestFailed": "请求未能完成。请重试。",
     "badRequest": "请求未能完成。请检查您的输入。",
     "resourceNotFound": "未找到请求的资源。",


### PR DESCRIPTION
## Summary

Three independent 1.19.0 pre-tag-smoke follow-ups, all frontend-only: a
multi-layer import fan-out under-counts its own results, the admin jobs
list goes stale after a retry, and a stored `internal_error` reads
differently in the UI than in the CLI.

## Changes

- **#2034** — `commitFanOut`'s parent job settles `fanned_out` with no
  `dataset_id`, so `BulkTrackingList`'s `completedEntries` never counted it:
  a 3-layer GeoPackage fan-out showed "0 datasets added" even though every
  layer imported. On full success, `UploadForm` now replaces the parent
  entry with one tracked entry per queued layer, using the backend's own
  `new_job_id`, so each layer is tracked and counted like a normal import.
- **#2033** — `useAdminJobs` had no `refetchInterval`, and the retry
  mutation invalidated the list only once, right after firing the retry
  request. A retried job that settled a second later kept showing its
  stale status until a manual reload. It now polls every 3s while the
  current page has a `pending`/`running` row and stops once every row is
  terminal.
- **#2035** — `JobProgress`, `JobList`, and `SourcePanel` all fell back to
  the generic "An unexpected error occurred" for a stored `internal_error`,
  while the CLI printed an operator-facing hint pointing at the server
  log. Added `common:errors.internalFailureReason` (en/es/fr/de/zh) with
  the CLI's sentence and switched all three call sites to it.
  `SourcePanel` uses the identical `describeFailureReason` fallback
  pattern as the two surfaces the report named, so it's included for the
  same fix to hold "everywhere."

## Area

- [x] Frontend (UI, components, hooks)
- [x] Import / Ingestion

## Testing

- [x] Unit tests pass (`npm test`) — full suite: 462 files / 6114 tests
      passed; `npm run test:coverage`, `npm run lint`, `npm run typecheck`,
      `npm run build`, and `npm run test:i18n` all pass.
- [x] No tests needed beyond the above (no e2e/manual — each fix has a
      focused regression test that fails on the pre-fix code; verified by
      reverting each source change locally and re-running its test)

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: new user-facing strings added to all 5 locales (en, fr, es, de, zh)
- [x] No new lint warnings (`eslint`)
- [x] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed) — N/A, no schema change
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys — N/A, not a docs/marketing deploy

Closes #2034
Closes #2033
Closes #2035
