### PR TITLE
chore(release): 1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+## [1.19.1] - 2026-09-12
+
 ### Fixed
 
 - A token refresh that failed temporarily, because of a rate limit, a server error or a dropped
@@ -3892,7 +3894,8 @@ regression-covered fixes:
 - Initial public release of the GeoLens catalog, API, map builder, CLI, SDKs,
   Docker development stack, and public documentation entrypoints.
 
-[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.19.0...HEAD
+[Unreleased]: https://github.com/geolens-io/geolens/compare/v1.19.1...HEAD
+[1.19.1]: https://github.com/geolens-io/geolens/compare/v1.19.0...v1.19.1
 [1.19.0]: https://github.com/geolens-io/geolens/compare/v1.18.1...v1.19.0
 [1.18.1]: https://github.com/geolens-io/geolens/compare/v1.18.0...v1.18.1
 [1.18.0]: https://github.com/geolens-io/geolens/compare/v1.17.0...v1.18.0

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -752,7 +752,7 @@ _is_production = settings.is_production
 # Fallback below covers running from a source checkout with no `uv pip
 # install -e .` (no metadata to read); keep it in lockstep with
 # pyproject.toml — `make bump` rewrites it.
-_FALLBACK_APP_VERSION = "1.19.0"
+_FALLBACK_APP_VERSION = "1.19.1"
 
 
 def _resolve_app_version() -> str:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -19263,7 +19263,7 @@
     "summary": "PostGIS-native geospatial data catalog with OGC API Features and Records support",
     "termsOfService": "https://github.com/geolens-io/geolens/blob/main/LICENSE",
     "title": "GeoLens API",
-    "version": "1.19.0"
+    "version": "1.19.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolens-backend"
-version = "1.19.0"
+version = "1.19.1"
 description = "PostGIS-native GIS data catalog"
 # Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
 # the exact patch pin) as the project's tested runtime.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "geolens-backend"
-version = "1.19.0"
+version = "1.19.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-cli"
-version = "1.19.0"
+version = "1.19.1"
 description = "Apache-2.0 command-line interface for the GeoLens API. Login, scan, publish, and export STAC against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/docs-contract.json
+++ b/docs-contract.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Canonical cross-surface facts for the GeoLens README, marketing site (getgeolens.com/src), and docs site (getgeolens.com/docs). Validated against scripts/install.sh + backend/pyproject.toml by scripts/check_docs_contract.py (geolens CI). The getgeolens.com repo vendors a copy and enforces the same `forbidden` list in its own CI. See docs-internal/DOC-CONSISTENCY-STRATEGY for the full design. Edit a fact ONCE here (and in its canonical source) — the gates make every surface follow.",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "install": {
     "oneLiner": "curl -fsSL https://getgeolens.com/install.sh | sh",
     "sourceBuild": "bash scripts/install.sh",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.19.1",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens-mcp"
-version = "1.19.0"
+version = "1.19.1"
 description = "Apache-2.0 read-only Model Context Protocol (MCP) server for GeoLens. Lets coding agents discover datasets, inspect schemas, and ask spatial questions against any GeoLens instance."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.geolens-io/geolens",
   "title": "GeoLens",
   "description": "Read-only access to a self-hosted GeoLens spatial catalog: datasets, features, maps, sandboxed SQL.",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "websiteUrl": "https://docs.getgeolens.com/",
   "repository": {
     "url": "https://github.com/geolens-io/geolens",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "geolens-mcp",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "geolens"
-version = "1.19.0"
+version = "1.19.1"
 source = { editable = "../sdks/python" }
 dependencies = [
     { name = "attrs" },
@@ -244,7 +244,7 @@ requires-dist = [
 
 [[package]]
 name = "geolens-mcp"
-version = "1.19.0"
+version = "1.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolens",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolens",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolens",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",

--- a/sdks/python/.openapi-python-client.yaml
+++ b/sdks/python/.openapi-python-client.yaml
@@ -4,7 +4,7 @@ project_name_override: geolens
 package_name_override: geolens
 # Rewritten on every `make sdks` run by scripts/sync_sdk_versions.py to match
 # backend/openapi.json info.version. Do not edit by hand.
-package_version_override: 1.19.0
+package_version_override: 1.19.1
 
 # Cleaner enum output (matches our pydantic v2 backend's enum emission).
 literal_enums: true

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geolens"
-version = "1.19.0"
+version = "1.19.1"
 description = "Auto-generated Python SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolens/sdk",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hey-api/client-fetch": "0.13.1"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolens/sdk",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Auto-generated TypeScript SDK for the GeoLens API. Typed clients with Bearer + API-key auth helpers.",
   "license": "Apache-2.0",
   "author": "Carto Concepts, LLC",


### PR DESCRIPTION
## Summary

Promote the completed 1.19.1 changelog wave and bump every version site to 1.19.1 through the repository's canonical `make bump` workflow.

## Area

- [ ] Backend (API, services, models)
- [ ] Frontend (UI, components, hooks)
- [ ] Infrastructure (Docker, nginx)
- [ ] Tiles / Rendering
- [ ] Auth / Permissions
- [ ] Import / Ingestion
- [ ] OGC / Standards
- [x] Docs / Config

## Config / API impact

Version metadata changes from 1.19.0 to 1.19.1 across the backend, frontend, CLI, MCP server, SDK packages, OpenAPI snapshot, lockfiles and docs contract. No API shape, schema, migration or runtime configuration changes.

## Testing

- [ ] Unit tests pass (`pytest` / `npm test`)
- [ ] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [x] No tests needed (docs, config, etc.)

- `make version-check`: pass; all 21 version sites agree on 1.19.1
- `git diff --check`: clean
- pre-commit hooks: pass

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 5 locales (en, fr, es, de, zh)
- [x] No new lint warnings (`ruff check`, `eslint`)
- [ ] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing
