### PR TITLE
fix(config,ai): document the per-worker rate-limit default; scale sandbox slots by worker count

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1060,7 +1060,9 @@ FRONTEND_PORT=8080
 # DB_USE_EXTERNAL_POOLER=false
 
 # Per-process sandbox query slots under DB_USE_EXTERNAL_POOLER. Set it when more
-# than one API replica shares the pooler: pooler budget / (replicas * workers).
+# than one API replica shares the pooler: a third of the pooler's connections,
+# divided by replicas times workers, so ordinary requests keep the rest. Chat
+# can hold two connections per slot.
 # Type: integer (minimum 1) or empty | Default: empty (4 / UVICORN_WORKERS)
 # SANDBOX_QUERY_SLOTS=
 

--- a/.env.example
+++ b/.env.example
@@ -274,6 +274,8 @@ GEOLENS_ADMIN_PASSWORD=
 # Number of uvicorn worker processes. Dev compose default 1 (compatible with
 # --reload). Production deploy: 2-4 depending on CPU.
 # Multiplies request concurrency but also process memory (~150M baseline per worker).
+# fix(#2041): docker-compose.prod.yml defaults this to 2. Pair 2 or more with
+# REDIS_URL so rate limits are counted once for the API, not once per worker.
 # Type: integer | Default: 1
 # UVICORN_WORKERS=1
 
@@ -738,6 +740,9 @@ FRONTEND_PORT=8080
 # back to per-worker counting rather than dropping the limit. Only redis:// and
 # rediss:// URLs can hold the buckets; any other scheme keeps them per worker
 # and says so once at startup.
+# fix(#2041): docker-compose.prod.yml runs two API workers with this unset, so
+# a stock install counts limits per worker and logs rate_limit_storage_not_configured.
+# The bundled valkey service (compose profile cloud-dev) is redis://valkey:6379/0.
 # Type: string | No default
 # Example: redis://redis:6379/0
 # REDIS_URL=
@@ -1049,6 +1054,8 @@ FRONTEND_PORT=8080
 # --- External Connection Pooler ---
 # [OPTIONAL] Enable external connection pooler mode (PgBouncer, RDS Proxy)
 # Disables prepared statements across all database consumers (FastAPI, Procrastinate).
+# fix(#2045): the pooler budget is shared by every API worker, so the sandbox
+# query slots each worker admits are divided by UVICORN_WORKERS.
 # Type: boolean | Default: false
 # DB_USE_EXTERNAL_POOLER=false
 

--- a/.env.example
+++ b/.env.example
@@ -1059,6 +1059,11 @@ FRONTEND_PORT=8080
 # Type: boolean | Default: false
 # DB_USE_EXTERNAL_POOLER=false
 
+# Per-process sandbox query slots under DB_USE_EXTERNAL_POOLER. Set it when more
+# than one API replica shares the pooler: pooler budget / (replicas * workers).
+# Type: integer (minimum 1) or empty | Default: empty (4 / UVICORN_WORKERS)
+# SANDBOX_QUERY_SLOTS=
+
 # --- Connection Pool Tuning ---
 # Ignored when DB_USE_EXTERNAL_POOLER=true.
 # [OPTIONAL] Maximum persistent connections in the SQLAlchemy pool

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -191,6 +191,19 @@ jobs:
           done
           echo "frontend -> /api/health never returned 200"; exit 1
 
+      - name: Assert the template boot counts rate limits per worker
+        # fix(#2041): the template .env leaves REDIS_URL empty while the prod
+        # compose runs two API workers, so each worker logs this notice once at
+        # startup. A silent boot means that default or the notice changed.
+        run: |
+          docker compose -f docker-compose.prod.yml logs --no-color api > /tmp/api-boot.log 2>&1
+          COUNT="$(grep -c 'rate_limit_storage_not_configured' /tmp/api-boot.log || true)"
+          echo "rate_limit_storage_not_configured notices in the api log: ${COUNT:-0}"
+          if [ "${COUNT:-0}" -lt 1 ]; then
+            echo "::error::api never logged rate_limit_storage_not_configured; the template default (REDIS_URL empty, UVICORN_WORKERS 2) or its startup notice changed"
+            exit 1
+          fi
+
       # E2E through the PROD reverse proxy: now that the published stack is
       # healthy, drive the existing Playwright audit suite against the prod nginx
       # (127.0.0.1:8080) via E2E_BASE_URL. release.yml is gated on this workflow's

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -195,7 +195,16 @@ jobs:
         # fix(#2041): the template .env leaves REDIS_URL empty while the prod
         # compose runs two API workers, so each worker logs this notice once at
         # startup. A silent boot means that default or the notice changed.
+        env:
+          # Free-text on a branch dispatch: pass via env, reference as "$VAR".
+          SMOKED_VERSION: ${{ steps.ver.outputs.version }}
         run: |
+          # fix(#2041 codex r3): images before 1.19.0 predate the notice, and a
+          # branch dispatch may smoke one; the boot itself already passed above.
+          if [ "${SMOKED_VERSION}" != "latest" ] && [ "$(printf '%s\n' 1.19.0 "${SMOKED_VERSION}" | sort -V | head -n1)" != "1.19.0" ]; then
+            echo "image tag ${SMOKED_VERSION} predates the rate_limit_storage_not_configured notice (1.19.0); skipping this assertion"
+            exit 0
+          fi
           docker compose -f docker-compose.prod.yml logs --no-color api > /tmp/api-boot.log 2>&1
           COUNT="$(grep -c 'rate_limit_storage_not_configured' /tmp/api-boot.log || true)"
           echo "rate_limit_storage_not_configured notices in the api log: ${COUNT:-0}"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -509,6 +509,9 @@ class Settings(BaseSettings):
     # fix(#2045): the worker count the compose files export as UVICORN_WORKERS;
     # under an external pooler sandbox_bounds divides the query budget by it.
     uvicorn_workers: int = 1
+    # fix(#2045 codex r1): a process cannot see how many API replicas share the
+    # pooler, so this states the per-process sandbox share outright when set.
+    sandbox_query_slots: int | None = Field(default=None, ge=1)
     db_pool_size: int = Field(default=10, ge=1)
     # SQLAlchemy uses -1 for unlimited overflow / disabled recycling.
     db_max_overflow: int = Field(default=3, ge=-1)
@@ -681,6 +684,8 @@ class Settings(BaseSettings):
         # so an unset value arrives as "" — normalize to None (LOG_JSON fallback)
         # instead of failing the Literal validation at boot.
         "environment",
+        # fix(#2045 codex r1): compose passes "${SANDBOX_QUERY_SLOTS:-}"; "" is unset.
+        "sandbox_query_slots",
         mode="before",
     )
     @classmethod

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -506,6 +506,9 @@ class Settings(BaseSettings):
     env_only_config: bool = False
 
     db_use_external_pooler: bool = False
+    # fix(#2045): the worker count the compose files export as UVICORN_WORKERS;
+    # under an external pooler sandbox_bounds divides the query budget by it.
+    uvicorn_workers: int = 1
     db_pool_size: int = Field(default=10, ge=1)
     # SQLAlchemy uses -1 for unlimited overflow / disabled recycling.
     db_max_overflow: int = Field(default=3, ge=-1)

--- a/backend/app/processing/ai/sandbox_bounds.py
+++ b/backend/app/processing/ai/sandbox_bounds.py
@@ -53,10 +53,10 @@ def capacity_bound() -> int:
     small calc is repeated.
     """
     if settings.db_use_external_pooler:
-        # NullPool: the real budget belongs to PgBouncer/RDS Proxy, invisible
-        # here. Keep a throttle at the default-pool value rather than sizing
-        # from settings that no longer apply.
-        return 4
+        # fix(#2045): NullPool, so the budget belongs to PgBouncer/RDS Proxy and
+        # every uvicorn worker draws on that ONE pooler. Divide the default-pool
+        # throttle by the worker count, never below one, instead of per worker.
+        return max(1, 4 // max(1, settings.uvicorn_workers))
     overflow = max(0, settings.db_max_overflow)
     return max(1, (settings.db_pool_size + overflow) // 3)
 

--- a/backend/app/processing/ai/sandbox_bounds.py
+++ b/backend/app/processing/ai/sandbox_bounds.py
@@ -53,6 +53,10 @@ def capacity_bound() -> int:
     small calc is repeated.
     """
     if settings.db_use_external_pooler:
+        # fix(#2045 codex r1): a process cannot see how many API replicas share
+        # the pooler, so an explicit per-process share wins whenever it is set.
+        if settings.sandbox_query_slots is not None:
+            return settings.sandbox_query_slots
         # fix(#2045): NullPool, so the budget belongs to PgBouncer/RDS Proxy and
         # every uvicorn worker draws on that ONE pooler. Divide the default-pool
         # throttle by the worker count, never below one, instead of per worker.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4300,7 +4300,10 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # only ingest slot. Cap 1485 -> 1488, exact.
     # fix(#2045): +3 — `uvicorn_workers`, so sandbox_bounds can divide the
     # external-pooler query budget by the worker count. Cap 1488 -> 1491, exact.
-    "backend/app/core/config.py": 1491,
+    # fix(#2045 codex r1): +5 — `sandbox_query_slots`, the explicit per-process
+    # share for API replicas sharing one pooler, plus its blank-to-None entry.
+    # Cap 1491 -> 1496, exact.
+    "backend/app/core/config.py": 1496,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -4298,7 +4298,9 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1710 codex r3): +3 — `worker_queues` gains "download" and the note
     # saying to pin a second worker to it, so a slow origin cannot hold the
     # only ingest slot. Cap 1485 -> 1488, exact.
-    "backend/app/core/config.py": 1488,
+    # fix(#2045): +3 — `uvicorn_workers`, so sandbox_bounds can divide the
+    # external-pooler query budget by the worker count. Cap 1488 -> 1491, exact.
+    "backend/app/core/config.py": 1491,
     # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
     # that gave PersistentConfig a batch eviction. The code is small
     # (apply_side_effects_batch, plus splitting the process-local half of

--- a/backend/tests/test_sandbox_query_endpoint_565.py
+++ b/backend/tests/test_sandbox_query_endpoint_565.py
@@ -1387,6 +1387,19 @@ def test_capacity_bound_divides_the_pooler_budget_by_worker_count(
     assert capacity_bound() == expected
 
 
+def test_capacity_bound_prefers_an_explicit_slot_count_under_a_pooler(monkeypatch):
+    """fix(#2045): an explicit SANDBOX_QUERY_SLOTS beats the worker split."""
+    from app.core.config import settings
+    from app.processing.ai.sandbox_bounds import capacity_bound
+
+    monkeypatch.setattr(settings, "db_use_external_pooler", True)
+    monkeypatch.setattr(settings, "uvicorn_workers", 2)
+    monkeypatch.setattr(settings, "sandbox_query_slots", 3)
+    assert capacity_bound() == 3
+    monkeypatch.setattr(settings, "sandbox_query_slots", None)
+    assert capacity_bound() == 2
+
+
 def test_capacity_bound_keeps_per_pool_sizing_without_a_pooler(monkeypatch):
     """Each worker owns its pool there, so the worker count must not divide it."""
     from app.core.config import settings
@@ -1396,6 +1409,7 @@ def test_capacity_bound_keeps_per_pool_sizing_without_a_pooler(monkeypatch):
     monkeypatch.setattr(settings, "db_pool_size", 10)
     monkeypatch.setattr(settings, "db_max_overflow", 3)
     monkeypatch.setattr(settings, "uvicorn_workers", 8)
+    monkeypatch.setattr(settings, "sandbox_query_slots", 3)
     assert capacity_bound() == 4
 
 

--- a/backend/tests/test_sandbox_query_endpoint_565.py
+++ b/backend/tests/test_sandbox_query_endpoint_565.py
@@ -1374,6 +1374,31 @@ def test_capacity_bound_is_pool_derived_and_at_least_one():
     assert _capacity_bound() >= 1
 
 
+@pytest.mark.parametrize(("workers", "expected"), [(1, 4), (2, 2), (8, 1)])
+def test_capacity_bound_divides_the_pooler_budget_by_worker_count(
+    monkeypatch, workers, expected
+):
+    """fix(#2045): one external pooler serves every worker, so 4 is split N ways."""
+    from app.core.config import settings
+    from app.processing.ai.sandbox_bounds import capacity_bound
+
+    monkeypatch.setattr(settings, "db_use_external_pooler", True)
+    monkeypatch.setattr(settings, "uvicorn_workers", workers)
+    assert capacity_bound() == expected
+
+
+def test_capacity_bound_keeps_per_pool_sizing_without_a_pooler(monkeypatch):
+    """Each worker owns its pool there, so the worker count must not divide it."""
+    from app.core.config import settings
+    from app.processing.ai.sandbox_bounds import capacity_bound
+
+    monkeypatch.setattr(settings, "db_use_external_pooler", False)
+    monkeypatch.setattr(settings, "db_pool_size", 10)
+    monkeypatch.setattr(settings, "db_max_overflow", 3)
+    monkeypatch.setattr(settings, "uvicorn_workers", 8)
+    assert capacity_bound() == 4
+
+
 async def test_success_shape_and_truncation(
     client: AsyncClient, admin_auth_header, test_db_session
 ):

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -340,6 +340,8 @@ services:
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-}
       PRIVACY_URL: ${PRIVACY_URL:-}
       DCAT_CONTACT_EMAIL: ${DCAT_CONTACT_EMAIL:-}
+      # fix(#2041): empty = rate limits are counted per worker (two above); a
+      # shared Valkey/Redis here, e.g. the cloud-dev valkey service, shares them.
       REDIS_URL: "${REDIS_URL:-}"
       CDN_BASE_URL: "${CDN_BASE_URL:-}"
       PRESIGNED_MULTIPART_THRESHOLD_MB: "${PRESIGNED_MULTIPART_THRESHOLD_MB:-100}"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -326,6 +326,8 @@ services:
       GEOLENS_API_RUN_MIGRATIONS: "${GEOLENS_API_RUN_MIGRATIONS:-true}"
       # Prod default 2 workers (dev uses 1 to keep --reload working).
       UVICORN_WORKERS: "${UVICORN_WORKERS:-2}"
+      # fix(#2045): per-process sandbox slots when API replicas share a pooler.
+      SANDBOX_QUERY_SLOTS: "${SANDBOX_QUERY_SLOTS:-}"
       UVICORN_TIMEOUT_KEEP_ALIVE: "${UVICORN_TIMEOUT_KEEP_ALIVE:-5}"
       UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN: "${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-30}"
       # fix(#643): recycle each worker after this many requests (empty disables).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -390,6 +390,8 @@ services:
       PYTHONPATH: /app
       GEOLENS_API_RUN_MIGRATIONS: "${GEOLENS_API_RUN_MIGRATIONS:-true}"
       UVICORN_WORKERS: "${UVICORN_WORKERS:-1}"
+      # fix(#2045): per-process sandbox slots when API replicas share a pooler.
+      SANDBOX_QUERY_SLOTS: "${SANDBOX_QUERY_SLOTS:-}"
       UVICORN_TIMEOUT_KEEP_ALIVE: "${UVICORN_TIMEOUT_KEEP_ALIVE:-5}"
       UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN: "${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-30}"
       # fix(#1240, #651): prometheus_client multiprocess mode, api service only


### PR DESCRIPTION
## Summary

Two follow-ups from the per-process coordination audit in #2037.

#2041: the bundled production compose keeps two API workers with `REDIS_URL` empty, so a stock install counts rate limits per worker and the paired search/facets exemption only holds when both calls reach one worker. The decision recorded on the issue is to keep that default. One worker would drop the `UVICORN_MAX_REQUESTS` recycling that only exists under a uvicorn supervisor (#643, #1687), and bundling valkey by default would also switch on the credentialed-refresh store, which is a minor-release change rather than a patch. This PR documents the state where operators set those values and makes Prod Compose Smoke assert it.

#2045: `capacity_bound()` returned a flat 4 on the `db_use_external_pooler` branch, but that pooler is one budget shared by every uvicorn worker, so N workers admitted 4N concurrent sandbox queries. The pooler branch now divides the budget by the worker count.

## Changes

- `.env.example`: the `UVICORN_WORKERS` entry says the production compose defaults to 2 and to pair 2 or more with `REDIS_URL`. The `REDIS_URL` entry says a stock install counts limits per worker, names the boot notice, and names the bundled `valkey` service (`cloud-dev` profile) as one shared store. The `DB_USE_EXTERNAL_POOLER` entry says the sandbox slots are divided by the worker count.
- `docker-compose.prod.yml`: one comment above the api service's `REDIS_URL` line. No structural change.
- `.github/workflows/prod-smoke.yml`: after the health curl, a step that fails unless the api log contains `rate_limit_storage_not_configured`, which is what the template boot (`REDIS_URL` empty, two workers) logs once per worker. It reads the logs of the stack already booted, so there is no second boot. A branch dispatch can smoke an older image, so the step reads the resolved version through an env var and exits 0 with one line when it is not `latest` and sorts below 1.19.0, the first release carrying the notice.
- `backend/app/core/config.py`: `uvicorn_workers: int = 1`, read from `UVICORN_WORKERS`, which both compose files already export (prod 2, dev 1; the image CMD default is 1). The exact LOC cap in `test_layering.py` moves 1488 -> 1491.
- `backend/app/processing/ai/sandbox_bounds.py`: the pooler branch returns `max(1, 4 // max(1, settings.uvicorn_workers))`. The per-pool branch keeps its sizing because each worker owns its pool there.
- Codex round 1: a process cannot discover how many API replicas share the pooler, so `Settings.sandbox_query_slots` (env `SANDBOX_QUERY_SLOTS`, at least 1 when set, blank means unset) states the per-process share outright. The pooler branch returns it when set and otherwise keeps the worker split; the per-pool branch ignores it. Documented next to `DB_USE_EXTERNAL_POOLER` in `.env.example` and passed to the api service by both compose manifests, since neither uses `env_file`.
- `backend/tests/test_sandbox_query_endpoint_565.py`: pooler on with 1, 2 and 8 workers gives 4, 2 and 1; pooler on with 2 workers and `SANDBOX_QUERY_SLOTS=3` gives 3, unset gives 2; pooler off ignores both. The 2-worker, 8-worker and explicit-slot cases fail against the code they replace.
- `RUNBOOK.md` and `.github/CONTRIBUTING.md` were checked. Their `UVICORN_WORKERS` statements still read correctly, so they are untouched.

## Area

- [x] Backend (API, services, models)
- [ ] Frontend (UI, components, hooks)
- [x] Infrastructure (Docker, nginx)
- [ ] Tiles / Rendering
- [ ] Auth / Permissions
- [ ] Import / Ingestion
- [ ] OGC / Standards
- [x] Docs / Config

## Config / API impact

Two new optional API settings: `UVICORN_WORKERS` (default 1) and `SANDBOX_QUERY_SLOTS` (default unset). Both compose manifests pass `SANDBOX_QUERY_SLOTS` to the api service as `"${SANDBOX_QUERY_SLOTS:-}"`. No schema change, no API change, no new compose service or default.

## Testing

- [x] Unit tests pass (`pytest` / `npm test`)
- [x] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)

- `uv run pytest tests/test_sandbox_query_endpoint_565.py -k capacity_bound`: 6 passed. With `sandbox_bounds.py` checked out from main the 2-worker and 8-worker cases fail; with the round-0 file the explicit-slot case fails.
- `Settings(sandbox_query_slots="")` is None, `"3"` is 3, `0` is rejected at boot. `tests/test_phase_275_compose_alignment.py`, `test_phase_271_pool_config.py`, `test_phase_273_env_example_admin.py`: 14 passed.
- `uv run pytest tests/test_layering.py -q`: 50 passed.
- `uv run ruff check . && uv run ruff format --check .`: clean.
- `python3 backend/tests/finding_markers.py`, `make env-doc-check`, `make public-surface-check`: pass.
- `docker compose config -q` on both manifests: parse. The new smoke step's shell body was dry-run against a log with the notice, a log without it, and an empty file: exit 0, 1, 1. The version gate was dry-run for `latest`, 1.19.0, 1.19.1, 1.20.0 and 2.0.0 (assert) and 1.18.1, 1.9.9 (skip).
- The live smoke runs on the next release tag or a `workflow_dispatch`.

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 5 locales (en, fr, es, de, zh)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [ ] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing

Closes #2041
Closes #2045
