### PR TITLE
fix(security): patch Python container OS layer

### DIFF
--- a/.github/workflows/dep-audit.yml
+++ b/.github/workflows/dep-audit.yml
@@ -116,7 +116,7 @@ jobs:
               exit 1
             fi
           done
-          include=$(printf '[{"image":"%s","enforce":"1"},{"image":"%s","enforce":"1"},{"image":"%s","enforce":"1"},{"image":"postgis/postgis:18-3.6","enforce":"0"}]' \
+          include=$(printf '[{"image":"%s","enforce":"1"},{"image":"%s","enforce":"0"},{"image":"%s","enforce":"1"},{"image":"postgis/postgis:18-3.6","enforce":"0"}]' \
             "$node_image" "$python_image" "$nginx_image")
           echo "include=$include" >> "$GITHUB_OUTPUT"
 
@@ -128,11 +128,12 @@ jobs:
       fail-fast: false
       matrix:
         # `enforce: "1"` fails the job on a fixable CRITICAL CVE; `enforce: "0"`
-        # is report-only. The slim/alpine images we pin (node/python/nginx) are
-        # controllable — a CRITICAL there is actionable (bump the tag), so they
-        # ENFORCE; their tags come from the Dockerfile `FROM` lines via the
-        # resolve-docker-audit-matrix job above, so this can't drift out of
-        # sync. postgis/postgis:18-3.6 is an uncontrollable third-party fat
+        # is report-only. Node/nginx enforce their upstream base scans. Python
+        # reports upstream findings here and ENFORCES the upgraded backend-system
+        # stage in python-system-audit: even the newest Python patch tag can lag
+        # Debian security packages, which our shared OS stage installs.
+        # Tags come from Dockerfile FROM lines so the matrix cannot drift.
+        # postgis/postgis:18-3.6 is an uncontrollable third-party fat
         # Debian-13 image whose CRITICAL set is dominated by CVEs in baked-in Go
         # binaries that only the upstream maintainer can rebuild — and that set
         # shifts with every Trivy DB update. Gating on it would make CI red on
@@ -161,6 +162,26 @@ jobs:
           # Scoped, justified CVE suppressions only (see .trivyignore.yaml's
           # `vulnerabilities:` section). Trivy <0.71 does not auto-detect the YAML
           # ignore file, so point at it explicitly.
+          trivyignores: ".trivyignore.yaml"
+
+  python-system-audit:
+    name: Python OS layer scan (Trivy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Both backend builder and runtime inherit this exact OS layer. No cache
+      # ensures a successful scan includes the current Debian security packages.
+      - name: Build the shared patched Python OS layer
+        run: docker build --pull --no-cache --target backend-system --tag geolens-python-system:audit .
+      - name: Enforce fixable critical vulnerabilities in the patched layer
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: geolens-python-system:audit
+          format: "table"
+          severity: "CRITICAL"
+          exit-code: "1"
+          ignore-unfixed: true
           trivyignores: ".trivyignore.yaml"
 
   iac-scan:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,35 @@
 # syntax=docker/dockerfile:1
 
 # ==============================================================================
-# Stage 1: backend-builder — uv sync, all build-time prep
+# Stage 1: backend-system — patched OS packages shared by build and runtime
 # ==============================================================================
-# Build-time deps (apt cache, intermediate uv-sync state) are confined to this
-# stage. The runtime layer rebuilds from a clean python:3.14-slim base and
-# only copies the resolved /app venv from this builder.
-FROM python:3.14.6-slim AS backend-builder
+# Dependabot bumps this concrete patch pin. Both backend stages inherit this
+# system layer so they use the same patched runtime libraries.
+# Security invariant: fail closed if the mirror cannot supply fixed Perl.
+FROM python:3.14.7-slim AS backend-system
+
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
+    gdal-bin \
+    libexpat1 \
+    xmlsec1 libxmlsec1-openssl \
+    && dpkg --compare-versions \
+        "$(dpkg-query -W -f='${Version}' perl-base)" \
+        ge '5.40.1-6+deb13u1' && \
+    rm -rf /var/lib/apt/lists/*
+
+# ==============================================================================
+# Stage 2: backend-builder — uv sync, all build-time prep
+# ==============================================================================
+# Build-time artifacts (uv cache and intermediate sync state) remain confined
+# to this stage. The runtime later copies only the resolved /app environment.
+FROM backend-system AS backend-builder
 
 # uv is build-time + runtime: see runtime-stage comment below for runtime rationale.
 # Aligned uv installer pin across builder + runtime stages.
 COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /uvx /bin/
 
 WORKDIR /app
-
-# Refresh base image packages and install runtime deps the resolved venv needs
-# at install time (gdal-bin, libexpat1 for rasterio, libxmlsec1 for SAML).
-# These are reinstalled cleanly in the runtime stage; they're here so `uv sync`
-# can run native-extension build steps.
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && \
-    apt-get install -y --no-install-recommends \
-    gdal-bin \
-    libexpat1 \
-    xmlsec1 libxmlsec1-openssl \
-    && rm -rf /var/lib/apt/lists/*
 
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
@@ -98,11 +104,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     done
 
 # ==============================================================================
-# Stage 2: backend-base — clean python:3.14-slim runtime; venv from builder
+# Stage 3: backend-base — patched runtime; venv from builder
 # ==============================================================================
-# True multi-stage split: runtime starts from a fresh
-# python:3.14-slim base (no apt-cache layer from builder, no intermediate
-# uv-sync state). Only the resolved /app/.venv + code arrive via COPY --from.
+# True multi-stage split: runtime starts from backend-system, not the builder,
+# so no uv cache or intermediate sync state crosses into the runtime image.
+# Only the resolved /app/.venv + code arrive via COPY --from.
 #
 # Note: uv is kept in the runtime layer because the entrypoints and CMD use
 # `uv run --no-dev` to launch uvicorn/worker inside the project environment.
@@ -111,24 +117,16 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Dockerfile to install a locked wheel into this completed runtime image.
 # gcc/dev libs are still excluded from the runtime layer.
 #
-# Pin: see the `FROM python:3.14-slim` line below (Dependabot bumps the exact
+# Pin: see the `FROM python:3.14-slim` line above (Dependabot bumps the exact
 # patch, so this prose names only the minor). backend/pyproject.toml
 # requires-python>=3.13 for adopter flexibility; this image ships the pinned
 # 3.14-slim as the project's tested runtime.
 # See backend/pyproject.toml comment at requires-python for the matching note.
-FROM python:3.14.6-slim AS backend-base
+FROM backend-system AS backend-base
 
 # uv kept for `uv run --no-dev` launch pattern (entrypoints + CMD).
 # Aligned uv installer pin across builder + runtime stages.
 COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /uvx /bin/
-
-# Runtime apt deps — clean install on a fresh layer (no apt cache from builder).
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && \
-    apt-get install -y --no-install-recommends \
-    gdal-bin \
-    libexpat1 \
-    xmlsec1 libxmlsec1-openssl \
-    && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user (shared by api and worker runtime targets).
 RUN groupadd --system --gid 1001 appgroup && \

--- a/backend/tests/test_docker_audit_regressions.py
+++ b/backend/tests/test_docker_audit_regressions.py
@@ -142,8 +142,35 @@ def test_docker_audit_matrix_resolver_pins_match_dockerfile_from_tags():
             f"{image} (resolved by dep-audit.yml) has no matching FROM line in Dockerfile"
         )
 
+    python_image = re.search(
+        r"^FROM (python:\S+) AS backend-system$", dockerfile_text, re.MULTILINE
+    )
+    assert python_image is not None
     report_only = [entry for entry in resolved if entry["enforce"] == "0"]
-    assert report_only == [{"image": "postgis/postgis:18-3.6", "enforce": "0"}]
+    assert report_only == [
+        {"image": python_image.group(1), "enforce": "0"},
+        {"image": "postgis/postgis:18-3.6", "enforce": "0"},
+    ]
+
+
+def test_python_system_audit_builds_and_enforces_patched_stage():
+    jobs = yaml.safe_load(DEP_AUDIT_WORKFLOW.read_text())["jobs"]
+    steps = jobs["python-system-audit"]["steps"]
+    build_step = next(step for step in steps if "run" in step)
+    scan_step = next(
+        step for step in steps if "aquasecurity/trivy-action" in step.get("uses", "")
+    )
+
+    assert "docker build --pull --no-cache" in build_step["run"]
+    assert "--target backend-system" in build_step["run"]
+    assert "--tag geolens-python-system:audit" in build_step["run"]
+    expected_scan_config = {
+        "image-ref": "geolens-python-system:audit",
+        "severity": "CRITICAL",
+        "exit-code": "1",
+        "ignore-unfixed": True,
+    }
+    assert expected_scan_config.items() <= scan_step["with"].items()
 
 
 def test_backend_runtime_does_not_recursively_chown_application_tree():

--- a/backend/tests/test_phase_272_dockerfile.py
+++ b/backend/tests/test_phase_272_dockerfile.py
@@ -24,14 +24,39 @@ PYPROJECT = REPO_ROOT / "backend" / "pyproject.toml"
 class TestInf06MultiStage:
     def test_dockerfile_has_builder_stage(self):
         text = DOCKERFILE.read_text()
-        assert re.search(r"^FROM\s+\S+\s+AS\s+backend-builder\s*$", text, re.M), (
-            "Dockerfile must declare a `FROM ... AS backend-builder` stage"
+        assert re.search(
+            r"^FROM\s+backend-system\s+AS\s+backend-builder\s*$", text, re.M
+        ), (
+            "Dockerfile must derive backend-builder from the patched backend-system stage"
         )
 
     def test_dockerfile_has_runtime_stage(self):
         text = DOCKERFILE.read_text()
-        assert re.search(r"^FROM\s+\S+\s+AS\s+backend-base\s*$", text, re.M), (
-            "Dockerfile must declare a `FROM ... AS backend-base` runtime stage"
+        assert re.search(
+            r"^FROM\s+backend-system\s+AS\s+backend-base\s*$", text, re.M
+        ), "Dockerfile must derive backend-base from the patched backend-system stage"
+
+    def test_backend_system_enforces_perl_security_floor(self):
+        text = DOCKERFILE.read_text()
+        system_stage = text.split("FROM backend-system AS backend-builder", 1)[0]
+        assert "apt-get upgrade -y --no-install-recommends" in system_stage
+        assert re.search(
+            r"dpkg\s+--compare-versions\s+.*perl-base.*"
+            r"ge\s+['\"]5\.40\.1-6\+deb13u1['\"]",
+            system_stage,
+            re.S,
+        ), "backend-system must fail if perl-base is below the fixed Debian version"
+
+    def test_backend_system_owns_shared_runtime_packages(self):
+        text = DOCKERFILE.read_text()
+        system_stage, following_stages = text.split(
+            "FROM backend-system AS backend-builder", 1
+        )
+        backend_stages = following_stages.split("FROM postgres:", 1)[0]
+        for package in ("gdal-bin", "libexpat1", "xmlsec1", "libxmlsec1-openssl"):
+            assert package in system_stage
+        assert "apt-get install" not in backend_stages, (
+            "backend packages must be installed once in backend-system"
         )
 
     def test_runtime_copies_venv_from_builder(self):
@@ -127,30 +152,18 @@ class TestInf14NginxMime:
 
 class TestInf15PythonPinReconciliation:
     def test_dockerfile_pins_python_consistently(self):
-        """INF-15: backend-builder and backend-base pin the same concrete
-        python:x.y.z-slim base.
+        """INF-15: the shared backend system stage pins python:x.y.z-slim.
 
-        Asserts the invariant (a concrete patch pin, identical across both named
-        backend stages) rather than a hard-coded literal. Dependabot bumps the
-        patch; the stale `python:3.14.3-slim` literal this test used to assert is
-        exactly the drift fix(#423) removed from the Dockerfile prose.
+        Dependabot bumps the concrete patch; builder and runtime both derive
+        from this stage so their Python and patched Debian packages stay aligned.
         """
         text = DOCKERFILE.read_text()
-        # Base image keyed by backend stage alias, e.g. "python:3.14.6-slim".
-        bases = dict(
-            (alias, base)
-            for base, alias in re.findall(
-                r"^FROM\s+(\S+)\s+AS\s+(backend-builder|backend-base)\s*$", text, re.M
-            )
+        match = re.search(
+            r"^FROM\s+(python:\d+\.\d+\.\d+-slim)\s+AS\s+backend-system\s*$",
+            text,
+            re.M,
         )
-        for alias in ("backend-builder", "backend-base"):
-            assert re.fullmatch(r"python:\d+\.\d+\.\d+-slim", bases.get(alias, "")), (
-                f"{alias} stage must pin a concrete python:x.y.z-slim base, "
-                f"got {bases.get(alias)!r}"
-            )
-        assert bases["backend-builder"] == bases["backend-base"], (
-            f"backend-builder and backend-base must pin the same python base; got {bases}"
-        )
+        assert match, "backend-system stage must pin a concrete python:x.y.z-slim base"
 
     def test_pyproject_requires_python_at_least_3_13(self):
         text = PYPROJECT.read_text()


### PR DESCRIPTION
## Summary

The pinned Python slim image currently ships `perl-base 5.40.1-6`, which Trivy reports with three fixable critical CVEs. This change creates a shared patched OS stage for both backend build and runtime images, requires Debian's fixed `5.40.1-6+deb13u1` package, and gates that built stage in CI while retaining the raw upstream scan as a report.

## Changes

- bump the backend Python image from 3.14.6-slim to 3.14.7-slim
- install upgraded OS and runtime packages once in `backend-system`, inherited by builder and runtime
- fail the image build when `perl-base` is below `5.40.1-6+deb13u1`
- add an enforcing Trivy job for the uncached patched stage and keep the upstream Python image report-only
- cover the shared stage, package floor, and workflow enforcement with regression tests

## Area

- [ ] Backend (API, services, models)
- [ ] Frontend (UI, components, hooks)
- [x] Infrastructure (Docker, nginx)
- [ ] Tiles / Rendering
- [ ] Auth / Permissions
- [ ] Import / Ingestion
- [ ] OGC / Standards
- [x] Docs / Config

## Testing

- [x] Unit tests pass (`32 passed`: `test_phase_272_dockerfile.py` and `test_docker_audit_regressions.py`)
- [x] Manual testing: uncached linux/amd64 `backend-system` build passed and installed `perl-base 5.40.1-6+deb13u1`
- [ ] Playwright e2e (if UI changes)
- [ ] No tests needed (docs, config, etc.)
- Trivy 0.70.0 with `--scanners vuln --severity CRITICAL --ignore-unfixed --exit-code 1`: upstream baseline 3 critical findings; patched stage 0
- Full backend `ruff check .` and `ruff format --check .` passed
- `docker build --check .` and `git diff --check` passed

No API, schema, migration, or runtime configuration contract changes.

## Checklist

- [x] Code follows existing project conventions
- [x] i18n: no user-facing strings changed
- [x] No new lint warnings (`ruff check`)
- [ ] TypeScript compiles without errors
- [ ] Migration included (if DB schema changed)
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing
