### PR TITLE
fix(demo): verify deployed maps and await composition readiness

### DIFF
--- a/.github/workflows/demo-smoke.yml
+++ b/.github/workflows/demo-smoke.yml
@@ -1,0 +1,51 @@
+name: Demo Browser Smoke
+
+# The live demo is deployed separately from image publication. Run this after
+# deployment; tag-triggered compose smoke checks an isolated stack instead.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Expected deployed version (for example 1.19.1)
+        required: true
+        type: string
+      legacy_readiness:
+        description: Allow older releases without the composite map readiness marker
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: demo-browser-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Verify anonymous demo and showcase maps
+        env:
+          E2E_DEMO_BASE_URL: https://demo.getgeolens.com
+          E2E_EXPECT_VERSION: ${{ inputs.version }}
+          E2E_DEMO_LEGACY_READINESS: ${{ inputs.legacy_readiness && '1' || '0' }}
+        run: npm run e2e:smoke:demo
+      - name: Upload browser evidence
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: demo-browser-smoke
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 14

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -20,14 +20,18 @@ npm run e2e:smoke        # the smoke subset (core + builder + fixtures)
 ## Configs
 
 - `playwright.config.ts`: the default config (Chromium), used by every
-  `e2e:smoke:*` script except builder-hardening.
+  `e2e:smoke:*` script except builder-hardening and demo.
 - `playwright.builder-hardening.config.ts`: a separate config that runs only
   `builder-hardening.spec.ts` across Chromium, Firefox, and WebKit.
+- `playwright.demo.config.ts`: an opt-in, anonymous, read-only smoke against a
+  named demo origin. It has no setup or cleanup project and is excluded from
+  the default config.
 
-The browser projects in both configs create one temporary vector dataset for
-catalog-dependent flows. The cleanup project removes it after the browser tests
-finish, including failed runs. The API-only export suite manages its own fixture
-and does not require a browser install.
+The browser projects in the default and builder-hardening configs create one
+temporary vector dataset for catalog-dependent flows. Their cleanup project
+removes it after the browser tests finish, including failed runs. The demo
+config performs no setup, cleanup, authentication, or writes. The API-only
+export suite manages its own fixture and does not require a browser install.
 
 Against a host-run backend (uvicorn on the host + docker Postgres), the seeding
 ingest cannot work — set `E2E_SKIP_SEED=1` to make setup authenticate and save
@@ -44,3 +48,16 @@ The `e2e:smoke:*` scripts in the root `package.json` group specs by area
 `perf`). Specs not listed in a smoke group (e.g. `download-cog-token`,
 `sec-audit`, `plugin-lifecycle`, `builder-unified-stack`) run only via the
 catch-all `npm run e2e`.
+
+Run the deployed-demo smoke only against an explicitly named origin:
+
+```bash
+E2E_DEMO_BASE_URL=https://demo.getgeolens.com \
+E2E_EXPECT_VERSION=1.19.1 \
+npm run e2e:smoke:demo
+```
+
+The suite requires the ViewerMap composite `data-map-ready` contract. For an
+older release that predates it, explicitly set `E2E_DEMO_LEGACY_READINESS=1`;
+the report annotates the weaker fallback and still requires both
+`data-tiles-loaded` and a completed dataset feature or tile response.

--- a/e2e/demo-smoke.spec.ts
+++ b/e2e/demo-smoke.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+
+const SHOWCASE_MAP_NAMES = [
+  'Restless Earth',
+  'The Matterhorn in 3D',
+  'Manhattan - A Century of Skyline',
+  'Hurricane Alley - Major Atlantic Storms Since 1950',
+  'Everything That Fell From the Sky',
+  'New York From Orbit - Sentinel-2, by Reference',
+] as const;
+
+const CLOUDFLARE_BEACON =
+  /^https:\/\/static\.cloudflareinsights\.com\/beacon\.min\.js(?:\/|$)/;
+const ABORTED_REQUEST = /(?:ERR_ABORTED|NS_BINDING_ABORTED|cancelled)/i;
+const ALLOW_LEGACY_READINESS = process.env.E2E_DEMO_LEGACY_READINESS === '1';
+
+type BrowserDiagnostics = {
+  assertClean: () => void;
+  successfulDataRequests: string[];
+};
+
+function isMapDataRequest(url: string): boolean {
+  const path = new URL(url).pathname;
+  return (
+    /^\/api\/tiles\/.+\.pbf$/.test(path) ||
+    /^\/raster-tiles\//.test(path) ||
+    /^\/api\/datasets\/[^/]+\/features\.geojson$/.test(path)
+  );
+}
+
+function observeBrowser(page: Page): BrowserDiagnostics {
+  const errors: string[] = [];
+  const successfulDataRequests: string[] = [];
+
+  page.on('pageerror', (error) => errors.push(`page error: ${error.message}`));
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    if (CLOUDFLARE_BEACON.test(message.location().url)) return;
+    errors.push(`console error: ${message.text()}`);
+  });
+  page.on('response', (response) => {
+    const url = response.url();
+    if (response.status() >= 400 && !CLOUDFLARE_BEACON.test(url)) {
+      errors.push(`HTTP ${response.status()}: ${url}`);
+    }
+  });
+  page.on('requestfinished', async (request) => {
+    if (!isMapDataRequest(request.url())) return;
+    const response = await request.response();
+    if (response?.ok()) successfulDataRequests.push(request.url());
+  });
+  page.on('requestfailed', (request) => {
+    const url = request.url();
+    const reason = request.failure()?.errorText ?? 'unknown failure';
+    if (CLOUDFLARE_BEACON.test(url)) return;
+    if (ABORTED_REQUEST.test(reason)) return;
+    errors.push(`request failed (${reason}): ${url}`);
+  });
+
+  return {
+    assertClean: () => expect(errors, errors.join('\n')).toEqual([]),
+    successfulDataRequests,
+  };
+}
+
+async function attachScreenshot(page: Page, testInfo: TestInfo, name: string) {
+  const path = testInfo.outputPath(name);
+  await page.screenshot({ fullPage: true, path });
+  await testInfo.attach(name, {
+    path,
+    contentType: 'image/png',
+  });
+}
+
+test.describe('live demo read-only smoke', () => {
+  test('cold anonymous root remains the searchable catalog', async ({ page, request }, testInfo) => {
+    const diagnostics = observeBrowser(page);
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByRole('combobox', { name: 'Search the catalog...' })).toBeVisible();
+    await expect(page.getByRole('region', { name: 'Search results' })).toBeVisible();
+    await expect(page.getByTestId('search-result-card').first()).toBeVisible();
+
+    const [authConfigResponse, healthResponse] = await Promise.all([
+      request.get('/api/auth/config/'),
+      request.get('/api/health'),
+    ]);
+    expect(authConfigResponse.ok(), `auth config returned HTTP ${authConfigResponse.status()}`).toBeTruthy();
+    expect(healthResponse.ok(), `health returned HTTP ${healthResponse.status()}`).toBeTruthy();
+
+    const authConfig = await authConfigResponse.json();
+    expect(authConfig.landing_first).toBe(false);
+
+    const health = await healthResponse.json();
+    expect(health.status).toBe('healthy');
+    if (process.env.E2E_EXPECT_VERSION) {
+      expect(health.version).toBe(process.env.E2E_EXPECT_VERSION);
+    }
+
+    await attachScreenshot(page, testInfo, 'anonymous-catalog.png');
+    diagnostics.assertClean();
+  });
+
+  for (const name of SHOWCASE_MAP_NAMES) {
+    test(`catalog opens a data-ready map: ${name}`, async ({ page }, testInfo) => {
+      const diagnostics = observeBrowser(page);
+
+      await page.goto('/maps', { waitUntil: 'domcontentloaded' });
+      const search = page.getByRole('textbox', { name: 'Search maps...' });
+      await expect(search).toBeVisible();
+      await search.fill(name);
+
+      const mapLink = page.getByRole('link', { name, exact: true });
+      await expect(mapLink).toBeVisible();
+      await mapLink.click();
+      await expect(page).toHaveURL(/\/maps\/[0-9a-f-]+$/);
+
+      const viewer = page.getByRole('region', { name: 'Map viewer' });
+      await expect(viewer).toBeVisible();
+      await expect(page.locator('canvas.maplibregl-canvas')).toBeVisible();
+
+      if (ALLOW_LEGACY_READINESS && (await viewer.getAttribute('data-map-ready')) === null) {
+        testInfo.annotations.push({
+          type: 'legacy readiness',
+          description: 'Target lacks data-map-ready; using data-tiles-loaded plus completed data requests',
+        });
+        await expect(viewer).toHaveAttribute('data-tiles-loaded', 'true', { timeout: 60_000 });
+      } else {
+        await expect(viewer).toHaveAttribute('data-map-ready', 'true', { timeout: 60_000 });
+      }
+      if (name === 'The Matterhorn in 3D') {
+        await expect(viewer).toHaveAttribute('data-terrain-ready', 'true', { timeout: 60_000 });
+      }
+
+      await expect
+        .poll(() => diagnostics.successfulDataRequests.length, {
+          message: `${name} reached the viewer without completing a dataset feature or tile request`,
+          timeout: 60_000,
+        })
+        .toBeGreaterThan(0);
+      await expect(page.locator('[data-sonner-toast][data-type="error"]')).toHaveCount(0);
+
+      await attachScreenshot(
+        page,
+        testInfo,
+        `${name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}.png`,
+      );
+      diagnostics.assertClean();
+    });
+  }
+});

--- a/frontend/src/components/viewer/ViewerMap.tsx
+++ b/frontend/src/components/viewer/ViewerMap.tsx
@@ -36,7 +36,7 @@ import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { MapBasemapConfig, MapTerrainConfig, SharedLayerResponse } from '@/types/api';
 import { getAdapter } from '@/components/builder/layer-adapters/registry';
 import type { AdapterLayerInput } from '@/components/builder/layer-adapters/types';
-import { resolveAdapterType, prefixed, getDataDrivenColumnsForLayer, registerBasemapStyleGeneration } from '@/components/builder/map-sync';
+import { resolveAdapterType, prefixed, getDataDrivenColumnsForLayer, isDemTerrainVisualSuppressed, registerBasemapStyleGeneration } from '@/components/builder/map-sync';
 import { applyMapBasemapAppearance, syncMapComposition } from '@/components/builder/map-composition-sync';
 import type { SyncLayerInput } from '@/components/builder/map-sync';
 import { asFeatureCollection, fetchBoundedGeoJson } from '@/api/geojson-z';
@@ -277,11 +277,25 @@ export const ViewerMap = memo(function ViewerMap({
     )),
     [layerEntries],
   );
+  const boundedGeoJsonRequest = useMemo(() => ({
+    layers: boundedGeoJsonLayers,
+    apiKey,
+    embedToken,
+  }), [boundedGeoJsonLayers, apiKey, embedToken]);
+  const completedBoundedGeoJsonRequestRef = useRef<object | null>(null);
+  const [geojsonVersion, setGeojsonVersion] = useState(0);
 
-  // `tilesIdle` drives the `data-tiles-loaded` DOM attribute on the outer
-  // container. The Playwright showcase-smoke spec polls for this attribute to
-  // avoid an arbitrary `waitForTimeout` delay after networkidle.
+  // MapLibre activity feeds the composite readiness attributes on the outer
+  // container. A raw idle alone is insufficient because viewer-owned sources
+  // can arrive later with async config, tokens, or bounded GeoJSON.
   const [tilesIdle, setTilesIdle] = useState(false);
+  const tilesLoadingHandlerRef = useRef<(() => void) | null>(null);
+  const tilesIdleHandlerRef = useRef<(() => void) | null>(null);
+  // A MapLibre `idle` can precede async token/config/GeoJSON work. Track which
+  // exact composition request was applied and then observed at a later idle so
+  // an already-idle basemap cannot certify a newly arrived data overlay.
+  const appliedCompositionRef = useRef<object | null>(null);
+  const settledCompositionRef = useRef<object | null>(null);
   const [popupInfo, setPopupInfo] = useState<{
     longitude: number;
     latitude: number;
@@ -331,10 +345,46 @@ export const ViewerMap = memo(function ViewerMap({
     fallbackToRawUrlOnError: true,
   });
 
+  const boundedGeoJsonReady = boundedGeoJsonLayers.length === 0
+    || completedBoundedGeoJsonRequestRef.current === boundedGeoJsonRequest;
+  const layerTokensReady = layers.length === 0 || Boolean(embedToken) || layers.every(
+    (layer) => tokenMap.has(layer.dataset_id),
+  );
+  // Identity is deliberate: every dependency that can alter sources/layers
+  // creates a new request. Until that request is applied and reaches idle, the
+  // previous request's readiness cannot leak into the DOM contract.
+  const compositionRequest = useMemo(() => ({
+    layers,
+    tokenMap,
+    tileConfigReady,
+    cdnBaseUrl: tileConfig?.cdn_base_url,
+    sourceLayerPrefix: tileConfig?.mvt_source_layer_prefix,
+    showBasemapLabels,
+    embedToken: embedToken ?? null,
+    geojsonVersion,
+    mapStyle,
+  }), [
+    layers,
+    tokenMap,
+    tileConfigReady,
+    tileConfig?.cdn_base_url,
+    tileConfig?.mvt_source_layer_prefix,
+    showBasemapLabels,
+    embedToken,
+    geojsonVersion,
+    mapStyle,
+  ]);
+  const compositionRequestRef = useRef(compositionRequest);
+  compositionRequestRef.current = compositionRequest;
+
+  const markMapLoading = useCallback(() => {
+    settledCompositionRef.current = null;
+    setTilesIdle(false);
+  }, []);
+
   // Fetch bounded GeoJSON data for small 3D datasets (auto-switch from MVT per D-07)
   // and for eligible point cluster layers.
   // Fetch is independent of map readiness — data lands in a ref, repaint is separate.
-  const [geojsonVersion, setGeojsonVersion] = useState(0);
   useEffect(() => {
     if (boundedGeoJsonLayers.length === 0) {
       if (geojsonDataRef.current.size > 0) {
@@ -365,6 +415,7 @@ export const ViewerMap = memo(function ViewerMap({
       );
       if (!cancelled) {
         geojsonDataRef.current = newMap;
+        completedBoundedGeoJsonRequestRef.current = boundedGeoJsonRequest;
         setGeojsonVersion((v) => v + 1);
       }
     }
@@ -372,7 +423,7 @@ export const ViewerMap = memo(function ViewerMap({
       // Individual layer errors are already toasted above; this only fires on unexpected scaffolding failure
     });
     return () => { cancelled = true; };
-  }, [boundedGeoJsonLayers, apiKey, embedToken, t]);
+  }, [boundedGeoJsonLayers, boundedGeoJsonRequest, apiKey, embedToken, t]);
 
   // Trigger repaint when GeoJSON-Z data arrives and map is ready
   useEffect(() => {
@@ -473,22 +524,26 @@ export const ViewerMap = memo(function ViewerMap({
       // image (knownImagesOnly: false) to keep the public console clean.
       map.setMissingStyleImageResolver(makeStyleImageMissingResolver(map, { knownImagesOnly: false }));
 
-      // `idle` fires when no tiles are loading, no transitions are in
-      // progress, and no animations are running. We flip the container's
-      // data-tiles-loaded attribute to true on idle so Playwright (and V-13's
-      // loading-affordance consumers) can rely on a deterministic signal
-      // instead of an arbitrary wait.
-      // fix(#430 V-13): re-arm on every camera move instead of firing once — the
-      // attribute previously never toggled back to "false" after the initial
-      // idle, so it couldn't distinguish "settled" from "tiles loading after
-      // a pan/zoom" (a false "map fully rendered" signal mid-move).
-      map.on('movestart', () => setTilesIdle(false));
-      map.on('idle', () => setTilesIdle(true));
+      // `dataloading` covers app-driven source/style work that does not move
+      // the camera (async token arrival, terrain seeding, GeoJSON replacement,
+      // and style swaps). The old movestart-only re-arm allowed the initial
+      // basemap idle to stay true while those overlays were still loading.
+      tilesLoadingHandlerRef.current = markMapLoading;
+      tilesIdleHandlerRef.current = () => {
+        const styleReady = map.isStyleLoaded() === true;
+        settledCompositionRef.current = styleReady
+          ? appliedCompositionRef.current
+          : null;
+        setTilesIdle(styleReady);
+      };
+      map.on('movestart', tilesLoadingHandlerRef.current);
+      map.on('dataloading', tilesLoadingHandlerRef.current);
+      map.on('idle', tilesIdleHandlerRef.current);
 
       setMapReady(true);
       onMapReady?.(map);
     },
-    [onMapReady, embedToken, t, recoverTileAuth],
+    [onMapReady, embedToken, t, recoverTileAuth, markMapLoading],
   );
 
   // Stable list of interactive (non-heatmap, visible) layer IDs for query operations
@@ -823,6 +878,7 @@ export const ViewerMap = memo(function ViewerMap({
       basemapConfig: bc,
     } = syncInputsRef.current;
     if (!tcReady) return;
+    markMapLoading();
     const tileBaseUrl = resolveTileBaseUrl(tc);
     const syncInputs: SyncLayerInput[] = createViewerLayerEntries(ls).map(({ layer, key }) => (
       toViewerSyncInput(layer, key, vl)
@@ -845,7 +901,22 @@ export const ViewerMap = memo(function ViewerMap({
       showBasemapLabels: sbl,
       reorderDataLayerIds: syncInputs,
     });
-  }, []);
+    const renderableEntries = createViewerLayerEntries(ls).filter(({ layer }) => (
+      !isDemTerrainVisualSuppressed(layer)
+    ));
+    const hasViewerSources = managedSourcesRef.current.size > 0
+      && [...managedSourcesRef.current].every((sourceId) => Boolean(map.getSource(sourceId)));
+    const hasViewerLayers = renderableEntries.length > 0
+      && renderableEntries.every(({ layer, key }) => (
+        viewerManagedLayerIds(layer, key).every((layerId) => Boolean(map.getLayer(layerId)))
+      ));
+    // A terrain-render-mode DEM deliberately has no ordinary style layer or
+    // managed composition source; useViewerTerrain owns its terrain-dem source.
+    const hasOnlySuppressedTerrain = ls.length > 0 && renderableEntries.length === 0;
+    appliedCompositionRef.current = hasOnlySuppressedTerrain || (hasViewerSources && hasViewerLayers)
+      ? compositionRequestRef.current
+      : null;
+  }, [markMapLoading]);
 
   // Sync layers to map (on data/visibility changes)
   useEffect(() => {
@@ -900,6 +971,7 @@ export const ViewerMap = memo(function ViewerMap({
     if (!map || !mapReady || (!embedToken && tokenMap.size === 0)) return;
     const tileBaseUrl = resolveTileBaseUrl({ cdn_base_url: cdnBaseUrl });
 
+    let rearmed = false;
     for (const { layer, key } of layerEntries) {
       const token = tokenMap.get(layer.dataset_id) ?? null;
       // Skip rasters — their tile_url is stable, no refresh needed.
@@ -908,6 +980,10 @@ export const ViewerMap = memo(function ViewerMap({
       const source = map.getSource(sourceId);
       // Only vector sources need query-param URL refreshes.
       if (source && source.type === 'vector') {
+        if (!rearmed) {
+          markMapLoading();
+          rearmed = true;
+        }
         const strategy = getClusterSourceStrategy(layer);
         const builder = layer.style_config?.builder;
         // Per-layer source in viewer context (no dedupe by table_name), so
@@ -936,7 +1012,7 @@ export const ViewerMap = memo(function ViewerMap({
         (source as VectorTileSource).setTiles([newUrl]);
       }
     }
-  }, [tokenMap, layerEntries, mapReady, cdnBaseUrl, embedToken]);
+  }, [tokenMap, layerEntries, mapReady, cdnBaseUrl, embedToken, markMapLoading]);
 
   // Toggle visibility when visibleLayers set changes.
   // Note: runSync also calls syncVisibility via syncLayersToMap, but this
@@ -995,6 +1071,8 @@ export const ViewerMap = memo(function ViewerMap({
     if (!map) return;
 
     const onStyleLoad = () => {
+      markMapLoading();
+      appliedCompositionRef.current = null;
       managedSourcesRef.current = new Set();
       prevOrderKeyRef.current = '';
       // Guard: if layers haven't loaded yet, skip — the sync effect will
@@ -1016,7 +1094,7 @@ export const ViewerMap = memo(function ViewerMap({
     return () => {
       map.off('style.load', onStyleLoad);
     };
-  }, [mapReady, embedToken, runSync, reseedTerrainOnStyleLoad, applyViewerBasemapConfig]);
+  }, [mapReady, embedToken, runSync, reseedTerrainOnStyleLoad, applyViewerBasemapConfig, markMapLoading]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -1027,6 +1105,16 @@ export const ViewerMap = memo(function ViewerMap({
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      const map = mapRef.current;
+      if (map && tilesLoadingHandlerRef.current) {
+        map.off('movestart', tilesLoadingHandlerRef.current);
+        map.off('dataloading', tilesLoadingHandlerRef.current);
+      }
+      if (map && tilesIdleHandlerRef.current) {
+        map.off('idle', tilesIdleHandlerRef.current);
+      }
+      appliedCompositionRef.current = null;
+      settledCompositionRef.current = null;
       mapRef.current = null;
     };
   }, []);
@@ -1042,6 +1130,19 @@ export const ViewerMap = memo(function ViewerMap({
     const invalidateTileTokens = useInvalidateTileTokens();
   const { contextLost, reload } = useWebGLRecovery(mapRef, mapReady, invalidateTileTokens);
 
+  const compositionPrerequisitesReady = layers.length === 0 || (
+    tileConfigReady && layerTokensReady && boundedGeoJsonReady
+  );
+  const compositionSettled = layers.length === 0 || (
+    appliedCompositionRef.current === compositionRequest
+    && settledCompositionRef.current === compositionRequest
+  );
+  const viewerReady = mapReady
+    && tilesIdle
+    && compositionPrerequisitesReady
+    && compositionSettled
+    && (!terrainExpected || terrainReady);
+
   return (
     <div
       className={`relative h-full w-full ${!mapReady ? 'bg-muted animate-pulse' : ''}`}
@@ -1051,7 +1152,8 @@ export const ViewerMap = memo(function ViewerMap({
       // pattern as DatasetMap's shell).
       role="region"
       aria-label={t('viewer.map.ariaLabel', { defaultValue: 'Map viewer' })}
-      data-tiles-loaded={tilesIdle ? 'true' : 'false'}
+      data-tiles-loaded={viewerReady ? 'true' : 'false'}
+      data-map-ready={viewerReady ? 'true' : 'false'}
       data-terrain-ready={terrainReady ? 'true' : 'false'}
     >
       <MapGL

--- a/frontend/src/components/viewer/__tests__/ViewerMap.visibility-idle-retry.test.tsx
+++ b/frontend/src/components/viewer/__tests__/ViewerMap.visibility-idle-retry.test.tsx
@@ -4,7 +4,7 @@
 // fix registers map.once('idle', applyVisibilityDiff) so the toggle re-applies
 // once the map settles (mirrors the BuilderMap idle-retry pattern).
 import type { ReactNode } from 'react';
-import { render, waitFor } from '@/test/test-utils';
+import { act, render, waitFor } from '@/test/test-utils';
 import { ViewerMap } from '../ViewerMap';
 import type { SharedLayerResponse } from '@/types/api';
 
@@ -36,8 +36,13 @@ type FakeMap = {
   emit: (event: string, payload?: unknown) => void;
 };
 
+type TestToken =
+  | { kind: 'vector'; token: string }
+  | { kind: 'raster'; tile_url: string };
+
 const mapState = vi.hoisted(() => {
   const handlers = new Map<string, Set<(payload?: unknown) => void>>();
+  const sources = new Map<string, { type: string }>();
   const canvas = {
     width: 800, height: 600, clientWidth: 800, clientHeight: 600,
     style: { cursor: '' },
@@ -63,7 +68,7 @@ const mapState = vi.hoisted(() => {
     // Return truthy for every layer id so adapter.syncVisibility actually
     // dispatches setLayoutProperty when the diff applies.
     getLayer: vi.fn(() => ({ id: 'x' })),
-    getSource: vi.fn(() => null),
+    getSource: vi.fn((sourceId: string) => sources.get(sourceId) ?? null),
     getStyle: vi.fn(() => ({ version: 8, sources: {}, layers: [] })),
     queryRenderedFeatures: vi.fn(() => []),
     getCanvas: vi.fn(() => canvas),
@@ -77,7 +82,9 @@ const mapState = vi.hoisted(() => {
     setPaintProperty: vi.fn(),
     setFilter: vi.fn(),
     addLayer: vi.fn(),
-    addSource: vi.fn(),
+    addSource: vi.fn((sourceId: string, spec: { type: string }) => {
+      sources.set(sourceId, { type: spec.type });
+    }),
     removeLayer: vi.fn(),
     triggerRepaint: vi.fn(),
     setLayerZoomRange: vi.fn(),
@@ -90,6 +97,7 @@ const mapState = vi.hoisted(() => {
     handlers,
     reset: () => {
       handlers.clear();
+      sources.clear();
       Object.values(fakeMap).forEach((v) => {
         if (typeof v === 'function' && 'mockClear' in v) (v as ReturnType<typeof vi.fn>).mockClear();
       });
@@ -125,6 +133,15 @@ const tileConfigState = vi.hoisted(() => ({
   } | null,
 }));
 
+const tokenState = vi.hoisted(() => ({
+  data: new Map<string, TestToken>([['dataset-pt', { kind: 'vector', token: 't' }]]),
+}));
+
+const terrainState = vi.hoisted(() => ({
+  ready: false,
+  expected: false,
+}));
+
 vi.mock('@/hooks/use-settings', () => ({
   useBasemaps: () => ({ data: [] }),
   useTileConfig: () => ({ data: tileConfigState.data }),
@@ -135,16 +152,31 @@ vi.mock('@/hooks/use-webgl-recovery', () => ({
 }));
 vi.mock('@/components/viewer/hooks/use-viewer-tokens', () => ({
   // Provide a token so the main sync effect's token gate doesn't short-circuit.
-  useViewerTokens: () => ({ tokenMap: new Map([['dataset-pt', { kind: 'vector', token: 't' }]]) }),
+  useViewerTokens: () => ({ tokenMap: tokenState.data }),
 }));
 vi.mock('@/components/viewer/hooks/use-viewer-terrain', () => ({
-  useViewerTerrain: () => ({ terrainReady: false, reseedTerrainOnStyleLoad: vi.fn() }),
-  isViewerTerrainExpected: () => false,
+  useViewerTerrain: () => ({ terrainReady: terrainState.ready, reseedTerrainOnStyleLoad: vi.fn() }),
+  isViewerTerrainExpected: () => terrainState.expected,
 }));
 vi.mock('@/components/map/MapCoordReadout', () => ({ MapCoordReadout: () => null }));
 vi.mock('@/components/builder/map-sync', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/components/builder/map-sync')>();
   return { ...actual, applyBasemapConfigToMap: vi.fn(), syncLayersToMap: vi.fn() };
+});
+vi.mock('@/components/builder/map-composition-sync', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/components/builder/map-composition-sync')>();
+  return {
+    ...actual,
+    syncMapComposition: vi.fn(({ map, layers, managedSourcesRef }) => {
+      if (layers.length === 0) return;
+      if (layers.every((layer: { is_dem?: boolean; style_config?: { render_mode?: string } | null }) => (
+        layer.is_dem === true && layer.style_config?.render_mode === 'terrain'
+      ))) return;
+      const sourceId = 'viewer-source-points';
+      if (!map.getSource(sourceId)) map.addSource(sourceId, { type: 'vector' });
+      managedSourcesRef.current = new Set([sourceId]);
+    }),
+  };
 });
 vi.mock('@/lib/builder/basemap-style-mutation', () => ({ applySublayerOverrides: vi.fn() }));
 
@@ -189,6 +221,9 @@ describe('ViewerMap visibility idle-retry (BUG-037)', () => {
       cdn_base_url: null,
       mvt_source_layer_prefix: 'data',
     };
+    tokenState.data = new Map([['dataset-pt', { kind: 'vector', token: 't' }]]);
+    terrainState.ready = false;
+    terrainState.expected = false;
   });
 
   it('does not run visibility sync for an unresolved tenant source-layer prefix', async () => {
@@ -244,5 +279,99 @@ describe('ViewerMap visibility idle-retry (BUG-037)', () => {
       'visibility',
       'none',
     );
+  });
+
+  it('does not reuse the initial basemap idle for an asynchronously added data layer', async () => {
+    mapState.fakeMap.isStyleLoaded.mockReturnValue(true);
+    tokenState.data = new Map();
+
+    const { rerender, getByRole } = renderViewer(new Set(['pt-layer']));
+    const mapRegion = getByRole('region', { name: 'Map viewer' });
+
+    await waitFor(() => expect(mapState.fakeMap.setTransformRequest).toHaveBeenCalled());
+    act(() => { mapState.fakeMap.emit('idle'); });
+
+    // The basemap has settled, but the data-layer token has not arrived and no
+    // ViewerMap-owned source/layer has been composed yet.
+    expect(mapRegion).toHaveAttribute('data-tiles-loaded', 'false');
+    expect(mapRegion).toHaveAttribute('data-map-ready', 'false');
+
+    tokenState.data = new Map([['dataset-pt', { kind: 'vector', token: 'late' }]]);
+    rerender(
+      <ViewerMap
+        layers={[LAYER]}
+        basemapStyle="openfreemap-positron"
+        basemapConfig={null}
+        showBasemapLabels={true}
+        terrainConfig={null}
+        initialViewState={{ center_lng: 0, center_lat: 0, zoom: 2, bearing: 0, pitch: 0 }}
+        visibleLayers={new Set(['pt-layer'])}
+      />,
+    );
+
+    await waitFor(() => expect(mapState.fakeMap.addSource).toHaveBeenCalled());
+    expect(mapRegion).toHaveAttribute('data-map-ready', 'false');
+
+    // Only an idle observed after the current composition was attached can
+    // certify it. Later source activity re-arms the same contract.
+    act(() => { mapState.fakeMap.emit('idle'); });
+    await waitFor(() => expect(mapRegion).toHaveAttribute('data-map-ready', 'true'));
+    expect(mapRegion).toHaveAttribute('data-tiles-loaded', 'true');
+
+    act(() => { mapState.fakeMap.emit('dataloading'); });
+    expect(mapRegion).toHaveAttribute('data-map-ready', 'false');
+    expect(mapRegion).toHaveAttribute('data-tiles-loaded', 'false');
+
+    act(() => { mapState.fakeMap.emit('idle'); });
+    await waitFor(() => expect(mapRegion).toHaveAttribute('data-map-ready', 'true'));
+  });
+
+  it('settles a terrain-only composition after the terrain source load cycle', async () => {
+    const terrainLayer: SharedLayerResponse = {
+      ...LAYER,
+      id: 'terrain-layer',
+      dataset_id: 'dataset-dem',
+      table_name: 'terrain_dem',
+      geometry_type: null,
+      is_dem: true,
+      layer_type: 'raster_geolens',
+      style_config: { render_mode: 'terrain' },
+    };
+    mapState.fakeMap.isStyleLoaded.mockReturnValue(true);
+    tokenState.data = new Map([['dataset-dem', { kind: 'raster' as const, tile_url: '/dem/{z}/{x}/{y}.png' }]]);
+    terrainState.expected = true;
+
+    const { rerender, getByRole } = render(
+      <ViewerMap
+        layers={[terrainLayer]}
+        basemapStyle="openfreemap-positron"
+        terrainConfig={{ enabled: true, source_dataset_id: 'dataset-dem', exaggeration: 1 }}
+        initialViewState={{ center_lng: 0, center_lat: 0, zoom: 2, bearing: 0, pitch: 0 }}
+        visibleLayers={new Set(['terrain-layer'])}
+      />,
+    );
+    const mapRegion = getByRole('region', { name: 'Map viewer' });
+
+    await waitFor(() => expect(mapState.fakeMap.setTransformRequest).toHaveBeenCalled());
+    act(() => { mapState.fakeMap.emit('idle'); });
+    expect(mapRegion).toHaveAttribute('data-map-ready', 'false');
+
+    // The terrain hook owns this source outside syncMapComposition. Its data
+    // activity re-arms readiness, and terrainReady alone cannot bypass idle.
+    act(() => { mapState.fakeMap.emit('dataloading'); });
+    terrainState.ready = true;
+    rerender(
+      <ViewerMap
+        layers={[terrainLayer]}
+        basemapStyle="openfreemap-positron"
+        terrainConfig={{ enabled: true, source_dataset_id: 'dataset-dem', exaggeration: 1 }}
+        initialViewState={{ center_lng: 0, center_lat: 0, zoom: 2, bearing: 0, pitch: 0 }}
+        visibleLayers={new Set(['terrain-layer'])}
+      />,
+    );
+    expect(mapRegion).toHaveAttribute('data-map-ready', 'false');
+
+    act(() => { mapState.fakeMap.emit('idle'); });
+    await waitFor(() => expect(mapRegion).toHaveAttribute('data-map-ready', 'true'));
   });
 });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "e2e:smoke:reupload": "npx playwright test e2e/reupload-multi-layer-gpkg.spec.ts --project=chromium",
     "e2e:smoke:audit": "npx playwright test e2e/accessibility.spec.ts e2e/post-impl-validation.spec.ts e2e/record-detail-ux-audit.spec.ts e2e/showcase-smoke.spec.ts e2e/showcase-smoke-anonymous.spec.ts --project=chromium",
     "e2e:smoke:perf": "npx playwright test e2e/perf/builder-large-map.spec.ts --project=chromium",
+    "e2e:smoke:demo": "npx playwright test -c playwright.demo.config.ts",
     "e2e:export": "npx playwright test e2e/export-runtime.spec.ts --project=api --workers=1 --retries=0",
     "e2e:ui": "npx playwright test --ui",
     "check:readme-locales": "node scripts/check-readme-locales.mjs",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ assertWorktreeMatchesStack();
 
 export default defineConfig({
   testDir: './e2e',
+  testIgnore: /demo-smoke\.spec\.ts/,
   timeout: 60_000,
   expect: { timeout: 10_000 },
   fullyParallel: false,
@@ -40,7 +41,7 @@ export default defineConfig({
     },
     {
       name: 'chromium',
-      testIgnore: /export-runtime\.spec\.ts/,
+      testIgnore: /(?:demo-smoke|export-runtime)\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
         storageState: 'playwright/.auth/user.json',

--- a/playwright.demo.config.ts
+++ b/playwright.demo.config.ts
@@ -1,0 +1,64 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const configuredBaseURL = process.env.E2E_DEMO_BASE_URL;
+
+if (!configuredBaseURL) {
+  throw new Error(
+    'E2E_DEMO_BASE_URL is required. Example: E2E_DEMO_BASE_URL=https://demo.getgeolens.com npm run e2e:smoke:demo',
+  );
+}
+
+const demoBaseURL = new URL(configuredBaseURL);
+if (!['http:', 'https:'].includes(demoBaseURL.protocol)) {
+  throw new Error('E2E_DEMO_BASE_URL must use http:// or https://');
+}
+if (demoBaseURL.username || demoBaseURL.password) {
+  throw new Error('E2E_DEMO_BASE_URL must not contain credentials');
+}
+if (demoBaseURL.pathname !== '/' || demoBaseURL.search || demoBaseURL.hash) {
+  throw new Error('E2E_DEMO_BASE_URL must be an origin without a path, query, or fragment');
+}
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: 'demo-smoke.spec.ts',
+  timeout: 90_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  outputDir: 'test-results/demo',
+  reporter: process.env.CI
+    ? [
+        ['github'],
+        ['html', { outputFolder: 'playwright-report/demo', open: 'never' }],
+      ]
+    : [
+        ['list'],
+        ['html', { outputFolder: 'playwright-report/demo', open: 'never' }],
+      ],
+  use: {
+    baseURL: demoBaseURL.origin,
+    locale: 'en-US',
+    storageState: { cookies: [], origins: [] },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'demo-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: [
+            '--enable-unsafe-swiftshader',
+            '--use-gl=swiftshader',
+            '--enable-webgl',
+            '--ignore-gpu-blocklist',
+          ],
+        },
+      },
+    },
+  ],
+});

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,6 +86,7 @@ needs the `upload` and `export` capabilities on the seeding account.
 | `install.sh` | First-run installer (see below) |
 | `preflight-env.sh` | Refuse a `.env` line Compose cannot load, then validate the boot-required settings (JWT secret, admin creds, encryption key shape) as Compose will resolve them, shell environment first and then `.env`, via `make preflight` / `make dev` |
 | `check-env.sh` | Probe the running stack's env, DB connectivity, and GDAL via `make doctor` (requires the stack up) |
+| `check-demo-config.sh` | Read-only check that the public demo's rendered Compose config and API container have `LANDING_FIRST=false`, no `landing_first` DB override exists, and the effective public value is `false` |
 | `init-db.sh` | Initialize the PostGIS database schema (mounted into the db container's init) |
 | `init-test-db.sh` | Initialize a host-accessible `geolens_test` database (extensions, schemas, roles) for local `psql` debugging. Not used by CI. CI and pytest each bootstrap their own test databases. |
 | `backup-entrypoint.sh` | Scheduled `pg_dump` backups with retention + optional S3 upload (the default Docker Compose backup service) |
@@ -94,6 +95,23 @@ needs the `upload` and `export` capabilities on the seeding account.
 | `run-baseline.sh` | Run performance baselines |
 | `analyze-query-plans.sh` | Analyze slow query plans |
 | `cleanup-test-pollution.sql` | Remove leftover test data (manual `psql`) |
+
+Run the demo-specific guard from the checkout on the demo host after recreating
+the API container. It inspects the rendered Compose value, running container,
+and bundled database, then checks the value exposed by the public auth
+configuration endpoint:
+
+```bash
+sh scripts/check-demo-config.sh
+```
+
+The command is read-only and intentionally fails when any DB override remains,
+even a stored `false`: the demo's catalog-first behavior is owned by its
+environment configuration, and an old override can silently take precedence
+later. If it fails, reset **Login as Landing Page** in Admin → Settings → Auth,
+set `LANDING_FIRST=false` in the demo deployment environment, recreate
+the API service, and run the check again. Do not turn on `ENV_ONLY_CONFIG` as a
+shortcut; that changes the configuration contract for every setting.
 
 ## Build & release glue
 

--- a/scripts/check-demo-config.sh
+++ b/scripts/check-demo-config.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Read-only guard for the public demo's catalog-first landing contract.
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+PROJECT_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+DEMO_BASE_URL="${DEMO_BASE_URL:-https://demo.getgeolens.com}"
+
+case "$COMPOSE_FILE" in
+    /*) COMPOSE_PATH=$COMPOSE_FILE ;;
+    *) COMPOSE_PATH=$PROJECT_ROOT/$COMPOSE_FILE ;;
+esac
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+compose() {
+    docker compose -f "$COMPOSE_PATH" \
+        --project-directory "$PROJECT_ROOT" "$@"
+}
+
+command -v docker >/dev/null 2>&1 || fail "docker is required"
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+[ -f "$COMPOSE_PATH" ] || fail "compose file not found: $COMPOSE_PATH"
+
+# Render Compose so this also catches a pending .env change that would take
+# effect at the next recreate. Parse in memory and emit only this non-secret
+# value; never print or persist the full rendered configuration.
+declared_env="$(compose config --format json | python3 -c '
+import json
+import sys
+
+environment = json.load(sys.stdin)["services"]["api"]["environment"]
+value = environment.get("LANDING_FIRST")
+if value is None:
+    raise SystemExit("api.environment.LANDING_FIRST is missing")
+print("{}|{}".format(value, environment.get("ENV_ONLY_CONFIG", "false")))
+')" || fail "could not resolve API LANDING_FIRST from the Compose configuration"
+
+declared_landing=${declared_env%%|*}
+declared_env_only=${declared_env#*|}
+
+case "$(printf '%s' "$declared_landing" | tr '[:upper:]' '[:lower:]')" in
+    false | 0 | no | off) ;;
+    *) fail "Compose API LANDING_FIRST must resolve to false; got '$declared_landing'" ;;
+esac
+case "$(printf '%s' "$declared_env_only" | tr '[:upper:]' '[:lower:]')" in
+    false | 0 | no | off) ;;
+    *) fail "Compose API ENV_ONLY_CONFIG must remain false; got '$declared_env_only'" ;;
+esac
+
+# Inspect the running container, not only .env: a changed file has no effect
+# until Compose recreates the API container.
+# The single-quoted variables expand inside the API container.
+# shellcheck disable=SC2016
+runtime="$(compose exec -T api sh -c \
+    'printf "%s|%s\n" "${LANDING_FIRST-__unset__}" "${ENV_ONLY_CONFIG-false}"')" \
+    || fail "could not read the API container environment"
+landing_env=${runtime%%|*}
+env_only_config=${runtime#*|}
+
+case "$(printf '%s' "$landing_env" | tr '[:upper:]' '[:lower:]')" in
+    false | 0 | no | off) ;;
+    *) fail "API container LANDING_FIRST must resolve to false; got '$landing_env'" ;;
+esac
+case "$(printf '%s' "$env_only_config" | tr '[:upper:]' '[:lower:]')" in
+    false | 0 | no | off) ;;
+    *) fail "API container ENV_ONLY_CONFIG must remain false; got '$env_only_config'" ;;
+esac
+
+# Query only the one configuration row. psql inherits credentials inside the
+# bundled DB container, so the command does not print or copy a password.
+# The single-quoted variables expand inside the DB container.
+# shellcheck disable=SC2016
+db_override="$(compose exec -T db sh -c \
+    'exec psql -X -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At' <<'SQL'
+SELECT COALESCE(
+    (SELECT value::text FROM catalog.app_settings WHERE key = 'landing_first'),
+    '__unset__'
+);
+SQL
+)" || fail "could not read catalog.app_settings"
+
+[ "$db_override" = "__unset__" ] \
+    || fail "catalog.app_settings still overrides landing_first: $db_override"
+
+auth_config="$(curl -fsSL --max-redirs 3 --max-time 15 \
+    "${DEMO_BASE_URL%/}/api/auth/config/")" \
+    || fail "could not fetch the public auth configuration"
+effective="$(printf '%s' "$auth_config" | python3 -c '
+import json
+import sys
+
+value = json.load(sys.stdin).get("landing_first")
+if not isinstance(value, bool):
+    raise SystemExit("landing_first is missing or is not a boolean")
+print(str(value).lower())
+')" || fail "public auth configuration did not contain a boolean landing_first"
+
+[ "$effective" = "false" ] \
+    || fail "public effective landing_first must be false; got '$effective'"
+
+printf 'PASS: demo landing configuration is catalog-first\n'
+printf '  Compose LANDING_FIRST: %s\n' "$declared_landing"
+printf '  API LANDING_FIRST: %s\n' "$landing_env"
+printf '  API ENV_ONLY_CONFIG: %s\n' "$env_only_config"
+printf '  DB landing_first override: unset\n'
+printf '  Public effective landing_first: %s\n' "$effective"

--- a/scripts/tests/test-check-demo-config.sh
+++ b/scripts/tests/test-check-demo-config.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+REPO_ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+FAKE_BIN="$(mktemp -d)"
+trap 'rm -rf "$FAKE_BIN"' EXIT HUP INT TERM
+
+cat >"$FAKE_BIN/docker" <<'EOF'
+#!/bin/sh
+case " $* " in
+    *" config --format json "*) printf '{"services":{"api":{"environment":{"LANDING_FIRST":"%s","ENV_ONLY_CONFIG":"%s"}}}}\n' "${TEST_DECLARED_ENV:-false}" "${TEST_DECLARED_ENV_ONLY:-false}" ;;
+    *" exec -T api "*) printf '%s|%s\n' "${TEST_LANDING_ENV:-false}" "${TEST_ENV_ONLY_CONFIG:-false}" ;;
+    *" exec -T db "*) printf '%s\n' "${TEST_DB_OVERRIDE:-__unset__}" ;;
+    *) exit 2 ;;
+esac
+EOF
+
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/bin/sh
+printf '{"landing_first":%s}\n' "${TEST_EFFECTIVE:-false}"
+EOF
+
+chmod +x "$FAKE_BIN/docker" "$FAKE_BIN/curl"
+
+PATH="$FAKE_BIN:$PATH" "$REPO_ROOT/scripts/check-demo-config.sh" >/dev/null
+
+if TEST_DECLARED_ENV=true PATH="$FAKE_BIN:$PATH" \
+    "$REPO_ROOT/scripts/check-demo-config.sh" >/dev/null 2>&1; then
+    printf 'FAIL: a pending Compose true value was accepted\n' >&2
+    exit 1
+fi
+
+if TEST_DECLARED_ENV_ONLY=true PATH="$FAKE_BIN:$PATH" \
+    "$REPO_ROOT/scripts/check-demo-config.sh" >/dev/null 2>&1; then
+    printf 'FAIL: an ENV_ONLY_CONFIG shortcut was accepted\n' >&2
+    exit 1
+fi
+
+if TEST_DB_OVERRIDE='{"v": true}' PATH="$FAKE_BIN:$PATH" \
+    "$REPO_ROOT/scripts/check-demo-config.sh" >/dev/null 2>&1; then
+    printf 'FAIL: a DB override was accepted\n' >&2
+    exit 1
+fi
+
+if TEST_EFFECTIVE=true PATH="$FAKE_BIN:$PATH" \
+    "$REPO_ROOT/scripts/check-demo-config.sh" >/dev/null 2>&1; then
+    printf 'FAIL: an effective true value was accepted\n' >&2
+    exit 1
+fi
+
+printf 'PASS: demo config checker accepts the intended state and rejects drift\n'


### PR DESCRIPTION
## Summary

A basemap idle event could report a public map ready before its asynchronous data layers or terrain finished loading. Require the current composition to be attached and settled, and add a repeatable anonymous demo deployment check. Follow-up to the v1.19.1 release in #2059.

## Changes

- Require current tokens, configuration, bounded GeoJSON completion, source/layer attachment, terrain activation, and a subsequent idle event for viewer readiness. Cover terrain-only maps and reset readiness when new loading starts.
- Add `npm run e2e:smoke:demo` and a manual **Demo Browser Smoke** workflow. Check anonymous catalog entry, health/version, and six showcase maps through catalog clicks. Save browser evidence and reject application/network errors.
- Keep existing locally seeded showcase tests separate. Older releases require explicit legacy readiness mode.
- Add a read-only demo configuration guard for declared Compose settings, running API settings, the database override, and public effective settings.

No API schema, database migration, dependency, or general authentication-default changes. New environment options configure the test runner only; the configuration guard does not mutate settings.

## Area

- [x] Frontend (UI, components, hooks)
- [x] Tiles / Rendering
- [x] Docs / Config

## Testing

- [x] Frontend build, lint, typecheck, and coverage: 462 files / 6,127 tests passed; line coverage 80.14%.
- [x] ViewerMap regression suite: 47 tests passed.
- [x] New demo suite against edited frontend with public demo API proxy: 7/7 passed in strict readiness mode; all saved screenshots inspected.
- [x] Live demo v1.19.1: 7/7 passed with explicitly annotated legacy readiness.
- [x] Local `e2e:smoke:audit`: 78 passed, 10 seed-dependent showcase tests skipped.
- [x] Configuration checker passed against the demo VM; mocked drift tests, POSIX syntax, ShellCheck, Actionlint, version coherence, and diff checks passed.

This changes the readiness contract and verification tooling, with no visual layout change. Browser screenshots are generated as Playwright artifacts by the demo workflow. No new code has been deployed to the demo by this PR.

### CI dependency scan

The [Python base-image scan](https://github.com/geolens-io/geolens/actions/runs/34705223668) reports three critical findings in the unchanged `python:3.14.6-slim` image: CVE-2026-13221, CVE-2026-42496, and CVE-2026-8376. Trivy reports installed `perl-base` 5.40.1-6 and fixed version 5.40.1-6+deb13u1. This PR does not change image pins or suppress these findings.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: no new user-facing strings
- [x] No new lint warnings
- [x] TypeScript compiles without errors
- [x] No schema change requiring a migration
- [x] No secrets or credentials in the diff
