### PR TITLE
refactor(backend): reduce noise and remove unused helpers

### DIFF
--- a/.github/ADR-002.md
+++ b/.github/ADR-002.md
@@ -477,6 +477,6 @@ migrating a column.
 
 - `RUNBOOK.md` section 9 states Decision 7's retention windows for operators.
 - `.github/ARCHITECTURE.md` maps where the modules named above live.
-- `AGENTS.md`, under "Inline review-comment convention", holds the rule this document
-  exists to satisfy: a comment that cites a finding must cite something a reader can
-  look up.
+- [AGENTS.md — Contracts and Comments](../AGENTS.md#contracts-and-comments) prefers
+  local explanations; source comments should reference this record only when its
+  broader contract is needed.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,12 +87,12 @@ repos:
         files: '^backend/app/(modules/catalog|standards)/.*\.py$'
 
       - id: no-unscoped-finding-markers
-        name: "AGENTS.md — a finding marker in a backend/app comment or docstring needs a #issue anchor"
+        name: "AGENTS.md — remove unscoped finding tags from backend documentation"
         description: >
-          AGENTS.md ("Inline review-comment convention") requires a comment or
-          docstring that references a review finding to carry a lookup-able
-          anchor — a PR or issue number — not a bare tag that resolves only in
-          someone's private context.
+          AGENTS.md ("Contracts and Comments") prefers plain explanations over
+          finding tags and review history. Remove unnecessary tags; do not add
+          anchors merely to pass this legacy guard. A retained reference must
+          provide essential context and identify a public issue or PR.
 
           This hook runs backend/tests/finding_markers.py over the whole of
           backend/app. That detector parses each module, reads comments and
@@ -111,16 +111,16 @@ repos:
           it gets zero tolerance rather than a debt ledger.
           backend/tests/test_openapi_finding_markers.py pins that half.
 
-          Write `fix(#1234): <one line>`, or just drop the tag and let the
-          sentence stand — a note about a deliberate limitation does not need a
-          prefix to be understood.
+          Drop unnecessary tags and preserve the useful explanation. Anchored
+          references remain accepted for exceptional cases; they are not the
+          default comment format.
         language: system
         entry: python3 backend/tests/finding_markers.py
         pass_filenames: false
         files: '^backend/(app/.*\.py|openapi\.json|tests/(finding_markers|test_openapi_finding_markers)\.py)$'
 
       - id: no-agent-tag-markers
-        name: "AGENTS.md — a `ponytail:` tag needs a same-line fix(#N) anchor outside backend/app"
+        name: "AGENTS.md — remove unscoped agent tags"
         description: >
           The denylist half of the same rule, for the file types the AST
           detector above does not parse (frontend/, e2e/, cli/, mcp/, plus
@@ -137,8 +137,8 @@ repos:
           for f in "$@"; do
             if grep -nFi "ponytail:" "$f" | grep -viE "fix\(#[0-9]+\)"; then
               echo "FAIL: $f has an unscoped finding marker (see above).";
-              echo "  Use fix(#<issue>) ponytail: <context> on the same line, or remove the tag.";
-              echo "  See AGENTS.md > Inline review-comment convention.";
+              echo "  Remove the agent tag and keep the useful explanation.";
+              echo "  See AGENTS.md > Contracts and Comments.";
               rc=1;
             fi;
           done;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ make env-test
 python3 backend/tests/finding_markers.py
 ```
 
-Keep tracked `_MODULE_LOC_CAPS` entries in `test_layering.py` at exact line counts with a brief rationale; follow its inclusion test for newly oversized modules. `UNANCHORED_MARKER_DEBT` in `finding_markers.py` counts markers, not lines: lower/delete entries when debt is removed; never increase them to pass a gate.
+Keep tracked `_MODULE_LOC_CAPS` entries in `test_layering.py` at exact line counts with a brief current rationale, not a history of cap changes; follow its inclusion test for newly oversized modules. `UNANCHORED_MARKER_DEBT` in `finding_markers.py` counts markers, not lines: lower/delete entries when debt is removed; never increase them to pass a gate.
 
 `make ai-evals` costs live provider tokens and needs the dev DB/provider key (normally `ANTHROPIC_API_KEY`). Ensure `.env.test`, if present, does not override working dev credentials.
 
@@ -76,7 +76,9 @@ Frontend change: from the worktree run `cd frontend && API_PROXY_TARGET=http://l
 - API schema changes, including published route docstrings/Pydantic field descriptions, require `make sdks` (refreshes OpenAPI and both SDKs), then `cd frontend && npm run types:generate`. Frontend drift gate: `npm run types:check`. Commit generated changes only when source changes require them.
 - Never hand-edit generated SDK code or `frontend/src/types/api.generated.ts`. SDK auth/entry wrappers (`auth.py`, `__init__.py`, `auth.ts`, `index.ts`) are hand-maintained; CLI and MCP wrap the SDK.
 - New UI strings use `t()` with keys in all five locales (en/es/fr/de/zh); run `cd frontend && npm run test:i18n`. `defaultValue` is insufficient. Keep plural suffixes consistent; `_many` does not fall back to `_other`. French count 0 uses `_one`, so interpolate `{{count}}` instead of hardcoding 1.
-- Comments explain non-obvious reasons/traps; docstrings state contracts. Avoid narration/history. Review references need an issue/PR anchor plus the invariant, at most three lines: `// fix(#1234): suppress basemap row click during multi-selection`. Bare private tracker IDs fail finding-marker checks. Outside `backend/app/`, `no-agent-tag-markers` needs the `fix(#issue)` anchor on the same line as the tag; a bare tag fails there too.
+- Comments explain non-obvious reasons or constraints; docstrings state contracts. Remove comments that repeat names or nearby code. Prefer a short explanation such as `// Storage may be unavailable; guest browsing must still work.`
+- Keep provenance in Git history, issues and PRs. Do not prefix source comments/docstrings with `fix(#1234)`, phase IDs, review rounds, agent names or private finding codes. Retain a reference only when it supplies essential context the local explanation cannot express; state the current constraint first and keep the reference brief.
+- Preserve functional annotations such as `noqa`, `type: ignore`, `eslint-disable`, `@ts-expect-error`, `# broad:` and CodeQL directives. Legacy finding-marker checks permit anchored references but do not require them: remove unnecessary tags rather than adding anchors to satisfy a check. Never remove the safety rationale merely to remove its tag.
 - Put `# broad: <reason>` on the same line as every `except Exception`. Follow CodeQL marker placement below.
 
 ## Security

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -28,11 +28,11 @@ import app.core.db.models  # noqa: F401
 import app.processing.embeddings.models  # noqa: F401
 import app.processing.ai.token_usage  # noqa: F401
 import app.modules.catalog.sources.models  # noqa: F401
-import app.modules.tenancy.models  # noqa: F401 -- register tenancy models (Phase 1207)
+import app.modules.tenancy.models  # noqa: F401 -- register tenancy models
 
 config = context.config
 if config.config_file_name is not None:
-    # fix(#1755 item 8): the stdlib default disable_existing_loggers=True sets
+    # The stdlib default disable_existing_loggers=True sets
     # .disabled on every logger registered before this call and not named in
     # alembic.ini, and nothing in the app or the test suite restores that flag.
     fileConfig(config.config_file_name, disable_existing_loggers=False)
@@ -46,7 +46,7 @@ _log = logging.getLogger("alembic.env")
 def _discover_migration_paths() -> list[str]:
     """Return migration directories from installed plugins.
 
-    fix(#1665): an empty entry-point group means no overlay is installed.
+    An empty entry-point group means no overlay is installed.
     Any installed provider failure must abort migration to prevent a
     successful exit over an incomplete schema.
     """
@@ -80,7 +80,7 @@ def _propagate_extra_paths_to_live_script(live_script, extra_paths) -> None:
     The CLI creates this object before env.py runs, so changing Config alone
     leaves the live revision graph unchanged. Preserve the core versions path.
 
-    fix(#1778): propagation failure must abort migration; otherwise the CLI
+    Propagation failure must abort migration; otherwise the CLI
     can report success while skipping installed overlay revisions.
     """
     try:
@@ -99,7 +99,7 @@ def _propagate_extra_paths_to_live_script(live_script, extra_paths) -> None:
         )
     except Exception as exc:  # broad: abort on any overlay failure.
         raise RuntimeError(
-            "MIG-04: failed to propagate enterprise version dirs onto the "
+            "Failed to propagate enterprise version directories onto the "
             "live ScriptDirectory — 'alembic upgrade heads' would silently "
             "skip the enterprise e-chain. This is a configuration error, not "
             "OSS; refusing to migrate with an incomplete version_locations "
@@ -110,7 +110,7 @@ def _propagate_extra_paths_to_live_script(live_script, extra_paths) -> None:
 # Append enterprise migration paths to version_locations
 _extra_paths = _discover_migration_paths()
 
-# GAP-013: if this is explicitly an enterprise deployment but no enterprise
+# If this is explicitly an enterprise deployment but no enterprise
 # migration paths were discovered, fail loudly rather than silently migrating a
 # fresh DB without the e-chain (which dies later on SAML UndefinedColumn).
 if (
@@ -125,18 +125,18 @@ if (
         "fresh DB would migrate without e001/e002 and break SAML login."
     )
 
-# GUARD-01 (Phase 1207): mode-aware tenancy migration presence assertion.
+# Mode-aware tenancy migration presence assertion.
 # When GEOLENS_TENANCY_MODE=multi_tenant the dormant-tenancy migration
 # (0005_dormant_tenancy) MUST be present in the resolved version chain.
 # A multi_tenant deploy without 0005 would boot without the tenant_id
-# columns and the partial-unique indexes, silently violating TSEAM-01/02.
+# columns and the partial-unique indexes, silently violating tenant isolation.
 #
 # We check for the file directly in the versions directory — the core
 # migration is always present in the core package, so this guard only fires
 # when someone has set GEOLENS_TENANCY_MODE=multi_tenant against a code tree
 # where 0005 was somehow removed (e.g. a bad manual patch or a partial
 # backport).  We deliberately do NOT import app code here (no settings load)
-# to mirror the GAP-013 guard above and avoid import-time side effects.
+# to mirror the enterprise guard above and avoid import-time side effects.
 _tenancy_mode = os.environ.get("GEOLENS_TENANCY_MODE", "").lower().strip()
 if _tenancy_mode == "multi_tenant":
     import pathlib as _pathlib
@@ -149,8 +149,8 @@ if _tenancy_mode == "multi_tenant":
             "'0005_dormant_tenancy' was not found at "
             f"{_tenancy_file}. "
             "Refusing to run migrations — a multi_tenant deploy without "
-            "0005 would lack the tenant_id columns and partial-unique indexes "
-            "(TSEAM-01/02). Ensure the core package is at Phase 1207+ or "
+            "0005 would lack the tenant_id columns and partial-unique indexes. "
+            "Install a core package containing 0005_dormant_tenancy or "
             "unset GEOLENS_TENANCY_MODE to use single_tenant mode."
         )
 
@@ -159,7 +159,7 @@ if _extra_paths:
     _all_paths = _base_versions + " " + " ".join(_extra_paths)
     config.set_main_option("version_locations", _all_paths)
 
-    # MIG-04: see _propagate_extra_paths_to_live_script's docstring above.
+    # See _propagate_extra_paths_to_live_script's docstring above.
     # Tolerant of offline / no-active-context (revision command,
     # autogenerate) — those construct their ScriptDirectory from the
     # (now-augmented) Config directly, so there is nothing live to patch.
@@ -187,7 +187,7 @@ def include_object(obj, name, type_, reflected, compare_to):
     HNSW index is built at runtime. Neither appears in model metadata, so
     comparing them would emit incorrect removal operations.
 
-    fix(#435): SAML columns belong to core migration 0008 and must remain
+    SAML columns belong to core migration 0008 and must remain
     visible to drift detection, including on Community deployments.
     """
     if name and name.startswith("procrastinate_"):

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -44,74 +44,28 @@ _log = logging.getLogger("alembic.env")
 
 
 def _discover_migration_paths() -> list[str]:
-    """Discover additional migration version directories from plugins.
+    """Return migration directories from installed plugins.
 
-    GAP-013: this discovery path is load-bearing for enterprise deployments —
-    a dropped enterprise entry point silently omits e001/e002 from
-    ``version_locations``, which later surfaces as an unexplained
-    ``Can't locate revision 'e002_add_saml_columns'`` (existing enterprise DB)
-    or a SAML ``UndefinedColumn`` at login (fresh enterprise DB).
-
-    fix(#1665): ANY failure of an enumerated entry point raises. "Overlay not
-    installed" is represented by the entry-point group being EMPTY, not by an
-    entry point that fails — ``entry_points()`` only enumerates what an
-    installed distribution declared, so a Community install never enters the
-    loop body at all. (Verified: a stock OSS container reports
-    ``entry_points(group="geolens.migrations") == []``.)
-
-    That is the correction this function needed. It previously read a
-    ``ModuleNotFoundError`` / ``ImportError`` from ``ep.load()`` as "the overlay
-    package is simply not installed" and continued silently, and read the two
-    broken classes below as merely worth an ``ERROR`` log:
-
-    - a non-import failure of ``ep.load()`` (bad editable install, import-time
-      error in the overlay module);
-    - any exception from CALLING the loaded path provider — including an
-      ``ImportError`` from a missing submodule inside it (Codex PR #250 review).
-
-    All three left that overlay's revisions out of ``version_locations``.
-    Alembic then computed heads over an incomplete graph and ``upgrade heads``
-    exited 0 having skipped a whole chain — including the RLS policies an
-    overlay's migrations own. Deployment pipelines gate on that exit code, so a
-    partial schema was reported as a successful migration. An ERROR log is not
-    enough when the process goes on to claim success.
-
-    The lenient first branch was the subtlest of the three: a missing submodule
-    or dependency inside the overlay's own module surfaces as
-    ``ModuleNotFoundError`` from ``ep.load()``, which is indistinguishable at
-    that point from the module being absent — so a broken overlay was skipped
-    without even an ``ERROR``. Treating the group's emptiness as the signal
-    removes the need to tell those apart.
-
-    The ``GEOLENS_EDITION=enterprise`` guard below does not cover any of this:
-    it fires only when NO paths were discovered at all, so a broken overlay
-    alongside a working one passed straight through it.
+    fix(#1665): an empty entry-point group means no overlay is installed.
+    Any installed provider failure must abort migration to prevent a
+    successful exit over an incomplete schema.
     """
     paths = []
     for ep in iter_entry_points(group="geolens.migrations"):
-        # Reaching this body at all means a distribution DECLARED the entry
-        # point, so the overlay IS installed. A Community install has an empty
-        # group and never gets here — which is why every failure below refuses
-        # to migrate rather than being read as "overlay absent".
-        #
-        # Step 1 — import the entry point.
         try:
             fn = ep.load()
-        except Exception as exc:
+        except Exception as exc:  # broad: abort on any overlay failure.
             raise RuntimeError(
                 f"geolens.migrations entry point {getattr(ep, 'name', ep)!r} is "
                 "installed but failed to import; refusing to migrate with an "
                 "incomplete version_locations set"
             ) from exc
-        # Step 2 — load() succeeded. Any failure calling its path provider —
-        # incl. an ImportError from a missing submodule inside it — is likewise
-        # a broken overlay.
         try:
             if callable(fn):
                 for p in fn():
                     if pathlib.Path(p).is_dir():
                         paths.append(p)
-        except Exception as exc:
+        except Exception as exc:  # broad: abort on any overlay failure.
             raise RuntimeError(
                 f"geolens.migrations entry point {getattr(ep, 'name', ep)!r} is "
                 "installed but its migration-path provider failed; refusing to "
@@ -121,41 +75,18 @@ def _discover_migration_paths() -> list[str]:
 
 
 def _propagate_extra_paths_to_live_script(live_script, extra_paths) -> None:
-    """MIG-04: propagate the discovered overlay version dirs onto the LIVE
-    ScriptDirectory the running command already constructed.
+    """Add overlay paths to the existing ScriptDirectory and rebuild its map.
 
-    alembic's CLI builds ``ScriptDirectory.from_config(config)`` ONCE, then
-    runs this env.py via ``script.run_env()``. The
-    ``config.set_main_option(...)`` call at the call site mutates the Config
-    AFTER that ScriptDirectory was built, so the upgrade walk (which is
-    driven by the already-constructed ScriptDirectory) never sees the
-    enterprise version dirs — ``alembic upgrade heads`` would silently apply
-    ONLY the core head and SKIP the enterprise e-chain (e001/e002), leaving
-    SAML columns absent on a GEOLENS_EDITION=enterprise deployment. (The
-    conftest test harness sidesteps this by setting version_locations on the
-    Config BEFORE ``command.upgrade``; the production CLI path cannot.)
+    The CLI creates this object before env.py runs, so changing Config alone
+    leaves the live revision graph unchanged. Preserve the core versions path.
 
-    We refresh the live ScriptDirectory's version_locations and rebuild its
-    RevisionMap so the heads-plural walk picks up the enterprise branch.
-
-    fix(#1778): this used to log an ERROR and let the caller fall through to
-    ``run_migrations_online()``, exiting 0 — the exact anti-pattern the
-    GAP-013 docstring above corrected for ``_discover_migration_paths``. This
-    function only ever runs when ``extra_paths`` is non-empty, i.e. an
-    overlay is definitely installed, so a failure here means its revisions
-    are unreachable from the live upgrade walk — raise rather than let the
-    run report success over an incomplete schema.
+    fix(#1778): propagation failure must abort migration; otherwise the CLI
+    can report success while skipping installed overlay revisions.
     """
     try:
         from alembic.script import revision as _alembic_revision
 
-        # The default ScriptDirectory derives its core versions dir IMPLICITLY
-        # from `script_location` (alembic/versions) and leaves
-        # `version_locations` EMPTY. Seeding only the enterprise paths would
-        # therefore DROP the core revisions (e001's down_revision
-        # `0002_procrastinate` would go missing → KeyError). Seed the base
-        # versions dir explicitly alongside the overlay paths so BOTH chains
-        # are walked.
+        # An empty version_locations uses the implicit core versions directory.
         existing = list(getattr(live_script, "version_locations", []) or [])
         if not existing:
             existing = [str(pathlib.Path(live_script.dir) / "versions")]
@@ -163,13 +94,10 @@ def _propagate_extra_paths_to_live_script(live_script, extra_paths) -> None:
             if p not in existing:
                 existing.append(p)
         live_script.version_locations = existing
-        # Rebuild the memoized revision map so the enterprise revisions are
-        # walked (RevisionMap lazily reads version_locations via the bound
-        # _load_revisions callable on the same ScriptDirectory instance).
         live_script.revision_map = _alembic_revision.RevisionMap(
             live_script._load_revisions
         )
-    except Exception as exc:
+    except Exception as exc:  # broad: abort on any overlay failure.
         raise RuntimeError(
             "MIG-04: failed to propagate enterprise version dirs onto the "
             "live ScriptDirectory — 'alembic upgrade heads' would silently "
@@ -237,7 +165,7 @@ if _extra_paths:
     # (now-augmented) Config directly, so there is nothing live to patch.
     try:
         _live_script = context.script  # the EnvironmentContext's ScriptDirectory
-    except Exception:
+    except Exception:  # broad: offline commands may have no active context.
         _live_script = None
     if _live_script is not None:
         _propagate_extra_paths_to_live_script(_live_script, _extra_paths)
@@ -253,32 +181,14 @@ def include_name(name, type_, parent_names):
 
 
 def include_object(obj, name, type_, reflected, compare_to):
-    """Skip procrastinate-managed objects and the runtime-built HNSW index.
+    """Exclude objects managed outside SQLAlchemy from autogenerate.
 
-    Procrastinate's tables, types, indexes, sequences, and triggers are created
-    via raw SQL in ``0002_procrastinate.py`` and are not declared as SQLAlchemy
-    models. Without this filter, ``alembic check`` and autogenerate diff produce
-    false-positive ``remove_table`` / ``remove_index`` ops because the metadata
-    lacks them.
+    Procrastinate creates its objects through raw SQL. The dimension-dependent
+    HNSW index is built at runtime. Neither appears in model metadata, so
+    comparing them would emit incorrect removal operations.
 
-    ``ix_record_embeddings_hnsw`` is a pgvector HNSW index created and dropped
-    at runtime by ``embeddings/service.py`` (``rebuild_embedding_column``) once
-    an embedding dimension is configured. It cannot be a static model index —
-    the ``embedding`` column starts dimensionless — so it is intentionally
-    absent from the metadata. Without skipping it, autogenerate emits a phantom
-    ``remove_index`` whenever the index exists in the DB but not the model; under
-    ``pytest -n4`` a sibling test that built it on the shared worker DB before
-    ``alembic check`` ran turned this into a high-rate flake in
-    ``test_alembic_check_no_drift``.
-
-    fix(#435): the four ``oauth_providers`` SAML columns used to be excluded here
-    on OSS-only deployments, because only the enterprise overlay's
-    ``e002_add_saml_columns`` created them and autogenerate reported four phantom
-    ``add_column`` ops. Core migration ``0008_oauth_saml_columns`` now creates them
-    unconditionally (``ADD COLUMN IF NOT EXISTS``), so an OSS database at head has
-    them for real. The filter had become a blind spot: dropping or retyping a
-    now-core-owned column still passed ``alembic check``. See migration-audit H-21
-    for the original rationale.
+    fix(#435): SAML columns belong to core migration 0008 and must remain
+    visible to drift detection, including on Community deployments.
     """
     if name and name.startswith("procrastinate_"):
         return False

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -125,18 +125,8 @@ if (
         "fresh DB would migrate without e001/e002 and break SAML login."
     )
 
-# Mode-aware tenancy migration presence assertion.
-# When GEOLENS_TENANCY_MODE=multi_tenant the dormant-tenancy migration
-# (0005_dormant_tenancy) MUST be present in the resolved version chain.
-# A multi_tenant deploy without 0005 would boot without the tenant_id
-# columns and the partial-unique indexes, silently violating tenant isolation.
-#
-# We check for the file directly in the versions directory — the core
-# migration is always present in the core package, so this guard only fires
-# when someone has set GEOLENS_TENANCY_MODE=multi_tenant against a code tree
-# where 0005 was somehow removed (e.g. a bad manual patch or a partial
-# backport).  We deliberately do NOT import app code here (no settings load)
-# to mirror the enterprise guard above and avoid import-time side effects.
+# Multi-tenant mode requires migration 0005 for tenant columns and unique indexes.
+# Check the packaged file directly to avoid importing application settings here.
 _tenancy_mode = os.environ.get("GEOLENS_TENANCY_MODE", "").lower().strip()
 if _tenancy_mode == "multi_tenant":
     import pathlib as _pathlib

--- a/backend/app/api/middleware/liveness.py
+++ b/backend/app/api/middleware/liveness.py
@@ -1,15 +1,7 @@
-"""The one definition of "this request is the liveness probe".
+"""Identify liveness requests before dependency-backed middleware runs.
 
-fix(#1778): ``/health/live`` lets an orchestrator ask whether the API
-process is alive without asking whether its dependencies are, so the
-request must not touch the DB, cache, or object storage — in
-multi_tenant mode a DB-backed middleware once turned a database outage
-into a ``403`` on the probe, the restart loop the split exists to
-prevent.
-
-The predicate lives here so a later DB-backed middleware has one
-obvious thing to call (``tests/test_health_liveness_split_1778.py``
-enforces it). Path matching is exact, not prefix-based:
+``/health/live`` reports whether the API process is alive without touching the
+database, cache, or object storage. Path matching is exact, not prefix-based:
 ``scope["path"]`` is ``/health/live`` directly or behind Nginx;
 ``/api/health/live`` is also accepted for an edge without that rewrite.
 """

--- a/backend/app/api/middleware/tenant_context.py
+++ b/backend/app/api/middleware/tenant_context.py
@@ -1,8 +1,8 @@
 """Tenant-context middleware.
 
-TSEAM-04: resolves a tenant signal (subdomain or JWT claim) into
+Resolves a tenant signal (subdomain or JWT claim) into
 ``request.state.tenant_id``. Single-tenant (default): strict no-op, one
-boolean check, no DB lookup (T-1207-08 byte-identical guarantee).
+boolean check and no database lookup.
 
 Multi-tenant: reads the first ``Host`` subdomain label or a ``tid``
 claim from a verified GeoLens Bearer JWT, resolves it to the tenant
@@ -12,8 +12,8 @@ mismatches before the request reaches application code. A non-GeoLens
 bearer token may proceed only after the Host resolves a tenant; requests
 with neither signal stay unscoped so RLS fails closed.
 
-Slug→UUID resolution happens here, not in the GUC layer: the Phase 1208
-RLS GUC casts to ``::uuid``, so ``current_tenant_var`` must carry a UUID,
+Slug→UUID resolution happens here because the RLS GUC casts to ``::uuid``,
+so ``current_tenant_var`` must carry a UUID,
 never a slug.
 """
 
@@ -40,7 +40,7 @@ logger = structlog.stdlib.get_logger(__name__)
 
 # Regex for a safe subdomain label (alphanumeric + hyphens, 1-63 chars, no
 # leading/trailing hyphens). This is the attacker-controlled input from the
-# Host header — validate strictly (T-1207-05).
+# Host header, so validate it strictly.
 _SUBDOMAIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$")
 
 # Reserved labels below the configured base domain are service endpoints, not
@@ -164,8 +164,8 @@ def _extract_jwt_tenant_claim(authorization: str) -> str | None:
 async def _resolve_tenant_uuid(tenant_signal: str | None) -> str | None:
     """Resolve an untrusted Host signal against the tenant registry.
 
-    The Phase 1208 RLS GUC casts to ``::uuid``, so ``current_tenant_var``
-    must hold a UUID string, never a slug (Gap A, PR #256).
+    The RLS GUC casts to ``::uuid``, so ``current_tenant_var`` must hold a
+    UUID string, never a slug.
 
     UUID-shaped host labels are not trusted tenant identities. Both UUIDs
     and slugs are resolved against ``catalog.tenants`` (no RLS, needs no
@@ -190,7 +190,7 @@ async def _resolve_tenant_uuid(tenant_signal: str | None) -> str | None:
         from app.core.db import async_session
 
         async with async_session() as session:
-            # Bound params (T-1208-01); catalog.tenants has no RLS (registry).
+            # Use bound params; catalog.tenants has no RLS because it is the registry.
             if tenant_uuid is not None:
                 resolved = await session.scalar(
                     text("SELECT id FROM catalog.tenants WHERE id = :tenant_id"),
@@ -222,12 +222,12 @@ class TenantContextMiddleware(BaseHTTPMiddleware):
     """
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        # TSEAM-04 fast path: single_tenant is the default and the vast
+        # Single-tenant mode is the common fast path and the vast
         # majority of deployments. One boolean check, zero state mutation.
         if not is_multi_tenant():
             return await call_next(request)
 
-        # fix(#1778): the liveness probe resolves no tenant. Sent to a
+        # The liveness probe resolves no tenant. Sent to a
         # tenant hostname, it would reach `_resolve_tenant_uuid` below,
         # which reads the DB — with the DB unreachable that returns None
         # and this middleware answers 403, restart-looping an API that
@@ -321,10 +321,10 @@ class TenantContextMiddleware(BaseHTTPMiddleware):
         if tenant_id is not None:
             logger.debug("Tenant context resolved", tenant_id=tenant_id)
 
-        # ISO-01 (Phase 1208-01): bridge request.state.tenant_id → current_tenant_var
+        # Bridge request.state.tenant_id → current_tenant_var
         # so the after_begin hook on the engine can read the tenant id when the
         # request handler opens a DB session (get_db or raw async_session).
-        # Use a token for reset so the var never bleeds across requests (T-1208-03).
+        # Use a token for reset so the var never bleeds across requests.
         token = current_tenant_var.set(tenant_id)
         try:
             return await call_next(request)

--- a/backend/app/api/middleware/tenant_context.py
+++ b/backend/app/api/middleware/tenant_context.py
@@ -131,12 +131,6 @@ def _classify_tenant_host(host: str) -> _TenantHost:
     return _TenantHost(True, label)
 
 
-def _extract_subdomain(host: str) -> str | None:
-    """Return a tenant slug only from an explicitly trusted Host suffix."""
-    classified = _classify_tenant_host(host)
-    return classified.signal if classified.trusted else None
-
-
 def _extract_jwt_tenant_claim(authorization: str) -> str | None:
     """Return the tenant UUID from a verified GeoLens access token.
 

--- a/backend/app/api/middleware/tenant_context.py
+++ b/backend/app/api/middleware/tenant_context.py
@@ -227,16 +227,8 @@ class TenantContextMiddleware(BaseHTTPMiddleware):
         if not is_multi_tenant():
             return await call_next(request)
 
-        # The liveness probe resolves no tenant. Sent to a
-        # tenant hostname, it would reach `_resolve_tenant_uuid` below,
-        # which reads the DB — with the DB unreachable that returns None
-        # and this middleware answers 403, restart-looping an API that
-        # would have served catalog reads (the loop `/health/live` exists
-        # to prevent).
-        #
-        # Deliberately BEFORE the Host checks too: `_classify_tenant_host`
-        # rejects an untrusted Host with a 400, and a kubelet probing by
-        # pod IP sends exactly that.
+        # Liveness bypasses tenant lookup so a database outage cannot trigger restarts.
+        # It also bypasses Host validation because kubelet probes may use a pod IP.
         if is_liveness_request(request.scope):
             return await call_next(request)
 

--- a/backend/app/core/csv_safety.py
+++ b/backend/app/core/csv_safety.py
@@ -1,21 +1,10 @@
-"""One spreadsheet-formula escaping rule for every CSV this product writes.
+"""Spreadsheet-formula escaping shared by every CSV export.
 
-fix(#1778): previously duplicated across two private copies and missing
-entirely from the dataset export, whose column-name validation never checked
-cell values — letting an editor on any public dataset store a property
-starting with ``=``, ``+``, ``-`` or ``@`` that executes when a visitor opens
-the downloaded CSV. The escape is a leading TAB, which spreadsheets read as
-"this cell is text".
-
-Strict by default: every cell starting with a trigger character is escaped,
-even a string that only looks numeric (e.g. account id ``-001``) — the right
-trade for the audit-log and admin-user exports.
-
-fix(#1778): ``allow_numeric`` exists only for the
-dataset export and must be decided by COLUMN TYPE, never by the value's
-shape — ``-12`` is a measurement in a numeric column but an indistinguishable
-formula fragment in a text column. ``numeric_column_names`` is the intended
-source of that decision.
+Formula-triggering cells receive a leading tab so spreadsheets read them as
+text. Escaping is strict by default, including strings that look numeric such
+as account ID ``-001``. Dataset exports may set ``allow_numeric`` according to
+the declared column type; a value's shape alone cannot distinguish a numeric
+measurement from a formula fragment in a text column.
 """
 
 from __future__ import annotations
@@ -51,9 +40,8 @@ NUMERIC_SQL_TYPES: frozenset[str] = frozenset(
 def escape_csv_formula(value: str, *, allow_numeric: bool = False) -> str:
     """Prefix a formula-triggering cell with a tab so it is read as text.
 
-    ``allow_numeric`` leaves a cell alone when it is a well-formed decimal
-    number. Pass it only for a column whose declared type is numeric; see the
-    module docstring for why the value's shape is not enough on its own.
+    ``allow_numeric`` leaves well-formed decimal numbers alone. Pass it only
+    for a column whose declared type is numeric.
     """
     if not value or value[0] not in FORMULA_PREFIXES:
         return value

--- a/backend/app/core/db/sqlstate.py
+++ b/backend/app/core/db/sqlstate.py
@@ -1,8 +1,4 @@
-"""PostgreSQL SQLSTATE helpers for classifying database errors (fix(#435)).
-
-Handlers used to catch `Exception` (or bare `DBAPIError`) and guess. A dropped
-table, a statement timeout, and a lost connection are very different events, and
-only the first of them is a domain condition the API should paper over.
+"""PostgreSQL SQLSTATE helpers for classifying database errors.
 
 SQLSTATE reference: https://www.postgresql.org/docs/current/errcodes-appendix.html
 """

--- a/backend/app/core/db/sqlstate.py
+++ b/backend/app/core/db/sqlstate.py
@@ -10,7 +10,7 @@ from sqlalchemy.exc import DBAPIError
 # The relation the query names does not exist. Not always damage: raster and
 # VRT datasets carry a synthetic `table_name` with no PostGIS table behind it.
 #
-# fix(#435): `3F000` (invalid_schema_name) is deliberately NOT in this set —
+# `3F000` (invalid_schema_name) is deliberately NOT in this set —
 # a `SELECT` against a missing schema reports `42P01`, not `3F000`; Postgres
 # raises `3F000` from DDL paths, where it means the schema itself is gone.
 # Treating it as "empty dataset" would have hidden real provisioning drift.
@@ -52,10 +52,8 @@ _OPERATIONAL_CLASSES = frozenset(
 # States that mean "the caller's value does not fit the column it was
 # compared against", as opposed to an outage or a bug in our own SQL.
 #
-# fix(#1778): one definition, read by the OGC items handler and the native
-# features list, since they had drifted — the OGC router carried this set
-# inline while the native one tested a narrower `BAD_QUERY_INPUT`, so the
-# same failure was a 400 through one endpoint and a 503 through the other.
+# Shared by the OGC items handler and native features list so both classify
+# input failures consistently.
 #
 # Class 22 is data_exception as a whole. asyncpg reports a client-side encode
 # failure (an int outside int8, say) as plain 22000 on a bare
@@ -119,7 +117,7 @@ def is_operational(exc: DBAPIError) -> bool:
     return code[:2] in _OPERATIONAL_CLASSES
 
 
-# fix(#1847): another transaction owns rows this one needs. Both states mean
+# Another transaction owns rows this one needs. Both states mean
 # the same to a caller: nothing was written, and a retry lands after the owner
 # commits. 40001 is excluded as unreachable at READ COMMITTED.
 LOCK_CONFLICT = frozenset(

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -201,12 +201,8 @@ def _validate_join_fields(source, join_dataset, join_fields: list[str]) -> None:
                 detail=f"Unknown join column: {name!r}",
             )
     generated = spatial_join_output_columns(join_fields)
-    # Generated names must be unique among THEMSELVES first --
-    # a join column named `count` prefixes to `join_count`, already
-    # generated for the match count, so a source-only check misses the
-    # collision. A duplicate check, not "reject `count`": the collision is
-    # a property of the generated names, so it still holds if the prefix
-    # changes; a repeated field is already rejected by the request schema.
+    # Check generated names against each other as well as source columns:
+    # a transferred `count` becomes `join_count`, colliding with the match count.
     duplicates = sorted({name for name in generated if generated.count(name) > 1})
     if duplicates:
         raise HTTPException(
@@ -366,7 +362,7 @@ async def _validate_materialize_params(
     Each check has a second, run-time half in the worker, since the queue
     wait sits between the two and the world can move underneath it.
     """
-    # Select_by_location takes the same mask pair clip does, so
+    # `select_by_location` takes the same mask pair clip does, so
     # it takes the same two checks. Rule 1 applies to BOTH datasets either way.
     if body.operation in MASK_OPERATIONS and body.mask_dataset_id is not None:
         # Access + polygon checks happen here at enqueue time; the worker
@@ -478,33 +474,13 @@ async def analysis_materialize_endpoint(
     # reservation happens at registration time in the worker.
     await check_upload_quota(db, user.id, 0, request)
 
-    # One materialize at a time per user: each queued job is an
-    # unbounded-ish CTAS. Soft cap: a TOCTOU race can briefly admit two;
-    # add a DB-side partial unique index for a hard guarantee.
+    # Serialize count-and-create per tenant until commit so concurrent requests
+    # cannot bypass tenant or per-user caps. Single-tenant mode uses a shared key.
+    # Wait for this brief admission lock instead of rejecting a busy lock.
     #
-    # The slot is held on a heartbeat LEASE, not job status --
-    # the worker renews heartbeat_at every 30s, so a stale lease on a
-    # "running" job means a hard-killed worker, and the slot releases
-    # rather than waiting for the 60-min JOB_TIMEOUT_SECONDS backstop.
-    # Elapsed time cannot define staleness because a legitimate
-    # materialization can outlive any fixed window.
-    #
-    # The pending branch MUST stay status-only: a pending job is never
-    # claimed, so heartbeat_at/started_at are both NULL, and a cutoff
-    # comparison would drop it from the count, defeating the cap.
-    # coalesce(heartbeat_at, started_at) covers pre-heartbeat rows. The
-    # client applies no staleness rule of its own (AnalysisJobWatcher.tsx)
-    # -- a released lease just lets the next create succeed server-side.
-    #
-    # Serialize admission per tenant before counting, or the
-    # caps are check-then-insert -- N users could all read a count below
-    # the ceiling and all create a job, ending up over it. A
-    # transaction-scoped advisory lock held until commit makes
-    # count-then-create atomic. Blocking, not pg_try_advisory_xact_lock:
-    # admissions should queue for the microseconds this takes, not fail.
-    # In single-tenant mode the key is constant, correctly serializing
-    # every admission on the deployment (and incidentally hardening the
-    # soft per-user cap above).
+    # Running jobs hold a renewable heartbeat lease, allowing recovery from a
+    # killed worker without expiring legitimate long jobs. Pending jobs count by
+    # status alone because they have no heartbeat; started_at covers legacy rows.
     await db.execute(
         text("SELECT pg_advisory_xact_lock(hashtextextended(:admission_key, 0))"),
         {

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -45,7 +45,7 @@ from app.platform.jobs.defer_guard import (
     make_ingest_job_failed_rollback,
 )
 
-# fix(#691): the lease window lives beside the heartbeat machinery so the
+# The lease window lives beside the heartbeat machinery so the
 # per-job status read applies the identical rule.
 from app.platform.jobs.heartbeat import (
     ANALYSIS_MATERIALIZE_LEASE_SECONDS as MATERIALIZE_LEASE_SECONDS,
@@ -60,26 +60,21 @@ router = APIRouter(
 
 _SAFE_COLUMN_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
-# fix(#1015): ceiling on active materializes for one tenant, above the
-# one-per-user cap rather than replacing it -- a tenant with N users
-# could otherwise hold N active CTASes, and #1012's raised per-statement
-# work_mem times an unbounded count is the same outage in a new place.
-# Three: WORKER_CONCURRENCY=1 default means one running plus two queued,
-# the count #1012's work_mem division is sized against. Module constant,
-# not a Settings field: nobody has asked to tune it yet (#1013).
+# Limit active materializations per tenant as well as per user. The default
+# single worker can run one and queue two, keeping concurrent CTAS memory
+# within the worker budget.
 MAX_ACTIVE_MATERIALIZES_PER_TENANT = 3
 
-# fix(#766): PostgreSQL has no equality operator for these types, so a
+# PostgreSQL has no equality operator for these types, so a
 # dissolve GROUP BY on such a column fails the CTAS with an opaque 42883
 # after the queue wait. GDAL maps nested GeoJSON objects to `json`, so
 # real uploads hit this. Rejected at enqueue with the column named.
 
-# fix(#695): Procrastinate ranks by per-job priority (DESC, default 0),
+# Procrastinate ranks by per-job priority (DESC, default 0),
 # not queue name, so a 300s analysis CTAS enqueued first would
 # head-of-line block every upload on the shared single worker.
-# Below-default priority lets interactive ingest win the fetch. Known
-# tradeoff: a steady upload stream can starve queued analysis
-# indefinitely -- acceptable for background work (#696 for a budget knob).
+# Below-default priority lets interactive ingest win the fetch. A steady
+# upload stream can therefore delay background analysis indefinitely.
 ANALYSIS_JOB_PRIORITY = -10
 
 
@@ -91,7 +86,7 @@ ANALYSIS_JOB_PRIORITY = -10
 # failures, server faults rather than bad requests.
 _SANDBOX_STATUS = {
     "query_busy": status.HTTP_429_TOO_MANY_REQUESTS,
-    # fix(#1014): server-at-capacity is also a 429, but a distinct
+    # Server-at-capacity is also a 429, but a distinct
     # category so the message isn't relabelled as the per-user one.
     "query_at_capacity": status.HTTP_429_TOO_MANY_REQUESTS,
     "query_timeout": status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -121,7 +116,7 @@ _POLYGONAL_TYPES = {"POLYGON", "MULTIPOLYGON"}
 # Size-gate ceilings live in app.platform.analysis_sql (shared with the
 # worker's pre-CTAS recheck). Counted via resolve_source_feature_count: the
 # cached snapshot when present, a LIMIT-bounded live count when it's NULL
-# (fix(#701): NULL-as-zero would admit exactly the unknown-size datasets
+# (NULL-as-zero would admit exactly the unknown-size datasets
 # these gates exist for).
 
 
@@ -132,7 +127,7 @@ async def _load_mask_dataset(
     datasets of a two-layer operation) and require it to be polygonal --
     unioning points/lines produces a mask that clips nothing meaningful.
 
-    fix(#955): shared with select_by_location, which takes its selection
+    Shared with select_by_location, which takes its selection
     geometry from the same mask pair; both ceilings apply unchanged. The
     over-limit message still says "to clip with" -- reads slightly off for
     a selection, but is wired through error-map.ts and four locales.
@@ -161,7 +156,7 @@ async def _load_mask_dataset(
 async def _load_join_dataset(
     db: AsyncSession, join_dataset_id: uuid.UUID, user: Identity
 ):
-    """Fetch + visibility-check a spatial-join layer (fix(#953)).
+    """Fetch and visibility-check a spatial-join layer.
 
     Rule 1 applies to BOTH datasets, same treatment ``_load_mask_dataset``
     gives the clip mask. No geometry-type requirement, unlike the mask: a
@@ -180,7 +175,7 @@ def _reject_generated_column_collision(source, generated: Iterable[str]) -> None
     generated ones, so a same-named source column reaches the CTAS twice
     and fails with an opaque "column specified more than once" after the
     whole queue wait. Named at enqueue instead. Shared form of the guard
-    dissolve applies to ``source_count`` (fix(#954): measure and
+    dissolve applies to ``source_count`` (measure and
     spatial_join both need it too).
     """
     source_columns = {col.get("name") for col in (source.column_info or []) if col}
@@ -206,7 +201,7 @@ def _validate_join_fields(source, join_dataset, join_fields: list[str]) -> None:
                 detail=f"Unknown join column: {name!r}",
             )
     generated = spatial_join_output_columns(join_fields)
-    # fix(#1097): generated names must be unique among THEMSELVES first --
+    # Generated names must be unique among THEMSELVES first --
     # a join column named `count` prefixes to `join_count`, already
     # generated for the match count, so a source-only check misses the
     # collision. A duplicate check, not "reject `count`": the collision is
@@ -231,7 +226,7 @@ def _column_names(dataset) -> set[str]:
 
 
 def _validate_intersect_columns(source, overlay) -> None:
-    """422 on any column an overlay would emit twice (fix(#956)).
+    """Raise 422 for any column an overlay would emit twice.
 
     An overlay is the first operation to carry columns from BOTH inputs
     onto every output row, so a same-named column in the two layers is
@@ -261,7 +256,7 @@ def _validate_intersect_columns(source, overlay) -> None:
                 "choose a different layer."
             ),
         )
-    # fix(#1097): a carried column may not sit in the alias namespace. Both
+    # A carried column may not sit in the alias namespace. Both
     # layers, since an overlay carries columns from both and shares the
     # statement with _gl_src_type and _gl_mask_gid. Checked against the
     # PREFIX, not the alias names, so a later alias is covered for free.
@@ -279,12 +274,8 @@ def _validate_intersect_columns(source, overlay) -> None:
                 "columns. Rename it, or choose a different layer."
             ),
         )
-    # fix(#1099): no ungroupable-type branch here any more. The overlay's
-    # attributes used to ride through `_mask_pieces`, named in the
-    # aggregate's GROUP BY, which meant json/xml columns took an overlay
-    # layer out of service entirely. render_intersect_pairs now groups by
-    # the two gids alone and joins the overlay back where no grouping
-    # applies, so the column type stops mattering. Dissolve's by_field
+    # Overlay attributes are joined after ``render_intersect_pairs`` groups by
+    # the two gids, so their column types do not affect grouping. Dissolve's by_field
     # guard above stays: that one really does group by a user-chosen column.
 
 
@@ -309,11 +300,8 @@ async def analysis_preview_endpoint(
     join_dataset = None
     if body.join_dataset_id is not None:
         join_dataset = await _load_join_dataset(db, body.join_dataset_id, user)
-        # fix(#1097): unconditionally, matching materialize -- the guard
-        # used to be `if body.join_fields`, but _validate_join_fields also
-        # checks the ALWAYS-generated join_count against source columns, so
-        # a source with a join_count column previewed fine and then failed
-        # Create on the identical form.
+        # Always validate because the generated join_count can collide even
+        # when the caller supplies no join fields.
         _validate_join_fields(dataset, join_dataset, body.join_fields or [])
     try:
         return await run_analysis_preview(
@@ -323,7 +311,7 @@ async def analysis_preview_endpoint(
             user.id,
             mask_dataset=mask_dataset,
             join_dataset=join_dataset,
-            # fix(#716): safe here — `user.id` is evaluated above, and neither
+            # Safe here — `user.id` is evaluated above, and neither
             # this handler nor any middleware reads ORM state afterwards.
             release_session=True,
         )
@@ -378,7 +366,7 @@ async def _validate_materialize_params(
     Each check has a second, run-time half in the worker, since the queue
     wait sits between the two and the world can move underneath it.
     """
-    # fix(#955): select_by_location takes the same mask pair clip does, so
+    # Select_by_location takes the same mask pair clip does, so
     # it takes the same two checks. Rule 1 applies to BOTH datasets either way.
     if body.operation in MASK_OPERATIONS and body.mask_dataset_id is not None:
         # Access + polygon checks happen here at enqueue time; the worker
@@ -417,10 +405,7 @@ def _build_analysis_job_metadata(
     geometry is deliberately NOT stored: it can be kilobytes, and a marker
     suffices.
 
-    Extracted from the handler (#1097): this per-operation dispatch block
-    grows with every new operation and tripped ruff's C901 threshold at
-    the fourth one. Nothing here touches the request, session, or job row,
-    so it lifts out whole.
+    This helper is pure: it does not touch the request, session, or job row.
     """
     meta: dict[str, Any] = {
         "operation": body.operation,
@@ -431,7 +416,7 @@ def _build_analysis_job_metadata(
         meta["distance_meters"] = body.distance_meters
     if body.by_field is not None:
         meta["by_field"] = body.by_field
-    # fix(#1097): the second layer is recorded for EVERY operation that
+    # The second layer is recorded for EVERY operation that
     # consumes one, not just clip, so a failed run stays diagnosable.
     # mask_source stays scoped to operations that can take a DRAWN mask;
     # intersect rejects one, so "layer" there would be a constant.
@@ -454,7 +439,7 @@ async def analysis_materialize_endpoint(
     dataset_id: uuid.UUID,
     body: AnalysisMaterializeRequest,
     request: Request,
-    # fix(#692): materialize creates a dataset, so it carries the same
+    # Materialize creates a dataset, so it carries the same
     # permission as every ingest endpoint. It also hands the caller a
     # durable, caller-owned copy of the source attributes (a centroid
     # preserves every column), the outcome download endpoints gate on
@@ -497,12 +482,12 @@ async def analysis_materialize_endpoint(
     # unbounded-ish CTAS. Soft cap: a TOCTOU race can briefly admit two;
     # add a DB-side partial unique index for a hard guarantee.
     #
-    # fix(#691): the slot is held on a heartbeat LEASE, not job status --
+    # The slot is held on a heartbeat LEASE, not job status --
     # the worker renews heartbeat_at every 30s, so a stale lease on a
     # "running" job means a hard-killed worker, and the slot releases
     # rather than waiting for the 60-min JOB_TIMEOUT_SECONDS backstop.
-    # Elapsed time alone was tried and reverted (#682): a legitimate
-    # materialize can outlive any window.
+    # Elapsed time cannot define staleness because a legitimate
+    # materialization can outlive any fixed window.
     #
     # The pending branch MUST stay status-only: a pending job is never
     # claimed, so heartbeat_at/started_at are both NULL, and a cutoff
@@ -511,7 +496,7 @@ async def analysis_materialize_endpoint(
     # client applies no staleness rule of its own (AnalysisJobWatcher.tsx)
     # -- a released lease just lets the next create succeed server-side.
     #
-    # fix(#1015): serialize admission per tenant before counting, or the
+    # Serialize admission per tenant before counting, or the
     # caps are check-then-insert -- N users could all read a count below
     # the ceiling and all create a job, ending up over it. A
     # transaction-scoped advisory lock held until commit makes
@@ -534,10 +519,10 @@ async def analysis_materialize_endpoint(
     lease_cutoff = datetime.now(timezone.utc) - timedelta(
         seconds=MATERIALIZE_LEASE_SECONDS
     )
-    # fix(#1015): the liveness rule is shared by both caps, applying
+    # The liveness rule is shared by both caps, applying
     # identically at tenant scope.
     active_predicate = (
-        # fix(#682): the analysis marker in user_metadata, NOT
+        # The analysis marker in user_metadata, NOT
         # source_filename -- an upload named "analysis-data.geojson" would
         # otherwise lock the uploader out of analysis. Written in the same
         # transaction as the job row, so this never misses one.
@@ -562,7 +547,7 @@ async def analysis_materialize_endpoint(
             detail="An analysis job is already running; wait for it to finish",
         )
 
-    # fix(#1015): tenant ceiling above the per-user cap. In single-tenant
+    # Tenant ceiling above the per-user cap. In single-tenant
     # mode there's one tenant by definition, so the unfiltered count IS the
     # tenant's. IngestJob.tenant_id is already indexed
     # (ix_catalog_ingest_jobs_tenant_id), so the multi-tenant filter needs
@@ -585,9 +570,9 @@ async def analysis_materialize_endpoint(
         db, f"analysis-{body.operation}", "", user.id
     )
     job.user_metadata = {"analysis": _build_analysis_job_metadata(body, dataset)}
-    # ux(#698): stamp a step so a pending job reads as "queued" rather than
+    # Stamp a step so a pending job reads as "queued" rather than
     # indistinguishable from a broken one -- matters more since analysis
-    # deliberately defers below default priority (#703) and can wait
+    # deliberately defers below default priority and can wait
     # behind uploads for minutes. Free-form String(32).
     job.current_step = "queued"
     await db.commit()
@@ -604,7 +589,7 @@ async def analysis_materialize_endpoint(
         extra_kwargs: dict[str, object] = {}
         if body.mask_dataset_id is not None:
             extra_kwargs["mask_dataset_id"] = str(body.mask_dataset_id)
-        # Same rolling-deploy rule for the join params (fix(#953)).
+        # Apply the same rolling-deploy rule to the join parameters.
         if body.join_dataset_id is not None:
             extra_kwargs["join_dataset_id"] = str(body.join_dataset_id)
             if body.join_fields:

--- a/backend/app/modules/catalog/datasets/api/router_analysis.py
+++ b/backend/app/modules/catalog/datasets/api/router_analysis.py
@@ -1,4 +1,4 @@
-"""Dataset analysis endpoints: parameterized PostGIS operations (M4)."""
+"""Dataset analysis endpoints for parameterized PostGIS operations."""
 
 import re
 import uuid

--- a/backend/app/modules/catalog/datasets/api/router_data.py
+++ b/backend/app/modules/catalog/datasets/api/router_data.py
@@ -111,7 +111,6 @@ async def get_dataset_rows_endpoint(
     Uses cursor-based pagination: pass ``after`` (gid) to fetch the next page.
     Supports column filtering via query params: ``filter[column_name]=value``.
     """
-    # Fetch dataset
     dataset = await get_dataset(db, dataset_id)
     if dataset is None:
         raise HTTPException(
@@ -119,10 +118,8 @@ async def get_dataset_rows_endpoint(
             detail="Dataset not found",
         )
 
-    # Visibility check
     await check_dataset_access_or_anonymous(db, dataset, dataset_id, user)
 
-    # Extract filter[col]=value params
     filters: dict[str, str] = {}
     for key, value in request.query_params.items():
         if key.startswith("filter[") and key.endswith("]") and value:

--- a/backend/app/modules/catalog/datasets/api/router_data.py
+++ b/backend/app/modules/catalog/datasets/api/router_data.py
@@ -61,7 +61,7 @@ router = APIRouter(
 
 
 def _semantic_search_rate_limit(_request: Request | None = None) -> str:
-    """SEC-S11: per-IP rate limit for embedding-cost endpoints."""
+    """Per-IP rate limit for embedding-cost endpoints."""
     return f"{get_cached_semantic_search_rate_limit()}/minute"
 
 
@@ -78,7 +78,7 @@ async def list_related_datasets(
     db: AsyncSession = Depends(get_db),
 ) -> RelatedDatasetsResponse:
     """Return top-5 datasets similar to this one by embedding cosine similarity."""
-    # SEC-S05: visibility-gate the SEED before reading its embedding -- an
+    # Visibility-gate the SEED before reading its embedding -- an
     # anonymous attacker could otherwise probe any UUID via a
     # cosine-distance oracle leaking content about the private seed. The
     # neighbor query already applies apply_visibility_filter separately.
@@ -136,7 +136,7 @@ async def get_dataset_rows_endpoint(
             filters=filters if filters else None,
         )
     except DBAPIError as exc:
-        # fix(#435): only a caller-caused error is a 400; connection loss,
+        # Only a caller-caused error is a 400; connection loss,
         # statement timeout, and permission failures fall through to the
         # central 503 handler rather than being reported as the caller's fault.
         if sqlstate(exc) in BAD_QUERY_INPUT:
@@ -236,9 +236,9 @@ async def dataset_maps(
     """Return maps that contain this dataset, filtered by caller's RBAC visibility."""
     from app.modules.catalog.maps.service import get_maps_for_dataset
 
-    # WR-02: gate on dataset visibility before listing maps -- without this,
+    # Gate on dataset visibility before listing maps -- without this,
     # anonymous callers could probe any dataset_id UUID to confirm it
-    # exists (an existence oracle, analogous to SEC-S05).
+    # exists, which would otherwise provide an existence oracle.
     dataset = await get_dataset(db, dataset_id)
     if dataset is None:
         raise HTTPException(
@@ -272,7 +272,7 @@ async def _roll_publication_version(db: AsyncSession, dataset: DatasetModel) -> 
 
     A signed tile template binds the dataset's ``publication_version``, so
     rolling it in the transition's own transaction is what makes an unpublish
-    reach the stateless tile path (#1963). Takes both catalog rows in house
+    reach the stateless tile path. Takes both catalog rows in house
     order first, since the roll makes the caller a two-row writer; call it
     immediately before the writes, with every workflow query already done.
     """
@@ -332,13 +332,13 @@ async def update_publication_status(
             ),
         )
 
-    # fix(#1963): the transition rolls the signed-scope counter, so this
+    # The transition rolls the signed-scope counter, so this
     # handler dirties the datasets row too and must take both in house order.
-    # Placed after the workflow query, immediately before the writes (#1864).
+    # Keep this immediately before the writes and after the workflow query.
     await _roll_publication_version(db, dataset)
     dataset.record.record_status = target
     await workflow.on_transition(context)
-    # fix(#1178): writes record_status without going through
+    # Writes record_status without going through
     # update_user_metadata, so it must run the same inherited-keyword
     # check or the ordinary publish flow warns nobody.
     warning = await inherited_keyword_disclosure_warning(
@@ -398,7 +398,7 @@ async def set_target_status(
             detail=f"Unknown status value: '{current}' or '{target}'",
         )
 
-    # fix(#1864): every workflow query runs BEFORE the pair lock, so the rows
+    # Every workflow query runs BEFORE the pair lock, so the rows
     # are not held across extension I/O. `allowed_transitions` reads
     # `context.from_status`, never the record, so validating the whole chain
     # up front sees exactly what the per-step loop saw.
@@ -429,14 +429,14 @@ async def set_target_status(
         chain.append((next_status, context))
         idx = next_idx
 
-    # fix(#1963): once for the whole chain, immediately before its writes.
+    # Once for the whole chain, immediately before its writes.
     await _roll_publication_version(db, dataset)
 
     for next_status, context in chain:
         dataset.record.record_status = next_status
         await workflow.on_transition(context)
 
-    # fix(#1178): the ordinary publish flow (DatasetPage's publish toggle)
+    # The ordinary publish flow (DatasetPage's publish toggle)
     # lands here, not in update_user_metadata -- the inherited-keyword
     # check has to run after the chain completes.
     warning = await inherited_keyword_disclosure_warning(

--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -163,7 +163,6 @@ async def get_vrt_status(
         )
     user_roles = await check_dataset_access(db, dataset, dataset_id, user)
 
-    # Load VRT RasterAsset
     asset_result = await db.execute(
         select(RasterAsset).where(RasterAsset.dataset_id == dataset_id)
     )
@@ -175,7 +174,6 @@ async def get_vrt_status(
 
     vrt_status = vrt_asset.status or "ready"
 
-    # Latest completed generation for last_generation_at
     gen_result = await db.execute(
         select(VrtGeneration)
         .where(
@@ -446,7 +444,6 @@ async def regenerate_vrt_endpoint(
     # any authenticated user could otherwise trigger it on a peer's raster.
     await check_dataset_write_access(db, dataset, dataset_id, user)
 
-    # Load VRT RasterAsset
     asset_result = await db.execute(
         select(RasterAsset).where(RasterAsset.dataset_id == dataset_id)
     )
@@ -468,7 +465,6 @@ async def regenerate_vrt_endpoint(
             },
         )
 
-    # Count sources
     count_result = await db.execute(
         text(
             "SELECT COUNT(*) FROM catalog.vrt_source_links WHERE vrt_dataset_id = :id"
@@ -477,7 +473,6 @@ async def regenerate_vrt_endpoint(
     )
     src_count = count_result.scalar() or 0
 
-    # Create VrtGeneration record
     generation = VrtGeneration(
         vrt_dataset_id=dataset_id,
         status="pending",

--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -54,7 +54,7 @@ async def _load_source_datasets(
 ) -> dict[uuid.UUID, object]:
     """Load VRT source datasets by id in one query, records eager-loaded.
 
-    fix(#435): both VRT source endpoints called `get_dataset()` once per
+    Both VRT source endpoints called `get_dataset()` once per
     member row, so a 200-source VRT cost 200 round trips. The per-row
     `can_access_dataset()` call stays -- it's the permission seam's
     decision, and batching it too would risk skipping an overlay's policy.
@@ -100,7 +100,7 @@ async def list_vrt_sources(
         """),
         {"vrt_id": str(dataset_id)},
     )
-    # SEC-E: SEC-C authorizes sources only at link time with no migration
+    # Sources are authorized only at link time, with no migration
     # re-authorizing pre-existing links, so a VRT may hold member rows the
     # caller can't access. Drop those here so title/CRS/resolution/extent
     # never leak; non-raising (can_access_dataset) since a 404 would abort
@@ -187,7 +187,7 @@ async def get_vrt_status(
     last_generation_at = last_gen.completed_at if last_gen else None
 
     # Raw total link count, intentionally including ALL links, while
-    # source_health below reflects only accessible members (SEC-E).
+    # source_health below reflects only accessible members.
     # Recomputing from the filtered set would leak the unauthorized delta.
     count_result = await db.execute(
         text(
@@ -241,7 +241,7 @@ async def get_vrt_status(
     )
     source_health_list = []
     storage = get_storage()
-    # SEC-E: drop members the caller cannot access (legacy links / authz
+    # Drop members the caller cannot access (legacy links / authz
     # drift) before probing storage, so their existence/health never leaks.
     ext = get_permission_extension()
 
@@ -266,7 +266,7 @@ async def get_vrt_status(
         if src_dataset is None or not await ext.can_access_dataset(
             db, src_dataset, row.source_dataset_id, user, user_roles=user_roles
         ):
-            # SEC-E: omit unauthorized members before any storage.exists probe.
+            # Omit unauthorized members before any storage.exists probe.
             continue
         sources_to_check.append(row)
 
@@ -284,14 +284,14 @@ async def get_vrt_status(
                 for row in sources_to_check
             )
         )
-        # feat(#1221): a replaced member probes healthy on its own, but the
+        # A replaced member probes healthy on its own, but the
         # parent's stored VRT still names the old COG -- surface that as
         # the member's own "stale" state instead of "fine".
-        # fix(#1290): compares STATE (what the member IS vs what the VRT
+        # Compares STATE (what the member IS vs what the VRT
         # was built FROM), not timestamps -- a replacement's `ingested_at`
         # commits after a concurrent rebuild's read, so a timestamp
         # comparison can read a healthy member as stale. `built_from` NULL
-        # means pre-#1290 VRTs, which fall back to the timestamp comparison.
+        # means older VRTs, which fall back to the timestamp comparison.
         built_from = vrt_asset.built_from or None
         built_at = vrt_asset.last_regenerated_at or vrt_asset.ingested_at
         for row, file_exists in zip(sources_to_check, exists_results):
@@ -328,11 +328,9 @@ async def get_vrt_status(
 def _vrt_generation_item(generation: Any, *, include_detail: bool) -> VrtGenerationItem:
     """One row of a VRT dataset's regeneration history.
 
-    fix(#1860): visibility alone used to gate this list, leaking every
-    row's ``error_message`` (GDAL/VRT failure text naming server paths)
-    and ``triggered_by`` (a raw user id) to any signed-in reader of a
-    public/internal dataset. ``include_detail`` is the
-    ``can_view_dataset_provenance`` answer; both fields null otherwise,
+    ``error_message`` can name server paths and ``triggered_by`` contains a
+    raw user id. ``include_detail`` is the
+    ``can_view_dataset_provenance`` answer; both fields are null otherwise,
     matching what ``DatasetRefreshRunResponse`` redacts for the same reader.
 
     No per-row "you triggered this one" arm: every ``VrtGeneration``
@@ -389,7 +387,7 @@ async def list_vrt_generations(
             status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
         )
     user_roles = await check_dataset_access(db, dataset, dataset_id, user)
-    # fix(#1860): visibility and disclosure are two questions. The check
+    # Visibility and disclosure are two questions. The check
     # above settles the first; this settles the second.
     can_view_detail = can_view_dataset_provenance(dataset.record, user, user_roles)
 
@@ -453,9 +451,7 @@ async def regenerate_vrt_endpoint(
             status_code=status.HTTP_404_NOT_FOUND, detail="VRT asset not found"
         )
 
-    # fix(#1955): the lock, then the status re-read under it. The two used to
-    # be a status check followed by a lock, which leaves the window the second
-    # of two concurrent triggers lands in.
+    # Lock before re-reading status so concurrent triggers cannot both proceed.
     if not await admit_vrt_mutation(db, dataset_id, vrt_asset):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -498,7 +494,7 @@ async def regenerate_vrt_endpoint(
     # Dispatch with orphan guard: closes the SYNCHRONOUS failure
     # (Procrastinate unreachable at enqueue time) by reverting the mutation
     # before it's ever visible. A worker dying AFTER a successful dispatch
-    # is fix(#1267)'s ``sweep_stale_vrt_assets`` job to reconcile instead.
+    # is reconciled by the ``sweep_stale_vrt_assets`` job instead.
     async def _defer() -> None:
         await defer_async_with_tenant(
             get_catalog_port().regenerate_vrt_task(),

--- a/backend/app/modules/catalog/datasets/api/router_vrt.py
+++ b/backend/app/modules/catalog/datasets/api/router_vrt.py
@@ -52,12 +52,9 @@ VrtMutationResponse = get_catalog_port().vrt_mutation_response_model()
 async def _load_source_datasets(
     db: AsyncSession, dataset_ids: list[uuid.UUID]
 ) -> dict[uuid.UUID, object]:
-    """Load VRT source datasets by id in one query, records eager-loaded.
+    """Load VRT source datasets in one query with records eager-loaded.
 
-    Both VRT source endpoints called `get_dataset()` once per
-    member row, so a 200-source VRT cost 200 round trips. The per-row
-    `can_access_dataset()` call stays -- it's the permission seam's
-    decision, and batching it too would risk skipping an overlay's policy.
+    Keep per-member can_access_dataset checks so overlays can apply their policy.
     """
     if not dataset_ids:
         return {}

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -51,29 +51,9 @@ from app.platform.sandbox.schemas import SandboxError
 PREVIEW_FEATURE_CAP = 500
 
 
-# fix(#1014): global cap on concurrent previews, on top of the per-user
-# pg_try_advisory_xact_lock in execute_safe (which only stops ONE user
-# stacking previews). fix(#716) measured the need: at two pool slots per
-# preview, 7 concurrent previews exhausted the 13-slot pool
-# (db_pool_size 10 + db_max_overflow 3), blocking every worker endpoint
-# for the 30s pool_timeout until an HTTP 500. #716 halved the cost to
-# one slot; derived from the configured pool, not hardcoded, since a
-# fixed ceiling could exceed a small-pool deployment's real connections.
-#
-# A QUARTER, not a third: the REST endpoint costs one slot
-# (release_session), but the AI chat path holds two (can't release its
-# session). Sizing against that worst case keeps previews under half
-# the pool -- 3 on the default 13-slot pool, floored at 1.
-#
-# GLOBAL, not tenant-scoped, since total connections are what's
-# contended, not a per-tenant resource. PER WORKER PROCESS, since a
-# semaphore can't span processes -- each worker has its own pool, so the
-# ratio holds per pool even though UVICORN_WORKERS=2 doubles the
-# deployment-wide ceiling.
-#
-# With DB_USE_EXTERNAL_POOLER=true the engine uses NullPool, so the real
-# budget belongs to PgBouncer/RDS Proxy, invisible here -- fall back to
-# the value the default pool produces instead.
+# Each AI preview may hold two connections, so cap each worker at one quarter
+# of its pool to reserve half for other traffic. External poolers hide their
+# capacity; use the default local-pool budget in that mode.
 _EXTERNAL_POOLER_PREVIEW_BOUND = 3
 
 
@@ -96,13 +76,9 @@ _GEOJSON_PRECISION = 6
 async def resolve_source_feature_count(
     db: AsyncSession, dataset: Dataset, *, cap: int
 ) -> int:
-    """Feature count for enqueue gating, bounded by ``cap``.
+    """Return the cached count, or probe live rows up to ``cap + 1``.
 
-    Uses the cached catalog snapshot when present. When it is NULL (legacy
-    imports, ``register_existing_table`` paths), a NULL-as-zero default
-    would admit exactly the unknown-size datasets the OOM gates exist for
-    (fix(#701)) -- so count the physical table instead, stopping at
-    ``cap + 1`` rows so the probe itself stays bounded.
+    Unknown counts must be measured so enqueue limits cannot be bypassed.
     """
     if dataset.feature_count is not None:
         return dataset.feature_count
@@ -130,10 +106,10 @@ async def _resolve_bbox_source_count(
     WHOLE-table total, and pairing "500 of 22,324" with a viewport-scoped
     result would assert something the result doesn't support.
 
-    fix(#727): runs through ``execute_safe`` inside
+    Runs through ``execute_safe`` inside
     ``run_analysis_preview``'s ``_preview_slots`` block, not a bare
     ``db.execute`` on the caller's session (which reintroduced the
-    pool-exhaustion class fix(#716)/fix(#1014) prevent). Returns a real
+    pool-exhaustion class the semaphore prevents). Returns a real
     count or ``None`` on timeout/failure, never a capped number dressed
     up as exact.
 
@@ -165,15 +141,9 @@ def build_preview_sql(
     schema in multi-tenant).
     """
     if request.operation == "intersect" and mask_table_ref is not None:
-        # Rendered whole in analysis_sql: an overlay is a JOIN with a GROUP BY,
-        # not a per-row expression, so it shares none of the lateral template
-        # below. See render_intersect_preview for why match_count rides this
-        # statement as a window rather than costing a second overlay.
-        #
-        # fix(#727): bbox passes straight through to
-        # render_intersect_preview/render_intersect_pairs -- it does NOT
-        # share the WHERE clause the other operations compose through below
-        # (this branch returns first), so it needed its own plumbing.
+        # Intersect is a grouped join, not a per-row expression. Its renderer
+        # receives bbox directly and includes match_count as a window to avoid
+        # repeating the overlay.
         return render_intersect_preview(
             table_ref,
             mask_table_ref,
@@ -183,7 +153,7 @@ def build_preview_sql(
     extra_cols = ""
     extra_joins = ""
     if join_table_ref is not None:
-        # fix(#953): unlike every other operation, the geometry comes back
+        # Unlike every other operation, the geometry comes back
         # unchanged, so the preview MUST carry join_count as a property or
         # it renders pixel-identical to the layer already on the map.
         cols, extra_joins = render_spatial_join(
@@ -191,19 +161,19 @@ def build_preview_sql(
         )
         extra_cols = f", {cols}"
     elif request.operation == "measure":
-        # fix(#954): same reason -- the measured value IS the result and the
+        # Same reason -- the measured value IS the result and the
         # geometry is unchanged, so it has to ride along as a property.
         cols, extra_joins = render_measure_columns(src="_src")
         extra_cols = f", {cols}"
     if mask_table_ref is not None and request.operation == "select_by_location":
-        # fix(#955): a selection keeps whole geometries, so the row filter IS
+        # A selection keeps whole geometries, so the row filter IS
         # the operation; the identity lateral keeps the query shape (and
         # NOT_EMPTY_PREDICATE) common with every other branch.
         cte = ""
         lateral = "(SELECT geom_4326 AS geom_out OFFSET 0)"
         where = render_select_by_location_where(mask_table_ref, src="_src")
     elif mask_table_ref is not None:
-        # fix(#693): layer-sourced clip previews subdivide the mask once and
+        # Layer-sourced clip previews subdivide the mask once and
         # join it per row instead of unioning the whole layer per request;
         # see render_clip_layer_join for the measured rationale.
         cte, lateral, where = render_clip_layer_join(mask_table_ref, src="_src")
@@ -216,17 +186,9 @@ def build_preview_sql(
             mask=request.mask,
         )
         lateral = f"(SELECT {expr} AS geom_out OFFSET 0)"
-    # fix(#680): drop NULL/EMPTY results in SQL, not Python -- the row cap
-    # applies to raw rows, so boundary-grazing clips (ST_Intersects true,
-    # EMPTY extract) could consume the whole budget and hide real matches.
-    #
-    # fix(#700): the LATERAL subquery's OFFSET 0 blocks pull-up (else
-    # three outer references to geom_out evaluate three times per row);
-    # the join shape keeps ORDER BY gid on the pkey index for early stop.
-    #
-    # fix(#727): the viewport bbox joins this predicate list, not the
-    # whole FROM, so it stays index-drivable and ORDER BY gid still rides
-    # the pkey index over the smaller on-screen source.
+    # Filter empty results before the row cap so boundary-only clips cannot
+    # hide valid matches. OFFSET 0 prevents repeated evaluation of geom_out;
+    # keeping bbox in the predicates preserves index-driven gid ordering.
     extra_predicates = NOT_EMPTY_PREDICATE
     if request.bbox is not None:
         extra_predicates = (
@@ -269,7 +231,7 @@ def _preview_extra_columns(
 def _json_safe(value: Any) -> Any:
     """Make one transferred property value JSON-serializable.
 
-    fix(#1097): a spatial join can transfer a ``bytea`` column back as raw
+    A spatial join can transfer a ``bytea`` column back as raw
     ``bytes``, which Pydantic's JSON serializer 500s on; encode as
     PostgreSQL's ``\\x``-hex, matching ``to_jsonb(t.*)`` in the features API.
 
@@ -328,7 +290,7 @@ async def run_analysis_preview(
     qualifies, and no middleware reads the ORM user after the handler; the AI
     chat tool does NOT (reads ``user.id`` again after).
 
-    ``request.bbox`` (fix(#727)), when present, scopes the row cap to the
+    ``request.bbox``, when present, scopes the row cap to the
     viewport before ``ORDER BY gid`` applies; the AI chat tool never sets it.
     """
     table_ref = _safe_table_ref(dataset.table_name)
@@ -355,15 +317,10 @@ async def run_analysis_preview(
     # emits them (immediately after gid and the geometry). Must stay in step
     # with build_preview_sql's extra_cols above — the rows come back positional.
     extra_columns = _preview_extra_columns(request, join_table_ref)
-    # fix(#716): read everything off the ORM objects BEFORE releasing the
-    # session. `execute_safe` opens its own connection (needs READ ONLY +
-    # SET LOCAL ROLE, unavailable on the caller's session), so without this
-    # the handler holds two of the pool's 13 slots for the whole sandbox
-    # query. `rollback()` returns the connection, so a preview costs one
-    # slot instead of two -- at two slots, 7 concurrent previews exhaust
-    # the pool and every endpoint on the worker 500s on pool_timeout.
+    # Read ORM state before rollback releases the caller's connection.
+    # execute_safe needs its own connection for READ ONLY and SET LOCAL ROLE.
     source_feature_count = dataset.feature_count
-    # fix(#727): whether the cached snapshot above gets overridden by a live,
+    # Whether the cached snapshot above gets overridden by a live,
     # bbox-scoped count. Cheap check only; the count itself runs inside the
     # _preview_slots block below via execute_safe, which opens its own
     # connection and has no ordering dependency on the rollback below.
@@ -372,7 +329,7 @@ async def run_analysis_preview(
     )
     if release_session:
         await db.rollback()
-    # fix(#1014): fail fast at the bound rather than queueing -- the client
+    # Fail fast at the bound rather than queueing -- the client
     # holds a request open, so waiting turns a fast failure into a slow one.
     # `.locked()` then `async with` is atomic here despite looking like
     # check-then-act: no await between them, and acquiring a free-slot
@@ -387,7 +344,7 @@ async def run_analysis_preview(
             "Try again in a moment.",
         )
     async with _preview_slots:
-        # fix(#727): the bbox-scoped denominator lives in this slot too, not
+        # The bbox-scoped denominator lives in this slot too, not
         # before it. Read first, before the geometry query, so a preview
         # whose denominator loses the race for the sandbox's per-user
         # advisory lock still gets a geometry result even if the count
@@ -403,7 +360,7 @@ async def run_analysis_preview(
             row_limit=PREVIEW_FEATURE_CAP,
             concurrency_key=str(user_id),
         )
-        # fix(#1097): inside the same slot as the geometry query, not after
+        # Inside the same slot as the geometry query, not after
         # it -- both open their own sandbox connection, so releasing the
         # semaphore between them would let _MAX_CONCURRENT_PREVIEWS stop
         # bounding connections while the uncapped, both-layer count query
@@ -415,14 +372,8 @@ async def run_analysis_preview(
         )
     features: list[dict[str, Any]] = []
     bbox: list[float] | None = None
-    # fix(#956): intersect's exact total rides its own preview statement as a
-    # trailing window column (see build_preview_sql). Read off any row -- the
-    # window is computed before the cap, so every row carries the true total.
-    #
-    # fix(#1097): seeded to 0, not None, for intersect: the window column
-    # rides ON the rows, so zero overlapping pairs means no row to read it
-    # off, which would wrongly report `match_count: null` (the contract's
-    # "could not be computed" state) for a correct, ordinary empty answer.
+    # Intersect carries its uncapped total as a window column. Seed zero because
+    # an empty result has no row from which to read that valid total.
     inline_match_count: int | None = 0 if request.operation == "intersect" else None
     for row in result.rows:
         if request.operation == "intersect":
@@ -479,7 +430,7 @@ async def _resolve_match_count(
 
     Its own statement, since the row cap would otherwise lie: summing
     per-row counts across 500 of 12,000 polygons answers a question
-    nobody asked (fix(#953); fix(#955) reuses it for selected-record totals).
+    nobody asked (; reuses it for selected-record totals).
 
     Degrades to None rather than failing the preview: it runs second, so
     it can lose the per-user lock to another request or outrun the

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -1,4 +1,4 @@
-"""Parameterized PostGIS analysis operations (M4) — preview path.
+"""Parameterized PostGIS analysis preview operations.
 
 Server-built SQL only: every statement renders from a fixed template plus
 Pydantic-validated parameters, executed through the read-only sandbox rails

--- a/backend/app/modules/catalog/datasets/domain/service_analysis.py
+++ b/backend/app/modules/catalog/datasets/domain/service_analysis.py
@@ -99,22 +99,12 @@ async def resolve_source_feature_count(
 async def _resolve_bbox_source_count(
     db: AsyncSession, table_ref: str, bbox: list[float], user_id: uuid.UUID
 ) -> int | None:
-    """Exact 1:1-operation denominator scoped to a preview's viewport bbox, or
-    ``None`` if it could not be computed within the query budget.
+    """Return an exact viewport-scoped source count, or None on query failure.
 
-    Bypasses the cached ``dataset.feature_count`` deliberately: that's a
-    WHOLE-table total, and pairing "500 of 22,324" with a viewport-scoped
-    result would assert something the result doesn't support.
-
-    Runs through ``execute_safe`` inside
-    ``run_analysis_preview``'s ``_preview_slots`` block, not a bare
-    ``db.execute`` on the caller's session (which reintroduced the
-    pool-exhaustion class the semaphore prevents). Returns a real
-    count or ``None`` on timeout/failure, never a capped number dressed
-    up as exact.
-
-    Takes ``table_ref`` (LOGICAL ``data`` schema), not ``dataset``:
-    ``execute_safe`` does the tenant-schema rewrite itself.
+    The cached feature_count covers the whole table and cannot describe a viewport.
+    Run through execute_safe inside _preview_slots so this query shares the
+    preview connection budget. Pass a logical data-schema table_ref; execute_safe
+    rewrites the tenant schema.
     """
     predicate = render_bbox_predicate(bbox, src="_t")
     count_sql = f"SELECT count(*)::bigint AS source_count FROM {table_ref} AS _t WHERE {predicate}"
@@ -425,17 +415,10 @@ _ROW_FILTERING_OPERATIONS = ("clip", "select_by_location", "intersect")
 async def _resolve_match_count(
     db: AsyncSession, count_sql: str, user_id: uuid.UUID
 ) -> int | None:
-    """Exact total for an operation whose result the preview cap would mislead
-    about, or None when it could not be computed.
+    """Return the full match count, or ``None`` if the count query fails.
 
-    Its own statement, since the row cap would otherwise lie: summing
-    per-row counts across 500 of 12,000 polygons answers a question
-    nobody asked (; reuses it for selected-record totals).
-
-    Degrades to None rather than failing the preview: it runs second, so
-    it can lose the per-user lock to another request or outrun the
-    statement timeout scanning both layers -- neither a reason to discard
-    a preview that already succeeded.
+    Count separately because capped preview rows cannot establish a total.
+    Lock contention or timeout must not discard an otherwise successful preview.
     """
     try:
         result = await execute_safe(

--- a/backend/app/modules/catalog/datasets/domain/service_create.py
+++ b/backend/app/modules/catalog/datasets/domain/service_create.py
@@ -61,11 +61,8 @@ async def create_empty_dataset(
                 f"Invalid column name: {col.name!r}. "
                 "Must start with a letter or underscore and contain only alphanumeric characters and underscores."
             )
-        # SAFE_COLUMN_NAME_RE allows a leading underscore and no
-        # length bound, but the feature write path can address neither: a
-        # column like `_notes` was created but silently dropped every write,
-        # and a name over 63 chars gets truncated by Postgres DDL while
-        # column_info keeps the full string. Refuse at creation instead.
+        # Apply the feature-write name rules at creation: leading underscores are
+        # unwritable, and PostgreSQL truncates names over 63 characters.
         if not is_writable_feature_column(lower_name):
             raise ValueError(
                 f"Invalid column name: {col.name!r}. "
@@ -133,8 +130,7 @@ async def create_empty_dataset(
         column_info=column_info,
         source_format="created",
         srid=4326,
-        # The table column is generic geometry(Geometry, 4326); storing
-        # POINT here rejected Polygon/LineString inserts the column accepts.
+        # Match the generic geometry column so created datasets accept every subtype.
         geometry_type="GEOMETRY",
         feature_count=0,
         visibility="private",
@@ -198,10 +194,8 @@ async def create_dataset(
         ing = ingestion
 
     spatial_extent_value = None
-    # An antimeridian-crossing source produces a two-ring
-    # MULTIPOLYGON extent; accepting only POLYGON here silently nulled
-    # Record.spatial_extent on first ingest. Both satisfy
-    # chk_records_spatial_extent_type.
+    # Antimeridian extents are two-ring MULTIPOLYGONs; both polygon types
+    # satisfy chk_records_spatial_extent_type.
     if ing.extent_wkt and ing.extent_wkt.startswith(("POLYGON", "MULTIPOLYGON")):
         spatial_extent_value = func.ST_GeomFromText(ing.extent_wkt, 4326)
 
@@ -277,11 +271,8 @@ async def create_dataset(
     if ing.column_info:
         await auto_detect_relationships(session, dataset.id, record.id, ing.column_info)
 
-    # Dataset.create was invisible in the audit trail -- emitted
-    # here, not per-router, so every creation path funnels through one
-    # emit site instead of risking a missed call at each call site.
-    # No ip_address: a domain-layer function with no Request, matching the
-    # reupload.commit precedent (tasks_common.py).
+    # Emit once in the domain so every creation path is audited.
+    # No ip_address is available here because the domain receives no Request.
     from app.modules.audit.service import (
         AuditEvent,
         audit_emit,

--- a/backend/app/modules/catalog/datasets/domain/service_create.py
+++ b/backend/app/modules/catalog/datasets/domain/service_create.py
@@ -61,7 +61,7 @@ async def create_empty_dataset(
                 f"Invalid column name: {col.name!r}. "
                 "Must start with a letter or underscore and contain only alphanumeric characters and underscores."
             )
-        # fix(#1778): SAFE_COLUMN_NAME_RE allows a leading underscore and no
+        # SAFE_COLUMN_NAME_RE allows a leading underscore and no
         # length bound, but the feature write path can address neither: a
         # column like `_notes` was created but silently dropped every write,
         # and a name over 63 chars gets truncated by Postgres DDL while
@@ -133,7 +133,7 @@ async def create_empty_dataset(
         column_info=column_info,
         source_format="created",
         srid=4326,
-        # fix(#430): the table column is generic geometry(Geometry, 4326); storing
+        # The table column is generic geometry(Geometry, 4326); storing
         # POINT here rejected Polygon/LineString inserts the column accepts.
         geometry_type="GEOMETRY",
         feature_count=0,
@@ -198,7 +198,7 @@ async def create_dataset(
         ing = ingestion
 
     spatial_extent_value = None
-    # fix(#934): an antimeridian-crossing source produces a two-ring
+    # An antimeridian-crossing source produces a two-ring
     # MULTIPOLYGON extent; accepting only POLYGON here silently nulled
     # Record.spatial_extent on first ingest. Both satisfy
     # chk_records_spatial_extent_type.
@@ -207,7 +207,7 @@ async def create_dataset(
 
     record_type = "table" if ing.geometry_type is None else "vector_dataset"
 
-    # fix(#302): authoritative count-cap check at the point the Record row is
+    # Authoritative count-cap check at the point the Record row is
     # created — the upload-time check_upload_quota cannot be atomic because
     # this row only comes to exist here, after the pre-check passed.
     from app.modules.quota.service import reserve_dataset_slot
@@ -229,7 +229,7 @@ async def create_dataset(
     dataset = Dataset(
         record_id=record.id,
         table_name=table_name,
-        # fix(#1218): first ingest IS the first successful materialization,
+        # First ingest IS the first successful materialization,
         # so stamp it here rather than leaving every dataset reporting null.
         #
         # A Python datetime, NOT func.now(): a SQL expression leaves the
@@ -277,7 +277,7 @@ async def create_dataset(
     if ing.column_info:
         await auto_detect_relationships(session, dataset.id, record.id, ing.column_info)
 
-    # fix(#1230): dataset.create was invisible in the audit trail -- emitted
+    # Dataset.create was invisible in the audit trail -- emitted
     # here, not per-router, so every creation path funnels through one
     # emit site instead of risking a missed call at each call site.
     # No ip_address: a domain-layer function with no Request, matching the

--- a/backend/app/modules/catalog/datasets/domain/service_create.py
+++ b/backend/app/modules/catalog/datasets/domain/service_create.py
@@ -1,4 +1,4 @@
-"""Dataset creation paths: empty + materialized (extracted from service.py — Phase 224)."""
+"""Dataset creation paths for empty and materialized datasets."""
 
 from __future__ import annotations
 

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -1,4 +1,4 @@
-"""Dataset lifecycle operations: delete + version history (extracted from service.py — Phase 224)."""
+"""Dataset lifecycle operations: deletion and version history."""
 
 from __future__ import annotations
 

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -62,7 +62,7 @@ async def reap_managed_storage(prefixes: list[str], tenant_id: str | None) -> No
     """Delete every object under GeoLens-managed prefixes for one dataset.
 
     Extracted from ``delete_dataset``'s two branches, which reaped
-    identically from different prefix lists, when fix(#1452) pushed the
+    identically from different prefix lists, when pushed the
     function past ruff's complexity ceiling. The import stays function-local
     so tests keep patching the provider attribute.
     """
@@ -86,7 +86,7 @@ async def _relation_oid(
     so a role that doesn't own the relation could be blind to it; pg_class
     is visible to every role and every relation kind.
 
-    fix(#1456): returns the oid rather than a bare bool so ONE probe answers
+    Returns the oid rather than a bare bool so ONE probe answers
     both questions the delete asks -- whether anything occupies the name,
     and which relation it is. None is the only "absent" answer.
     """
@@ -124,7 +124,7 @@ async def delete_dataset(
     order. Raises ValueError if dataset not found, name mismatch, or invalid
     table name.
 
-    fix(#1452): a dataset registered from an existing PostGIS table is
+    A dataset registered from an existing PostGIS table is
     DETACHED rather than dropped -- the catalog row, grants, tiles, search
     and embedding rows go, but the operator's table survives with its rows.
     See :func:`app.platform.dataset_origin.geolens_owns_table`.
@@ -149,7 +149,7 @@ async def delete_dataset(
 
     record_type = dataset.record.record_type
 
-    # fix(#1452): registration copies no data -- it points the catalog at a
+    # Registration copies no data -- it points the catalog at a
     # table the operator built and keeps writing to. Deleting the dataset
     # therefore has to detach, not drop, or it destroys the original rather
     # than a GeoLens-managed copy. Decides the DROP alone; name retirement
@@ -158,7 +158,7 @@ async def delete_dataset(
         dataset.source_format, record_type, dataset.origin_ref
     )
 
-    # fix(#1452): whether this delete FREES the name is separate from
+    # Whether this delete FREES the name is separate from
     # ownership -- a detach frees nothing while the relation stands, but a
     # registered dataset whose table was already dropped frees the name
     # like an ingested delete, and skipping its tombstone reopens GH-1443.
@@ -166,14 +166,14 @@ async def delete_dataset(
     # extra one only costs a rename before re-registering.
     name_is_freed = True
 
-    # fix(#1456): identity of the relation this delete frees, read while
+    # Identity of the relation this delete frees, read while
     # it's still there. Stays None where no relation held the name -- the
     # raster/VRT branch (synthetic `raster_<hex>` table_name) and a detach
     # whose table was already dropped. NULL means "nothing to identify",
     # never "no owner".
     relation_oid: int | None = None
 
-    # fix(#1847): lock job rows before the table and the pair; a worker
+    # Lock job rows before the table and the pair; a worker
     # holds its job row before either, and the record delete cascades into them.
     from app.platform.catalog_locks import lock_ingest_jobs
     from app.platform.jobs.models import IngestJob
@@ -184,14 +184,14 @@ async def delete_dataset(
         if record_type == "raster_dataset":
             # Guard: prevent deletion if any VRT still references this COG.
             #
-            # fix(#1327): a reference is committed OR in flight -- an add
+            # A reference is committed OR in flight -- an add
             # staged by add_vrt_source has no vrt_source_links row until
             # its regeneration publishes, so the second branch closes that
             # gap by asking the not-yet-applied set too.
             #
             # Membership uses `@>`, not jsonb_array_elements_text: jsonb
             # containment is TOTAL, so a column holding JSON `null`
-            # (#1322) answers false instead of raising. Only
+            # answers false instead of raising. Only
             # 'pending'/'running' generations count.
             refs_result = await session.execute(
                 text(
@@ -233,22 +233,21 @@ async def delete_dataset(
             raise RuntimeError(
                 "Dataset deletion is missing tenant context in multi-tenant mode"
             )
-        # fix(#1847): includes the raster child, which the record delete
+        # Includes the raster child, which the record delete
         # cascades to and the replace worker holds across its upload.
         await lock_catalog_rows_for_write(session, dataset, with_raster_asset=True)
 
         storage_prefixes = tuple(prefixes)
     else:
-        # fix(#430): vector ingest persists originals/{id}/ (archived source)
-        # and vectors/{id}/quicklook_256.png; the old branch only dropped
-        # the table, orphaning both objects forever (no reaper).
+        # Vector ingest persists originals/{id}/ and
+        # vectors/{id}/quicklook_256.png, so deletion removes both objects.
         tenant_id = current_tenant_var.get()
         if is_multi_tenant() and tenant_id is None:
             raise RuntimeError(
                 "Dataset deletion is missing tenant context in multi-tenant mode"
             )
         data_schema = tenant_data_schema(tenant_id)
-        # fix(#1456): probe ahead of the branch, not inside the detach arm.
+        # Probe ahead of the branch, not inside the detach arm.
         # After the DROP below the pg_class row is gone within this
         # transaction, so this is the last moment the relation can be
         # identified -- and the detach arm needs the same read anyway.
@@ -279,18 +278,18 @@ async def delete_dataset(
         # is worse than leaving it (linearization isn't reversible; a
         # column drop rewrites the table for nothing). Re-registering
         # reapplies all three idempotently.
-        # fix(#1847): ahead of the reap, behind the DROP. See the raster branch.
+        # Ahead of the reap, behind the DROP. See the raster branch.
         await lock_catalog_rows_for_write(session, dataset)
 
         storage_prefixes = (f"originals/{dataset_id}/", f"vectors/{dataset_id}/")
 
-    # fix(#1443): retire the name before releasing it, so the tile
+    # Retire the name before releasing it, so the tile
     # router's table_name -> metadata map can't hold a stale entry.
     # session.add lands in the same transaction as the DROP and record
     # delete: a crash rolls back the whole delete, never a freed name
     # with no tombstone.
     #
-    # fix(#1452): except when detached with the relation left standing --
+    # Except when detached with the relation left standing --
     # nothing was released, so retiring would make the table permanently
     # unregisterable. Reads `name_is_freed`, not `owns_table`, since a
     # registered dataset whose table was ALREADY gone also needs the
@@ -299,7 +298,7 @@ async def delete_dataset(
     # serves at most the 60s meta-cache TTL of the SAME dataset's rows.
     #
     # ONE residual: an operator dropping that relation AFTER this reads
-    # it frees the name untombstoned. fix(#1456) records its identity
+    # it frees the name untombstoned. The relation probe records its identity
     # here for a future closure (nothing reads it yet) -- why the ELSE
     # branch below exists, on this no-tombstone path.
     if name_is_freed:
@@ -308,7 +307,7 @@ async def delete_dataset(
                 table_name=table_name,
                 tenant_id=dataset.tenant_id,
                 dataset_id=dataset_id,
-                # fix(#1456): captured while their sources are alive (oid
+                # Captured while their sources are alive (oid
                 # before the DROP above, created_by before the record delete
                 # below). The oid identifies the relation for ONE cluster
                 # lifetime only -- pg_dump/restore doesn't preserve oids, so
@@ -319,7 +318,7 @@ async def delete_dataset(
             )
         )
     elif relation_oid is not None:
-        # fix(#1456): no name was released, so nothing goes in the
+        # No name was released, so nothing goes in the
         # retirement set -- recorded HERE or never, since created_by dies
         # with the record row and the oid dies when the operator drops
         # the relation. Separate table so no retirement-set reader has to
@@ -341,22 +340,18 @@ async def delete_dataset(
     await session.delete(dataset.record)
 
     if record_type not in RASTER_FAMILY_RECORD_TYPES:
-        # fix(#1427): purge the dropped table's MVT tiles -- the old cache
-        # key had no dataset id, so a name freed above was immediately
-        # reusable and its successor could be served this dataset's bytes.
+        # Purge MVT tiles so a reused table name cannot serve stale bytes and
+        # orphaned entries do not linger until TTL. Raster/VRT tiles come from
+        # Titiler and are excluded.
         #
-        # fix(#1429)/fix(#1444): non-load-bearing now (tile keys carry the
-        # dataset id) but stays, since orphaned entries are dead weight
-        # until TTL. Raster/VRT excluded -- their tiles come from Titiler.
-        #
-        # fix(#1847): runs with the catalog pair held, before the commit.
+        # Runs with the catalog pair held, before the commit.
         from app.platform.cache.provider import get_tile_cache
 
         tile_cache = get_tile_cache()
         if tile_cache is not None:
             await tile_cache.invalidate_table(table_name)
 
-    # fix(#1429): the matching eviction of the tile router's table_name ->
+    # The matching eviction of the tile router's table_name ->
     # metadata map is NOT here, it is at the two delete endpoints after
     # their commit -- the DROP above doesn't lock catalog.datasets, so a
     # concurrent tile request inside this still-open transaction would
@@ -371,7 +366,7 @@ async def delete_dataset(
         table_name=table_name,
         record_type=record_type,
         title=confirm_title,
-        # fix(#1452): both flags recorded because they disagree in the one
+        # Both flags recorded because they disagree in the one
         # case worth reading about later -- a detach whose table was
         # already gone still retires the name.
         table_detached=not owns_table,

--- a/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
+++ b/backend/app/modules/catalog/datasets/domain/service_lifecycle.py
@@ -61,10 +61,7 @@ class DatasetDeletion(NamedTuple):
 async def reap_managed_storage(prefixes: list[str], tenant_id: str | None) -> None:
     """Delete every object under GeoLens-managed prefixes for one dataset.
 
-    Extracted from ``delete_dataset``'s two branches, which reaped
-    identically from different prefix lists, when pushed the
-    function past ruff's complexity ceiling. The import stays function-local
-    so tests keep patching the provider attribute.
+    Import the storage provider locally so callers and tests can replace it.
     """
     from app.platform.storage.provider import get_storage
 
@@ -129,10 +126,7 @@ async def delete_dataset(
     and embedding rows go, but the operator's table survives with its rows.
     See :func:`app.platform.dataset_origin.geolens_owns_table`.
     """
-    # Function-local import via the service.py façade is intentional -- it
-    # lets tests mock `service.get_dataset` to inject fixture datasets
-    # without a DB. Hoisting to module-top broke 7 tests that patch the
-    # façade attribute.
+    # Resolve through the façade at call time so tests can replace service.get_dataset.
     from app.modules.catalog.datasets.domain.service import get_dataset
     from app.modules.catalog.features.service import lock_catalog_rows_for_write
 
@@ -158,12 +152,9 @@ async def delete_dataset(
         dataset.source_format, record_type, dataset.origin_ref
     )
 
-    # Whether this delete FREES the name is separate from
-    # ownership -- a detach frees nothing while the relation stands, but a
-    # registered dataset whose table was already dropped frees the name
-    # like an ingested delete, and skipping its tombstone reopens GH-1443.
-    # True by default: a missing tombstone is the disclosure risk; an
-    # extra one only costs a rename before re-registering.
+    # Retire a registered table name only if its relation is already absent.
+    # Default to retirement: a missing tombstone risks stale tile disclosure,
+    # while an extra tombstone only requires a new name for registration.
     name_is_freed = True
 
     # Identity of the relation this delete frees, read while
@@ -283,24 +274,14 @@ async def delete_dataset(
 
         storage_prefixes = (f"originals/{dataset_id}/", f"vectors/{dataset_id}/")
 
-    # Retire the name before releasing it, so the tile
-    # router's table_name -> metadata map can't hold a stale entry.
-    # session.add lands in the same transaction as the DROP and record
-    # delete: a crash rolls back the whole delete, never a freed name
-    # with no tombstone.
+    # Commit name retirement with the DROP and record deletion so rollback cannot
+    # leave a freed name without a tombstone. This also applies to a registered
+    # dataset whose relation is already absent.
     #
-    # Except when detached with the relation left standing --
-    # nothing was released, so retiring would make the table permanently
-    # unregisterable. Reads `name_is_freed`, not `owns_table`, since a
-    # registered dataset whose table was ALREADY gone also needs the
-    # tombstone (GH-1443). The surviving-relation case is bounded:
-    # generate_table_name blocks ingest on it, so stale tile metadata
-    # serves at most the 60s meta-cache TTL of the SAME dataset's rows.
-    #
-    # ONE residual: an operator dropping that relation AFTER this reads
-    # it frees the name untombstoned. The relation probe records its identity
-    # here for a future closure (nothing reads it yet) -- why the ELSE
-    # branch below exists, on this no-tombstone path.
+    # A surviving detached relation must remain registerable. It blocks name reuse,
+    # so stale tile metadata serves only the same dataset until its cache expires.
+    # An operator can later drop that relation without creating a tombstone; its
+    # identity is recorded below, but no consumer currently closes that gap.
     if name_is_freed:
         session.add(
             RetiredTableName(

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -1,4 +1,4 @@
-"""Dataset metadata + attribute operations (extracted from service.py — Phase 224)."""
+"""Dataset metadata and attribute operations."""
 
 from __future__ import annotations
 

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -292,7 +292,7 @@ async def update_user_metadata(
     """Update user-editable fields including extended metadata.
 
     Accepts a DatasetMeta Pydantic model. Only updates fields that are
-    explicitly set (not None). Raises ValueError if dataset not found.
+    explicitly set. Raises ValueError if dataset not found.
     Does not commit; caller controls transaction scope.
 
     ``warnings_out`` collects non-blocking warnings from the metadata extension.
@@ -436,10 +436,9 @@ async def sample_example_values(
 ) -> list | None:
     """Up to ten distinct non-null values of one column, or None.
 
-    Reads the data table, so call it BEFORE the catalog pair is locked
-    None for a geometry column, an unsafe name, or any query
-    failure; the read runs in a savepoint so a failure leaves the
-    transaction usable.
+    Sample before locking the catalog pair because this reads the data table.
+    Returns None for geometry columns, unsafe names or query failures; a savepoint
+    keeps the transaction usable.
     """
     if not data_type or "geometry" in data_type.lower():
         return None

--- a/backend/app/modules/catalog/datasets/domain/service_metadata.py
+++ b/backend/app/modules/catalog/datasets/domain/service_metadata.py
@@ -91,7 +91,7 @@ def compute_schema_diff(
         ],
         "row_count_old": old_feature_count,
         "row_count_new": new_feature_count,
-        # fix(#1746): `None` on either side is UNKNOWN, not zero -- coercing
+        # `None` on either side is UNKNOWN, not zero -- coercing
         # it invented a delta the size of whichever count was known. An
         # unknown difference is reported as unknown.
         "row_count_delta": (
@@ -134,9 +134,10 @@ _NON_CLEARABLE_FIELDS = {"title"}
 def _apply_simple_field_assignments(
     record: Any, dataset: Dataset, meta: "DatasetMeta"
 ) -> bool:
-    """Apply scalar fields present in the request body, including explicit
-    nulls — fix(#458): clears were silently dropped before. Absent fields
-    keep PATCH semantics; _NON_CLEARABLE_FIELDS (title, NOT NULL) drop nulls."""
+    """Apply request fields, including explicit nulls.
+
+    Absent fields retain PATCH semantics; ``_NON_CLEARABLE_FIELDS`` drop nulls.
+    """
     mutated = False
     targets = ((record, _RECORD_FIELD_MAP), (dataset, _DATASET_FIELD_MAP))
     for target, field_map in targets:
@@ -170,10 +171,8 @@ async def _apply_visibility_change(
 ) -> bool:
     """Set record.visibility, blocking a change that would strand a shared map.
 
-    fix(#931): the gate used to be ``new != public and old == public``, blind
-    to an internal map using the dataset -- that flip silently lost the
-    layer for every signed-in viewer. The helper now compares the before
-    and after audiences itself, so no gate is needed here.
+    The helper compares the before and after audiences so internal-map
+    viewers are protected as well as public-map viewers.
     """
     from app.modules.catalog.maps.service import (
         find_maps_broken_by_dataset_visibility,
@@ -196,7 +195,7 @@ async def _apply_visibility_change(
     if new_visibility == record.visibility:
         return True
     record.visibility = new_visibility
-    # fix(#1963): a visibility change moves who may read the dataset, so it
+    # A visibility change moves who may read the dataset, so it
     # retires outstanding tile signatures exactly as a status change does.
     # `update_user_metadata` already holds both catalog rows.
     await bump_publication_version_on(session, dataset)
@@ -245,7 +244,7 @@ async def _apply_record_status_change(
                 raise ValueError(f"Cannot publish: {'; '.join(error_msgs)}")
         record.published_at = func.now()
     record.record_status = new_status
-    # fix(#1963): a tile signature binds this counter, so rolling it retires
+    # A tile signature binds this counter, so rolling it retires
     # the ones minted under the status being left. `update_user_metadata`
     # already holds both catalog rows.
     await bump_publication_version_on(session, dataset)
@@ -296,9 +295,7 @@ async def update_user_metadata(
     explicitly set (not None). Raises ValueError if dataset not found.
     Does not commit; caller controls transaction scope.
 
-    ``warnings_out``, when provided, collects advisory (non-blocking)
-    warnings -- currently the inherited-keyword disclosure check below
-    (feat #1070).
+    ``warnings_out`` collects non-blocking warnings from the metadata extension.
     """
     dataset = await get_dataset(session, dataset_id)
     if dataset is None:
@@ -308,7 +305,7 @@ async def update_user_metadata(
 
     record = dataset.record
 
-    # fix(#1881): lock the pair before the first write, whatever the body
+    # Lock the pair before the first write, whatever the body
     # names -- a workflow hook may write the datasets row on a
     # record_status body. `is_dem` writes raster_assets, so it extends the
     # lock order to that child.
@@ -350,10 +347,10 @@ async def update_user_metadata(
     if meta.is_dem is not None:
         mutated_flags.append(await _apply_is_dem(session, dataset_id, meta.is_dem))
 
-    # feat(#1070): after the visibility/record_status helpers resolve, ask
+    # After the visibility/record_status helpers resolve, ask
     # of the RESOLVED state whether keywords inherited from the analysis
     # source now reach anyone who cannot open that source. Advisory, never
-    # blocking. fix(#1178): shared helper, since the publication-status
+    # blocking. Use the shared helper because the publication-status
     # endpoints write record_status without coming through here.
     if meta.visibility is not None or meta.record_status is not None:
         from app.modules.catalog.records.inherited import (
@@ -440,7 +437,7 @@ async def sample_example_values(
     """Up to ten distinct non-null values of one column, or None.
 
     Reads the data table, so call it BEFORE the catalog pair is locked
-    (#1847). None for a geometry column, an unsafe name, or any query
+    None for a geometry column, an unsafe name, or any query
     failure; the read runs in a savepoint so a failure leaves the
     transaction usable.
     """
@@ -485,7 +482,7 @@ async def reset_attribute(
     field_name/data_type and clears user_modified_fields and description.
     `example_values` is the result of `sample_example_values`; a caller
     holding the catalog pair must sample before taking it, since sampling
-    reads the data table (#1847). Left unset, this samples first. Raises
+    reads the data table. Left unset, this samples first. Raises
     ValueError if attribute not found.
     """
     attr = await get_attribute(session, attribute_id)

--- a/backend/app/modules/catalog/datasets/domain/service_query.py
+++ b/backend/app/modules/catalog/datasets/domain/service_query.py
@@ -238,9 +238,7 @@ async def get_dataset_detail(
     dataset_asset_rows = await get_catalog_port().get_dataset_assets(db, dataset.id)
     stac_assets_dict = {}
     for da in dataset_asset_rows:
-        # This path built its assets straight off the ORM rows
-        # and never consulted the allowlist, so an internal key leaked its
-        # href, filename and size to every viewer of a public dataset.
+        # Apply the asset allowlist before exposing href, filename, or size.
         if not is_public_asset_key(da.key):
             continue
         stac_assets_dict[da.key] = StacAsset(
@@ -405,10 +403,8 @@ async def get_dataset_rows(
 
         next_cursor = rows[-1]["gid"] if rows and len(rows) == limit else None
     except DBAPIError as exc:
-        # Was `except Exception`, so connection loss, timeouts, and
-        # permission failures all rendered as a valid dataset with zero rows.
-        # Only an absent table still degrades to an empty page (normal for
-        # raster/VRT's synthetic table_name); the rest reach the 503 path.
+        # Only an absent backing table degrades to an empty page, as for raster/VRT
+        # synthetic table names. Operational failures must reach the 503 handler.
         if sqlstate(exc) not in TABLE_ABSENT:
             raise
         await db.rollback()  # transaction aborted; read-only, so safe

--- a/backend/app/modules/catalog/datasets/domain/service_query.py
+++ b/backend/app/modules/catalog/datasets/domain/service_query.py
@@ -1,4 +1,4 @@
-"""Dataset read-side queries: lookup, list, detail, rows (extracted from service.py — Phase 224)."""
+"""Dataset read queries for lookup, listing, details, and rows."""
 
 from __future__ import annotations
 

--- a/backend/app/modules/catalog/datasets/domain/service_query.py
+++ b/backend/app/modules/catalog/datasets/domain/service_query.py
@@ -81,7 +81,7 @@ async def list_datasets(
     total = await session.execute(count_stmt)
     total_count = total.scalar_one()
 
-    # fix(#430): Record.created_at is a non-unique server-default; add a
+    # Record.created_at is a non-unique server-default; add a
     # unique tiebreaker so pagination over batch-seeded rows is stable.
     paginated_stmt = (
         filtered_stmt.offset(skip)
@@ -149,7 +149,7 @@ async def get_datasets_list(
         for row in sc_result.all():
             source_counts[row.vrt_dataset_id] = row.cnt
 
-    # fix(#1103): one visibility query for the page, not one per row.
+    # One visibility query for the page, not one per row.
     from app.modules.catalog.authorization import visible_lineage_summaries
 
     lineage = await visible_lineage_summaries(
@@ -165,7 +165,7 @@ async def get_datasets_list(
             source_count=source_counts.get(str(d.id)),
             base_url=base_url,
             lineage_summary=lineage[d.record_id],
-            # feat(#1316): per-row — the page can mix the caller's own
+            # Per-row — the page can mix the caller's own
             # datasets with peers' public ones, so one page-level flag would
             # either over- or under-redact.
             can_view_provenance=can_view_dataset_provenance(d.record, user, user_roles),
@@ -212,10 +212,9 @@ async def get_dataset_detail(
     # sequentially on the caller's own session through CatalogPort so catalog
     # does not import processing-owned raster ORM classes directly.
     #
-    # fix(#1436): NOT asyncio.gather'd -- AsyncSession isn't safe for
-    # concurrent use (asyncpg serializes per-connection anyway), and giving
-    # each branch its own async_session() (the fix used elsewhere) would
-    # nest a pool checkout on top of the caller's held connection, exhausting
+    # AsyncSession is not safe for concurrent use, and giving each branch its
+    # own session would nest a pool checkout on top of the caller's held
+    # connection, exhausting
     # the default 10+3 pool at ~13 concurrent detail requests. These are
     # three fast point lookups, so sequential cost is negligible by comparison.
     record_type = getattr(dataset.record, "record_type", None)
@@ -239,7 +238,7 @@ async def get_dataset_detail(
     dataset_asset_rows = await get_catalog_port().get_dataset_assets(db, dataset.id)
     stac_assets_dict = {}
     for da in dataset_asset_rows:
-        # fix(#1290): this path built its assets straight off the ORM rows
+        # This path built its assets straight off the ORM rows
         # and never consulted the allowlist, so an internal key leaked its
         # href, filename and size to every viewer of a public dataset.
         if not is_public_asset_key(da.key):
@@ -273,22 +272,22 @@ async def get_dataset_detail(
         source_count=source_count,
         base_url=base_url,
         stac_assets=stac_assets_dict or None,
-        # feat(#765): detail only, and only when the requester can reach the
+        # Detail only, and only when the requester can reach the
         # source dataset.
         derived_from=await visible_derived_from(
             db, dataset.record.derived_from, user, user_roles
         ),
-        # fix(#1103): the prose names the same datasets the reference points at.
+        # The prose names the same datasets the reference points at.
         lineage_summary=await visible_lineage_summary(
             db, dataset.record, user, user_roles
         ),
-        # feat(#1316): owner-or-admin only; every other accessible-dataset
+        # Owner-or-admin only; every other accessible-dataset
         # reader (named or anonymous) gets origin_uri/origin_ref nulled.
         can_view_provenance=can_view_dataset_provenance(
             dataset.record, user, user_roles
         ),
     )
-    # fix(#430): genericity probe (helpers.py) keeps all draw modes.
+    # Genericity probe (helpers.py) keeps all draw modes.
     if response is not None and dataset.source_format == "created":
         response.has_generic_geometry = await dataset_geom_is_generic(
             db, dataset.table_name
@@ -303,7 +302,7 @@ _GEOM_COLUMN_NAMES = frozenset({"geom", "geom_4326", "wkb_geometry"})
 def _build_select_cols(column_info: list[dict]) -> list[str]:
     """Return the non-geometry columns to project, with `gid` always present.
 
-    fix(#1778): names are emitted quoted. Membership is still decided on the
+    Names are emitted quoted. Membership is still decided on the
     bare name, so quote at emission rather than in the list.
     """
     select_cols: list[str] = []
@@ -338,7 +337,7 @@ def _build_where_filters(
         if col_name not in valid_columns:
             continue
         param_key = f"f_{col_name}"
-        # fix(#1778): quoted, for the same reason as _build_select_cols.
+        # Quoted, for the same reason as _build_select_cols.
         where_clauses.append(
             f"CAST({_safe_column_ref(col_name)} AS text) ILIKE :{param_key}"
         )
@@ -406,14 +405,14 @@ async def get_dataset_rows(
 
         next_cursor = rows[-1]["gid"] if rows and len(rows) == limit else None
     except DBAPIError as exc:
-        # fix(#435): was `except Exception`, so connection loss, timeouts, and
+        # Was `except Exception`, so connection loss, timeouts, and
         # permission failures all rendered as a valid dataset with zero rows.
         # Only an absent table still degrades to an empty page (normal for
         # raster/VRT's synthetic table_name); the rest reach the 503 path.
         if sqlstate(exc) not in TABLE_ABSENT:
             raise
         await db.rollback()  # transaction aborted; read-only, so safe
-        # fix(#435): a missing schema reports 42P01 too, so the code alone
+        # A missing schema reports 42P01 too, so the code alone
         # can't tell a synthetic raster table from a never-provisioned
         # tenant schema. Only the second is drift and must not read as empty.
         if not await schema_exists(db, _schema):

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -49,11 +49,11 @@ async def _load_self_record_and_embedding(
 ) -> tuple[uuid.UUID, tuple[list[float], str, str | None]] | None:
     """Return (record_id, anchor) for the dataset, or None if either is absent.
 
-    fix(#1580): ``anchor`` is ``(embedding, model_name, config_fingerprint)``
+    ``anchor`` is ``(embedding, model_name, config_fingerprint)``
     -- the vector alone doesn't say which model produced it, so every later
     read on this path compares inside that same space.
 
-    SEC-S05: callers MUST gate visibility on the seed dataset BEFORE calling
+    Callers MUST gate visibility on the seed dataset BEFORE calling
     this -- the embedding read has no permission filter and would otherwise
     be a cosine-similarity oracle on private record content. The API router
     (datasets/api/router_data.py:list_related_datasets) already does this;
@@ -79,7 +79,7 @@ async def _compute_neighbor_distances(
 ) -> dict[uuid.UUID, float]:
     """Cosine-distance every neighbor against the seed embedding.
 
-    fix(#1580): scored inside the anchor's own vector space -- a neighbour
+    Scored inside the anchor's own vector space -- a neighbour
     holding a row under another model would otherwise be scored off
     whichever row came back last, so the selection could be right while
     the printed similarity is wrong.
@@ -114,7 +114,7 @@ async def get_related_datasets(
             return []
         record_id, anchor = seed
 
-        # fix(#1580): selection and scoring stay in one vector space AND on
+        # Selection and scoring stay in one vector space AND on
         # one ROW -- the anchor read above is handed in rather than taken
         # again, since two reads under READ COMMITTED can straddle a worker
         # committing a newer row, ranking against one vector and scoring
@@ -230,7 +230,7 @@ async def _visible_relationships(
         visible_items.append(
             {
                 "id": rel.id,
-                # fix(#315): emit dereferenceable Dataset.id, not the stored record_id.
+                # Emit dereferenceable Dataset.id, not the stored record_id.
                 "source_dataset_id": source_dataset_id,
                 "target_dataset_id": target_ds.id,
                 "source_column": rel.source_column,
@@ -255,7 +255,7 @@ async def list_relationships(
     """List FK relationships where this dataset is the source.
 
     Per-row visibility filtering means a public source never leaks a private
-    target's id/title; ``skip``/``limit`` apply to the visible subset (PERF-N16).
+    target's id/title; ``skip``/``limit`` apply to the visible subset.
     Thin wrapper over :func:`list_relationships_with_total` (drops the count).
     """
     page, _ = await list_relationships_with_total(
@@ -273,7 +273,7 @@ async def list_relationships_with_total(
     skip: int = 0,
     limit: int | None = None,
 ) -> tuple[list, int]:
-    """Paginated relationships plus the total VISIBLE count (GAP-033).
+    """Return paginated relationships plus the total visible count.
 
     Returns ``(page_items, total)`` where ``total`` is the number of visible
     relationships before ``skip``/``limit`` so callers can detect more pages.
@@ -354,7 +354,7 @@ async def _detect_fk_candidates(
     Returns a dict mapping each source column name to the list of target record_ids
     that have a matching identifier attribute. Empty dict if no candidates.
 
-    PERF-N4: bulk IN (...) match instead of per-candidate query.
+    Uses one bulk ``IN`` match instead of a query per candidate.
     """
     candidates = [
         col["name"]
@@ -512,7 +512,7 @@ async def _fetch_target_rows(
     after: int,
 ) -> list[dict]:
     """Window-fetch matching target rows as gid+properties dicts."""
-    # fix(#1104): project the row before to_jsonb -- serializing t.* first
+    # Project the row before to_jsonb -- serializing t.* first
     # passes a curved source `geom` through the geometry->jsonb cast, which
     # raises even though the subtraction then discards it.
     from app.modules.catalog.features.service import live_property_columns
@@ -520,7 +520,7 @@ async def _fetch_target_rows(
     prop_cols = await live_property_columns(session, target_table)
     prop_sel = f", {prop_cols}" if prop_cols else ""
     table_ref = get_catalog_port().quote_table(target_table)
-    # fix(#1113): the match runs against the BASE table, inside the
+    # The match runs against the BASE table, inside the
     # projection -- a relationship may legitimately target a column the
     # projection drops (e.g. `geom`/`geom_4326`), and predicating on the
     # projected alias made such a fetch an undefined-column error.
@@ -590,7 +590,7 @@ async def get_related_records(
     ) or not SAFE_COLUMN_NAME_RE.match(rel.target_column):
         raise ValueError("Invalid column name in relationship")
 
-    # fix(#315): a raster/VRT endpoint dataset (or a cold-evicted/partial
+    # A raster/VRT endpoint dataset (or a cold-evicted/partial
     # vector table) resolves to a missing data.<table>, raising
     # UndefinedTableError. Map that to 503 instead of an uncaught 500 that
     # holds the DB connection.

--- a/backend/app/modules/catalog/datasets/domain/service_relationships.py
+++ b/backend/app/modules/catalog/datasets/domain/service_relationships.py
@@ -1,4 +1,4 @@
-"""Dataset relationship operations (extracted from service.py — Phase 224)."""
+"""Dataset relationship operations."""
 
 from __future__ import annotations
 

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -656,7 +656,6 @@ async def get_features_geojson_z(
         "to_jsonb(t.*) - 'gid' - 'geom_4326' AS properties"
     )
     row_source = await _projected_row_source(db, table_name, with_geometry=True)
-    # Fetch cap+1 to detect truncation without a separate COUNT query
     data_sql = f"SELECT {select_cols} FROM {row_source} t ORDER BY gid LIMIT :limit"
     result = await db.execute(text(data_sql).bindparams(limit=cap + 1))
     rows = [dict(row._mapping) for row in result.all()]
@@ -666,10 +665,8 @@ async def get_features_geojson_z(
         rows = rows[:cap]
 
     if not truncated:
-        # All features returned — row count is authoritative
         total_count = len(rows)
     elif cached_feature_count is not None:
-        # Use caller-supplied cached count to avoid extra query
         total_count = cached_feature_count
     else:
         count_sql = f"SELECT COUNT(*) FROM {get_catalog_port().quote_table(table_name)}"

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -83,9 +83,8 @@ def _parse_naive_timestamp(raw: str) -> datetime:
     return value
 
 
-# Binding raw left SQLAlchemy typing every bind VARCHAR, causing
-# 42883 on non-text filters. Each entry pairs a parser with the bind's DB
-# type — matches exactly what the queryables document (Part 3) advertises.
+# Pair each parser with its database bind type so non-text comparisons match
+# the types advertised by queryables.
 _PROPERTY_FILTER_BINDS: dict[str, tuple[Callable[[str], Any], Any]] = {
     "text": (str, sa_types.Text()),
     "character varying": (str, sa_types.Text()),
@@ -153,12 +152,9 @@ _MULTI_TYPES = {"MULTIPOINT", "MULTILINESTRING", "MULTIPOLYGON"}
 
 
 class UnwritablePropertyError(ValueError):
-    """A column that exists but that the feature write path cannot address.
+    """A real column that the stricter feature-write name rules cannot address.
 
-    ``_COLUMN_NAME_RE`` is stricter than the read path's regexes,
-    so a real ``_notes``/``:id`` column (e.g. Socrata) that GET returns could
-    silently fail to write — POST/PUT answered 201/200 with nothing stored.
-    Refusing the name up front turns that silent data loss into a 422.
+    Reject such names, including _notes and :id, to prevent silent data loss.
     """
 
 
@@ -271,7 +267,7 @@ def parse_bbox(bbox: str | Sequence[float]) -> list[float]:
 async def live_property_columns(db: AsyncSession, table_name: str) -> str:
     """Quoted select-list of the table's live columns minus gid/geom/geom_4326.
 
-    To_jsonb serializes EVERY column first, and the
+    `to_jsonb` serializes EVERY column first, and the
     geometry→jsonb cast raises on curved input in `geom` — projecting here
     keeps the cast from ever seeing it. Queries live schema, not
     `Dataset.column_info`, which can drift on re-upload. Colons
@@ -590,9 +586,7 @@ async def get_features(
     # rows rather than a comparison against a count that may be estimated.
     bind_values["limit"] = limit + 1
 
-    # cql2_binds plus the property-filter binds typed from the live schema
-    # Both name parameters in the data query and the count query
-    # query, so one list serves both.
+    # CQL2 and typed property binds are shared by the data and count queries.
     extra_binds = [*(cql2_binds or ()), *typed_binds]
 
     def _with_extra_binds(stmt):
@@ -761,14 +755,10 @@ async def effective_geometry_type(session: AsyncSession, dataset) -> str:
 
 
 def _validate_geometry_structure(geometry: dict) -> BaseGeometry:
-    """Reject degenerate or topologically invalid geometry before PostGIS.
+    """Reject malformed geometry with ValueError before it reaches PostGIS.
 
-    Degenerate-but-valid input (2-point rings, empty arrays)
-    crashed ST_GeomFromGeoJSON into a 500; raises ValueError instead (400).
-
-    Returns the shapely geometry itself, not None — Shapely
-    auto-closes an unclosed ring but ST_GeomFromGeoJSON does not, so callers
-    must write the returned, normalized geometry, not the client's dict.
+    Return the normalized Shapely geometry. Shapely closes unclosed rings but
+    ST_GeomFromGeoJSON does not, so callers must write the returned geometry.
     """
     try:
         geom = shapely_shape(geometry)
@@ -1017,8 +1007,7 @@ async def _refresh_count_and_extent(
     Returns (feature_count, extent_wkt) in a single query instead of the
     5 queries that extract_metadata() runs.
     """
-    # Records.spatial_extent admits only POLYGON or
-    # MULTIPOLYGON (chk_records_spatial_extent_type, ), but
+    # records.spatial_extent admits only POLYGON/MULTIPOLYGON, but
     # ST_Extent of a single point / axis-collinear points casts to POINT /
     # LINESTRING and would be rejected. ST_Expand always returns the
     # bounding-box POLYGON, so only the degenerate cases get padded;
@@ -1280,10 +1269,8 @@ async def _apply_incremental_metadata(
 ) -> bool:
     """Update feature_count alone when the write provably left the extent alone.
 
-    Returns False when the fast path does not apply, falling back to a full
-    recompute. `_refresh_count_and_extent` runs a full-table
-    COUNT + ST_Extent on every write, so a client digitizing 200 points
-    paid that cost 200 times with no bulk feature endpoint.
+    Returns False when a full COUNT + ST_Extent recompute is needed.
+    Interior edits can update the count without scanning the full table.
     """
     from app.modules.catalog.datasets.domain.models import Dataset as DatasetModel
 

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -30,7 +30,7 @@ _COLUMN_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,62}$")
 
 
 def _parse_int(raw: str) -> int:
-    # fix(#1778): the per-type bound is applied by check_pg_value_range,
+    # The per-type bound is applied by check_pg_value_range,
     # which knows whether the column is int2, int4 or int8.
     return int(raw)
 
@@ -83,7 +83,7 @@ def _parse_naive_timestamp(raw: str) -> datetime:
     return value
 
 
-# fix(#1778): binding raw left SQLAlchemy typing every bind VARCHAR, causing
+# Binding raw left SQLAlchemy typing every bind VARCHAR, causing
 # 42883 on non-text filters. Each entry pairs a parser with the bind's DB
 # type — matches exactly what the queryables document (Part 3) advertises.
 _PROPERTY_FILTER_BINDS: dict[str, tuple[Callable[[str], Any], Any]] = {
@@ -120,7 +120,7 @@ def _property_filter_bind(param_name: str, column: str, pg_type: str | None, raw
     parse, sa_type = mapping
     try:
         value = parse(raw)
-        # fix(#1778): in range for the COLUMN, not merely parseable as a
+        # In range for the COLUMN, not merely parseable as a
         # Python value — 1e100 against a real column or 2147483648 against
         # an integer column is a legal comparison no stored value can
         # satisfy, silently answering 200 with zero features otherwise.
@@ -141,7 +141,7 @@ GEOJSON_TYPE_MAP: dict[str, set[str]] = {
     "MultiLineString": {"MultiLineString"},
     "Polygon": {"Polygon", "MultiPolygon"},
     "MultiPolygon": {"MultiPolygon"},
-    # fix(#430): storable in a generic GEOMETRY column (map presence is
+    # Storable in a generic GEOMETRY column (map presence is
     # enough) and in a typed GEOMETRYCOLLECTION column (the dataset check
     # constraint allows it); every other typed dataset reports a mismatch.
     # Nested collections are rejected earlier at the schema guard.
@@ -155,7 +155,7 @@ _MULTI_TYPES = {"MULTIPOINT", "MULTILINESTRING", "MULTIPOLYGON"}
 class UnwritablePropertyError(ValueError):
     """A column that exists but that the feature write path cannot address.
 
-    fix(#1778): ``_COLUMN_NAME_RE`` is stricter than the read path's regexes,
+    ``_COLUMN_NAME_RE`` is stricter than the read path's regexes,
     so a real ``_notes``/``:id`` column (e.g. Socrata) that GET returns could
     silently fail to write — POST/PUT answered 201/200 with nothing stored.
     Refusing the name up front turns that silent data loss into a 422.
@@ -180,10 +180,10 @@ def _reject_unknown_properties(
 ) -> None:
     """Raise if a property key names no real attribute column, or an unwritable one.
 
-    fix(#458): a silently dropped unknown key is a PUT footgun (not
+    A silently dropped unknown key is a PUT footgun (not
     written, and replace nulls the column) — reject as a 400 instead.
 
-    fix(#1778): a real but unwritable column is refused too. ``replaces_all``
+    A real but unwritable column is refused too. ``replaces_all``
     writes EVERY known column, so one unwritable column blocks the whole PUT.
     """
     allowed = {c["name"] for c in column_info}
@@ -248,14 +248,14 @@ def parse_bbox(bbox: str | Sequence[float]) -> list[float]:
         values = [float(v) for v in bbox]
         if len(values) not in (4, 6):
             raise ValueError("bbox must have 4 or 6 values")
-    # SEC-FU-06: reject NaN/Inf coordinates. Python's float() accepts "nan",
+    # Reject NaN/Inf coordinates. Python's float() accepts "nan",
     # "inf", "-inf" (and JSON 1e400 parses to +Inf) — PostGIS handles these
     # inconsistently, risking malformed geometries. This is the single home
-    # for the guard; do not let another copy grow elsewhere (#430 BA-12).
+    # for the guard; do not let another copy grow elsewhere.
     for i, v in enumerate(values):
         if not math.isfinite(v):
             raise ValueError(
-                f"SEC-FU-06: bbox coordinate at index {i} is non-finite ({v!r}); "
+                f"bbox coordinate at index {i} is non-finite ({v!r}); "
                 "only finite floats are accepted"
             )
     if len(values) == 6:
@@ -271,10 +271,10 @@ def parse_bbox(bbox: str | Sequence[float]) -> list[float]:
 async def live_property_columns(db: AsyncSession, table_name: str) -> str:
     """Quoted select-list of the table's live columns minus gid/geom/geom_4326.
 
-    fix(#1104): to_jsonb serializes EVERY column first, and the
+    To_jsonb serializes EVERY column first, and the
     geometry→jsonb cast raises on curved input in `geom` — projecting here
     keeps the cast from ever seeing it. Queries live schema, not
-    `Dataset.column_info`, which can drift on re-upload. fix(#1113): colons
+    `Dataset.column_info`, which can drift on re-upload. Colons
     are backslash-escaped too (`text()` parses `:name` as a bind param even
     quoted; Socrata ships columns named `:id`). Valid only inside `text()`.
     """
@@ -299,7 +299,7 @@ async def live_property_columns(db: AsyncSession, table_name: str) -> str:
 async def feature_table_exists(db: AsyncSession, table_name: str) -> bool:
     """Whether the tenant-schema data table currently exists.
 
-    fix(#1614): ``get_column_info`` returns [] both for zero attribute
+    ``get_column_info`` returns [] both for zero attribute
     columns and a MISSING table — callers need to tell those apart, since a
     missing table is the same retryable 503 the feature query paths report.
     """
@@ -321,7 +321,7 @@ async def get_feature_queryable_columns(
 ) -> list[dict]:
     """Live column name/type rows for Part 3 queryables and CQL2 filtering.
 
-    fix(#1614): same live-schema authority rule as ``live_property_columns`` —
+    Same live-schema authority rule as ``live_property_columns`` —
     the filterable set must match the table the SQL runs against, not the
     stored ``Dataset.column_info`` snapshot. The catalog port resolves the
     tenant schema itself when none is passed.
@@ -356,7 +356,7 @@ async def _property_filter_predicates(
 ) -> tuple[list[str], dict, list]:
     """Compose the `"col" = :prop_col` predicates for the property filters.
 
-    Returns (where_clauses, raw_string_binds, typed_binds). fix(#1778): the
+    Returns (where_clauses, raw_string_binds, typed_binds). The
     live schema decides how each value is typed, costing one
     information_schema round trip only when a filter is present.
     """
@@ -381,7 +381,7 @@ async def _property_filter_predicates(
     return clauses, raw_binds, typed_binds
 
 
-# fix(#1778): counting inside a LIMIT caps filtered-count cost instead of
+# Counting inside a LIMIT caps filtered-count cost instead of
 # scaling O(N) per page. Exact up to this cap (100 OGC max-size pages);
 # past it the planner's estimate answers (X-GeoLens-Number-Matched header).
 _FILTERED_COUNT_CAP = 20_000
@@ -390,7 +390,7 @@ _FILTERED_COUNT_CAP = 20_000
 class FeaturePage(NamedTuple):
     """One page of features plus what the caller needs to paginate it.
 
-    fix(#1778): ``has_more`` exists because ``total`` may be the planner's
+    ``has_more`` exists because ``total`` may be the planner's
     estimate — a `next` link decided from ``offset + limit < total`` could
     drop mid-result-set. Answered by over-fetching one row, never the count.
     """
@@ -469,7 +469,7 @@ def _floor_estimated_total(
 ) -> int:
     """Raise an estimated total to the rows the page can prove exist.
 
-    fix(#1778): only when the total started as an estimate, and only to
+    Only when the total started as an estimate, and only to
     rows proven to exist — an EXACT count is never raised, an empty page
     proves nothing (flooring by offset + len(rows) would invent matches out
     of the offset alone), and a keyset page passes offset=0 since the query
@@ -499,14 +499,14 @@ async def get_features(
 ) -> FeaturePage:
     """Fetch paginated features from a data table as GeoJSON-ready dicts.
 
-    fix(#1778): ``total_is_estimate`` is True past ``_FILTERED_COUNT_CAP``,
+    ``total_is_estimate`` is True past ``_FILTERED_COUNT_CAP``,
     and ``has_more`` (not ``total``) must drive pagination links.
     ``cql2_where``/``cql2_binds`` must come from
-    ``app.standards.ogc.filtering`` (fix(#1614)), the only sanctioned
+    ``app.standards.ogc.filtering``, the only sanctioned
     producer of typed CQL2 binds. Raises ValueError (400) on a bad property
     filter or an out-of-int8 pagination integer.
     """
-    # fix(#1778): pagination integers reach the driver untyped, and FastAPI's
+    # Pagination integers reach the driver untyped, and FastAPI's
     # `int` has no upper bound. A value outside int8 can't be encoded at all
     # — asyncpg raises a bare DBAPIError (SQLSTATE 22000) from its encode
     # path — so refuse it here, where the message can name the parameter.
@@ -586,12 +586,12 @@ async def get_features(
             f"{where_sql} ORDER BY gid LIMIT :limit OFFSET :offset"
         )
         bind_values["offset"] = offset
-    # fix(#1778): one row past the page, so `has_more` is a fact about the
+    # One row past the page, so `has_more` is a fact about the
     # rows rather than a comparison against a count that may be estimated.
     bind_values["limit"] = limit + 1
 
     # cql2_binds plus the property-filter binds typed from the live schema
-    # (fix(#1778)); both name parameters in the data query AND the count
+    # Both name parameters in the data query and the count query
     # query, so one list serves both.
     extra_binds = [*(cql2_binds or ()), *typed_binds]
 
@@ -746,7 +746,7 @@ async def _geom_column_is_generic(session: AsyncSession, table_name: str) -> boo
 async def effective_geometry_type(session: AsyncSession, dataset) -> str:
     """Geometry type for feature-write validation and insert SQL.
 
-    fix(#430): generic-column created datasets must accept ANY subtype
+    Generic-column created datasets must accept ANY subtype
     forever, even after refresh_dataset_metadata derives a concrete DISPLAY
     type from the rows (so the builder renders the layer instead of an
     invisible fill). Validation keys on the actual column genericity, never
@@ -763,10 +763,10 @@ async def effective_geometry_type(session: AsyncSession, dataset) -> str:
 def _validate_geometry_structure(geometry: dict) -> BaseGeometry:
     """Reject degenerate or topologically invalid geometry before PostGIS.
 
-    fix(#458): degenerate-but-valid input (2-point rings, empty arrays)
+    Degenerate-but-valid input (2-point rings, empty arrays)
     crashed ST_GeomFromGeoJSON into a 500; raises ValueError instead (400).
 
-    fix(#1778): returns the shapely geometry itself, not None — Shapely
+    Returns the shapely geometry itself, not None — Shapely
     auto-closes an unclosed ring but ST_GeomFromGeoJSON does not, so callers
     must write the returned, normalized geometry, not the client's dict.
     """
@@ -793,7 +793,7 @@ def _validate_geometry_type(geojson_type: str, dataset_geometry_type: str) -> No
     # Normalize dataset type (stored UPPERCASE in DB) to GeoJSON mixed case.
     # str.title() fails for compound words: "LINESTRING" -> "Linestring" not "LineString".
     # Use a direct mapping instead.
-    # fix(#430): a generic-typed dataset (GEOMETRY column) accepts any subtype;
+    # A generic-typed dataset (GEOMETRY column) accepts any subtype;
     # only reject genuinely non-geometry GeoJSON.
     if dataset_geometry_type.strip().upper() == "GEOMETRY":
         if GEOJSON_TYPE_MAP.get(geojson_type.strip()) is None:
@@ -806,7 +806,7 @@ def _validate_geometry_type(geojson_type: str, dataset_geometry_type: str) -> No
         "MULTILINESTRING": "MultiLineString",
         "POLYGON": "Polygon",
         "MULTIPOLYGON": "MultiPolygon",
-        # fix(#430): without this entry a GEOMETRYCOLLECTION-typed dataset
+        # Without this entry a GEOMETRYCOLLECTION-typed dataset
         # normalizes to its raw uppercase name and never matches the
         # mixed-case compatibility set above.
         "GEOMETRYCOLLECTION": "GeometryCollection",
@@ -892,7 +892,7 @@ async def replace_feature(
     """
     _validate_geometry_type(geometry.get("type", ""), dataset_geometry_type)
     normalized_geom = _validate_geometry_structure(geometry)
-    # fix(#1778): replace nulls every known column, so an unwritable one makes
+    # Replace nulls every known column, so an unwritable one makes
     # the documented semantics unachievable even when the request omits it.
     _reject_unknown_properties(properties, column_info, replaces_all=True)
 
@@ -971,7 +971,7 @@ async def update_feature(
     sql = _update_capturing_prior_bounds(
         get_catalog_port().quote_table(table_name), sets
     )
-    # codeql[py/sql-injection] fix(#1615): every assigned column is an existing column_info name matching _COLUMN_NAME_RE; values travel as bound params; table via quote_table
+    # codeql[py/sql-injection] every assigned column is an existing column_info name matching _COLUMN_NAME_RE; values travel as bound params; table via quote_table
     result = await db.execute(text(sql).bindparams(**params))
     prior = result.first()
     if prior is None:
@@ -1017,8 +1017,8 @@ async def _refresh_count_and_extent(
     Returns (feature_count, extent_wkt) in a single query instead of the
     5 queries that extract_metadata() runs.
     """
-    # fix(#430): records.spatial_extent admits only POLYGON or
-    # MULTIPOLYGON (chk_records_spatial_extent_type, fix(#892)), but
+    # Records.spatial_extent admits only POLYGON or
+    # MULTIPOLYGON (chk_records_spatial_extent_type, ), but
     # ST_Extent of a single point / axis-collinear points casts to POINT /
     # LINESTRING and would be rejected. ST_Expand always returns the
     # bounding-box POLYGON, so only the degenerate cases get padded;
@@ -1040,13 +1040,13 @@ async def _refresh_count_and_extent(
     )
     row = result.one()
     count, extent_wkt, xmin, xmax = int(row[0]), row[1], row[2], row[3]
-    # fix(#934): a table honestly crossing ±180 must not store the naive
+    # A table honestly crossing ±180 must not store the naive
     # near-global fold on refresh; emit the two-ring MULTIPOLYGON instead. A
     # crossing dataset's naive width always exceeds 180 degrees, so the
     # ordinary case skips the second aggregate and stays byte-identical.
     if xmin is not None and xmax is not None and float(xmax) - float(xmin) > 180.0:
         # Same tenant data schema the quoted reference above resolves to;
-        # the helper quotes identifiers itself (fix(#934)).
+        # the helper quotes identifiers itself.
         from app.core.db.tenant_schema import tenant_data_schema
         from app.core.db.tenant_session import current_tenant_var
 
@@ -1072,7 +1072,7 @@ _CONCRETE_GEOMETRY_TYPES = {
 async def _derive_created_geometry_type(session: AsyncSession, table_name: str) -> str:
     """Concrete display geometry_type for a created (generic-column) dataset.
 
-    fix(#430): the 'GEOMETRY' sentinel renders as an invisible fill layer in
+    The 'GEOMETRY' sentinel renders as an invisible fill layer in
     the builder (classifyGeometry -> 'other'). Derive from the rows:
     a homogeneous layer gets its real type, a single-family mix gets the
     MULTI variant, a cross-family mix (or anything unexpected) stays generic —
@@ -1126,7 +1126,7 @@ def geojson_bounds(geometry: dict | None) -> Bounds | None:
 
 # The envelope of the row version a write is about to overwrite or remove.
 #
-# fix(#1778): captured as part of the mutating statement, not a separate
+# Captured as part of the mutating statement, not a separate
 # unlocked SELECT before it — a concurrent edit could otherwise move the
 # feature out of the stored extent and commit in the gap, leaving envelope
 # values that were true when read but false by the time of the write, and
@@ -1182,10 +1182,10 @@ async def lock_catalog_rows_for_write(
 
     Entry point to `platform.catalog_locks.lock_catalog_rows` — call from
     ANY request path that dirties either row. Returns None unless the extent
-    is a simple POLYGON (#934): an antimeridian-crossing dataset stores a
+    is a simple POLYGON: an antimeridian-crossing dataset stores a
     two-ring MULTIPOLYGON whose ST_XMin/ST_XMax are -180/180, so a longitude
     in the gap would test inside a box the geometry never occupies.
-    fix(#1778): the lock must be taken before either metadata path reads the
+    The lock must be taken before either metadata path reads the
     extent, or interleaved read-decide-write could shrink it from a stale
     aggregate.
     """
@@ -1194,7 +1194,7 @@ async def lock_catalog_rows_for_write(
     from app.platform.catalog_locks import lock_catalog_rows
 
     # Through the port: `catalog/` may not import `app.processing.*`
-    # (test_layering CATPORT-02).
+    # as enforced by the layering test.
     raster_asset_cls = (
         get_catalog_port().raster_asset_orm_class() if with_raster_asset else None
     )
@@ -1281,7 +1281,7 @@ async def _apply_incremental_metadata(
     """Update feature_count alone when the write provably left the extent alone.
 
     Returns False when the fast path does not apply, falling back to a full
-    recompute. fix(#1778): `_refresh_count_and_extent` runs a full-table
+    recompute. `_refresh_count_and_extent` runs a full-table
     COUNT + ST_Extent on every write, so a client digitizing 200 points
     paid that cost 200 times with no bulk feature endpoint.
     """
@@ -1335,12 +1335,12 @@ async def refresh_dataset_metadata(
     """Refresh feature_count and extent on a Dataset after write operations.
 
     Uses one COUNT(*) + ST_Extent query instead of the 5-query
-    extract_metadata pipeline. fix(#1778): when every touched envelope is
+    extract_metadata pipeline. When every touched envelope is
     strictly inside the stored extent, it provably did not change and no
     scan runs at all; called with no keywords, the full recompute is
     unchanged.
     """
-    # fix(#1778): taken before EITHER branch reads the extent, so a skip
+    # Taken before EITHER branch reads the extent, so a skip
     # decision cannot be invalidated by a concurrent recompute.
     stored_box = await lock_catalog_rows_for_write(session, dataset)
 
@@ -1354,7 +1354,7 @@ async def refresh_dataset_metadata(
     ):
         return
 
-    # fix(#1847): INSIDE the lock, deliberately. A peer that measured before
+    # INSIDE the lock, deliberately. A peer that measured before
     # taking the lock cannot see this transaction's uncommitted row, and would
     # write a count and extent computed as though it did not exist.
     feature_count, extent_wkt = await _refresh_count_and_extent(
@@ -1362,14 +1362,14 @@ async def refresh_dataset_metadata(
     )
     dataset.feature_count = feature_count
 
-    # fix(#430): ST_Extent of a single point is a POINT and of axis-collinear
+    # ST_Extent of a single point is a POINT and of axis-collinear
     # points a LINESTRING, not always a POLYGON -- store any non-null extent.
     if extent_wkt:
         dataset.record.spatial_extent = func.ST_GeomFromText(extent_wkt, 4326)
     elif feature_count == 0:
         dataset.record.spatial_extent = None
 
-    # fix(#430): keep generic-column created datasets' DISPLAY
+    # Keep generic-column created datasets' DISPLAY
     # geometry_type in sync with their rows so the builder renders them (see
     # _derive_created_geometry_type). Validation stays generic via
     # effective_geometry_type(), so this never re-restricts what subtypes the

--- a/backend/app/modules/catalog/maps/service_crud.py
+++ b/backend/app/modules/catalog/maps/service_crud.py
@@ -411,7 +411,6 @@ async def list_maps(
     def _apply_vis_filter(stmt: Select) -> Select:
         return _apply_map_visibility_filter(stmt, user_id, is_admin)
 
-    # Build search/visibility filters (applied to both count and data queries)
     def _apply_extra_filters(stmt: Select) -> Select:
         if search:
             # SEC-FU-07 (sec-audit-20260519.md + WR-01): escape \, %, _ via
@@ -433,7 +432,6 @@ async def list_maps(
             stmt = stmt.where(Map.visibility == visibility)
         return stmt
 
-    # Resolve sort column
     sort_column_map = {
         "name": Map.name,
         "created_at": Map.created_at,
@@ -442,7 +440,6 @@ async def list_maps(
     col = sort_column_map.get(sort_by, Map.updated_at)
     order_clause = col.asc() if sort_dir == "asc" else col.desc()
 
-    # Total count (with RBAC + search/visibility filters)
     count_base = select(func.count()).select_from(Map)
     count_base = _apply_vis_filter(count_base)
     count_base = _apply_extra_filters(count_base)
@@ -660,7 +657,6 @@ async def duplicate_map(
 
     fork_name = await _generate_fork_name(session, source.name, user.id)
 
-    # Create new map - always private, no thumbnail, track lineage
     new_map = Map(
         name=fork_name,
         description=source.description,

--- a/backend/app/modules/catalog/maps/service_crud.py
+++ b/backend/app/modules/catalog/maps/service_crud.py
@@ -37,7 +37,7 @@ _UNSET = object()
 def new_map_asset_key(prefix: str, map_id: uuid.UUID, ext: str) -> str:
     """A storage key for one map image that no later upload can reuse.
 
-    fix(#1778): reused keys (``{prefix}/{map_id}.{ext}``) let a
+    Reused keys (``{prefix}/{map_id}.{ext}``) let a
     race outlive the row lock — request A re-reads a committed key as
     dead, request B writes and commits that same name, then A's delete
     lands on the object B just published (404). A fresh random component
@@ -62,7 +62,7 @@ async def lock_map_for_asset_write(session: AsyncSession, map_id: uuid.UUID) -> 
     Callers take it AFTER validating the payload, so no decode or image
     verification runs under the lock.
 
-    fix(#1778): overlapping uploads can race their cleanup and
+    Overlapping uploads can race their cleanup and
     strand the row on an object the other just deleted (404 on read).
     Held through the caller's commit; ``discard_map_asset_objects``
     re-reads the committed row as the other half, since a lock can't
@@ -70,7 +70,7 @@ async def lock_map_for_asset_write(session: AsyncSession, map_id: uuid.UUID) -> 
     three callers agree, and selects columns (not ``Map``) so a stale
     identity-mapped instance can't shadow a fresh commit.
 
-    fix(#1778): ``SET LOCAL lock_timeout = '2s'`` bounds the
+    ``SET LOCAL lock_timeout = '2s'`` bounds the
     wait, since a degraded storage backend could otherwise queue every
     writer behind this lock (a losing wait, 55P03, maps to 409).
     """
@@ -124,12 +124,12 @@ async def discard_map_asset_objects(
 ) -> None:
     """Best-effort removal of a map's stored thumbnail / OG-image objects.
 
-    fix(#1778): nothing ever called ``storage.delete`` for a ``maps/``
+    Nothing ever called ``storage.delete`` for a ``maps/``
     key, so deleted/re-uploaded images were orphaned undiscoverably.
     Shared by delete/upload handlers, all holding
     ``lock_map_for_asset_write`` from write to commit.
 
-    fix(#1778): re-reads the row rather than trusting the
+    Re-reads the row rather than trusting the
     caller's previous-key read (consistent with whatever committed
     last), and relies on ``new_map_asset_key`` never reusing keys since
     the re-read isn't atomic with the delete below.
@@ -147,7 +147,7 @@ async def discard_map_asset_objects(
     try:
         live = await _live_map_asset_keys(session, map_id)
     except Exception:  # broad: any failure of the post-commit read
-        # fix(#1778): the liveness read runs after commit, so a
+        # The liveness read runs after commit, so a
         # transient failure here shouldn't 500 an already-succeeded
         # request — skip the deletes; an orphan costs less than a live delete.
         logger.warning(
@@ -169,12 +169,8 @@ async def discard_map_asset_objects(
 class MapAssetPublication:
     """The objects written for a row that has not committed yet.
 
-    fix(#1778): the rollback used to be keyed on "did the block
-    raise", not "did the row commit" — anything after a successful commit
-    but still in scope (e.g. the icon route's ``session.refresh``) could
-    fail and delete an object the committed row references. Settling ends
-    the tracking, so the boundary is the commit itself, not the last
-    statement left in the block.
+    Settling ends tracking at commit. Later failures must not delete an object
+    already referenced by the committed row.
     """
 
     def __init__(self) -> None:
@@ -188,7 +184,7 @@ class MapAssetPublication:
         prefix vs deliberately-global sprite icons), and rollback deletes
         what it's given rather than resolving anything.
 
-        fix(#1778): call BEFORE awaiting the write — a PUT can
+        Call BEFORE awaiting the write — a PUT can
         land and still fail the client, so recording after left orphaned
         objects per retry. Recording first is free: rollback either
         deletes what this request wrote or no-ops on an unwritten key.
@@ -199,7 +195,7 @@ class MapAssetPublication:
     def committing(self) -> None:
         """A commit is about to be awaited, so its outcome stops being knowable.
 
-        fix(#1778): a lost connection between Postgres committing
+        A lost connection between Postgres committing
         and the ack arriving raises out of the await for a transaction
         that DID commit — from this mark until ``settled``, an exception
         says nothing about whether the row landed, so nothing is deleted.
@@ -238,7 +234,7 @@ class MapAssetPublication:
 async def map_asset_publication() -> AsyncIterator[MapAssetPublication]:
     """Undo object writes when the row that would name them never commits.
 
-    fix(#1778): the upload handlers write the image, then record
+    The upload handlers write the image, then record
     its key on the map row. A failure between those two left the object
     behind with nothing pointing at it, and since keys are never reused,
     every retry added another — undiscoverable, since nothing enumerates
@@ -257,7 +253,7 @@ async def map_asset_publication() -> AsyncIterator[MapAssetPublication]:
         yield publication
     except BaseException:
         if publication.outcome_unknown:
-            # fix(#1778): the exception arrived while a commit was in
+            # The exception arrived while a commit was in
             # flight, so it does not say whether the row landed. Deleting here
             # is the one irreversible option available.
             logger.warning(
@@ -358,16 +354,10 @@ async def _layer_counts_for_maps(
 ) -> dict[uuid.UUID, int]:
     """Layer counts for exactly the maps on one page of the gallery listing.
 
-    fix(#1778): the listing used to read counts from an uncorrelated
-    ``GROUP BY map_id`` subquery LEFT JOINed onto the page — Postgres has no
-    limit-pushdown through a left join, so every request aggregated all of
-    ``catalog.map_layers``, cost growing with total layer count, not page size.
-
-    A correlated scalar subquery fixes the common case but not the general
-    one: measured on 5000 maps x 8 layers, the subplan ran 50 times at
-    OFFSET 0 (2.5ms vs 12.3ms for the join) but 4050 times at OFFSET 4000,
-    losing to what it replaced. The only form bounded by the page at every
-    offset is a second query keyed on the ids the page returned — a bitmap
+    A second query keyed on the ids returned by the page keeps work bounded at
+    every offset. A correlated subquery degrades at high offsets, while an
+    uncorrelated grouped join aggregates the entire layer table. The keyed
+    query uses a bitmap
     index scan on ``map_layers.map_id``, measured 0.5-1.0ms at both offsets.
     """
     if not map_ids:
@@ -413,10 +403,10 @@ async def list_maps(
 
     def _apply_extra_filters(stmt: Select) -> Select:
         if search:
-            # SEC-FU-07 (sec-audit-20260519.md + WR-01): escape \, %, _ via
+            # Escape \, %, _ via
             # escape_ilike() before composing the pattern (backslash
             # escaped FIRST or later replacements double-escape).
-            # T-2: lower() both column and pattern to match the functional
+            # Lowercase both column and pattern to match the functional
             # trigram indexes (ix_maps_name_trgm, ix_maps_description_trgm)
             # — a bare ILIKE on the raw column falls back to a Seq Scan.
             pattern = f"%{escape_ilike(search)}%".lower()
@@ -454,7 +444,7 @@ async def list_maps(
             User.username.label("created_by_username"),
         )
         .outerjoin(User, Map.created_by == User.id)
-        # fix(#430): batch-seeded rows share a server-default timestamp; add a
+        # Batch-seeded rows share a server-default timestamp; add a
         # unique tiebreaker so pagination is stable.
         .order_by(order_clause, Map.id)
         .offset(skip)
@@ -684,9 +674,7 @@ async def duplicate_map(
     layers_result = await session.execute(
         select(MapLayer)
         .where(MapLayer.map_id == map_id)
-        .order_by(
-            MapLayer.sort_order, MapLayer.id
-        )  # fix(#430): deterministic tie-break
+        .order_by(MapLayer.sort_order, MapLayer.id)  # Deterministic tie-break
     )
     layers = layers_result.scalars().all()
 

--- a/backend/app/modules/catalog/maps/service_crud.py
+++ b/backend/app/modules/catalog/maps/service_crud.py
@@ -122,21 +122,12 @@ async def discard_map_asset_objects(
     map_id: uuid.UUID,
     storage_keys: Iterable[str | None],
 ) -> None:
-    """Best-effort removal of a map's stored thumbnail / OG-image objects.
+    """Remove obsolete thumbnail and OG-image objects after commit, best effort.
 
-    Nothing ever called ``storage.delete`` for a ``maps/``
-    key, so deleted/re-uploaded images were orphaned undiscoverably.
-    Shared by delete/upload handlers, all holding
-    ``lock_map_for_asset_write`` from write to commit.
-
-    Re-reads the row rather than trusting the
-    caller's previous-key read (consistent with whatever committed
-    last), and relies on ``new_map_asset_key`` never reusing keys since
-    the re-read isn't atomic with the delete below.
-
-    Always best effort — a refusing backend must not block a delete,
-    and an already-committed delete can't be undone by raising. Import
-    stays function-local, matching ``_reap_managed_storage``.
+    Callers hold lock_map_for_asset_write through commit. Re-read the committed
+    row before deleting, and rely on unique upload keys because the read and
+    delete are not atomic. A failed liveness read skips cleanup to protect live
+    objects; storage failures must not fail an already-committed request.
     """
     from app.platform.storage.provider import get_storage
     from app.platform.storage.titiler_url import resolve_current_storage_key
@@ -232,19 +223,11 @@ class MapAssetPublication:
 
 @asynccontextmanager
 async def map_asset_publication() -> AsyncIterator[MapAssetPublication]:
-    """Undo object writes when the row that would name them never commits.
+    """Track object writes and clean up those whose catalog rows never commit.
 
-    The upload handlers write the image, then record
-    its key on the map row. A failure between those two left the object
-    behind with nothing pointing at it, and since keys are never reused,
-    every retry added another — undiscoverable, since nothing enumerates
-    the ``maps/`` prefix.
-
-    Cleanup runs on any exception (including one the handler raises
-    itself) and never replaces it — a tidy-up failure is logged and
-    dropped so the caller still sees the real error. Runs only on what's
-    still pending (a settled publication rolls nothing back), and not at
-    all while a commit's outcome is indeterminate (see ``committing``).
+    Cleanup preserves the original exception and logs its own failures. Settled
+    publications need no rollback; an indeterminate commit outcome also skips
+    cleanup because the object may already be referenced by a committed row.
     """
     from app.platform.storage.provider import get_storage
 
@@ -352,13 +335,10 @@ async def get_map_with_layers(
 async def _layer_counts_for_maps(
     session: AsyncSession, map_ids: list[uuid.UUID]
 ) -> dict[uuid.UUID, int]:
-    """Layer counts for exactly the maps on one page of the gallery listing.
+    """Return layer counts for exactly the maps on one gallery page.
 
-    A second query keyed on the ids returned by the page keeps work bounded at
-    every offset. A correlated subquery degrades at high offsets, while an
-    uncorrelated grouped join aggregates the entire layer table. The keyed
-    query uses a bitmap
-    index scan on ``map_layers.map_id``, measured 0.5-1.0ms at both offsets.
+    A query keyed by page IDs bounds work at every offset and uses the
+    map_layers.map_id index without aggregating unrelated maps.
     """
     if not map_ids:
         return {}

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -20,20 +20,15 @@ from app.modules.catalog.datasets.domain.models import (
 )
 
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 async def get_record(session: AsyncSession, record_id: uuid.UUID) -> Record | None:
-    """Fetch a record by ID."""
     result = await session.execute(select(Record).where(Record.id == record_id))
     return result.scalar_one_or_none()
 
 
-# ---------------------------------------------------------------------------
 # Localized record text
-# ---------------------------------------------------------------------------
 
 
 async def list_translations(
@@ -102,9 +97,7 @@ async def delete_translation(
     await session.flush()
 
 
-# ---------------------------------------------------------------------------
 # Contacts
-# ---------------------------------------------------------------------------
 
 
 async def list_contacts(
@@ -215,9 +208,7 @@ async def delete_contact(
     await session.flush()
 
 
-# ---------------------------------------------------------------------------
 # Keywords
-# ---------------------------------------------------------------------------
 
 
 async def list_keywords(
@@ -305,9 +296,7 @@ async def delete_keyword(
     await session.flush()
 
 
-# ---------------------------------------------------------------------------
 # Distributions
-# ---------------------------------------------------------------------------
 
 
 async def record_publication_version(
@@ -546,9 +535,7 @@ async def _restore_generated_primary(
     return None
 
 
-# ---------------------------------------------------------------------------
 # Distribution generation
-# ---------------------------------------------------------------------------
 
 # Standard distribution templates: (distribution_type, format, url_template, title, protocol, media_type, is_primary)
 _DISTRIBUTION_TEMPLATES = [

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -110,7 +110,7 @@ async def list_contacts(
     """List contacts for a record, ordered by sort_order, with pagination."""
     result = await session.execute(
         select(RecordContact)
-        # fix(#1778): sort_order server-defaults to 0, so contacts added
+        # Sort_order server-defaults to 0, so contacts added
         # without an explicit order tie on it -- OFFSET/LIMIT paging over
         # the tie had no defined row order. RecordContact.id is unique.
         .where(RecordContact.record_id == record_id)
@@ -181,7 +181,7 @@ async def update_contact(
     if contact is None:
         raise ValueError(f"Contact {contact_id} not found")
 
-    # fix(#458): kwargs carry only explicitly-set fields (exclude_unset
+    # Kwargs carry only explicitly-set fields (exclude_unset
     # at the router), so apply nulls too — that's how a field is cleared.
     for key, value in kwargs.items():
         setattr(contact, key, value)
@@ -222,7 +222,7 @@ async def list_keywords(
     result = await session.execute(
         select(RecordKeyword)
         .where(RecordKeyword.record_id == record_id)
-        # fix(#430): deterministic order so paginated reads don't repeat/skip.
+        # Deterministic order so paginated reads don't repeat/skip.
         .order_by(RecordKeyword.id)
         .offset(skip)
         .limit(limit)
@@ -279,7 +279,7 @@ async def delete_keyword(
 ) -> None:
     """Delete a keyword by ID, scoped to its owning record.
 
-    fix(#463): scoping by ``record_id`` 404s a keyword belonging to a
+    Scoping by ``record_id`` 404s a keyword belonging to a
     different record, instead of deleting it through a mismatched path.
     """
     result = await session.execute(
@@ -304,7 +304,7 @@ async def record_publication_version(
 ) -> int | None:
     """The counter a stored tile template on this record is republished at.
 
-    fix(#2007): a distribution row is written once at ingest, so the vector
+    A distribution row is written once at ingest, so the vector
     template it stores has to be rewritten at read time to name the dataset's
     current publication version. None when the record has no dataset.
     """
@@ -326,7 +326,7 @@ async def list_distributions(
     result = await session.execute(
         select(RecordDistribution)
         .where(RecordDistribution.record_id == record_id)
-        # fix(#430): deterministic order so paginated reads don't repeat/skip.
+        # Deterministic order so paginated reads don't repeat/skip.
         .order_by(RecordDistribution.id)
         .offset(skip)
         .limit(limit)
@@ -350,7 +350,7 @@ async def _demote_other_primaries(
     keep_id: uuid.UUID | None = None,
     generated_only: bool = False,
 ) -> None:
-    """Clear ``is_primary`` on the record's other distributions (#1383).
+    """Clear ``is_primary`` on the record's other distributions.
 
     Issued BEFORE the row that claims the flag is written — ordering is the
     point, since ``uq_record_distribution_primary`` is a non-deferrable
@@ -404,7 +404,7 @@ async def create_distribution(
 ) -> RecordDistribution:
     """Create a manual distribution for a record.
 
-    fix(#1383): last write wins — ``is_primary=True`` demotes every other
+    Last write wins — ``is_primary=True`` demotes every other
     distribution on the record in this transaction (avoids two primaries
     with no tiebreak for OGC/STAC readers). Enforced by
     ``uq_record_distribution_primary`` (migration 0042); the demote just
@@ -445,7 +445,7 @@ async def update_distribution(
 
     Auto-generated distributions cannot be updated (raises ValueError).
     ``is_primary=True`` follows create_distribution's last-write-wins rule
-    (#1383); clearing it (``is_primary=False``) promotes nothing — a
+    Clearing it (``is_primary=False``) promotes nothing — a
     no-primary record is representable, and the next
     ``reconcile_distributions`` fills it.
     """
@@ -467,7 +467,7 @@ async def update_distribution(
     if kwargs.get("is_primary") is True:
         await _demote_other_primaries(session, record_id, keep_id=distribution_id)
 
-    # fix(#458): apply explicitly-set nulls too — see update_contact.
+    # Apply explicitly-set nulls too — see update_contact.
     for key, value in kwargs.items():
         setattr(dist, key, value)
 
@@ -482,7 +482,7 @@ async def delete_distribution(
 
     Auto-generated distributions cannot be deleted (raises ValueError).
     Deleting the row holding ``is_primary`` hands the flag back to the
-    generated default (#1383): withdrawing a row withdraws its claim.
+    generated default: withdrawing a row withdraws its claim.
     """
     result = await session.execute(
         select(RecordDistribution).where(
@@ -618,7 +618,7 @@ _DISTRIBUTION_TEMPLATES = [
 # generated set, so reconcile has to see it.
 _VECTOR_TILES_PAIR = ("vector_tiles", "pbf")
 
-# fix(#1463): this read ``OGC:WMTS``, which the tile URL does not speak — it is
+# This read ``OGC:WMTS``, which the tile URL does not speak — it is
 # a plain XYZ template, no capabilities document and no TileMatrixSet. Bare, to
 # match ``HTTP`` above: this vocabulary prefixes ``OGC:`` only for real OGC
 # services, and there is no OGC XYZ standard to claim. Payload semantics stay
@@ -685,8 +685,8 @@ async def generate_distributions(
     Spatial datasets get 9 rows; non-spatial get 2 (csv + OGC features).
     All auto_generated=True, merged via ``ON CONFLICT DO NOTHING``.
 
-    fix(#1383): ``is_primary`` is inserted only when no row already holds
-    it. fix(#1370): the existence probe reads only auto-generated rows, so
+    ``is_primary`` is inserted only when no row already holds
+    it. The existence probe reads only auto-generated rows, so
     a user's matching row can't block the platform's from being generated.
     """
     # Fetch the pairs this function owns for this record in a single query.
@@ -702,9 +702,9 @@ async def generate_distributions(
     )
     existing_set = {(row[0], row[1]) for row in existing_result.all()}
 
-    # fix(#1463): repairs a stale `OGC:WMTS` protocol stamped during
+    # Repairs a stale `OGC:WMTS` protocol stamped during
     # migration 0048's upgrade window. Partial mitigation — only reached on
-    # a modality-flip refresh (not fresh datasets); #1467 removes the window.
+    # a modality-flip refresh, not fresh datasets.
     if _VECTOR_TILES_PAIR in existing_set:
         await session.execute(
             update(RecordDistribution)
@@ -718,7 +718,7 @@ async def generate_distributions(
             .values(protocol=_VECTOR_TILES_PROTOCOL)
         )
 
-    # fix(#1383): the template's primary flag yields to whoever already
+    # The template's primary flag yields to whoever already
     # holds it — inserting a second would violate
     # `uq_record_distribution_primary` and abort the transaction.
     record_has_primary = await _record_has_primary(session, record_id)
@@ -784,7 +784,7 @@ async def generate_distributions(
     if not to_add:
         return []
 
-    # fix(#1370): ON CONFLICT DO NOTHING, not check-then-insert —
+    # ON CONFLICT DO NOTHING, not check-then-insert —
     # IntegrityError would abort the caller's transaction. Skipped rows stay
     # out of RETURNING, so `created` is truthful for is_primary normalization.
     result = await session.execute(
@@ -805,15 +805,15 @@ async def reconcile_distributions(
     table_name: str,
     geometry_type: str | None = None,
 ) -> tuple[list[RecordDistribution], list[tuple[str, str]]]:
-    """Bring a record's AUTO-GENERATED distributions in line with a modality.
+    """Bring a record's auto-generated distributions in line with a modality.
 
-    fix(#1314): merges rather than replaces — inserts what the modality adds
-    and DELETES auto-generated rows it excludes, taking user edits with
+    Merges rather than replaces — inserts what the modality adds
+    and deletes auto-generated rows it excludes, taking user edits with
     them. ``auto_generated=False`` rows and rows outside
     ``_GENERATED_PAIRS`` are never inserted or deleted here, though the
     ``is_primary`` demote below still reaches them (it is scoped to
-    ``auto_generated``, not to the pair set). fix(#1383): normalizes
-    ``is_primary`` unless a USER-authored primary already holds it. Returns
+    ``auto_generated``, not to the pair set). It normalizes
+    ``is_primary`` unless a user-authored primary already holds it. Returns
     ``(created, removed)``.
     """
     result = await session.execute(
@@ -843,10 +843,10 @@ async def reconcile_distributions(
         session, dataset_id, record_id, table_name, geometry_type=geometry_type
     )
 
-    # fix(#1314): chosen from the rows that ACTUALLY exist, not from the
+    # Chosen from the rows that ACTUALLY exist, not from the
     # modality alone — naming a pair with no generated row behind it would
     # clear the CSV flag and promote nothing, leaving no primary at all.
-    # fix(#1370) narrowed when that happens (a user's own GeoPackage entry
+    # Narrowed when that happens (a user's own GeoPackage entry
     # no longer suppresses the generated one) but did not remove it: a user
     # row at the exact template url makes the insert a no-op.
     generated = [
@@ -863,7 +863,7 @@ async def reconcile_distributions(
         ),
         None,
     )
-    # fix(#1383): a user's own row holding the flag outranks this
+    # A user's own row holding the flag outranks this
     # normalization, and skipping is what keeps the preservation policy above
     # literally true — the demote below is scoped to generated rows, so it
     # could not clear a user's flag anyway, and promoting beside one would

--- a/backend/app/modules/catalog/records/service.py
+++ b/backend/app/modules/catalog/records/service.py
@@ -110,7 +110,7 @@ async def list_contacts(
     """List contacts for a record, ordered by sort_order, with pagination."""
     result = await session.execute(
         select(RecordContact)
-        # Sort_order server-defaults to 0, so contacts added
+        # `sort_order` server-defaults to 0, so contacts added
         # without an explicit order tie on it -- OFFSET/LIMIT paging over
         # the tie had no defined row order. RecordContact.id is unique.
         .where(RecordContact.record_id == record_id)
@@ -444,7 +444,7 @@ async def update_distribution(
     """Update a distribution. Explicitly-set fields are applied, nulls included.
 
     Auto-generated distributions cannot be updated (raises ValueError).
-    ``is_primary=True`` follows create_distribution's last-write-wins rule
+    ``is_primary=True`` follows create_distribution's last-write-wins rule.
     Clearing it (``is_primary=False``) promotes nothing — a
     no-primary record is representable, and the next
     ``reconcile_distributions`` fills it.
@@ -618,12 +618,10 @@ _DISTRIBUTION_TEMPLATES = [
 # generated set, so reconcile has to see it.
 _VECTOR_TILES_PAIR = ("vector_tiles", "pbf")
 
-# This read ``OGC:WMTS``, which the tile URL does not speak — it is
-# a plain XYZ template, no capabilities document and no TileMatrixSet. Bare, to
-# match ``HTTP`` above: this vocabulary prefixes ``OGC:`` only for real OGC
-# services, and there is no OGC XYZ standard to claim. Payload semantics stay
-# in ``format`` and ``media_type``. Migration 0048's WHERE matches both values
-# below, so the three move together.
+# XYZ templates provide no capabilities document or TileMatrixSet, so their
+# protocol is unprefixed XYZ rather than an OGC service. Payload semantics
+# belong in format and media_type. Keep both values below aligned with
+# migration 0048, whose WHERE clause matches them.
 _VECTOR_TILES_PROTOCOL = "XYZ"
 _STALE_VECTOR_TILES_PROTOCOL = "OGC:WMTS"
 
@@ -843,12 +841,8 @@ async def reconcile_distributions(
         session, dataset_id, record_id, table_name, geometry_type=geometry_type
     )
 
-    # Chosen from the rows that ACTUALLY exist, not from the
-    # modality alone — naming a pair with no generated row behind it would
-    # clear the CSV flag and promote nothing, leaving no primary at all.
-    # Narrowed when that happens (a user's own GeoPackage entry
-    # no longer suppresses the generated one) but did not remove it: a user
-    # row at the exact template url makes the insert a no-op.
+    # Select only generated rows that exist; a user row at the exact template
+    # URL can make insertion a no-op.
     generated = [
         row
         for row in survivors + created
@@ -863,12 +857,8 @@ async def reconcile_distributions(
         ),
         None,
     )
-    # A user's own row holding the flag outranks this
-    # normalization, and skipping is what keeps the preservation policy above
-    # literally true — the demote below is scoped to generated rows, so it
-    # could not clear a user's flag anyway, and promoting beside one would
-    # advertise two primaries (now a `uq_record_distribution_primary`
-    # violation rather than a silent ambiguity).
+    # A user-authored primary takes precedence. Generated-row normalization cannot
+    # clear it, and promoting another row would violate the unique primary index.
     user_primary = await _record_has_primary(
         session, record_id, user_authored_only=True
     )

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -245,7 +245,7 @@ def _consolidate_dead_cumulative_metric_files() -> None:
 
 
 def _sweep_dead_worker_metrics_once() -> None:
-    """Run one reap pass (no loop, no sleep) -- split out for tests."""
+    """Run one metrics-file reap pass."""
     if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
         return
     from prometheus_client import multiprocess

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -45,14 +45,10 @@ def _sweep_lock_path(multiproc_dir: str) -> str:
     return os.path.join(multiproc_dir, "sweep.lock")
 
 
-# Upper bounds for http_request_duration_seconds (the only
-# `handler`-labelled latency histogram). The library default — (0.1, 0.5,
-# 1) + implicit +Inf — clamps p95 at 1.0, since histogram_quantile
-# returns the highest FINITE bound when the quantile lands in +Inf;
-# GeoLensApiInteractiveLatencyP95 fired on that ceiling, not real
-# latency. Kept short despite the cost (each bound adds one series per
-# `method` label value)
-# because the unlabelled sibling can't answer "p95 excluding tiles".
+# The handler-labelled histogram needs finite bounds above the latency alert
+# threshold: histogram_quantile returns the highest finite bound for +Inf.
+# Keep bucket count small because every bound adds a series per method;
+# the unlabelled histogram cannot exclude tile requests.
 LATENCY_LOWR_BUCKETS = (0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0)
 
 
@@ -258,7 +254,7 @@ def _sweep_dead_worker_metrics_once() -> None:
 async def sweep_dead_worker_metrics() -> None:
     """Background loop: reap and consolidate files left by dead workers.
 
-    Shutdown_worker_metrics() only runs on graceful
+    `shutdown_worker_metrics()` only runs on graceful
     shutdown, so an OOM-killed or SIGKILLed worker leaves its
     RSS/pool gauges and cumulative metric files behind (see
     _consolidate_dead_cumulative_metric_files()), inflating /metrics

--- a/backend/app/observability/metrics/__init__.py
+++ b/backend/app/observability/metrics/__init__.py
@@ -1,12 +1,12 @@
 """Prometheus metrics module for GeoLens: HTTP request instrumentation,
 job queue gauges, and connection pool gauges.
 
-fix(#1240, #651): without multiprocess mode, each worker answers /metrics
+Without multiprocess mode, each worker answers /metrics
 from its own registry, so scrapes sawtooth between per-process values and
 Prometheus reads every downward step as a fabricated counter reset.
 `expose()` already serves a merged registry whenever
 PROMETHEUS_MULTIPROC_DIR is set, which both compose files do by default
-(dev included), so #651 reproduces locally with no env wiring.
+(including development), so the behavior requires no extra environment wiring.
 """
 
 import asyncio
@@ -25,7 +25,7 @@ logger = structlog.stdlib.get_logger(__name__)
 # by a sibling that died without running its own shutdown hook.
 _SWEEP_INTERVAL_SECONDS = 60
 
-# fix(#1240, #651): must match the endpoint create_instrumentator() +
+# Must match the endpoint create_instrumentator() +
 # instrumentator.expose() below actually serve (its default, unoverridden).
 _METRICS_ENDPOINT_PATH = "/metrics"
 
@@ -40,12 +40,12 @@ def _sweep_lock_path(multiproc_dir: str) -> str:
     against concurrent scrape-vs-sweep file mutation. See
     _consolidate_dead_cumulative_metric_files() (writer/exclusive side)
     and the metrics-scrape middleware in init_metrics() (reader/shared
-    side); fix(#1240, #651).
+    side).
     """
     return os.path.join(multiproc_dir, "sweep.lock")
 
 
-# fix(#1517): upper bounds for http_request_duration_seconds (the only
+# Upper bounds for http_request_duration_seconds (the only
 # `handler`-labelled latency histogram). The library default — (0.1, 0.5,
 # 1) + implicit +Inf — clamps p95 at 1.0, since histogram_quantile
 # returns the highest FINITE bound when the quantile lands in +Inf;
@@ -59,7 +59,7 @@ LATENCY_LOWR_BUCKETS = (0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0)
 def init_metrics(app: FastAPI):
     """Instrument the FastAPI app and expose /metrics endpoint."""
     instrumentator = create_instrumentator()
-    # fix(#1517): buckets are passed HERE, not in create_instrumentator() —
+    # Buckets are passed HERE, not in create_instrumentator() —
     # Instrumentator.__init__ takes no bucket args; instrument() is the
     # only place they can be set (prometheus_fastapi_instrumentator 8.1.0).
     instrumentator.instrument(app, latency_lowr_buckets=LATENCY_LOWR_BUCKETS)
@@ -72,7 +72,7 @@ def init_metrics(app: FastAPI):
         exclusive lock can never rename a .db file out from under a
         scrape that already globbed it.
 
-        fix(#1240, #651): MultiProcessCollector.collect() tolerates a
+        MultiProcessCollector.collect() tolerates a
         path disappearing mid-scan only for gauge_live*.db; cumulative
         types re-raise FileNotFoundError, which would surface as an
         intermittent 500 when the 60s sweep's os.rename() lands
@@ -104,7 +104,7 @@ def init_metrics(app: FastAPI):
 def shutdown_worker_metrics() -> None:
     """Mark this worker process's multiprocess metric files dead.
 
-    fix(#1240, #651): under UVICORN_MAX_REQUESTS recycling (#643) a
+    Under UVICORN_MAX_REQUESTS recycling, a
     worker respawns mid-lifetime, not just at container shutdown;
     without this its mmap files linger and keep summing into every
     future scrape as a stale series. No-op when multiprocess mode isn't
@@ -174,7 +174,7 @@ def _iter_dead_pid_files(prefix: str, multiproc_dir: str) -> Iterator[tuple[int,
         yield pid, path
 
 
-# fix(#1240, #651): non-numeric suffix so _iter_dead_pid_files never
+# Non-numeric suffix so _iter_dead_pid_files never
 # mistakes this file itself for a dead worker's file.
 _ARCHIVE_SUFFIX = "archived"
 
@@ -182,8 +182,8 @@ _ARCHIVE_SUFFIX = "archived"
 def _consolidate_dead_cumulative_metric_files() -> None:
     """Fold dead workers' counter/histogram/summary files into one
     running total per type ("<type>_archived.db") instead of letting
-    them accumulate forever. mark_process_dead() never touches these
-    (fix(#1240), #651): their values are cumulative, summed across every
+    them accumulate forever. ``mark_process_dead()`` never touches these
+    because their values are cumulative and summed across every
     pid's file, so deleting one would silently subtract its contribution.
 
     Runs under one exclusive hold of the same lock the /metrics scrape
@@ -258,8 +258,8 @@ def _sweep_dead_worker_metrics_once() -> None:
 async def sweep_dead_worker_metrics() -> None:
     """Background loop: reap and consolidate files left by dead workers.
 
-    fix(#1240, #651): shutdown_worker_metrics() only runs on graceful
-    shutdown, so an OOM-killed/SIGKILLed worker (#643) leaves its
+    Shutdown_worker_metrics() only runs on graceful
+    shutdown, so an OOM-killed or SIGKILLed worker leaves its
     RSS/pool gauges and cumulative metric files behind (see
     _consolidate_dead_cumulative_metric_files()), inflating /metrics
     until the container restarts. No-op when multiprocess mode isn't

--- a/backend/app/observability/metrics/jobs.py
+++ b/backend/app/observability/metrics/jobs.py
@@ -86,17 +86,9 @@ async def _refresh_job_metrics() -> None:
             elif status == "doing":
                 jobs_active.labels(queue=q).set(count)
                 seen_doing.add(q)
-            # Deliberately no `succeeded`/`failed` branch here.
-            # The worker runs with delete_jobs="successful", so
-            # procrastinate_finish_job_v1 DELETEs the row while still
-            # `doing` — status='succeeded' is never written, so this 15s
-            # poll could never observe it (geolens_jobs_completed_total
-            # read a flat zero from day one). A `failed` branch would need
-            # a delta against a row-count snapshot, which breaks once
-            # purge_expired_terminal_jobs ages rows out mid-window. Both
-            # counters are instead incremented at the terminal transition
-            # by the worker middleware and stalled-job sweep in
-            # platform/jobs/worker.py, where nothing goes stale.
+            # Count terminal transitions in platform/jobs/worker.py, not this poll.
+            # Successful queue rows are deleted before polling can observe them, and
+            # terminal-row retention makes snapshot deltas unreliable for failures.
 
         # Zero gauges for previously seen queues with no matching rows this cycle.
         for q in _known_queues - seen_todo:

--- a/backend/app/observability/metrics/jobs.py
+++ b/backend/app/observability/metrics/jobs.py
@@ -47,22 +47,17 @@ staging_orphans_deleted_total = Counter(
     "Staging objects deleted for having no ingest-job row tracking them",
 )
 
-# fix(#1778): the delta snapshot this module used to keep is gone with
-# the last counter branch that read it. NOTE(#655): the first cycle
-# after boot seeded the counters with historical row counts; nothing
-# seeds them now, since neither counter derives from a row count.
-
-# Queues whose gauge children have been set at least once — zeroed (not
-# removed) when their todo/doing rows disappear from a cycle. fix(#655)
+# Queues whose gauge children have been set at least once. Their gauges are
+# zeroed, rather than removed, when no todo/doing rows remain.
 _known_queues: set[str] = set()
 
 
 async def _refresh_job_metrics() -> None:
     """Run one metrics collection cycle (no loop, no sleep).
 
-    Queries procrastinate_jobs for status counts grouped by queue and
-    updates the two gauges. fix(#1778): gauges only — both counters are
-    incremented at the terminal transition, in platform/jobs/worker.py.
+    Queries procrastinate_jobs for status counts grouped by queue and updates
+    the two gauges. Terminal counters are incremented at the transition in
+    platform/jobs/worker.py.
     """
     from app.core.db import engine
 
@@ -103,8 +98,7 @@ async def _refresh_job_metrics() -> None:
             # by the worker middleware and stalled-job sweep in
             # platform/jobs/worker.py, where nothing goes stale.
 
-        # fix(#655): zero gauges for previously seen queues with no todo/doing
-        # rows this cycle — they used to freeze at their last non-zero value
+        # Zero gauges for previously seen queues with no matching rows this cycle.
         for q in _known_queues - seen_todo:
             jobs_queue_depth.labels(queue=q).set(0)
         for q in _known_queues - seen_doing:

--- a/backend/app/observability/metrics/jobs.py
+++ b/backend/app/observability/metrics/jobs.py
@@ -35,7 +35,7 @@ jobs_failed_total = Counter(
     ["queue"],
 )
 
-# fix(#1249): staging objects deleted because no ingest_jobs row tracks
+# Staging objects deleted because no ingest_jobs row tracks
 # them. A true counter, not a polled gauge: the reconciliation pass runs
 # under pg_try_advisory_xact_lock, so at most one process per interval
 # deletes (and counts) any given object, incremented only after the
@@ -86,7 +86,7 @@ async def _refresh_job_metrics() -> None:
             elif status == "doing":
                 jobs_active.labels(queue=q).set(count)
                 seen_doing.add(q)
-            # fix(#1778): deliberately no `succeeded`/`failed` branch here.
+            # Deliberately no `succeeded`/`failed` branch here.
             # The worker runs with delete_jobs="successful", so
             # procrastinate_finish_job_v1 DELETEs the row while still
             # `doing` — status='succeeded' is never written, so this 15s

--- a/backend/app/processing/ai/chat_styles.py
+++ b/backend/app/processing/ai/chat_styles.py
@@ -50,21 +50,15 @@ async def _build_data_driven_style(
     ramp = tool_input.get("ramp", default_ramp)
     method = tool_input.get("method", "quantile")
     class_count = tool_input.get("class_count", 5)
-    class_count = max(2, min(class_count, 9))  # Clamp to 2-9 classes
+    class_count = max(2, min(class_count, 9))
 
-    # Find the layer to get table_name and geometry_type
-    target_layer = None
-    for layer in layers:
-        if layer.id == layer_id:
-            target_layer = layer
-            break
+    target_layer = next((layer for layer in layers if layer.id == layer_id), None)
 
     if not target_layer:
         return {"error": f"Layer {layer_id} not found"}
 
     table_name = target_layer.dataset_table_name
 
-    # Validate column exists in layer
     if target_layer.column_info:
         col_names = {c.get("name") for c in target_layer.column_info if c.get("name")}
         if column not in col_names:
@@ -90,19 +84,18 @@ async def _build_data_driven_style(
             allowed_tables=allowed_tables,
             port=port,
         )
-    else:
-        return await _build_graduated_style(
-            session,
-            table_name,
-            column,
-            ramp,
-            method,
-            class_count,
-            color_prop,
-            layer_id,
-            allowed_tables=allowed_tables,
-            port=port,
-        )
+    return await _build_graduated_style(
+        session,
+        table_name,
+        column,
+        ramp,
+        method,
+        class_count,
+        color_prop,
+        layer_id,
+        allowed_tables=allowed_tables,
+        port=port,
+    )
 
 
 async def _build_categorical_style(

--- a/backend/app/processing/ai/chat_styles.py
+++ b/backend/app/processing/ai/chat_styles.py
@@ -189,17 +189,10 @@ async def _build_graduated_style(
         # quantile: use the dynamically-computed quantiles from stats
         breaks = stats.get("quantiles", [])
 
-    # MapLibre rejects a step expression whose stops are not
-    # strictly ascending, and percentile_cont does not deduplicate, so any
-    # clustered column (70% of rows sharing one value, say) yields adjacent
-    # equal quantiles. Both frontend siblings guard this for the styles they
-    # build - classification.ts and DataDrivenStyleEditor.tsx each do
-    # `[...new Set(breaks)]` - but neither can see inside an expression the
-    # server assembled, and ChatPanel's validateChatPaint only filters paint
-    # KEYS by geometry type. A non-finite break is dropped for the same reason:
-    # it cannot be a valid stop, and it would make the actions frame
-    # unparseable in the browser. The colour slice is re-taken so the surviving
-    # breaks still span the whole ramp.
+    # MapLibre requires strictly increasing finite stops. Deduplicate quantiles
+    # server-side because frontend validation cannot repair generated expressions.
+    # Drop non-finite values to keep JSON valid, then resample colours so the
+    # remaining stops span the full ramp.
     breaks = sorted(
         {
             float(b)

--- a/backend/app/processing/ai/chat_styles.py
+++ b/backend/app/processing/ai/chat_styles.py
@@ -189,7 +189,7 @@ async def _build_graduated_style(
         # quantile: use the dynamically-computed quantiles from stats
         breaks = stats.get("quantiles", [])
 
-    # fix(#1778): MapLibre rejects a step expression whose stops are not
+    # MapLibre rejects a step expression whose stops are not
     # strictly ascending, and percentile_cont does not deduplicate, so any
     # clustered column (70% of rows sharing one value, say) yields adjacent
     # equal quantiles. Both frontend siblings guard this for the styles they

--- a/backend/app/processing/ai/schemas.py
+++ b/backend/app/processing/ai/schemas.py
@@ -128,20 +128,11 @@ def _validate_expression(expr: list) -> bool:
         return True
     if op == "match" and len(expr) >= 4:
         return True  # ["match", getter, val1, out1, ..., fallback]
+    # Stop values occupy every other slot starting at index 3.
     if op == "step" and len(expr) >= 4:
-        # Validate stop values are numeric: ["step", getter, default, stop1, out1, ...]
-        # Positions 3, 5, 7... are stop values (must be numeric)
-        for i in range(3, len(expr), 2):
-            if not isinstance(expr[i], (int, float)):
-                return False
-        return True
+        return all(isinstance(expr[i], (int, float)) for i in range(3, len(expr), 2))
     if op == "interpolate" and len(expr) >= 5:
-        # Validate stop values are numeric: ["interpolate", method, getter, stop1, out1, ...]
-        # Positions 3, 5, 7... are stop values (must be numeric)
-        for i in range(3, len(expr), 2):
-            if not isinstance(expr[i], (int, float)):
-                return False
-        return True
+        return all(isinstance(expr[i], (int, float)) for i in range(3, len(expr), 2))
     if op == "case" and len(expr) >= 3:
         return True
     if op in ("literal", "to-string", "to-number", "to-boolean"):
@@ -162,9 +153,7 @@ def _validate_expression(expr: list) -> bool:
         "!has",
     ):
         return True
-    if op in ("concat", "downcase", "upcase", "coalesce"):
-        return True
-    return False
+    return op in ("concat", "downcase", "upcase", "coalesce")
 
 
 def _paint_layer_type_for_geometry(geometry_type: str | None) -> str | None:

--- a/backend/app/processing/ai/schemas.py
+++ b/backend/app/processing/ai/schemas.py
@@ -173,9 +173,9 @@ def _valid_paint_props_for_geometry(
     geometry_type: str | None,
     render_mode: str | None = None,
 ) -> tuple[str | None, set[str]]:
-    # fix(#392): render-mode aware, mirroring frontend validateChatPaint —
-    # a heatmap-rendered layer's dataset_geometry_type is virtually always Point, so
-    # without this the geometry-type filter would strip every heatmap-* property. (audit WR-01)
+    # Render-mode aware, mirroring frontend validateChatPaint —
+    # a heatmap-rendered layer's dataset_geometry_type is virtually always Point.
+    # Without this branch, the geometry-type filter strips every heatmap property.
     if render_mode == "heatmap":
         return "heatmap", _VALID_PAINT_PROPS["heatmap"]
     layer_type = _paint_layer_type_for_geometry(geometry_type)
@@ -211,7 +211,7 @@ def validate_paint_with_feedback(
     Used by the chat service to feed validation feedback back to the LLM.
 
     render_mode: when 'heatmap', geometry-type filtering is skipped so
-    heatmap-* properties are kept instead of dropped (fix(#392)) — mirrors
+    heatmap-* properties are kept instead of dropped — mirrors
     the frontend's validateChatPaint render-mode awareness.
     """
     if not paint or (not geometry_type and render_mode != "heatmap"):
@@ -249,7 +249,7 @@ def validate_paint_property_names_with_feedback(
 ) -> tuple[list[str], list[str]]:
     """Validate paint property names for explicit style-clear actions.
 
-    render_mode: see validate_paint_with_feedback (fix(#392), audit WR-01).
+    render_mode: see validate_paint_with_feedback.
     """
     if not properties or (not geometry_type and render_mode != "heatmap"):
         return [], []
@@ -307,7 +307,7 @@ class LLMMapSpec(BaseModel):
     explanation: str = ""
 
 
-# fix(#1778): bounds on client-supplied chat context. Without them the
+# Bounds on client-supplied chat context. Without them the
 # only limit was DEFAULT_BODY_LIMIT_BYTES (10 MB, ~2.5M tokens), billed
 # to the provider and re-sent on each of up to 8 tool rounds.
 # enforce_ai_token_budget checks usage already recorded before the
@@ -375,7 +375,7 @@ class ChatRequest(BaseModel):
 
     @model_validator(mode="after")
     def _bound_total_payload(self) -> "ChatRequest":
-        # fix(#1778): layer context is free-form (column_info, sample_values),
+        # Layer context is free-form (column_info, sample_values),
         # so the per-field caps above do not bound it. Size the whole prompt
         # payload once instead of guessing a cap per nested field.
         total = _chat_payload_chars(self.message, self.history) + len(
@@ -403,7 +403,7 @@ class DatasetChatRequest(BaseModel):
 
     @model_validator(mode="after")
     def _bound_total_payload(self) -> "DatasetChatRequest":
-        # fix(#1778): same bound as ChatRequest; this route carries no layers.
+        # Same bound as ChatRequest; this route carries no layers.
         if _chat_payload_chars(self.message, self.history) > _MAX_CHAT_PAYLOAD_CHARS:
             raise ValueError(
                 "This chat request is too large. Start a new conversation."
@@ -461,7 +461,7 @@ class ChatAction(BaseModel):
     columns: list[str] | None = None  # for show_query_result (inline data table)
     row_count: int | None = None  # for show_query_result (total matched rows)
     truncated: bool | None = None  # for show_query_result (rows capped for payload)
-    # feat(#675): run_analysis handoff — lets the builder prefill the Analysis
+    # ``run_analysis`` handoff lets the builder prefill the Analysis
     # panel ("Save as dataset") from a chat preview. layer_id above is reused.
     operation: str | None = None  # for show_query_result (analysis operation)
     distance_meters: float | None = None  # for show_query_result (buffer distance)
@@ -533,7 +533,7 @@ class ChatResponse(BaseModel):
     actions: list[ChatAction]
 
 
-# Live provider probe (fix(#627))
+# Live provider probe
 
 
 class AIProbeCheck(BaseModel):

--- a/backend/app/processing/ai/service.py
+++ b/backend/app/processing/ai/service.py
@@ -715,7 +715,6 @@ def _build_tool_executor(
     port: "ProcessingPort",
 ) -> "Callable[[str, dict], Awaitable[dict]]":
     async def tool_executor(tool_name: str, tool_input: dict) -> dict:
-        """Dispatch an AI tool call to the appropriate handler and return the result."""
         if tool_name == "search_datasets":
             return {
                 "results": await _execute_search_tool(
@@ -727,7 +726,7 @@ def _build_tool_executor(
                     port=port,
                 )
             }
-        elif tool_name == "get_dataset_details":
+        if tool_name == "get_dataset_details":
             return await _execute_get_dataset_details(
                 session,
                 user,

--- a/backend/app/processing/ai/service.py
+++ b/backend/app/processing/ai/service.py
@@ -405,9 +405,7 @@ async def _retry_parse_map_spec(
     # no-tools single-round retry case naturally.
     provider_ext = get_ai_provider(provider)
 
-    # A single-round call still spends a round. Same
-    # accounting shape as the tool loops, so the structural gate does not
-    # have to carve out an exception it would then have to justify.
+    # Single-round calls count toward the round budget.
     async with usage_accounting(
         session, user_id=user_id, subsystem="map_generation", model=model
     ):
@@ -469,9 +467,7 @@ async def _repair_map_spec(
     )
     provider_ext = get_ai_provider(provider)
 
-    # A single-round call still spends a round. Same
-    # accounting shape as the tool loops, so the structural gate does not
-    # have to carve out an exception it would then have to justify.
+    # Single-round calls count toward the round budget.
     async with usage_accounting(
         session, user_id=user_id, subsystem="map_generation", model=model
     ):

--- a/backend/app/processing/ai/service.py
+++ b/backend/app/processing/ai/service.py
@@ -222,7 +222,7 @@ def _build_map_system_prompt(
     prompt = SYSTEM_PROMPT.format(basemap_instruction=basemap_instruction)
 
     # This path has no layer block, so a catalog tool result is the only
-    # untrusted text it ever sees. fix(#1778).
+    # untrusted text it ever sees.
     prompt += "\n" + TOOL_RESULT_PROTOCOL
 
     lang = lang_name(language)
@@ -288,7 +288,7 @@ async def _execute_search_tool(
                 sample[k] = v[:5] if isinstance(v, list) else v
             sample = sample or None
 
-        # fix(#1778): search includes other users' PUBLIC datasets, so an
+        # Search includes other users' PUBLIC datasets, so an
         # attacker's text here lands in a victim's model context, where the
         # model holds query_data and every editing tool. Scrub like content.
         results.append(
@@ -361,7 +361,7 @@ async def _execute_get_dataset_details(
             sample[k] = v[:5] if isinstance(v, list) else v
         sample = sample or None
 
-    # fix(#1778): same trust boundary as _execute_search_tool above — this tool
+    # Same trust boundary as _execute_search_tool above — this tool
     # reads any dataset the caller can see, including other users' public ones.
     return {
         "id": str(ds.id),
@@ -405,7 +405,7 @@ async def _retry_parse_map_spec(
     # no-tools single-round retry case naturally.
     provider_ext = get_ai_provider(provider)
 
-    # fix(#1778): a single-round call still spends a round. Same
+    # A single-round call still spends a round. Same
     # accounting shape as the tool loops, so the structural gate does not
     # have to carve out an exception it would then have to justify.
     async with usage_accounting(
@@ -422,7 +422,7 @@ async def _retry_parse_map_spec(
             max_tokens=1024,
             base_url=runtime_config.get("base_url"),
         )
-    # fix(#646, #648): retry/repair rounds spend real tokens -- record them
+    # Retry/repair rounds spend real tokens -- record them
     # or they bypass the daily AI budget.
     await record_token_usage(
         session,
@@ -447,7 +447,7 @@ async def _repair_map_spec(
     session: AsyncSession,
     user_id: uuid.UUID | None,
 ) -> LLMMapSpec:
-    """One repair round for schema-invalid specs (fix(#642)).
+    """Run one repair round for schema-invalid specs.
 
     Parse failures already get _retry_parse_map_spec; this is the sibling
     for valid-JSON-wrong-shape output. Feed the pydantic errors back to the
@@ -469,7 +469,7 @@ async def _repair_map_spec(
     )
     provider_ext = get_ai_provider(provider)
 
-    # fix(#1778): a single-round call still spends a round. Same
+    # A single-round call still spends a round. Same
     # accounting shape as the tool loops, so the structural gate does not
     # have to carve out an exception it would then have to justify.
     async with usage_accounting(
@@ -486,7 +486,7 @@ async def _repair_map_spec(
             max_tokens=1024,
             base_url=runtime_config.get("base_url"),
         )
-    # fix(#648): repair-round tokens must count toward the daily cap.
+    # Repair-round tokens must count toward the daily cap.
     await record_token_usage(
         session,
         user_id=user_id,
@@ -506,7 +506,7 @@ async def _repair_map_spec(
 def _snap_viewport_to_extent(spec: LLMMapSpec, extents: list[object]) -> None:
     """Pull an LLM viewport back to the layer data when it points elsewhere.
 
-    fix(#886): ``merge_bboxes`` folds per-dataset bboxes on the circle, so
+    ``merge_bboxes`` folds per-dataset bboxes on the circle, so
     datasets split across the antimeridian (e.g. Fiji at lon 179/-179) don't
     union to -180..180 and snap the centre to lon 0, a quarter of the planet
     from the data. The margin/centroid arithmetic needs a monotonic width, so
@@ -817,7 +817,7 @@ async def generate_map_from_prompt(
     if "error" in spec_dict:
         raise UserFacingAIError(spec_dict["error"])
 
-    # Validate with pydantic, with one LLM repair round (fix(#642))
+    # Validate with Pydantic, with one LLM repair round.
     try:
         spec = LLMMapSpec(**spec_dict)
     except ValidationError as ve:
@@ -887,7 +887,7 @@ async def stream_generate_map(
             )
             return result
 
-        # fix(#1778): without this, an exhaustion, a timeout or a client
+        # Without this, an exhaustion, a timeout or a client
         # disconnect (which cancels the task) bills the provider round but
         # never reaches catalog.ai_token_usage. Covers all three: timeout
         # counts arrive on __cause__; disconnect arrives as CancelledError,
@@ -916,7 +916,7 @@ async def stream_generate_map(
             output_tokens=result.output_tokens,
         )
 
-        # fix(#402): record BEFORE any post-LLM yield, so a client disconnect
+        # Record BEFORE any post-LLM yield, so a client disconnect
         # during the tool-event replay below can't skip accounting -- the
         # tokens are already spent once provider_ext.complete returns.
         await record_token_usage(
@@ -952,7 +952,7 @@ async def stream_generate_map(
             yield {"type": "error", "message": spec_dict["error"]}
             return
 
-        # fix(#642): one LLM repair round before surfacing a failure
+        # One LLM repair round before surfacing a failure
         try:
             spec = LLMMapSpec(**spec_dict)
         except ValidationError as ve:
@@ -987,7 +987,7 @@ async def stream_generate_map(
             "message": "Map generation timed out. Try a simpler prompt.",
         }
     except Exception as e:  # broad: SSE generator must yield error event for any unhandled SDK/runtime exception
-        # fix(#1778): a SQLAlchemy ProgrammingError carries the statement and
+        # A SQLAlchemy ProgrammingError carries the statement and
         # bound params, an APIStatusError carries the provider response body
         # and URL, and OpenAICredentialDestinationError names the configured
         # endpoint -- str(e) must never reach the browser. The passthrough is

--- a/backend/app/processing/ai/sql_generator.py
+++ b/backend/app/processing/ai/sql_generator.py
@@ -129,7 +129,7 @@ def build_sql_schema_context(
             sample_lines = []
             for col_name, values in list(layer.sample_values.items())[:5]:
                 vals = values[:5] if isinstance(values, list) else [values]
-                # fix(#1778): raw row content reaching the SQL-generation
+                # Raw row content reaching the SQL-generation
                 # prompt. A newline in a sample value would also end this `--`
                 # comment and let the rest of the value read as DDL, which the
                 # control-character strip closes along with the injection seeds.
@@ -156,7 +156,7 @@ def build_sql_user_message(
 ) -> str:
     """Build the per-call (dynamic) user message for the SQL generation call.
 
-    fix(#448): static reference lives in SQL_SYSTEM_PROMPT (cacheable);
+    Static reference lives in SQL_SYSTEM_PROMPT (cacheable);
     everything per-call goes here, so the Anthropic cache_control breakpoint
     sees a stable prefix and query_data avoids a full cache miss (and a
     double-billed question) on every call.
@@ -181,13 +181,13 @@ def build_sql_user_message(
 Respond with ONLY the SQL query (or an -- ERROR comment if the query cannot be generated). No explanation, no markdown, no code fences."""
 
 
-# fix(#935): the prompt must never hand-write a metric buffer. The bare
+# The prompt must never hand-write a metric buffer. The bare
 # ``ST_Buffer(geom::geography, N)::geometry`` form silently degrades past
 # 6 degrees of longitude (world Mercator fallback, error 1/cos(latitude))
 # and corrupts geometry crossing the antimeridian; ``render_geodesic_buffer``
-# fixes both (#883, #900, #902).
+# This covers both schema and prompt changes.
 #
-# fix(#1589): the prompt teaches only a marker, ``geolens_buffer(<geom>,
+# The prompt teaches only a marker, ``geolens_buffer(<geom>,
 # <metres>)``; ``buffer_marker.expand_buffer_markers`` renders the real
 # expression before anything else sees the SQL, so it never drifts from
 # prose. The only import kept from ``analysis_sql`` is
@@ -437,7 +437,7 @@ async def generate_sql(
     """
     provider = await LLM_PROVIDER.get(db)
     model = await LLM_MODEL_LIGHT.get(db)
-    # fix(#448): static reference → system prompt (stable prefix, provider
+    # Static reference → system prompt (stable prefix, provider
     # prompt-cacheable); schema + question → user message (sent once, not
     # twice as before).
     user_message = build_sql_user_message(
@@ -458,7 +458,7 @@ async def generate_sql(
     runtime_config = await provider_ext.resolve_runtime_config(db)
     base_url = runtime_config.get("base_url")
 
-    # fix(#1778): a single-round call still spends a round. Same
+    # A single-round call still spends a round. Same
     # accounting shape as the tool loops, so the structural gate does not
     # have to carve out an exception it would then have to justify.
     async with usage_accounting(db, user_id=user_id, subsystem="sql_gen", model=model):
@@ -498,7 +498,7 @@ async def generate_sql(
     # Strip leaked special tokens from local LLMs (e.g., <|im_start|>, <|im_end|>)
     sql = re.sub(r"<\|[^|]+\|>", "", sql).strip()
 
-    # fix(#1589): the prompt asks for geolens_buffer(<geom>, <metres>); the
+    # The prompt asks for geolens_buffer(<geom>, <metres>); the
     # canonical expression is rendered here, once, for every NL consumer. This
     # is the last point at which the text is still the model's, which is what
     # makes the marker a private protocol between the prompt and the server

--- a/backend/app/processing/ai/sql_generator.py
+++ b/backend/app/processing/ai/sql_generator.py
@@ -84,7 +84,6 @@ def build_sql_schema_context(
     Returns:
         DDL string with all table definitions separated by blank lines.
     """
-    # Check cache
     cache_key = _schema_cache_key(layers, map_id)
     now = time.monotonic()
     cached = _schema_cache.get(cache_key)
@@ -103,7 +102,6 @@ def build_sql_schema_context(
         if len(cols) > _MAX_COLUMNS:
             col_defs.append(f"  -- ... and {len(cols) - _MAX_COLUMNS} more columns")
 
-        # Add geom_4326 column if the layer has geometry
         if layer.geometry_type:
             geom_type_spec = layer.geometry_type
             col_defs.append(f"  geom_4326 geometry({geom_type_spec}, 4326)")
@@ -145,7 +143,6 @@ def build_sql_schema_context(
 
     result = "\n\n".join(parts)
 
-    # Store in cache (evict oldest if full)
     if len(_schema_cache) >= _SCHEMA_CACHE_MAX:
         oldest_key = min(_schema_cache, key=lambda k: _schema_cache[k][0])
         del _schema_cache[oldest_key]

--- a/backend/app/processing/ai/sql_generator.py
+++ b/backend/app/processing/ai/sql_generator.py
@@ -181,18 +181,10 @@ def build_sql_user_message(
 Respond with ONLY the SQL query (or an -- ERROR comment if the query cannot be generated). No explanation, no markdown, no code fences."""
 
 
-# The prompt must never hand-write a metric buffer. The bare
-# ``ST_Buffer(geom::geography, N)::geometry`` form silently degrades past
-# 6 degrees of longitude (world Mercator fallback, error 1/cos(latitude))
-# and corrupts geometry crossing the antimeridian; ``render_geodesic_buffer``
-# This covers both schema and prompt changes.
-#
-# The prompt teaches only a marker, ``geolens_buffer(<geom>,
-# <metres>)``; ``buffer_marker.expand_buffer_markers`` renders the real
-# expression before anything else sees the SQL, so it never drifts from
-# prose. The only import kept from ``analysis_sql`` is
-# ``MAX_BUFFER_METERS``, so the ceiling the prompt quotes is the one the
-# expander enforces.
+# Teach the geolens_buffer marker rather than raw geography buffers, whose
+# projection fallback can distort wide or antimeridian-spanning geometries.
+# expand_buffer_markers uses the canonical renderer; MAX_BUFFER_METERS keeps
+# the prompt's advertised limit aligned with the expander's enforced limit.
 _MAX_BUFFER_METERS_TEXT = f"{MAX_BUFFER_METERS:.0f}"
 
 SQL_SYSTEM_PROMPT = f"""\
@@ -437,9 +429,8 @@ async def generate_sql(
     """
     provider = await LLM_PROVIDER.get(db)
     model = await LLM_MODEL_LIGHT.get(db)
-    # Static reference → system prompt (stable prefix, provider
-    # prompt-cacheable); schema + question → user message (sent once, not
-    # twice as before).
+    # Keep static reference in the cacheable system prompt; send the schema
+    # and question once in the per-call user message.
     user_message = build_sql_user_message(
         question, schema_context, layer_descriptions=layer_descriptions
     )
@@ -458,9 +449,7 @@ async def generate_sql(
     runtime_config = await provider_ext.resolve_runtime_config(db)
     base_url = runtime_config.get("base_url")
 
-    # A single-round call still spends a round. Same
-    # accounting shape as the tool loops, so the structural gate does not
-    # have to carve out an exception it would then have to justify.
+    # Single-round calls count toward the round budget.
     async with usage_accounting(db, user_id=user_id, subsystem="sql_gen", model=model):
         result = await provider_ext.complete(
             model=model,

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -57,18 +57,11 @@ _SERVICE_IMPORT_INITIAL_PROGRESS = 0.1
 _SERVICE_IMPORT_HEARTBEAT_INTERVAL_SECONDS = 5.0
 _SERVICE_IMPORT_HEARTBEAT_INCREMENT = 0.05
 _SERVICE_IMPORT_HEARTBEAT_MAX_PROGRESS = 0.65
-# fix(#1778): the PRIMARY bound on one heartbeat tick's own DB wait, set as
-# `SET LOCAL lock_timeout`/`statement_timeout` on the tick's own transaction
-# (see _service_import_heartbeat_tick) so a blocked commit fails inside the
-# database and releases the connection, instead of leaving it checked out
-# and exhausting the pool under repeated stalls.
+# Bound each heartbeat transaction inside PostgreSQL so a blocked commit
+# releases its connection instead of exhausting the pool.
 _SERVICE_IMPORT_HEARTBEAT_TICK_DB_TIMEOUT_SECONDS = 3.0
-# fix(#1778): a SAFETY NET above the DB timeout above,
-# not the primary mechanism -- see _heartbeat_service_import_progress. Covers
-# only what a DB-side timeout cannot: a connection stuck before it ever
-# reaches Postgres (e.g. a network partition), where `SET LOCAL` never runs.
-# Comfortably above the DB timeout's own worst case (lock_timeout wait, then
-# statement_timeout once granted) so it should not fire in the common case.
+# This outer timeout covers failures before PostgreSQL can apply its limits,
+# such as a connection stalled by a network partition.
 _SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS = 10.0
 _ARCGIS_SERVICE_IMPORT_CHUNK_SIZE = 2000
 
@@ -130,10 +123,10 @@ async def _service_import_heartbeat_tick(
     Returns ``False`` when the caller's loop must stop (job vanished, or
     moved off the step this heartbeat belongs to), ``True`` otherwise. Split
     out of ``_heartbeat_service_import_progress`` so that function can
-    ``shield`` the whole tick from cancellation (fix(#1778)) — see its
+    ``shield`` the whole tick from cancellation — see its
     docstring.
 
-    fix(#1778): passes ``lock_timeout``/``statement_timeout`` INTO
+    Passes ``lock_timeout``/``statement_timeout`` INTO
     ``_job_phase_session`` (``lock_and_statement_timeout_ms``) rather than
     setting them after entering it, so they also cover the SELECT the
     helper runs internally — a SELECT can itself stall behind a lock the
@@ -142,7 +135,7 @@ async def _service_import_heartbeat_tick(
     releases the connection normally rather than leaving the caller to
     choose between waiting forever or abandoning it.
 
-    fix(#1778): the earlier SELECT is a snapshot, not a lock. If this
+    The earlier SELECT is a snapshot, not a lock. If this
     tick's own connection then stalls for a reason the DB timeout doesn't
     catch (e.g. before it reaches Postgres) past the caller's cancellation
     drain, the caller moves on while this shielded tick keeps running in
@@ -209,7 +202,7 @@ async def _heartbeat_service_import_progress(
 ) -> None:
     """Advance service-ingest progress while GDAL loads remote features.
 
-    fix(#1778): each tick runs under ``asyncio.shield`` so the caller's
+    Each tick runs under ``asyncio.shield`` so the caller's
     ``.cancel()`` can only land at the ``asyncio.sleep`` below, never
     mid-connect/write/close on the tick's own session. Without this, a
     cancel landing inside asyncpg's connection teardown left the
@@ -217,7 +210,7 @@ async def _heartbeat_service_import_progress(
     work as ``ConnectionError: unexpected connection_lost() call``.
     Shielding costs at most one tick's worth of extra shutdown latency.
 
-    fix(#1778): the ``_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS``
+    The ``_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS``
     drain that lets a shielded tick finish is a SAFETY NET, not the
     primary bound — that's the tick's own DB-side ``lock_timeout``/
     ``statement_timeout`` (see ``_service_import_heartbeat_tick``), which
@@ -237,13 +230,8 @@ async def _heartbeat_service_import_progress(
             try:
                 keep_going = await asyncio.shield(tick)
             except asyncio.CancelledError:
-                # The OUTER await was cancelled, not necessarily `tick` — let
-                # its already-open connection finish and close cleanly before
-                # this coroutine ends, but only for a bounded time (fix(#1778
-                # codex r2)): `asyncio.shield` here means a timeout below only
-                # stops WAITING for `tick`, it does not cancel it, so a tick
-                # stuck on something with no timeout of its own still gets to
-                # finish and close its own connection in the background.
+                # Give an already-open tick bounded time to close its connection.
+                # Shielding stops this wait without cancelling the tick itself.
                 if not tick.done():
                     try:
                         await asyncio.wait_for(
@@ -251,12 +239,8 @@ async def _heartbeat_service_import_progress(
                             timeout=_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS,
                         )
                     except asyncio.TimeoutError:
-                        # Expected to be rare after fix(#1778): the
-                        # tick's own DB-level timeout should have already
-                        # resolved it well within this window. Reaching this
-                        # means something OUTSIDE the database's own timeout
-                        # handling is stuck (e.g. the connection never reached
-                        # Postgres at all).
+                        # The database timeout did not engage, usually because
+                        # the connection never reached PostgreSQL.
                         structlog.get_logger().warning(
                             "service_import_heartbeat_drain_timed_out",
                             job_id=str(job_uuid),
@@ -375,10 +359,10 @@ def _should_unlink_staging(
       - Per-child S3 download (``file_path != original_file_path``): a private
         copy resolved by ``resolve_file_path`` as ``{job_id}_{name}``. No
         sibling shares it, so it is always safe to unlink — including for
-        fan-out children (GAP-018) and on failure (S3 is the source of truth).
+        fan-out children and on failure because S3 is the source of truth.
       - Shared local-staging file (``file_path == original_file_path``) of a
         fan-out child: NEVER unlink — siblings read the same file; the staging
-        retention policy reaps it later (GPKG-03 close-gate fix).
+        retention policy reaps it later.
       - Shared local-staging file of a non-fan-out job: unlink only on success;
         keep on failure so a retry can re-read it.
     """
@@ -412,13 +396,13 @@ async def ingest_file(
     8. Update job status to complete
     9. Clean up staging file
 
-    Session lifecycle (gh #100): the AsyncSession is split into two short-lived
+    The AsyncSession is split into two short-lived
     blocks so it is NOT held open across the long-running ``run_ogr2ogr``
     asyncio subprocess. Holding a session open across that subprocess in
     Python 3.14 + SQLAlchemy 2.0 + greenlet 3.3 corrupts the greenlet bridge
     state and the next ``session.execute()`` (e.g. ``clip_to_mercator_bounds``
     when it actually modifies rows) raises ``MissingGreenlet``. See
-    ``.planning/debug/worker-missing-greenlet-100.md`` for the full diagnosis.
+    the next database operation raises ``MissingGreenlet``.
     """
     _bind_task_log_context(task_name="ingest_file", job_id=job_id)
     from app.processing.ingest.ogr import build_pg_conn_str, run_ogr2ogr, run_ogrinfo
@@ -437,11 +421,11 @@ async def ingest_file(
 
     try:
         # ----------------------------------------------------------------- #
-        # Phase 1 (short-lived session via _job_phase_session — REMED-03 /
-        # P2-05): load job, mark running, validate, detect CRS, generate
+        # Phase 1 uses a short-lived session to load the job, mark it running,
+        # validate it, detect CRS, and generate the
         # table name. Snapshot values needed for phase 2 into local
         # variables so the ogr2ogr subprocess can run without a session
-        # held open (#100 greenlet rule lives in the helper docstring).
+        # held open.
         # ----------------------------------------------------------------- #
         async with _job_phase_session(
             job_uuid, phase="phase1", attempt_id=attempt_uuid
@@ -449,8 +433,7 @@ async def ingest_file(
             if job is None:
                 return
 
-            # 1. Update job to running (the fresh "validating" stamp rides the
-            # same commit — REMED-02 / ingest-audit P2-07, see the helper).
+            # Update the job and its validating step in the same commit.
             heartbeat_task = await claim_job_attempt_and_start_heartbeat(
                 session, job_uuid, attempt_uuid, job=job, current_step="validating"
             )
@@ -462,7 +445,7 @@ async def ingest_file(
 
             file_path = await resolve_file_path(file_path, job_id)
 
-            # Validate file content and safety before ogr2ogr (KISS-3).
+            # Validate file content and safety before ogr2ogr.
             try:
                 await _validate_upload_file_safety(
                     session,
@@ -481,7 +464,7 @@ async def ingest_file(
                     },
                 )
                 await session.commit()
-                # fix(#1778): NO unlink here (fix(#1290)'s raster-tail
+                # NO unlink here ('s raster-tail
                 # correction hadn't reached this copy). Unconditional delete
                 # destroyed a local-storage install's only copy of a file
                 # that then failed validation, leaving nothing to retry.
@@ -552,13 +535,13 @@ async def ingest_file(
         # ogr2ogr subprocess — NO session open. ogr2ogr writes to PostgreSQL
         # via its own libpq connection (db_conn_str), independent of the
         # SQLAlchemy session. Holding a session open across this subprocess
-        # is what triggers the MissingGreenlet bug (gh #100).
+        # can corrupt SQLAlchemy's greenlet bridge.
         # ----------------------------------------------------------------- #
         db_conn_str = build_pg_conn_str()
 
         # Check for user-specified geometry columns (override)
         # Lowercase column names: ogr2ogr lowercases them in PostGIS.
-        # CLEANUP-2: the individual column locals are re-derived inside
+        # The individual column values are re-derived inside
         # ``_detect_and_override_geometry`` from ``um``, so we only need
         # the boolean here to gate the import-as-non-spatial branch.
         user_wants_geom = bool(
@@ -575,10 +558,9 @@ async def ingest_file(
             srid_override=srid_override,
         )
 
-        # REMED-02 / ingest-audit P2-07: write current_step="ogr2ogr" BEFORE
-        # the long subprocess so the UI sees the transition even if ogr2ogr
-        # hangs. Brief-session pattern via _job_phase_session — the #100
-        # greenlet rule forbids holding a session open across run_ogr2ogr,
+        # Write current_step="ogr2ogr" before the long subprocess so the UI
+        # sees the transition even if ogr2ogr hangs. A brief session avoids
+        # holding a session open across run_ogr2ogr,
         # but the progress write must commit so it cannot be lost on
         # rollback if ogr2ogr raises.
         async with _job_phase_session(
@@ -604,24 +586,12 @@ async def ingest_file(
             original_filename=source_filename,
         )
 
-        # Determine the stored source format. A zip is a Shapefile bundle
-        # unless it holds a .gdb, and .kmz collapses to kml — see
-        # ingest/source_format.py for both. Resolved out here, not inside the
-        # phase-2 session, because the zip case reads the archive's central
-        # directory: same placement as the reupload path, which computes it
-        # right after its own file hash for the same reason.
+        # Resolve archive formats before phase 2 because ZIP inspection reads
+        # the central directory.
         source_format = await asyncio.to_thread(derive_source_format, file_path)
 
-        # Phase 2 (short-lived session via _job_phase_session — REMED-03/
-        # P2-05): post-ogr2ogr finalization, reloading the job fresh (its
-        # attributes were already snapshotted into ``um``/``source_filename``/
-        # ``layer_name`` above).
-        #
-        # fix(#1778): require_status="running" stops a paused (not dead)
-        # worker at the door before it wastefully runs the whole finalize
-        # pipeline against a row the sweep already failed — even though
-        # vector ingest writes no untracked storage a rollback can't undo,
-        # unlike the raster tails' phase 2 this mirrors.
+        # Finalize in a fresh session using the snapshotted job attributes.
+        # Requiring running status fences out attempts already failed by a sweep.
         async with _job_phase_session(
             job_uuid,
             phase="phase2",
@@ -631,14 +601,8 @@ async def ingest_file(
             if job is None:
                 return
 
-            # REMED-02/P2-07: progress signal, intentionally NOT committed
-            # here — it rides the same transaction as _finalize_ingest's
-            # terminal commit, so a rollback cleans it up too. The
-            # brief-session "ogr2ogr" write above is the durable checkpoint.
-            #
-            # REMED-03/P2-05: _job_phase_session owns rollback-on-exception;
-            # a raise here rolls back and re-raises for the outer
-            # `except Exception` handler to record via a fresh session.
+            # This progress signal shares the finalization transaction; the
+            # earlier ogr2ogr write is the durable checkpoint.
             job.current_step = "finalize"
             job.progress = 0.7
 
@@ -724,13 +688,13 @@ async def ingest_file(
                     original_srid=srid,
                     user_metadata=um,
                     attempt_id=attempt_uuid,
-                    # feat(#1218): no file_hash — it is computed on the
+                    # No file_hash — it is computed on the
                     # re-upload path only, and the allowlist omits absent keys.
                     origin_ref={"filename": source_filename},
                 )
             )
 
-            # 9c. Archive original file to storage provider (R-2).
+            # Archive the original file to the storage provider.
             await _archive_original_file(
                 session,
                 job=job,
@@ -738,11 +702,8 @@ async def ingest_file(
                 file_path=file_path,
             )
 
-            # METER-01 (Phase 1213-02): emit ingest billable event through the
-            # billing-import-free seam.  Best-effort fire-and-forget — errors
-            # logged inside _emit_billing_event; ingest outcome unaffected.
-            # tenant_id from current_tenant_var (set by 1208/1209 middleware).
-            # event_id = job_id so task retries stay idempotent at the DB layer.
+            # Billing is best-effort through the extension seam. Using job_id as
+            # event_id keeps task retries idempotent.
             from app.core.db.tenant_session import current_tenant_var
 
             await _emit_billing_event(
@@ -756,15 +717,8 @@ async def ingest_file(
     except (
         Exception
     ) as exc:  # broad: pipeline spans GDAL/PostGIS/S3/FS — any step can fail
-        # Write failure status via a fresh session — phase 1/2 sessions are
-        # already closed (or rolled back) by now. fix(#1778): routes through
-        # the shared `_cleanup_staging_on_failure` (see its docstring),
-        # which this tail previously pasted a narrower copy of, silently
-        # missing the `ingest_failed` notification.
-        #
-        # Mutates the ORM row it is given, so a NULL job (race with a row
-        # delete) skips it — no row left to fail — and the re-raise below
-        # still records the failure on the queue row.
+        # Record failure in a fresh session and emit the shared notification.
+        # A concurrently deleted job has no row left to update.
         try:
             async with _job_phase_session(
                 job_uuid,
@@ -791,14 +745,14 @@ async def ingest_file(
                         task="ingest_file",
                     )
         except DBAPIError as write_failure:
-            # fix(#1950): the budget covers the helper's own load, so
+            # The budget covers the helper's own load, so
             # an expiry there arrives here. Swallowed for the reason the helper
             # swallows its UPDATE's: the cause below is the task's outcome.
             log_job_error_write_failure(
                 write_failure, job_id=job_id, task="ingest_file"
             )
         finally:
-            # fix(#1213): the `finally` reapers gate on THIS
+            # The `finally` reapers gate on THIS
             # variable, so every exit from this handler sets it — the bounded
             # error write above can raise past a positional assignment.
             final_status = "failed"
@@ -811,15 +765,15 @@ async def ingest_file(
         # Local-file cleanup decision: see `_should_unlink_staging`'s
         # docstring for the three cases.
         #
-        # fix(#430): default TRUE (treat unknown as fan-out child) so a
+        # Default TRUE (treat unknown as fan-out child) so a
         # failed/absent lookup SKIPS destructive cleanup — deleting the
         # shared S3 staging original on a misdetected child would break
         # every sibling (retry=0). Cost: an orphan the retention policy reaps.
         is_fan_out_child = True
-        # fix(#1202): the presigned staging key, swept below.
+        # The presigned staging key, swept below.
         owned_staging_key: str | None = None
         try:
-            # REMED-03 / P2-05: route through _job_phase_session. The helper
+            # Route through _job_phase_session. The helper
             # yields the IngestJob row directly, so we just check user_metadata.
             async with _job_phase_session(
                 job_uuid, phase="cleanup_check", attempt_id=attempt_uuid
@@ -848,7 +802,7 @@ async def ingest_file(
             ):
                 Path(file_path).unlink(missing_ok=True)
 
-        # fix(#1213): shared with the reupload tail — after a
+        # Shared with the reupload tail — after a
         # presigned completion this reaps the FROZEN copy the job is bound to.
         async with cleanup_step("ingest_file downloaded source", job_id=job_id):
             await reap_downloaded_staging_source(
@@ -862,7 +816,7 @@ async def ingest_file(
                 is_fan_out_child=is_fan_out_child,
             )
 
-        # fix(#1202): sweep the presigned staging key too. The block
+        # Sweep the presigned staging key too. The block
         # above only reaps `original_file_path`, which after a presigned
         # completion is the FROZEN copy — so the key the client still holds a
         # PUT URL for was never touched. Shared with the raster tail so the
@@ -876,7 +830,7 @@ async def ingest_file(
 @task_app.task(
     queue="ingest",
     retry=0,
-    # fix(#1746): the context is how the task learns its own queue-row id, so
+    # The context is how the task learns its own queue-row id, so
     # a terminal failure can strip the raw token out of its own kwargs.
     pass_context=True,
     aliases=["app.ingest.tasks.ingest_service"],
@@ -895,8 +849,7 @@ async def ingest_service(
 ) -> None:
     """Background task: import a remote service layer via ogr2ogr.
 
-    feat(#1676): ``credential_ref`` is a one-use reference redeemed exactly
-    once below (same channel the refresh door has used since #1220);
+    ``credential_ref`` is a one-use reference redeemed exactly once below;
     ``token`` is the durable task argument, produced only when no shared
     credential store is configured. At most one is ever set — see
     ``resolve_worker_credential``/``resolve_dispatch_credential``.
@@ -906,7 +859,7 @@ async def ingest_service(
     metadata, samples); create Dataset record; compute quality score;
     update job to complete.
 
-    Session lifecycle (gh #100): same two-phase split as ``ingest_file`` —
+    The session uses the same two-phase split as ``ingest_file`` —
     closed before the ogr2ogr subprocess runs, reopened for finalization,
     so the SQLAlchemy greenlet bridge never has to survive across it.
     """
@@ -920,7 +873,7 @@ async def ingest_service(
     from app.processing.ingest.service import generate_table_name
     from app.platform.refresh.credentials import resolve_worker_credential
 
-    # IA-P0-03 defense-in-depth: revalidate source_url at fetch time.
+    # Revalidate source_url at fetch time as defense in depth.
     # The route-level check at commit_import covers the preview→commit
     # TOCTOU, but manifest-path jobs skip that route entirely. This
     # second check ensures all service-URL fetches see fresh DNS.
@@ -942,20 +895,16 @@ async def ingest_service(
     heartbeat_task: asyncio.Task[None] | None = None
 
     try:
-        # ----------------------------------------------------------------- #
-        # Phase 1 (short-lived session via _job_phase_session — REMED-03 /
-        # P2-05): load job, mark running, generate table name. Snapshot all
-        # values needed for phase 2.
-        # ----------------------------------------------------------------- #
+        # Phase 1 uses a short-lived session to load the job, mark it running,
+        # generate the table name, and snapshot values needed for phase 2.
         async with _job_phase_session(
             job_uuid, phase="phase1", attempt_id=attempt_uuid
         ) as (session, job):
             if job is None:
                 return
 
-            # 1. Update job to running.
-            # REMED-02 / ingest-audit P2-07: mirror ingest_file's progress
-            # writes so the polling UI shows step transitions for service
+            # Mirror ingest_file's progress writes so the polling UI shows
+            # step transitions for service
             # ingests too. The service path has the same step boundaries as
             # the file path (validating -> ogr2ogr -> finalize -> complete)
             # except there is no "archiving" — services don't archive originals.
@@ -994,7 +943,7 @@ async def ingest_service(
                 }
                 await session.commit()
 
-        # feat(#1676): redeem the one-use credential AFTER phase 1, not
+        # Redeem the one-use credential AFTER phase 1, not
         # before — a single-use secret must only be spent on an attempt
         # that's really going to run (phase 1's `claim_job_attempt_and_
         # start_heartbeat` returns None for a superseded one), and the
@@ -1008,9 +957,8 @@ async def ingest_service(
         # ogr2ogr subprocess — NO session open (would trigger MissingGreenlet).
         db_conn_str = build_pg_conn_str()
 
-        # REMED-02 / ingest-audit P2-07: stamp current_step="ogr2ogr" before
-        # the long remote-service fetch (same brief-session pattern as
-        # ingest_file). Routed through _job_phase_session per REMED-03.
+        # Stamp current_step="ogr2ogr" before the long remote-service fetch,
+        # using the same brief-session pattern as ingest_file.
         async with _job_phase_session(
             job_uuid, phase="progress_write_ogr2ogr", attempt_id=attempt_uuid
         ) as (
@@ -1022,7 +970,7 @@ async def ingest_service(
                 _progress_job.progress = _SERVICE_IMPORT_INITIAL_PROGRESS
                 await _progress_session.commit()
 
-        # WFS namespace retry via shared helper (KISS-8).
+        # Retry WFS namespaces through the shared helper.
         async def _do_import(layer_name: str) -> None:
             feature_count = None
             page_size = _ARCGIS_SERVICE_IMPORT_CHUNK_SIZE
@@ -1045,9 +993,8 @@ async def ingest_service(
                 and feature_count is not None
                 and feature_count > page_size
             ):
-                # fix(#1675): the guarded loop moved to tasks_common so the
-                # refresh executor pages the same way; per-page progress
-                # publishing stays an import-path concern via on_page.
+                # The shared guarded loop also serves refreshes; this import
+                # supplies its per-page progress callback.
                 async def _publish_page_progress(
                     imported_rows: int, total: int
                 ) -> None:
@@ -1112,9 +1059,7 @@ async def ingest_service(
                 with suppress(asyncio.CancelledError):
                     await service_progress_task
 
-        # Phase 2 (short-lived session): post-ogr2ogr finalization.
-        # fix(#1778): require_status="running", same reasoning as the
-        # sibling in ingest_file above.
+        # Requiring running status fences finalization against a failed attempt.
         async with _job_phase_session(
             job_uuid,
             phase="phase2",
@@ -1124,11 +1069,7 @@ async def ingest_service(
             if job is None:
                 return
 
-            # REMED-02 / ingest-audit P2-07: mirror ingest_file's phase-2
-            # progress write. Uncommitted — _finalize_ingest's terminal
-            # commit owns the transaction lifecycle.
-            # REMED-03 / P2-05: helper owns the rollback-on-exception shape
-            # that used to live as a manual try/except around this block.
+            # Finalization owns the transaction, including this progress write.
             job.current_step = "finalize"
             job.progress = 0.7
 
@@ -1171,16 +1112,9 @@ async def ingest_service(
                     user_metadata=um,
                     source_url=dataset_source_url,
                     attempt_id=attempt_uuid,
-                    # feat(#1218): base URL and layer identifier stay
-                    # separate so a refresh can re-address the layer without
-                    # re-parsing the URI (no token: per-call, transient).
-                    #
-                    # fix(#1218): `layer_id` here is whichever field
-                    # `build_gdal_source` treats as authoritative per service
-                    # type — layer_id for ArcGIS, layer NAME for WFS/OGC API
-                    # (the other is ignored). Storing only the numeric id
-                    # left WFS/OGC refs unable to name the layer once the
-                    # ingest job aged out.
+                    # Keep the base URL and service-specific layer identifier
+                    # separate so refresh can reconstruct the source after the
+                    # ingest job expires.
                     origin_ref={
                         "service_type": source_format,
                         "url": source_url,
@@ -1189,20 +1123,15 @@ async def ingest_service(
                             layer_id=layer_id,
                             layer_name=source_layer,
                         ),
-                        # fix(#1746): means "the last pull was MADE with a
-                        # token", not "the origin demanded one" — a public
-                        # service imported while holding a token is marked
-                        # too. So the refresh door treats it as a GATE, not
-                        # a verdict: it runs one token-less probe before
-                        # refusing. True or absent, never False —
-                        # `build_origin_ref` drops None, so an
-                        # unauthenticated pull needs no backfill.
+                        # This records token use, not proof that the origin
+                        # requires authentication; refresh probes without a
+                        # token before refusing.
                         "auth_required": True if token else None,
                     },
                 )
             )
 
-            # METER-01 (Phase 1213-02): emit ingest billable event.
+            # Emit ingest billable event.
             from app.core.db.tenant_session import current_tenant_var
 
             await _emit_billing_event(
@@ -1212,18 +1141,12 @@ async def ingest_service(
             )
 
     except Exception as exc:  # broad: PostGIS/DB ingest can fail at any step; mark job failed and re-raise
-        # feat(#1676): this task now HOLDS the claimed secret as a value, so it
-        # gets the same exact-value scrub `reupload_service` does, covering
-        # the token this attempt holds in whatever shape an origin echoes it
-        # back (the pattern-based layers only catch a token nobody holds).
-        # Mutated in place so the class survives the bare re-raise.
+        # Scrub the exact claimed token from any echoed error; pattern-based
+        # redaction cannot recognize arbitrary secret values. Mutate in place
+        # so the exception class survives the bare re-raise.
         scrub_secret_from_exception(exc, token)
-        # Write failure status via a fresh session — phase 1/2 sessions are
-        # already closed (or rolled back) by now. fix(#1778): routes through
-        # the same shared helper `reupload_service` uses (see `ingest_file`'s
-        # handler); the exact-value scrub above runs FIRST, so the helper's
-        # pattern-based redaction layers onto an exception that no longer
-        # carries this attempt's token in any shape.
+        # Record failure in a fresh session after exact-value scrubbing; the
+        # shared helper adds pattern-based redaction and notification handling.
         try:
             async with _job_phase_session(
                 job_uuid,
@@ -1250,7 +1173,7 @@ async def ingest_service(
                         task="ingest_service",
                     )
         except DBAPIError as write_failure:
-            # fix(#1950): the budget covers the helper's own load, so
+            # The budget covers the helper's own load, so
             # an expiry there arrives here. Swallowed for the reason the helper
             # swallows its UPDATE's: the cause below is the task's outcome.
             log_job_error_write_failure(
@@ -1258,7 +1181,7 @@ async def ingest_service(
             )
         raise
     finally:
-        # fix(#1755): `purge_token_on_failure` (`tasks_common.py`), the
+        # `purge_token_on_failure` (`tasks_common.py`), the
         # decorator around this task, must still see whatever exception
         # `ingest_service` itself raised, not one from a cleanup step.
         async with cleanup_step("ingest_service heartbeat", job_id=job_id):

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -317,19 +317,6 @@ async def _write_service_import_progress(
         await session.commit()
 
 
-async def _count_service_import_rows(table_name: str) -> int:
-    from app.core import db as db_module
-
-    async with db_module.async_session() as session:
-        result = await session.execute(
-            text(
-                f"SELECT COUNT(*) FROM "
-                f"{_qtable(table_name, schema=_current_tenant_schema())}"
-            )
-        )
-        return int(result.scalar_one())
-
-
 async def _fetch_arcgis_import_page_info(
     source_url: str, layer_id: int | str | None, token: str | None
 ) -> tuple[int | None, int | None, bool, str | None]:

--- a/backend/app/processing/ingest/tasks_vector.py
+++ b/backend/app/processing/ingest/tasks_vector.py
@@ -396,13 +396,8 @@ async def ingest_file(
     8. Update job status to complete
     9. Clean up staging file
 
-    The AsyncSession is split into two short-lived
-    blocks so it is NOT held open across the long-running ``run_ogr2ogr``
-    asyncio subprocess. Holding a session open across that subprocess in
-    Python 3.14 + SQLAlchemy 2.0 + greenlet 3.3 corrupts the greenlet bridge
-    state and the next ``session.execute()`` (e.g. ``clip_to_mercator_bounds``
-    when it actually modifies rows) raises ``MissingGreenlet``. See
-    the next database operation raises ``MissingGreenlet``.
+    Keep sessions closed during ``run_ogr2ogr``: holding one across the
+    subprocess can leave the next database operation raising ``MissingGreenlet``.
     """
     _bind_task_log_context(task_name="ingest_file", job_id=job_id)
     from app.processing.ingest.ogr import build_pg_conn_str, run_ogr2ogr, run_ogrinfo
@@ -464,14 +459,8 @@ async def ingest_file(
                     },
                 )
                 await session.commit()
-                # NO unlink here ('s raster-tail
-                # correction hadn't reached this copy). Unconditional delete
-                # destroyed a local-storage install's only copy of a file
-                # that then failed validation, leaving nothing to retry.
-                # `_should_unlink_staging` in the terminal `finally` already
-                # knows the right distinction and runs on this return, so
-                # let ONE exit decide rather than teach a second one the
-                # same rule.
+                # Let final cleanup distinguish staging from the only managed
+                # copy, which must survive validation failure for a retry.
                 final_status = "failed"
                 return
 

--- a/backend/app/processing/vector/quicklook.py
+++ b/backend/app/processing/vector/quicklook.py
@@ -90,16 +90,15 @@ def _draw_geometry(
             _draw_geometry(draw, sub, bounds, size, point_radius)
 
 
-def _compute_point_radius(num_points: int, size: int) -> float:
+def _compute_point_radius(num_points: int) -> float:
     """Scale point radius based on density. More points = smaller dots."""
     if num_points <= 50:
         return 6.0
-    elif num_points <= 200:
+    if num_points <= 200:
         return 4.5
-    elif num_points <= 1000:
+    if num_points <= 1000:
         return 3.0
-    else:
-        return 2.0
+    return 2.0
 
 
 def _blank_canvas(size: int) -> bytes:
@@ -229,7 +228,6 @@ def _render_quicklook_png(
     it via ``asyncio.to_thread``. Output bytes are identical to the
     prior inline implementation.
     """
-    # Parse geometries
     geometries = []
     num_points = 0
     for raw in geojson_strings:
@@ -253,7 +251,7 @@ def _render_quicklook_png(
     canvas = Image.new("RGB", (size, size), _BG_COLOR)
     draw = ImageDraw.Draw(canvas)
 
-    point_radius = _compute_point_radius(num_points, size)
+    point_radius = _compute_point_radius(num_points)
     for geom in geometries:
         _draw_geometry(draw, geom, view_bounds, size, point_radius)
 

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -540,13 +540,8 @@ async def get_collection_queryables(
     )
 
 
-# CQL2 compile is synchronous, event-loop-blocking work, and
-# the filter is the one input letting an anonymous caller choose how
-# much of it to buy. The single-pass rename in filtering.py cut the
-# pathological case from 2.4s to 40ms, but shapes under the bind cap
-# still reach hundreds of binds — the rename bounds cost per request,
-# this bounds rate. 10/second sits far above any interactive client
-# (QGIS/pygeoapi paging) and far below what keeps the loop busy.
+# CQL2 compilation blocks the event loop. Bind caps bound each request;
+# rate limiting bounds repeated work from anonymous callers.
 _FILTERED_ITEMS_RATE_LIMIT = "10/second"
 
 
@@ -706,12 +701,8 @@ async def get_collection_items(
     _validate_f_param(f)
     public_api_url = await get_public_api_url(db, request=request)
 
-    # The page-size ceiling is an admin-configurable PersistentConfig value,
-    # not a static Query(le=...). Per OGC
-    # API Features Core /req/core/fc-limit-response-1(C) a limit above the
-    # maximum SHALL NOT error — clamp to the ceiling instead (mirrors the STAC
-    # sibling STAC endpoint. max(1, ...) guards a ceiling mis-set to 0; the clamped value
-    # flows into the feature query and the echoed self/next links.
+    # OGC Features Core requires over-limit requests to clamp, not fail.
+    # Floor the configured ceiling at one; query and pagination links use this limit.
     max_page_size = await OGC_ITEMS_MAX_PAGE_SIZE.get(db)
     limit = min(limit, max(1, max_page_size))
 
@@ -834,11 +825,8 @@ async def get_collection_items(
         cql2_where, cql2_binds = compile_feature_cql2_ast(filter_ast, queryables)
 
     try:
-        # A full page must be distinguishable from a full
-        # *final* page, or a feature count that is an exact multiple of `limit`
-        # emits a phantom keyset `next` to an empty page.
-        # the over-fetch that answers it moved into get_features, which reports
-        # it as `has_more`, so every caller gets the same answer.
+        # Use get_features.has_more, determined by over-fetching, so a full final
+        # page does not advertise a next link to an empty page.
         page = await get_features(
             db,
             dataset.table_name,
@@ -862,16 +850,8 @@ async def get_collection_items(
             detail=str(exc),
         )
     except DBAPIError as exc:
-        # /with a filter or property-filter active,
-        # a type-shaped DB error is the filter itself (e.g. incomparable
-        # types pre-validation let through) — report as the caller's 400,
-        # never an unhandled 500 (QA finding B3). Only type/data SQLSTATEs
-        # count: class 22, 42xxx operator/cast, client-side bind
-        # DataErrors; everything else keeps the retryable 503.
-        # Classification lives in `is_caller_type_fault` (shared with the
-        # native features list); catch widened to DBAPIError since
-        # asyncpg reports an unencodable value as bare DBAPIError with
-        # SQLSTATE 22000, matching no narrower subclass.
+        # Filter type faults are caller errors; operational failures remain
+        # retryable. DBAPIError also covers asyncpg bind errors with no narrower subclass.
         caller_predicate = cql2_where is not None or bool(property_filters)
         if caller_predicate and is_caller_type_fault(exc):
             source = "CQL2 filter" if cql2_where is not None else "Property filter"
@@ -905,11 +885,8 @@ async def get_collection_items(
         active_params["bbox"] = bbox
     if datetime_param:
         active_params["datetime"] = datetime_param
-    # `include_geometry` is excluded from property_filters (it is
-    # listed in ogc_reserved) and was never added here either, so a client
-    # that opted out of geometry on page 1 got it back on page 2 via the
-    # rel=next link this block builds, and the self link stopped describing
-    # the request that produced the response.
+    # Preserve include_geometry in self and pagination links; it is excluded
+    # from property_filters because it controls the response shape.
     if not include_geometry:
         active_params["include_geometry"] = "false"
     if filter_expr is not None:

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -59,7 +59,7 @@ logger = structlog.stdlib.get_logger(__name__)
 
 _CRS84_URI = "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
 
-# fix(#1614): every route that runs _check_cold_rehydrate can answer 202
+# Every route that runs _check_cold_rehydrate can answer 202
 # {status: 'warming', job_id} in multi-tenant mode; declaring it keeps
 # generated SDK clients from discarding the body or raising UnexpectedStatus.
 COLD_WARMING_RESPONSE: dict = {
@@ -83,13 +83,12 @@ COLD_WARMING_RESPONSE: dict = {
 }
 
 
-# feat(#1614): SQLSTATEs that mean "the CQL2 filter doesn't type against this
+# SQLSTATEs that mean "the CQL2 filter doesn't type against this
 # table": undefined operator/function, datatype mismatch, cannot coerce,
 # indeterminate datatype. Deliberately NOT the whole 42 class — 42P01 is the
 # missing-table 503 and e.g. 42501 (privilege) is an operator problem.
 async def _emit_ogc_usage_event(table_name: str) -> None:
-    """Emit an OGC-serve usage event through the billing-import-free seam
-    (METER-03), after a successful OGC serve in multi_tenant mode.
+    """Emit an OGC usage event through the billing-import-free seam.
 
     Uses get_billing_extensions() + hasattr(ext, "on_usage_event"): with
     the cloud overlay active, CloudMeteringExtension updates
@@ -131,14 +130,14 @@ async def _check_cold_rehydrate(
     Mirrors the tile-router seam: returns None when record_status !=
     'cold', when not is_multi_tenant(), or when the Community extension
     returns None. A broad Exception logs and returns None — cold-check
-    failure MUST NEVER fail an OGC response (T-1214-17). When cold and
+    failure must never fail an OGC response. When cold and
     the overlay is present: 'hydrated' returns None; 'warming' returns a
     202 JSONResponse.
 
     Args:
         table_name: the dataset table_name.
         record_status: from the already-resolved dataset object — no
-            extra DB round-trip on the hot path (T-1214-18).
+            extra database round trip on the hot path.
         tenant_id: the server-resolved tenant UUID string.
     """
     # Fast path: table is hot.
@@ -155,9 +154,7 @@ async def _check_cold_rehydrate(
             table_name=table_name,
             tenant_id=tenant_id,
         )
-    except (
-        Exception
-    ):  # broad: cold-check failure must NEVER fail an OGC response (T-1214-17)
+    except Exception:  # broad: cold-check failure must never fail an OGC response
         logger.warning(
             "ogc_cold_rehydrate_check_failed",
             table_name=table_name,
@@ -300,11 +297,8 @@ async def conformance(f: str | None = Query(None)) -> ConformanceResponse:
             # OGC API Features Part 1: Core
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
-            # OGC API Features Part 3: Filtering. fix(#430) dropped these
-            # classes while per-dataset feature collections rejected `filter`
-            # with 400; feat(#1614) restored them in the same commit that made
-            # `filter=` + per-collection /queryables work, so they are never
-            # advertised ahead of the implementation.
+            # Part 3 conformance is advertised because `filter=` and
+            # per-collection queryables are implemented together.
             "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables",
             "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
             "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
@@ -368,7 +362,7 @@ async def get_dataset_collection(
             ]
         }
 
-    # fix(#315): raster/VRT datasets have no backing feature table, so they expose no
+    # Raster/VRT datasets have no backing feature table, so they expose no
     # feature items. Advertise itemType=coverage and omit the rel=items link so
     # clients are not led into the dead /items endpoint (which 404s, see
     # get_collection_items).
@@ -397,7 +391,7 @@ async def get_dataset_collection(
                 title="Features",
             )
         )
-        # feat(#1614): OGC Features Part 3 queryables link — required by the
+        # OGC Features Part 3 queryables link — required by the
         # conf/queryables class, vector collections only (raster has no items).
         links.append(
             OGCLink(
@@ -411,14 +405,14 @@ async def get_dataset_collection(
             )
         )
     else:
-        # fix(#315): a coverage collection has no rel=items, so without a
+        # A coverage collection has no rel=items, so without a
         # replacement link the body would only carry self+root and be a
         # dead-end. Advertise the raster tile endpoint so coverage clients have
         # something to dereference. NOTE: raster tiles are served at the public
         # APP origin (/raster-tiles/...), which nginx rewrites to the internal
         # tile proxy; the /api origin has no such route, so use public_app_url.
         public_app_url = await get_public_app_url(db, request=request)
-        # fix(#1372, #2007): versioned like every rendered template so a
+        # Versioned like every rendered template so a
         # refetching client stops sharing the unversioned cache entry.
         raster_tiles_path = (
             f"/raster-tiles/{dataset.id}/tiles/{{z}}/{{x}}/{{y}}.png"
@@ -455,15 +449,13 @@ async def get_dataset_collection(
         links=links,
     )
 
-    # METER-03 (Phase 1213-06): emit OGC collection-serve usage event through the
+    # Emit OGC collection-serve usage event through the
     # billing-import-free seam so the cloud overlay can update last_accessed_at.
     # Best-effort fire-and-forget — errors logged, response unaffected.
     if dataset.table_name:
         await _emit_ogc_usage_event(dataset.table_name)
 
-    # TYPE-N2: return the pydantic model directly so FastAPI's response_model
-    # validation actually runs. Previously this was wrapped in JSONResponse,
-    # which silently disabled response validation.
+    # Return the Pydantic model directly so FastAPI validates the response.
     return metadata
 
 
@@ -481,8 +473,8 @@ async def get_collection_queryables(
 ) -> JSONResponse:
     """Queryable properties for one feature collection (OGC Features Part 3).
 
-    feat(#1614): derived from the live table schema (never the stored
-    column_info snapshot) so the advertised set always matches what `filter=`
+    Derived from the live table schema rather than the stored column_info
+    snapshot, so the advertised set always matches what `filter=`
     on /items validates against. `additionalProperties: false` is what makes
     rejecting filters on unlisted properties spec-conformant.
     """
@@ -500,7 +492,7 @@ async def get_collection_queryables(
             ),
         )
 
-    # fix(#1614): a cold (evicted) table has no information_schema
+    # A cold (evicted) table has no information_schema
     # rows, so deriving queryables from it would publish an attribute-less
     # document as authoritative. Run the same cold-rehydrate seam as /items
     # BEFORE reading the live schema (202-warming instead of a wrong 200).
@@ -514,11 +506,11 @@ async def get_collection_queryables(
         if _q_cold_result is not None:
             return _q_cold_result
 
-    # fix(#1614): get_column_info returns [] for a MISSING table as
+    # `get_column_info` returns [] for a MISSING table as
     # well as for an attribute-less one. A missing table (partial ingest /
     # eviction race) must stay the same retryable 503 the /items path
     # reports, not publish an empty queryables document as authoritative.
-    # fix(#1614): schema-introspection database errors are
+    # Schema-introspection database errors are
     # operational — same 503 classification as the items path.
     try:
         if not await feature_table_exists(db, dataset.table_name):
@@ -548,7 +540,7 @@ async def get_collection_queryables(
     )
 
 
-# fix(#1845): CQL2 compile is synchronous, event-loop-blocking work, and
+# CQL2 compile is synchronous, event-loop-blocking work, and
 # the filter is the one input letting an anonymous caller choose how
 # much of it to buy. The single-pass rename in filtering.py cut the
 # pathological case from 2.4s to 40ms, but shapes under the bind cap
@@ -574,7 +566,7 @@ def _items_request_carries_no_filter(request: Request) -> bool:
     return "filter" not in request.query_params
 
 
-# fix(#1857): two of the four refusals are resource bounds on a VALID
+# Two of the four refusals are resource bounds on a VALID
 # filter, which the generic "invalid query parameters" 400 the route inherits
 # does not describe.
 FILTER_BAD_REQUEST_RESPONSE = {
@@ -611,7 +603,7 @@ FILTER_BAD_REQUEST_RESPONSE = {
         **ERROR_RESPONSES_PUBLIC,
         400: FILTER_BAD_REQUEST_RESPONSE,
     },
-    include_in_schema=False,  # trailing-slash alias, hidden from OpenAPI (ROUTE-01 pattern)
+    include_in_schema=False,  # Trailing-slash alias hidden from OpenAPI.
 )
 @ogc_features_router.get(
     "/collections/{dataset_id}/items",
@@ -683,8 +675,8 @@ async def get_collection_items(
         alias="filter",
         description=(
             "CQL2 filter expression evaluated server-side against this "
-            "collection's queryables document (feat(#1614), OGC Features "
-            "Part 3). Combines with bbox and property filters by AND."
+            "collection's OGC Features Part 3 queryables document. Combines "
+            "with bbox and property filters by AND."
         ),
     ),
     filter_lang: str = Query(
@@ -714,18 +706,18 @@ async def get_collection_items(
     _validate_f_param(f)
     public_api_url = await get_public_api_url(db, request=request)
 
-    # #665 review / #666: the items page-size ceiling is an admin-configurable
-    # PersistentConfig knob (Network tab), not a static Query(le=...). Per OGC
+    # The page-size ceiling is an admin-configurable PersistentConfig value,
+    # not a static Query(le=...). Per OGC
     # API Features Core /req/core/fc-limit-response-1(C) a limit above the
     # maximum SHALL NOT error — clamp to the ceiling instead (mirrors the STAC
-    # side, #664). max(1, ...) guards a ceiling mis-set to 0; the clamped value
+    # sibling STAC endpoint. max(1, ...) guards a ceiling mis-set to 0; the clamped value
     # flows into the feature query and the echoed self/next links.
     max_page_size = await OGC_ITEMS_MAX_PAGE_SIZE.get(db)
     limit = min(limit, max(1, max_page_size))
 
     dataset = await _get_visible_dataset(db, user, dataset_id)
 
-    # fix(#315): raster/VRT datasets have no backing PostGIS feature table, so a feature
+    # Raster/VRT datasets have no backing PostGIS feature table, so a feature
     # query would raise UndefinedTableError -> 500 (and hold a DB connection).
     # Return a fast 404 before any feature query is attempted.
     if dataset.record.record_type in RASTER_FAMILY_RECORD_TYPES:
@@ -737,7 +729,7 @@ async def get_collection_items(
             ),
         )
 
-    # feat(#1614): `filter=` is now evaluated server-side (compiled below,
+    # `filter=` is now evaluated server-side (compiled below,
     # after the cold-rehydrate seam). Filter geometries are WGS84-only —
     # reject any other filter-crs instead of misinterpreting coordinates.
     if filter_crs is not None and filter_crs != _CRS84_URI:
@@ -768,7 +760,7 @@ async def get_collection_items(
         "crs",
         "api_key",
         "include_geometry",
-        # feat(#1614): the CQL2 filter params bind explicitly above; keep them
+        # The CQL2 filter params bind explicitly above; keep them
         # out of property_filters so they never double as column filters.
         "filter",
         "filter-lang",
@@ -782,11 +774,11 @@ async def get_collection_items(
     if dataset.column_info:
         allowed_columns = {col["name"] for col in dataset.column_info if "name" in col}
 
-    # COLD-02 (Phase 1214-04): cold-rehydrate seam — BEFORE feature query.
-    # Uses the already-resolved dataset.record.record_status (no extra DB round-trip,
-    # T-1214-18). A cold-check failure is swallowed so it NEVER fails the OGC response
-    # (T-1214-17). Published/anon-shared datasets are hot so public viewers never
-    # receive 202-warming (T-1214-17).
+    # Cold-rehydrate seam — BEFORE feature query.
+    # Uses the already-resolved dataset.record.record_status with no extra DB
+    # round trip. A cold-check failure is swallowed so it never fails the OGC
+    # response. Published or anonymously shared datasets stay hot, so public
+    # viewers never receive a warming response.
     if dataset.table_name and dataset.record:
         _ogc_cold_tid = current_tenant_var.get(None)
         _ogc_cold_result = await _check_cold_rehydrate(
@@ -800,14 +792,13 @@ async def get_collection_items(
     # Reuse existing feature service. Pass the cached feature_count so the
     # pagination COUNT(*) collapses into a constant-time lookup, and honor
     # include_geometry so clients that don't need geometry avoid the
-    # ST_AsGeoJSON cost (PERF-N1).
-    # H-24: when after_gid is provided, the service uses keyset pagination and
+    # ST_AsGeoJSON cost. When after_gid is provided, the service uses keyset pagination and
     # ignores offset.
-    # fix(#315): the raster/VRT guard above only covers datasets that never
+    # The raster/VRT guard above only covers datasets that never
     # had a backing table. A genuinely-missing VECTOR table (cold-evicted /
     # partial ingest) still raises here; mirror list_features and return
     # 503, not an unhandled 500 that holds a DB connection.
-    # feat(#1614): compile the CQL2 filter against the live table schema —
+    # Compile the CQL2 filter against the live table schema —
     # the same schema authority the queryables document publishes. This runs
     # after the cold-rehydrate seam so a cold table warms (202) instead of
     # misreporting its columns as unknown queryables.
@@ -815,13 +806,13 @@ async def get_collection_items(
     cql2_binds: list = []
     if filter_expr is not None:
         # Ordering is deliberate: a parse failure is the caller's bug (400,
-        # no database access); then fix(#1614) — a missing table
+        # no database access); a missing table
         # yields an empty live schema, and compiling against it would 400
         # every attribute filter as an unknown property, so table
         # availability stays the retryable 503; schema-dependent validation
         # runs last.
         filter_ast = parse_feature_cql2(filter_expr, filter_lang)
-        # fix(#1614): the schema-introspection queries carry no
+        # The schema-introspection queries carry no
         # caller input, so any database error here is operational — classify
         # it exactly like the feature query's 503, not a 500.
         try:
@@ -843,9 +834,9 @@ async def get_collection_items(
         cql2_where, cql2_binds = compile_feature_cql2_ast(filter_ast, queryables)
 
     try:
-        # fix(#430): a full page must be distinguishable from a full
+        # A full page must be distinguishable from a full
         # *final* page, or a feature count that is an exact multiple of `limit`
-        # emits a phantom keyset `next` to an empty page. fix(#1778):
+        # emits a phantom keyset `next` to an empty page.
         # the over-fetch that answers it moved into get_features, which reports
         # it as `has_more`, so every caller gets the same answer.
         page = await get_features(
@@ -864,14 +855,14 @@ async def get_collection_items(
             cql2_binds=cql2_binds,
         )
     except ValueError as exc:
-        # fix(#1778): an unparseable property-filter value is rejected before
+        # An unparseable property-filter value is rejected before
         # the query runs, naming the property.
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
         )
     except DBAPIError as exc:
-        # feat(#1614)/fix(#1778): with a filter or property-filter active,
+        # /with a filter or property-filter active,
         # a type-shaped DB error is the filter itself (e.g. incomparable
         # types pre-validation let through) — report as the caller's 400,
         # never an unhandled 500 (QA finding B3). Only type/data SQLSTATEs
@@ -914,7 +905,7 @@ async def get_collection_items(
         active_params["bbox"] = bbox
     if datetime_param:
         active_params["datetime"] = datetime_param
-    # fix(#1778): include_geometry is excluded from property_filters (it is
+    # `include_geometry` is excluded from property_filters (it is
     # listed in ogc_reserved) and was never added here either, so a client
     # that opted out of geometry on page 1 got it back on page 2 via the
     # rel=next link this block builds, and the self link stopped describing
@@ -964,7 +955,7 @@ async def get_collection_items(
             type="application/json",
         ),
     ]
-    # H-24: emit a keyset `next` link when more rows exist — primary path.
+    # Emit a keyset `next` link when more rows exist — primary path.
     # Fall back to offset-based `next`/`prev` for legacy clients only when
     # the request itself used offset.
     if page.rows and page.has_more:
@@ -977,9 +968,8 @@ async def get_collection_items(
             )
         )
     elif after_gid is None and page.has_more:
-        # fix(#1778): was `offset + limit < total`. numberMatched may
-        # be the planner's estimate, and an estimate at or below the rows
-        # already served would have dropped the link mid-result-set.
+        # page.has_more drives the link because numberMatched may be a planner
+        # estimate at or below the number of rows already served.
         links.append(
             OGCLink(
                 rel="next",
@@ -1003,7 +993,7 @@ async def get_collection_items(
         links=links,
     )
 
-    # METER-03 (Phase 1213-06): emit OGC items-serve usage event through the
+    # Emit OGC items-serve usage event through the
     # billing-import-free seam so the cloud overlay can update last_accessed_at.
     # Best-effort fire-and-forget — errors logged, response unaffected.
     if dataset.table_name:
@@ -1050,7 +1040,7 @@ async def get_collection_item_feature(
     public_api_url = await get_public_api_url(db, request=request)
     dataset = await _get_visible_dataset(db, user, dataset_id)
 
-    # fix(#315): raster/VRT datasets have no backing PostGIS feature table, so a
+    # Raster/VRT datasets have no backing PostGIS feature table, so a
     # feature-by-id query would raise UndefinedTableError -> 500. Return 404
     # before any query is attempted.
     if dataset.record.record_type in RASTER_FAMILY_RECORD_TYPES:
@@ -1064,7 +1054,7 @@ async def get_collection_item_feature(
 
     has_geometry = dataset.geometry_type is not None
 
-    # COLD-02 (Phase 1214-04): cold-rehydrate seam — BEFORE feature-by-id query.
+    # Cold-rehydrate seam — BEFORE feature-by-id query.
     if dataset.table_name and dataset.record:
         _item_cold_tid = current_tenant_var.get(None)
         _item_cold_result = await _check_cold_rehydrate(
@@ -1075,7 +1065,7 @@ async def get_collection_item_feature(
         if _item_cold_result is not None:
             return _item_cold_result
 
-    # fix(#315): as with get_collection_items, a genuinely-missing VECTOR table
+    # As with get_collection_items, a genuinely-missing VECTOR table
     # (cold-evicted / partial ingest) raises ProgrammingError/OperationalError;
     # return 503 rather than an unhandled 500. The raster/VRT 404 guard above
     # handles datasets that never had a backing table.

--- a/backend/app/standards/ogc/router.py
+++ b/backend/app/standards/ogc/router.py
@@ -746,7 +746,6 @@ async def get_collection_items(
             detail=f"Unsupported filter-crs: only {_CRS84_URI} is supported.",
         )
 
-    # Parse bbox
     bbox_parsed = None
     if bbox:
         try:
@@ -779,7 +778,6 @@ async def get_collection_items(
         k: v for k, v in request.query_params.items() if k not in ogc_reserved
     } or None
 
-    # Build allowed_columns set from dataset column_info for validation
     allowed_columns = None
     if dataset.column_info:
         allowed_columns = {col["name"] for col in dataset.column_info if "name" in col}
@@ -900,19 +898,16 @@ async def get_collection_items(
             )
         raise
 
-    # Convert rows to GeoJSON features
-    features = []
-    for row in page.rows:
-        features.append(
-            {
-                "type": "Feature",
-                "id": row["gid"],
-                "geometry": row.get("geometry"),
-                "properties": row.get("properties", {}),
-            }
-        )
+    features = [
+        {
+            "type": "Feature",
+            "id": row["gid"],
+            "geometry": row.get("geometry"),
+            "properties": row.get("properties", {}),
+        }
+        for row in page.rows
+    ]
 
-    # Build pagination links
     base_path = f"/collections/{dataset_id}/items"
     active_params: dict[str, str] = {}
     if bbox:

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -1,6 +1,6 @@
 """STAC API router: landing page, conformance, collections, items, search.
 
-Visibility is enforced on all item-returning endpoints (Phase 1061 SEC-S01).
+Visibility is enforced on all item-returning endpoints.
 Anonymous users see only public+published raster records; authenticated users
 see public + their owned private + any restricted records granted to their roles.
 """
@@ -87,8 +87,8 @@ class GeoJSONResponse(JSONResponse):
 # Record types eligible for STAC
 _STAC_RECORD_TYPES = RASTER_FAMILY_RECORD_TYPES
 
-# Page-size ceiling shared by every item-returning STAC handler (H-24 lowered it
-# from 1000 to bound deep-paging cost). An over-maximum limit is CLAMPED, never
+# Page-size ceiling shared by every item-returning STAC handler to bound
+# deep-paging cost. An over-maximum limit is clamped, never
 # rejected: the STAC Item Search spec requires it and stac-api-validator
 # enforces it. One constant so a future ceiling change cannot miss a handler.
 _STAC_MAX_LIMIT = 200
@@ -120,7 +120,7 @@ def _stac_content_language_headers(
 
 
 def _published_raster_filters():
-    # Phase 1061 SEC-S01: aggregate queries scoped by CollectionDataset; item
+    # Aggregate queries scoped by CollectionDataset; item
     # bodies remain visibility-gated below via _base_published_raster_query.
     return (
         Record.record_type.in_(_STAC_RECORD_TYPES),
@@ -187,7 +187,7 @@ def _parse_extent_row(
 ) -> tuple[list[float] | None, list[str | None] | None, str | None]:
     """Parse a spatial/temporal extent + license DB row into STAC-ready values.
 
-    fix(#886): the leading six columns come from ``rollup_bbox_columns``, and
+    The leading six columns come from ``rollup_bbox_columns``, and
     the STAC Collection ``extent.spatial.bbox`` takes the spec form -- STAC
     inherits RFC 7946 §5.2, so a rollup that crosses the antimeridian must be
     served as ``west > east`` rather than the global bbox a naive fold produced.
@@ -238,14 +238,14 @@ async def _fetch_raster_meta(
 ) -> dict[str, dict]:
     """Bulk-fetch raster metadata for a set of dataset IDs.
 
-    Reads the shared raster query through CatalogPort (KISS-6). STAC items
+    Reads the shared raster query through CatalogPort. STAC items
     don't need vrt_type/resolution_strategy at this layer, which is what the
     port's ``_without_vrt`` reader means.
     """
     return await get_catalog_port().fetch_raster_meta_bulk_without_vrt(db, dataset_ids)
 
 
-# fix(#1108): sentinel distinguishing "the page loop did not precompute
+# Sentinel distinguishing "the page loop did not precompute
 # lineage" from a precomputed None (a record with no lineage at all).
 _LINEAGE_UNRESOLVED: Any = object()
 
@@ -268,11 +268,11 @@ async def _dataset_to_stac_item(
 ) -> dict:
     """Convert a Dataset ORM object to a STAC Item dict with presigned URLs.
 
-    ``spatial_extent_geojson`` (PERF-5) lets bulk callers (e.g. STAC items
+    ``spatial_extent_geojson`` lets bulk callers such as a STAC items
     page) skip per-dataset Python-side WKB deserialization in
     ``dataset_to_ogc_record`` by precomputing ST_AsGeoJSON in one query.
 
-    ``public_app_url`` (fix(#315) follow-up): the raster/VRT ``raster_tiles``
+    ``public_app_url`` (follow-up): the raster/VRT ``raster_tiles``
     asset is served at the public APP origin (/raster-tiles/...), not the /api
     origin, so it is threaded to both ``dataset_to_ogc_record`` and the
     presigned-URL ``build_assets`` re-build below.
@@ -287,11 +287,11 @@ async def _dataset_to_stac_item(
         spatial_extent_geojson=spatial_extent_geojson,
         public_app_url=public_app_url,
         preferred_languages=preferred_languages,
-        # fix(#1103): the prose names the same datasets the derived_from link
+        # The prose names the same datasets the derived_from link
         # below points at, and is gated the same way — per requester, on each
         # referenced dataset rather than on the output they can already see.
-        # fix(#1108): page loops precompute the whole page through
-        # visible_lineage_summaries (one query per page, mirroring PERF-5's
+        # Page loops precompute the whole page through
+        # visible_lineage_summaries, with one query per page like
         # spatial_extent_geojson); only single-item callers resolve here.
         lineage_summary=(
             await visible_lineage_summary(db, record, user, user_roles or set())
@@ -350,7 +350,7 @@ async def _visible_derived_from_id(
 ) -> str | None:
     """Source item id for a ``rel="derived_from"`` link, when it is fetchable.
 
-    feat(#765): gated on the same query the item endpoints serve from, so the
+    Gated on the same query the item endpoints serve from, so the
     link never points at an item this requester would get a 404 for, and a
     private source is omitted entirely rather than disclosed as a dangling id.
     """
@@ -435,7 +435,7 @@ def _base_published_raster_query(
 ):
     """Base select for published raster/VRT datasets with visibility enforced.
 
-    Phase 1061 SEC-S01: matches the OGC Features peer router. Anonymous users
+    Matches the OGC Features peer router. Anonymous users
     see only public+published records; authenticated users see public + their
     owned private + any restricted records granted to their roles.
     """
@@ -645,29 +645,29 @@ async def conformance() -> StacConformance:
 async def get_collections(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    # fix(#430): no-schema variant keeps this public endpoint anonymous in
+    # No-schema variant keeps this public endpoint anonymous in
     # the OpenAPI surface — the plain optional dep stamped bearer security here,
     # narrowing the generated SDK clients to AuthenticatedClient.
     user: Identity | None = Depends(get_optional_user_no_security_schema),
 ) -> StacCollectionListResponse:
     """List all STAC Collections."""
     stac_api_url, _ = await _resolve_urls(db, request)
-    # fix(#430): aggregate extent/keyword/EPSG summaries must exclude
+    # Aggregate extent/keyword/EPSG summaries must exclude
     # private-but-published rasters, matching the item-body visibility gate.
     user_roles = await _resolve_roles(db, user)
 
     coll_result = await db.execute(select(Collection))
     collections = coll_result.scalars().all()
 
-    # fix(#1778): these four aggregates used to asyncio.gather, each branch
-    # opening its own async_session() — a nested pool checkout on top of
+    # Run these four aggregates sequentially on the caller's session. Giving
+    # each branch its own async_session() creates a nested pool checkout on top of
     # the connection this request already holds via `db` (get_db never
     # commits on the read path, so it stays checked out for the whole
     # request). 5 checkouts per anonymous, uncached request exhausts the
     # default 13-connection pool at 3 concurrent requests. Run them
     # sequentially on the caller's own session instead, the same trade
-    # made in service_query.py's dataset-detail fetch (#1436): these are
-    # grouped-aggregate queries over the same joined set, so sequencing's
+    # used by the dataset-detail fetch. These are grouped aggregates over the
+    # same joined set, so sequencing's
     # wall-clock cost is negligible next to that risk, and unlike
     # dataset-detail this endpoint is anonymous.
 
@@ -829,12 +829,12 @@ async def get_collection(
     collection_id: str,
     request: Request,
     db: AsyncSession = Depends(get_db),
-    # fix(#430): no-schema variant — see get_collections above.
+    # No-schema variant — see get_collections above.
     user: Identity | None = Depends(get_optional_user_no_security_schema),
 ) -> StacCollection:
     """Get a single STAC Collection."""
     stac_api_url, _ = await _resolve_urls(db, request)
-    # fix(#430): scope aggregate summaries to visible rasters.
+    # Scope aggregate summaries to visible rasters.
     user_roles = await _resolve_roles(db, user)
 
     is_unassigned = collection_id == STAC_UNASSIGNED_COLLECTION_ID
@@ -1004,7 +1004,7 @@ async def get_collection_items(
     # limit actually served.
     limit = min(limit, _STAC_MAX_LIMIT)
     stac_api_url, public_api_url = await _resolve_urls(db, request)
-    # fix(#315): raster_tiles assets are served at the public APP origin.
+    # Raster tile assets use the public app origin.
     public_app_url = await get_public_app_url(db, request=request)
     user_roles = await _resolve_roles(db, user)
 
@@ -1037,7 +1037,7 @@ async def get_collection_items(
     total = (await db.execute(count_stmt)).scalar() or 0
 
     # Paginate
-    # fix(#1778): no ORDER BY meant OFFSET/LIMIT paging had no defined row
+    # No ORDER BY meant OFFSET/LIMIT paging had no defined row
     # order -- a plan change between page fetches could duplicate or drop
     # items across the rel=next chain. Record.created_at is a non-unique
     # server-default, so add Dataset.id as a tiebreaker, matching the
@@ -1049,7 +1049,7 @@ async def get_collection_items(
 
     # Bulk-fetch assets, raster metadata, and spatial-extent GeoJSON concurrently.
     # Bulk ST_AsGeoJSON in PostGIS is faster than per-dataset Python-side
-    # to_shape() WKB deserialization in dataset_to_ogc_record (PERF-5).
+    # to_shape() WKB deserialization in dataset_to_ogc_record.
     ds_ids = [d.id for d in datasets]
 
     async def _assets():
@@ -1078,7 +1078,7 @@ async def get_collection_items(
         _assets(), _raster(), _extents()
     )
 
-    # fix(#1108): lineage visibility for the whole page in one query
+    # Lineage visibility for the whole page in one query
     # instead of one visible_lineage_summary round trip per item.
     lineage_map = await visible_lineage_summaries(
         db, [d.record for d in datasets], user, user_roles or set()
@@ -1216,7 +1216,7 @@ async def get_collection_item(
 ) -> JSONResponse:
     """Get a single STAC Item within a collection."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
-    # fix(#315): raster_tiles assets are served at the public APP origin.
+    # Raster tile assets use the public app origin.
     public_app_url = await get_public_app_url(db, request=request)
     user_roles = await _resolve_roles(db, user)
 
@@ -1262,7 +1262,7 @@ async def get_item(
 ) -> JSONResponse:
     """Get a single STAC Item by dataset ID."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
-    # fix(#315): raster_tiles assets are served at the public APP origin.
+    # Raster tile assets use the public app origin.
     public_app_url = await get_public_app_url(db, request=request)
     user_roles = await _resolve_roles(db, user)
 
@@ -1296,7 +1296,7 @@ def _build_search_filters(
     """Build SQLAlchemy filter clauses for STAC search.
 
     Returns:
-        A tuple of (filter_clauses, ids_empty). ids_empty is True when an ids
+        A tuple of ``(filter_clauses, ids_empty)``. ``ids_empty`` is true when an ids
         parameter was provided but all values were invalid UUIDs, signaling
         that the caller should return an empty result immediately.
     """
@@ -1510,7 +1510,7 @@ async def _execute_search(
     )
     total = (await db.execute(count_stmt)).scalar() or 0
 
-    # fix(#1778): same missing-ORDER-BY hazard as get_collection_items -- add
+    # Same missing-ORDER-BY hazard as get_collection_items -- add
     # a deterministic tiebreaker before paging.
     stmt = stmt.order_by(Record.created_at.desc(), Dataset.id.desc())
     stmt = stmt.offset(offset).limit(limit)
@@ -1570,7 +1570,7 @@ async def _execute_search(
         _assets(), _raster(), _coll_membership()
     )
 
-    # fix(#1108): lineage visibility for the whole page in one query
+    # Lineage visibility for the whole page in one query
     # instead of one visible_lineage_summary round trip per item.
     lineage_map = await visible_lineage_summaries(
         db, [d.record for d in datasets], user, user_roles or set()
@@ -1663,7 +1663,7 @@ async def search_get(
 ) -> JSONResponse:
     """STAC Item Search (GET)."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
-    # fix(#315): raster_tiles assets are served at the public APP origin.
+    # Raster tile assets use the public app origin.
     public_app_url = await get_public_app_url(db, request=request)
     user_roles = await _resolve_roles(db, user)
     return await _execute_search(
@@ -1709,8 +1709,7 @@ class StacSearchBody(BaseModel):
     limit: int = Field(
         default=10,
         ge=1,
-        # WR-01 (Phase 1071) aligned GET/POST ceilings at le=200; the
-        # STAC hardening pass replaces the hard bound with clamping on all three
+        # GET and POST share the same ceiling. Clamp on all three
         # item-returning handlers — the Item Search spec (and stac-api-validator)
         # requires over-limit values to be clamped to the server maximum, not
         # rejected.
@@ -1728,7 +1727,7 @@ class StacSearchBody(BaseModel):
     @field_validator("intersects")
     @classmethod
     def _cap_intersects_size(cls, v: dict | None) -> dict | None:
-        # SEC-023 (sibling of SEC-FU-05): the GET `intersects` query param is
+        # The GET `intersects` query param is
         # capped at max_length=10000, but the POST body `intersects` dict
         # bypassed any bound and reached the same anonymous ST_GeomFromGeoJSON
         # predicate — a multi-megabyte GeoJSON could pin CPU/memory + a DB
@@ -1756,7 +1755,7 @@ async def search_post(
 ) -> JSONResponse:
     """STAC Item Search (POST with JSON body)."""
     stac_api_url, public_api_url = await _resolve_urls(db, request)
-    # fix(#315): raster_tiles assets are served at the public APP origin.
+    # Raster tile assets use the public app origin.
     public_app_url = await get_public_app_url(db, request=request)
     user_roles = await _resolve_roles(db, user)
 
@@ -1771,7 +1770,7 @@ async def search_post(
         collections=body.collections,
         ids=body.ids,
         intersects=body.intersects,
-        # Over-limit values clamp to the operational ceiling (H-24), required by
+        # Over-limit values clamp to the operational ceiling, required by
         # the Item Search spec instead of a le=200 rejection.
         limit=max(1, min(body.limit, _STAC_MAX_LIMIT)),
         offset=max(0, body.offset),
@@ -1798,7 +1797,7 @@ def _apply_datetime_filter(stmt, datetime_str: str):
     datetime_str = _validate_stac_datetime(datetime_str.strip())
     start, end = parse_ogc_datetime(datetime_str)
 
-    # fix(#430): admit null-temporal records — dataset_to_ogc_record
+    # Admit null-temporal records — dataset_to_ogc_record
     # advertises datetime=created_at for them, so filter by that same
     # fallback instant, comparing created_at against the requested bounds
     # rather than unconditionally including every null-temporal record
@@ -1811,7 +1810,7 @@ def _apply_datetime_filter(stmt, datetime_str: str):
         if start is not None:
             stmt = stmt.where(
                 (Record.temporal_end >= start)
-                # fix(#1778): a record with temporal_start set and
+                # A record with temporal_start set and
                 # temporal_end NULL (open-ended/ongoing) fell through every
                 # arm here — temporal_end >= start reads NULL,
                 # temporal_start >= start is false for a past start, and

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -268,11 +268,10 @@ async def _dataset_to_stac_item(
 ) -> dict:
     """Convert a Dataset ORM object to a STAC Item dict with presigned URLs.
 
-    ``spatial_extent_geojson`` lets bulk callers such as a STAC items
-    page) skip per-dataset Python-side WKB deserialization in
-    ``dataset_to_ogc_record`` by precomputing ST_AsGeoJSON in one query.
+    ``spatial_extent_geojson`` lets bulk callers precompute ST_AsGeoJSON in one
+    query, avoiding per-dataset WKB deserialization in ``dataset_to_ogc_record``.
 
-    ``public_app_url`` (follow-up): the raster/VRT ``raster_tiles``
+    ``public_app_url``: the raster/VRT ``raster_tiles``
     asset is served at the public APP origin (/raster-tiles/...), not the /api
     origin, so it is threaded to both ``dataset_to_ogc_record`` and the
     presigned-URL ``build_assets`` re-build below.
@@ -291,8 +290,7 @@ async def _dataset_to_stac_item(
         # below points at, and is gated the same way — per requester, on each
         # referenced dataset rather than on the output they can already see.
         # Page loops precompute the whole page through
-        # visible_lineage_summaries, with one query per page like
-        # spatial_extent_geojson); only single-item callers resolve here.
+        # visible_lineage_summaries; only single-item callers resolve here.
         lineage_summary=(
             await visible_lineage_summary(db, record, user, user_roles or set())
             if lineage_summary is _LINEAGE_UNRESOLVED
@@ -645,9 +643,8 @@ async def conformance() -> StacConformance:
 async def get_collections(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    # No-schema variant keeps this public endpoint anonymous in
-    # the OpenAPI surface — the plain optional dep stamped bearer security here,
-    # narrowing the generated SDK clients to AuthenticatedClient.
+    # Keep this endpoint anonymous in OpenAPI so generated clients do not
+    # require AuthenticatedClient for optional authentication.
     user: Identity | None = Depends(get_optional_user_no_security_schema),
 ) -> StacCollectionListResponse:
     """List all STAC Collections."""
@@ -1037,11 +1034,7 @@ async def get_collection_items(
     total = (await db.execute(count_stmt)).scalar() or 0
 
     # Paginate
-    # No ORDER BY meant OFFSET/LIMIT paging had no defined row
-    # order -- a plan change between page fetches could duplicate or drop
-    # items across the rel=next chain. Record.created_at is a non-unique
-    # server-default, so add Dataset.id as a tiebreaker, matching the
-    # convention _resolve_sort_order already uses for dataset listings.
+    # Record.created_at can tie, so add Dataset.id to keep pagination stable.
     stmt = stmt.order_by(Record.created_at.desc(), Dataset.id.desc())
     stmt = stmt.offset(offset).limit(limit)
     result = await db.execute(stmt)
@@ -1727,11 +1720,8 @@ class StacSearchBody(BaseModel):
     @field_validator("intersects")
     @classmethod
     def _cap_intersects_size(cls, v: dict | None) -> dict | None:
-        # The GET `intersects` query param is
-        # capped at max_length=10000, but the POST body `intersects` dict
-        # bypassed any bound and reached the same anonymous ST_GeomFromGeoJSON
-        # predicate — a multi-megabyte GeoJSON could pin CPU/memory + a DB
-        # connection. Cap the serialized size to match the GET handler.
+        # Match the GET handler’s 10,000-character bound on serialized intersects
+        # to limit anonymous geometry parsing and database work.
         max_serialized = 10000
         if v is not None and len(json.dumps(v)) > max_serialized:
             raise ValueError(
@@ -1797,28 +1787,16 @@ def _apply_datetime_filter(stmt, datetime_str: str):
     datetime_str = _validate_stac_datetime(datetime_str.strip())
     start, end = parse_ogc_datetime(datetime_str)
 
-    # Admit null-temporal records — dataset_to_ogc_record
-    # advertises datetime=created_at for them, so filter by that same
-    # fallback instant, comparing created_at against the requested bounds
-    # rather than unconditionally including every null-temporal record
-    # (which matched any datetime filter regardless of date).
-    # parse_ogc_datetime truncates to whole DAYS, so created_at comparisons
-    # are day-granular: a bound day includes any created_at within it
-    # (`created_at == start` alone only matched exact midnight).
+    # For records without temporal bounds, filter by created_at, matching the
+    # datetime advertised by dataset_to_ogc_record. parse_ogc_datetime truncates
+    # to days, so each bound includes any created_at within that day.
     null_temporal = Record.temporal_start.is_(None) & Record.temporal_end.is_(None)
     if "/" in datetime_str:
         if start is not None:
             stmt = stmt.where(
                 (Record.temporal_end >= start)
-                # A record with temporal_start set and
-                # temporal_end NULL (open-ended/ongoing) fell through every
-                # arm here — temporal_end >= start reads NULL,
-                # temporal_start >= start is false for a past start, and
-                # null_temporal is false since temporal_start IS set. The
-                # single-instant branch already treats NULL temporal_end as
-                # open, so an interval query matched fewer records than the
-                # instant alone. Mirror the end-bound clause's open-start
-                # arm below, symmetrically.
+                # A missing temporal_end is open-ended. Include it symmetrically with
+                # missing temporal_start so interval and instant queries agree.
                 | (Record.temporal_end.is_(None) & Record.temporal_start.isnot(None))
                 | (Record.temporal_start >= start)
                 | (null_temporal & (Record.created_at >= start))

--- a/backend/app/standards/stac/router.py
+++ b/backend/app/standards/stac/router.py
@@ -279,7 +279,6 @@ async def _dataset_to_stac_item(
     """
     record = dataset.record
 
-    # Build OGC record (base representation)
     ogc_record = dataset_to_ogc_record(
         dataset,
         public_api_url,
@@ -657,7 +656,6 @@ async def get_collections(
     # private-but-published rasters, matching the item-body visibility gate.
     user_roles = await _resolve_roles(db, user)
 
-    # Fetch all collections
     coll_result = await db.execute(select(Collection))
     collections = coll_result.scalars().all()
 
@@ -1226,7 +1224,6 @@ async def get_collection_item(
         db, collection_id, user, user_roles
     )
 
-    # Fetch published raster/VRT dataset within this collection
     stmt = _base_published_raster_query(user, user_roles).where(
         Dataset.id == item_id,
         collection_scope,
@@ -1293,7 +1290,6 @@ def _build_search_filters(
     *,
     bbox: str | list[float] | None = None,
     intersects: str | dict | None = None,
-    datetime_str: str | None = None,
     ids: str | list[str] | None = None,
     collections: str | list[str] | None = None,
 ) -> tuple[list, bool]:
@@ -1396,7 +1392,6 @@ def _build_search_links(
     stac_api_url: str,
     *,
     matched: int,
-    returned: int,
     offset: int,
     limit: int,
     bbox: str | list[float] | None = None,
@@ -1477,11 +1472,9 @@ async def _execute_search(
     Parameters accept both string (from GET query params) and native types
     (from POST JSON body) to avoid unnecessary serialization round-trips.
     """
-    # Build filters from search parameters
     filters, ids_empty = _build_search_filters(
         bbox=bbox,
         intersects=intersects,
-        datetime_str=datetime_str,
         ids=ids,
         collections=collections,
     )
@@ -1508,7 +1501,6 @@ async def _execute_search(
     for f in filters:
         stmt = stmt.where(f)
 
-    # Filter by datetime
     if datetime_str:
         stmt = _apply_datetime_filter(stmt, datetime_str)
 
@@ -1518,7 +1510,6 @@ async def _execute_search(
     )
     total = (await db.execute(count_stmt)).scalar() or 0
 
-    # Apply pagination
     # fix(#1778): same missing-ORDER-BY hazard as get_collection_items -- add
     # a deterministic tiebreaker before paging.
     stmt = stmt.order_by(Record.created_at.desc(), Dataset.id.desc())
@@ -1526,7 +1517,6 @@ async def _execute_search(
     result = await db.execute(stmt)
     datasets = result.unique().scalars().all()
 
-    # Fetch asset rows, raster metadata, and collection membership concurrently
     ds_ids = [d.id for d in datasets]
 
     async def _assets():
@@ -1586,7 +1576,6 @@ async def _execute_search(
         db, [d.record for d in datasets], user, user_roles or set()
     )
 
-    # Convert to STAC Items
     features = []
     for dataset in datasets:
         item = await _dataset_to_stac_item(
@@ -1607,11 +1596,9 @@ async def _execute_search(
         )
         features.append(item)
 
-    # Build links
     links = _build_search_links(
         stac_api_url,
         matched=total,
-        returned=len(features),
         offset=offset,
         limit=limit,
         bbox=bbox,
@@ -1846,20 +1833,19 @@ def _apply_datetime_filter(stmt, datetime_str: str):
                 | (Record.temporal_start.is_(None) & Record.temporal_end.isnot(None))
                 | (null_temporal & (Record.created_at < end + timedelta(days=1)))
             )
-    else:
+    elif start is not None:
         # Single instant (day-granular) — match records whose temporal range
         # contains it. Null-temporal records advertise datetime=created_at, so
         # they match when created_at falls anywhere on the requested day.
-        if start is not None:
-            range_contains = (
-                (Record.temporal_start <= start) | (Record.temporal_start.is_(None))
-            ) & ((Record.temporal_end >= start) | (Record.temporal_end.is_(None)))
-            stmt = stmt.where(
-                (range_contains & ~null_temporal)
-                | (
-                    null_temporal
-                    & (Record.created_at >= start)
-                    & (Record.created_at < start + timedelta(days=1))
-                )
+        range_contains = (
+            (Record.temporal_start <= start) | (Record.temporal_start.is_(None))
+        ) & ((Record.temporal_end >= start) | (Record.temporal_end.is_(None)))
+        stmt = stmt.where(
+            (range_contains & ~null_temporal)
+            | (
+                null_temporal
+                & (Record.created_at >= start)
+                & (Record.created_at < start + timedelta(days=1))
             )
+        )
     return stmt

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,6 +1,6 @@
-"""Compatibility shim — real code moved to app.platform.jobs.worker."""
+"""Container worker entry point delegating to the jobs runtime."""
 
-from app.platform.jobs.worker import main  # noqa: F401
+from app.platform.jobs.worker import main
 
 if __name__ == "__main__":
     import asyncio

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -30133,7 +30133,7 @@
             }
           },
           {
-            "description": "CQL2 filter expression evaluated server-side against this collection's queryables document (feat(#1614), OGC Features Part 3). Combines with bbox and property filters by AND.",
+            "description": "CQL2 filter expression evaluated server-side against this collection's OGC Features Part 3 queryables document. Combines with bbox and property filters by AND.",
             "in": "query",
             "name": "filter",
             "required": false,
@@ -30146,7 +30146,7 @@
                   "type": "null"
                 }
               ],
-              "description": "CQL2 filter expression evaluated server-side against this collection's queryables document (feat(#1614), OGC Features Part 3). Combines with bbox and property filters by AND.",
+              "description": "CQL2 filter expression evaluated server-side against this collection's OGC Features Part 3 queryables document. Combines with bbox and property filters by AND.",
               "title": "Filter"
             }
           },
@@ -30662,7 +30662,7 @@
     },
     "/collections/{dataset_id}/queryables": {
       "get": {
-        "description": "Queryable properties for one feature collection (OGC Features Part 3).\n\nfeat(#1614): derived from the live table schema (never the stored\ncolumn_info snapshot) so the advertised set always matches what `filter=`\non /items validates against. `additionalProperties: false` is what makes\nrejecting filters on unlisted properties spec-conformant.",
+        "description": "Queryable properties for one feature collection (OGC Features Part 3).\n\nDerived from the live table schema rather than the stored column_info\nsnapshot, so the advertised set always matches what `filter=`\non /items validates against. `additionalProperties: false` is what makes\nrejecting filters on unlisted properties spec-conformant.",
         "operationId": "get_collection_queryables_collections__dataset_id__queryables_get",
         "parameters": [
           {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "python-slugify>=8.0.4",
     "slowapi>=0.1.10",
     "boto3>=1.43.71",
-    # fix(#836): string credentials need no azure-identity dependency.
+    # String credentials need no azure-identity dependency.
     "azure-storage-blob>=12.24.0",
     # In-memory tile cache when REDIS_URL is unset.
     "cachetools>=7.1.7",
@@ -52,12 +52,12 @@ dependencies = [
     "itsdangerous>=2.2.0",
     # Security: pin transitive deps to versions without known CVEs
     # cryptography 46.0.7 patches a buffer-overflow bug affecting
-    # non-contiguous buffers passed to certain APIs (Dependabot #29).
+    # non-contiguous buffers passed to certain APIs.
     "cryptography>=46.0.7",
     # urllib3 2.7.0 patches decompression-bomb bypasses in streaming reads
-    # and drain_conn handling (Dependabot #36 / CVE-2026-44432).
+    # and drain_conn handling (CVE-2026-44432).
     "urllib3>=2.7.0",
-    # idna 3.15 patches a DoS in idna.encode() with crafted inputs (Dependabot #40 / CVE-2026-45409 / GHSA-65pc-fj4g-8rjx).
+    # idna 3.15 patches a DoS in idna.encode() with crafted inputs (CVE-2026-45409 / GHSA-65pc-fj4g-8rjx).
     "idna>=3.18",
     # >=1.0.1 fixes Host-header validation (CVE-2026-48710 / PYSEC-2026-161).
     "starlette>=1.6.0",
@@ -86,22 +86,14 @@ dev = [
 ]
 
 [tool.ruff.lint]
-# Ruff's defaults (E4/E7/E9/F) plus a cyclomatic-complexity gate. fix(#435): the
-# audit found 33 functions above McCabe 15 with no configured gate — a line cap on a
-# module does not stop one function accumulating branches, transaction boundaries,
-# I/O, authorization, and serialization concerns.
+# Enforce function complexity as well as module size.
 select = ["E4", "E7", "E9", "F", "C901"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 15
 
 [tool.ruff.lint.per-file-ignores]
-# Burn-down baseline: every file that exceeded McCabe 15 when the gate went in.
-# New code everywhere else is gated. This list may SHRINK, never grow — a new entry
-# means a new over-complex function. Start with `raster_tile_proxy` (30),
-# `_build_dataset_context` (35), and `_stream_openai_chat` (32): they combine the
-# most failure domains. The standards serializers (dcat, dcat_us, geodcat_ap, stac,
-# ogc) are compatibility mappings — churn-only rewrites there are not worth it.
+# Existing complexity debt: remove entries as functions shrink; never add entries.
 "app/modules/auth/oauth/service.py" = ["C901"]
 "app/modules/catalog/maps/filter_grammar.py" = ["C901"]
 "app/modules/catalog/maps/service_diff.py" = ["C901"]
@@ -111,18 +103,12 @@ max-complexity = 15
 "app/modules/catalog/search/service_records.py" = ["C901"]
 "app/modules/catalog/sources/router.py" = ["C901"]
 "app/modules/embed_tokens/service.py" = ["C901"]
-# fix(#836): the defaults.py baseline entry follows `complete` (McCabe 20) into
-# the AI-provider sub-module created by the facade split — retargeted, not new.
 "app/platform/extensions/defaults_ai_openai.py" = ["C901"]
 "app/processing/ai/chat_actions.py" = ["C901"]
 "app/processing/ai/metadata_service.py" = ["C901"]
 "app/processing/ai/service.py" = ["C901"]
 "app/processing/ai/streaming.py" = ["C901"]
 "app/processing/export/router.py" = ["C901"]
-# fix(#1042): the ingest/metadata.py baseline entry follows
-# `refresh_attribute_metadata` (McCabe 16, the file's only over-complex
-# function) into the sub-module created by the facade split — retargeted, not
-# new, same as the defaults_ai_openai.py entry above.
 "app/processing/ingest/metadata_attributes.py" = ["C901"]
 "app/processing/ingest/tasks_raster.py" = ["C901"]
 "app/processing/ingest/tasks_vector.py" = ["C901"]
@@ -145,17 +131,17 @@ asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 # --dist loadgroup makes the @pytest.mark.xdist_group marker effective under
 # pytest-xdist (default `load` scheduler ignores it). It co-locates the
-# global-state-mutating tenancy tests on one worker (v1042 isolation fix). It is
+# global-state-mutating tenancy tests on one worker. It is
 # a no-op for serial runs (no -n) and behaves like `load` for ungrouped tests.
 addopts = "-m 'not perf' --dist loadgroup"
 markers = [
     "perf: performance regression tests (deselected by default)",
-    "requires_ogr2ogr: tests that invoke ogr2ogr and need build_pg_conn_str redirected to the test database (K2-PRE; fixture lives in tests/conftest.py)",
-    "architecture: layering and boundary tests; opt-out locally with `-m 'not architecture'` (Phase 212 LAYER-01 guard)",
-    "lifecycle: edition deactivation/reactivation tests requiring enterprise overlay (Phase 220 LIFECYCLE-04)",
-    "rls: tests that enable FORCE RLS on the shared test DB (Phase 1208-03); scoped enable→disable via multi_tenant_rls fixture",
+    "requires_ogr2ogr: tests that invoke ogr2ogr and need build_pg_conn_str redirected to the test database (fixture: tests/conftest.py)",
+    "architecture: layering and boundary tests; opt-out locally with `-m 'not architecture'`",
+    "lifecycle: edition deactivation/reactivation tests requiring enterprise overlay",
+    "rls: tests that enable FORCE RLS on the shared test DB; scoped enable→disable via multi_tenant_rls fixture",
     "live_stack: tests requiring the full cloud-dev Docker stack (titiler + azurite running together, reachable from inside the Docker network; skipped in default CI)",
-    "xdist_group: pytest-xdist loadgroup marker; co-locates global-state-mutating tenancy tests on one worker (v1042 isolation fix)",
+    "xdist_group: pytest-xdist loadgroup marker; co-locates global-state-mutating tenancy tests on one worker",
 ]
 
 [tool.coverage.run]
@@ -164,12 +150,7 @@ omit = []
 
 [tool.coverage.report]
 show_missing = true
-# Coverage threshold ratchets upward as the suite grows (TEST-01, Phase 278).
-# Current: 80.0 (raised from 60 — the #561 -n4 run measured 85.49% actual; the
-# old 58.5/60 floors were toothless against a 25 pt regression. 80 keeps a
-# conservative ~5.5 pt buffer). To ratchet further: run `make test-cov`, take
-# the lowest stable run's pct, subtract a 1-2 pt buffer, and bump this number.
-# Never lower it without a documented rationale in CHANGELOG.
+# Raise the coverage floor as coverage improves; never lower it to pass.
 fail_under = 80
 exclude_lines = [
     "pragma: no cover",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,11 +2,7 @@
 name = "geolens-backend"
 version = "1.19.1"
 description = "PostGIS-native GIS data catalog"
-# Docker image (Dockerfile) ships python:3.14-slim (see the Dockerfile FROM for
-# the exact patch pin) as the project's tested runtime.
-# requires-python>=3.13 is the backward-compat floor for adopters
-# running their own Python (CI matrix could expand to test 3.13.x — deferred
-# to a future test-coverage milestone). Per INF-15.
+# Dockerfile pins the tested runtime; 3.13 is the compatibility floor.
 requires-python = ">=3.13"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
@@ -36,12 +32,9 @@ dependencies = [
     "python-slugify>=8.0.4",
     "slowapi>=0.1.10",
     "boto3>=1.43.71",
-    # Azure Blob Storage provider (STOR-01 / Phase 1210). fix(#836): azure-identity
-    # was dropped — the provider only accepts string credentials (connection string,
-    # SAS token, or account key; see platform/storage/azure.py) and nothing imports
-    # azure.identity. Reintroduce it only alongside a real DefaultAzureCredential path.
+    # fix(#836): string credentials need no azure-identity dependency.
     "azure-storage-blob>=12.24.0",
-    # PERF-01 (Phase 274): in-memory LRU fallback for tile cache when REDIS_URL is unset
+    # In-memory tile cache when REDIS_URL is unset.
     "cachetools>=7.1.7",
     "redis>=7.4.1",
     "jsonschema>=4.19",
@@ -49,16 +42,10 @@ dependencies = [
     "rasterio>=1.5.1",
     "Pillow>=12.3.0",
     "numpy>=2.5.2",
-    # 8.0.0 lifts the starlette<1.0.0 cap (prior 7.x pinned <1.0.0), which was
-    # the sole blocker preventing starlette>=1.0.1 from resolving for the
-    # CVE-2026-48710 fix below.
+    # >=8 permits the patched Starlette dependency below.
     "prometheus-fastapi-instrumentator>=8.1.0",
     "authlib>=1.7.1",  # CVE-2026-44681 (GHSA-r95x-qfjj-fjj2) — OIDC Implicit/Hybrid open redirect, fixed in 1.6.12 / 1.7.1
     "python-multipart>=0.0.27",
-    # httpx: promoted from [dependency-groups].dev to prod (dep-audit 2026-06-02).
-    # Imported directly by 12 production modules (catalog source adapters,
-    # processing/ai/llm_loop.py, processing/tiles/router.py); previously resolved
-    # only transitively via fastapi[standard]. Pin keeps it a first-class dep.
     "httpx>=0.27",
     "sse-starlette>=3.4.8",
     "sqlglot>=30.17.0",
@@ -72,11 +59,7 @@ dependencies = [
     "urllib3>=2.7.0",
     # idna 3.15 patches a DoS in idna.encode() with crafted inputs (Dependabot #40 / CVE-2026-45409 / GHSA-65pc-fj4g-8rjx).
     "idna>=3.18",
-    # starlette 1.0.1 fixes "BadHost": missing Host-header validation that
-    # poisons request.url.path and can bypass path-based auth checks
-    # (CVE-2026-48710 / PYSEC-2026-161 / GHSA-86qp-5c8j-p5mr). Requires
-    # prometheus-fastapi-instrumentator>=8.0.0 above; FastAPI (>=0.46.0) and
-    # sse-starlette (>=0.49.1) already permit starlette 1.x.
+    # >=1.0.1 fixes Host-header validation (CVE-2026-48710 / PYSEC-2026-161).
     "starlette>=1.6.0",
     # GeoParquet export writer (processing/export/parquet.py). The Debian GDAL
     # build has no Arrow/Parquet driver, so exports are written via pyarrow.

--- a/backend/tests/finding_markers.py
+++ b/backend/tests/finding_markers.py
@@ -1,7 +1,7 @@
 """Detector for unscoped finding markers in ``backend/app`` comments and docstrings.
 
 Stdlib only and importable without ``app.core.config``, so the pre-commit
-hook runs ``main()`` directly. AGENTS.md > Inline review-comment convention.
+hook runs ``main()`` directly. AGENTS.md > Contracts and Comments.
 """
 
 from __future__ import annotations
@@ -100,9 +100,8 @@ class Hit:
         )
 
 
-# How far from a marker an anchor may sit and still scope it. AGENTS.md caps
-# an inline review comment at three lines, so an anchor leading (or trailing)
-# its own block reaches its markers and a long docstring's does not.
+# Legacy references are scoped within three lines. Plain explanations without
+# finding tags are preferred; an anchor does not make a tag necessary.
 ANCHOR_WINDOW = 2
 
 
@@ -217,7 +216,6 @@ UNANCHORED_MARKER_DEBT: dict[str, int] = {
     "api/middleware/body_limit.py": 7,
     "api/middleware/logging.py": 2,
     "api/middleware/security.py": 7,
-    "api/middleware/tenant_context.py": 7,
     "core/catalog_port.py": 1,
     "core/config.py": 27,
     "core/crs_uri.py": 4,
@@ -265,7 +263,6 @@ UNANCHORED_MARKER_DEBT: dict[str, int] = {
     "modules/catalog/collections/models.py": 3,
     "modules/catalog/collections/router.py": 2,
     "modules/catalog/datasets/api/router.py": 3,
-    "modules/catalog/datasets/api/router_data.py": 4,
     "modules/catalog/datasets/api/router_export.py": 12,
     "modules/catalog/datasets/api/router_health.py": 2,
     "modules/catalog/datasets/api/router_metadata.py": 1,
@@ -276,14 +273,11 @@ UNANCHORED_MARKER_DEBT: dict[str, int] = {
     "modules/catalog/datasets/domain/schemas.py": 5,
     "modules/catalog/datasets/domain/service.py": 1,
     "modules/catalog/datasets/domain/service_create.py": 1,
-    "modules/catalog/datasets/domain/service_relationships.py": 4,
     "modules/catalog/datasets/domain/source_freshness.py": 3,
-    "modules/catalog/features/service.py": 2,
     "modules/catalog/maps/_router_helpers.py": 2,
     "modules/catalog/maps/filter_grammar.py": 1,
     "modules/catalog/maps/models.py": 5,
     "modules/catalog/maps/schemas.py": 6,
-    "modules/catalog/maps/service_crud.py": 3,
     "modules/catalog/maps/service_diff.py": 1,
     "modules/catalog/maps/service_public.py": 9,
     "modules/catalog/maps/style_json.py": 3,
@@ -364,7 +358,6 @@ UNANCHORED_MARKER_DEBT: dict[str, int] = {
     "processing/ingest/tasks_reupload.py": 7,
     "processing/ingest/tasks_stac_refresh.py": 4,
     "processing/ingest/tasks_staging.py": 6,
-    "processing/ingest/tasks_vector.py": 32,
     "processing/ingest/tasks_vrt.py": 7,
     "processing/ingest/url_fetch.py": 1,
     "processing/ingest/validation.py": 3,
@@ -379,8 +372,6 @@ UNANCHORED_MARKER_DEBT: dict[str, int] = {
     "processing/tiles/service.py": 16,
     "processing/tiles/signing.py": 5,
     "standards/ogc/errors.py": 2,
-    "standards/ogc/router.py": 15,
-    "standards/stac/router.py": 11,
 }
 
 
@@ -415,8 +406,8 @@ def check(app_root: Path = APP_ROOT) -> list[str]:
             continue
         problems.append(
             f"{module}: {_debt(module_hits)} unanchored finding markers, "
-            f"{allowed} recorded. Anchor the new one as `fix(#N): <invariant>`, "
-            "drop the tag and let the sentence stand, or — if it names a "
+            f"{allowed} recorded. Remove unnecessary tags and keep the explanation. "
+            "Anchor only an essential reference, or — if it names a "
             "published standard — add it to TECHNICAL_VOCABULARY:"
         )
         problems.extend(f"    {hit.describe()}" for hit in module_hits)
@@ -551,7 +542,7 @@ def main() -> int:
     )
     for line in problems:
         print(f"  {line}")
-    print("  See AGENTS.md > Inline review-comment convention.")
+    print("  See AGENTS.md > Contracts and Comments.")
     return 1
 
 

--- a/backend/tests/test_agent_tag_marker_hook.py
+++ b/backend/tests/test_agent_tag_marker_hook.py
@@ -1,16 +1,6 @@
-"""Wiring test for the ``no-agent-tag-markers`` pre-commit hook.
+"""Run the legacy agent-tag hook against its supported file types.
 
-gh#1960: the denylist half of AGENTS.md's inline review-comment convention
-covers the file types finding_markers.py's AST detector does not parse
-(frontend/, e2e/, cli/, mcp/, plus markdown/sql/yaml/json). It must accept
-the same fix(#<issue>) anchor the AST half accepts for that tag in
-backend/app, so the convention is not anchorable in one half of the repo and
-forbidden outright in the other.
-
-This runs the hook's actual `entry` command against fixture files, the same
-way pre-commit invokes it (shlex-split entry, filenames appended as further
-argv), rather than reimplementing its grep in Python — a rewrite of the
-escape hatch or the pattern breaks this test the same way it breaks the hook.
+Execute the configured command so changes to its shell matching are tested.
 """
 
 from __future__ import annotations

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -95,12 +95,12 @@ class TestListDatasets:
 
 
 # ---------------------------------------------------------------------------
-# Internal visibility tests (#930)
+# Internal visibility tests
 # ---------------------------------------------------------------------------
 
 
 class TestInternalVisibility:
-    """fix(#930): `internal` = any signed-in user, on a published record.
+    """`internal` = any signed-in user, on a published record.
 
     The two write paths produce different states — ``PATCH /datasets/{id}``
     leaves ``record_status`` at ``published``, while the CLI manifest intent
@@ -154,7 +154,7 @@ class TestInternalVisibility:
     ):
         """A non-admin owner keeps their own internal dataset in their list.
 
-        Before #930 the ``filter_visible`` conditions matched no internal
+        The visibility filter must include internal
         branch at all, so an internal dataset vanished from every non-admin
         list including its owner's.
         """
@@ -235,8 +235,8 @@ class TestInternalVisibility:
         ``status_filter`` is ``published OR created_by == <caller>``, so it
         already hides another user's draft from the team. Gating the internal
         branch on ``published`` as well would additionally hide the owner's own
-        draft from the owner — the list/detail split #930 exists to close, and
-        a repeat of the #929 creator-exemption bug. Private and public drafts
+        draft from the owner. This guards the list/detail split and the
+        creator exemption. Private and public drafts
         stay visible to their owner, and internal must match.
         """
         viewer_id = await self._own_user_id(client, viewer_auth_header)
@@ -322,7 +322,7 @@ class TestGetDataset:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """fix(#647): is_3d/n_dims/z_min/z_max surface from the Dataset row."""
+        """Is_3d/n_dims/z_min/z_max surface from the Dataset row."""
         admin_id = await _get_user_id(test_db_session, "admin")
         ds = await _create_dataset(
             test_db_session, created_by=admin_id, name="3D Meta DS"
@@ -534,7 +534,7 @@ class TestUpdateMetadata:
         viewer_auth_header: dict,
         test_db_session,
     ):
-        """fix(#931 codex r1/r3): `restricted` is a partial audience when, and
+        """`restricted` is a partial audience when, and
         only when, a grant reaches someone who would LOSE access.
 
         The `viewer_auth_header` fixture mints a real viewer and assigns the
@@ -551,7 +551,7 @@ class TestUpdateMetadata:
             map_visibility="internal",
             map_name=map_name,
         )
-        # fix(#931): borrows the seeded `viewer` role deliberately. This asserts
+        # Borrows the seeded `viewer` role deliberately. This asserts
         # BLOCKED, so it needs the role to have a member — `viewer_auth_header`
         # guarantees one, and the accounts other files leave on the shared
         # worker DB only reinforce it. The direction is what makes the ambient
@@ -574,7 +574,7 @@ class TestUpdateMetadata:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """fix(#931 codex r3): a grant row is not an audience.
+        """A grant row is not an audience.
 
         The granted role is created here and never populated, so the grant
         reaches nobody. Blocking would be a refusal that lies — the same defect
@@ -611,7 +611,7 @@ class TestUpdateMetadata:
         viewer_auth_header: dict,
         test_db_session,
     ):
-        """fix(#931 codex r4): a grant holder who cannot authenticate is not an
+        """A grant holder who cannot authenticate is not an
         audience.
 
         `get_optional_user` rejects a non-active account before it can render a
@@ -715,7 +715,7 @@ class TestUpdateMetadata:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """fix(#931 codex r5): a rank drop is not the same as someone losing access.
+        """A rank drop is not the same as someone losing access.
 
         No `viewer_auth_header` here, so the only accounts are the admin owner
         and other admins — all of whom keep access either way. The internal
@@ -748,7 +748,7 @@ class TestUpdateMetadata:
         viewer_auth_header: dict,
         test_db_session,
     ):
-        """fix(#1073): `internal -> restricted` when every active user holds a grant.
+        """`internal -> restricted` when every active user holds a grant.
 
         The slice this move cuts is the users no grant reaches. Once the
         context manager suspends the strays, the fixture viewer is the only
@@ -799,11 +799,11 @@ class TestUpdateMetadata:
         test_db_session,
         monkeypatch,
     ):
-        """feat(#1068): overriding reads while inheriting the community audience.
+        """Overriding reads while inheriting the community audience.
 
         Such an authority reports one policy and serves another, and core cannot
         see the disagreement — so it counts as unable to answer and takes the
-        refusal. This is #1111's protection, re-keyed from "is this object
+        refusal. The protection asks "is this object
         literally the default class" to "does this object still resolve reads
         the way the audience it is borrowing assumes". Same setup as the
         everyone-granted permit above, which returns 200 without the overlay.
@@ -869,7 +869,7 @@ class TestUpdateMetadata:
         combination is unreachable in a STORED matrix, since
         `validate_permission_matrix` rejects `manage_settings` on a non-admin
         role, but the seam is the authority and the matrix is only what the
-        database will store (#1021). So it is a supported configuration, and
+        database will store. It is therefore a supported configuration, and
         counting it as "cannot answer audience questions" would blanket-refuse
         visibility changes on a deployment whose read policy is the community
         one. Same setup as the everyone-granted permit, which returns 200.
@@ -922,14 +922,14 @@ class TestUpdateMetadata:
         test_db_session,
         monkeypatch,
     ):
-        """feat(#1068): an authority predating the seam cannot vouch for anything.
+        """An authority predating the seam cannot vouch for anything.
 
         Only an overlay declaring no EXTENSION_API_VERSION gets here — a
         declared-but-stale version fails the boot check outright. `restricted ->
         public` strands nobody under the community ladder and 200s without an
         overlay, but community math is exactly what an unknown authority is
         free to contradict, so the refusal covers every shared map using the
-        dataset. This is stricter than #1111's stopgap, which pre-filtered on a
+        dataset. This is stricter than pre-filtering on a
         rank comparison and so let widening moves through on the same community
         math it had just declared untrustworthy.
         """
@@ -984,14 +984,14 @@ class TestUpdateMetadata:
         test_db_session,
         monkeypatch,
     ):
-        """fix(#1126 codex P2): a PATCH that changes nothing strands nobody.
+        """A PATCH that changes nothing strands nobody.
 
         `_apply_visibility_change` runs for every non-null `visibility` in the
         body without comparing it to the stored one, and any client that round
         trips the whole record resubmits the current value. Under an authority
         that cannot answer, the conservative fallback named every shared map
         using the dataset, so that no-op 422'd with "this would strand
-        viewers". Before #1068 the rank comparison absorbed it: `X < X` is
+        viewers". A rank comparison alone cannot distinguish it: `X < X` is
         false for both audiences, so an unchanged visibility returned [] on
         its way past. Deleting the rank deleted that accident too.
 
@@ -1055,7 +1055,7 @@ class TestUpdateMetadata:
         test_db_session,
         monkeypatch,
     ):
-        """fix(#1126 codex P2): the early return belongs ABOVE the authority split.
+        """The early return belongs ABOVE the authority split.
 
         This pins the placement rather than the symptom. An overlay predicate
         that reads a nullable column yields NULL for a row, and
@@ -1115,11 +1115,11 @@ class TestUpdateMetadata:
         test_db_session,
         monkeypatch,
     ):
-        """feat(#1068): the payoff — an overlay deployment stops being refused blind.
+        """The payoff — an overlay deployment stops being refused blind.
 
         The overlay widens the `restricted` rung to reach the fixture viewer,
         who holds no grant. That is exactly the viewer the community query
-        cannot see and that #1111 had to assume the worst about.
+        cannot see.
 
         Both requests run against the same dataset in the same world and differ
         only in who the permission authority is: the community answer refuses,
@@ -1242,7 +1242,7 @@ class TestUpdateMetadata:
         viewer_auth_header: dict,
         test_db_session,
     ):
-        """feat(#1068): the owner exclusion is a consequence now, not a clause.
+        """The owner exclusion is a consequence now, not a clause.
 
         The old query excluded the owner and every admin by hand. Both fall out
         of the audience difference instead — an account in BOTH audiences was
@@ -1309,7 +1309,7 @@ class TestUpdateMetadata:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """fix(#931 codex r6): each audience is judged on its own.
+        """Each audience is judged on its own.
 
         A public dataset on BOTH a public and an internal map, moving to
         private. The public map strands its anonymous visitors and must be
@@ -1356,7 +1356,7 @@ class TestUpdateMetadata:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """fix(#931 codex r3): an unpublished record is already invisible to
+        """An unpublished record is already invisible to
         every shared-map audience.
 
         `filter_visible`'s status gate is `published OR created_by == <caller>`,
@@ -1386,19 +1386,19 @@ class TestUpdateMetadata:
     @pytest.mark.parametrize(
         ("dataset_visibility", "map_visibility", "new_visibility", "blocked"),
         [
-            # fix(#931): the case the old query missed entirely. An internal map
+            # The case the old query missed entirely. An internal map
             # reaches every signed-in user, so a dataset dropping to private
             # strands it — silently, before this.
             ("public", "internal", "private", True),
             ("internal", "internal", "private", True),
             ("internal", "internal", "restricted", True),
-            # ...and the move that only looks like it strands one. #930 made
+            # ...and the move that only appears to strand one. Internal visibility makes
             # internal a real dataset rung, so an internal map keeps working.
             # A rule written against the target value alone would block this.
             ("public", "internal", "internal", False),
             # A private map has no audience beyond its owner and grantees.
             ("public", "private", "private", False),
-            # fix(#931 codex r2): a restricted dataset with NO grants reaches
+            # A restricted dataset with NO grants reaches
             # nobody beyond its owner and admins, who keep access either way —
             # blocking that move would be a refusal that lies. The granted case
             # is covered separately below, since it needs a grant row.
@@ -1423,15 +1423,15 @@ class TestUpdateMetadata:
         new_visibility: str,
         blocked: bool,
     ):
-        """fix(#931): the block is a before/after comparison, not a list of
+        """The block is a before/after comparison, not a list of
         forbidden target values.
 
         ``find_public_maps_using_dataset`` matched ``Map.visibility == "public"``
         only, and its caller gated on ``old == public``, so an internal map was
-        invisible to both halves. Once #930 made ``internal`` a real dataset
+        invisible to both halves. Once ``internal`` became a real dataset
         rung the rule became a matrix, and each row here is one cell of it.
 
-        fix(#1073): the guard stopped refusing on a rank drop alone, so a
+        The guard stopped refusing on a rank drop alone, so a
         blocked row needs a real viewer standing in the slice being cut.
         Without this fixture the rows borrowed whatever active accounts earlier
         tests left on the worker DB — true in file order, false when a row runs
@@ -1572,7 +1572,7 @@ class TestAnonymousAccess:
         logged-in users only" for months. The public control rules out a 404
         from some unrelated cause: the same viewer sees a public dataset
         built the same way. The admin leg pins the other half of the help
-        text (fix(#690) review) — `can_access_dataset` returns True on the
+        text — `can_access_dataset` returns True on the
         admin role before it ever looks for a grant.
         """
         admin_id = await _get_user_id(test_db_session, "admin")
@@ -1610,7 +1610,7 @@ class TestAnonymousAccess:
     ):
         """The creator of a restricted dataset is exempt from the grant check.
 
-        fix(#929): restricted means "owner, admins, and grant holders". Before
+        Restricted means "owner, admins, and grant holders". Before
         the creator exemption, a non-admin owner who set their own dataset to
         restricted lost read access to it — grants have no write path, so the
         lockout was unrecoverable without manual SQL. Pins both the detail
@@ -1662,7 +1662,7 @@ class TestAnonymousAccess:
         other_search_ids = [f["id"] for f in other_search.json()["features"]]
         assert str(restricted.id) not in other_search_ids
 
-        # Mirrored gate (codex review on the #929 PR): the maps bulk access
+        # Mirrored gate: the maps bulk access
         # check replicates can_access_dataset's policy and must apply the
         # same creator exemption, or the owner cannot add their restricted
         # dataset to a map.
@@ -1688,7 +1688,7 @@ class TestAnonymousAccess:
         test_db_session,
         monkeypatch,
     ):
-        """fix(#929 review): bulk_check_dataset_access routes through the
+        """Bulk_check_dataset_access routes through the
         permission extension instead of an inline policy mirror, so an
         overlay that deliberately denies the creator is enforced on the
         map-attach paths — the case a hard-coded owner short-circuit got
@@ -1951,7 +1951,7 @@ class TestBulkDeleteDatasets:
         test_db_session,
         monkeypatch,
     ):
-        """fix(#1297): an unexpected exception's message must never reach the client.
+        """An unexpected exception's message must never reach the client.
 
         `DependentVrtError`/`ValueError` messages stay public (asserted by the
         two tests above); anything else — an asyncpg error, a storage SDK
@@ -2015,7 +2015,7 @@ class TestSingleDeleteDataset:
         test_db_session,
         monkeypatch,
     ):
-        """fix(#1317): unexpected delete errors do not reach the client."""
+        """Unexpected delete errors do not reach the client."""
         import structlog
 
         from app.modules.catalog.datasets.api import router as datasets_router

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -30,14 +30,12 @@ from tests.factories import (
 
 class TestListDatasets:
     async def test_list_datasets_requires_auth(self, client: AsyncClient):
-        """GET /datasets/ without token returns 401."""
         resp = await client.get("/datasets/")
         assert resp.status_code == 401
 
     async def test_list_datasets_empty(
         self, client: AsyncClient, admin_auth_header: dict
     ):
-        """GET /datasets/ returns a list (may be empty) with total field."""
         resp = await client.get("/datasets/", headers=admin_auth_header)
         assert resp.status_code == 200
         data = resp.json()
@@ -52,7 +50,6 @@ class TestListDatasets:
         viewer_auth_header: dict,
         test_db_session,
     ):
-        """Public dataset is visible to both admin and viewer."""
         admin_id = await _get_user_id(test_db_session, "admin")
         ds = await _create_dataset(
             test_db_session,
@@ -61,13 +58,11 @@ class TestListDatasets:
             name="Public DS",
         )
 
-        # Admin can see it
         resp = await client.get("/datasets/", headers=admin_auth_header)
         assert resp.status_code == 200
         admin_ids = [d["id"] for d in resp.json()["datasets"]]
         assert str(ds.id) in admin_ids
 
-        # Viewer can see it
         resp = await client.get("/datasets/", headers=viewer_auth_header)
         assert resp.status_code == 200
         viewer_ids = [d["id"] for d in resp.json()["datasets"]]
@@ -80,7 +75,6 @@ class TestListDatasets:
         viewer_auth_header: dict,
         test_db_session,
     ):
-        """Private dataset owned by admin is hidden from viewer."""
         admin_id = await _get_user_id(test_db_session, "admin")
         ds = await _create_dataset(
             test_db_session,
@@ -89,13 +83,11 @@ class TestListDatasets:
             name="Private DS",
         )
 
-        # Admin can see it
         resp = await client.get("/datasets/", headers=admin_auth_header)
         assert resp.status_code == 200
         admin_ids = [d["id"] for d in resp.json()["datasets"]]
         assert str(ds.id) in admin_ids
 
-        # Viewer cannot see it
         resp = await client.get("/datasets/", headers=viewer_auth_header)
         assert resp.status_code == 200
         viewer_ids = [d["id"] for d in resp.json()["datasets"]]

--- a/backend/tests/test_env_py_mig04_propagation.py
+++ b/backend/tests/test_env_py_mig04_propagation.py
@@ -103,7 +103,9 @@ def test_propagation_failure_raises_instead_of_logging_and_continuing():
     propagate = _load_real_propagate_fn()
     script = _ScriptThatRaisesOnAssignment()
 
-    with pytest.raises(RuntimeError, match="MIG-04") as excinfo:
+    with pytest.raises(
+        RuntimeError, match="Failed to propagate enterprise version directories"
+    ) as excinfo:
         propagate(script, ["/repo/enterprise/alembic_e/versions"])
 
     # The real failure is chained, not swallowed.

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -2398,169 +2398,13 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 }
 
 
-# fix(#435): each cap equals the file's current LOC, so these files can only shrink.
-# Every cap here used to carry 3-7% headroom, and each time a file grew into its cap
-# the cap was raised (five documented raises for tiles/router.py alone). That is how
-# "decomposition is queued" stayed true for a year while the routers grew past 2,000
-# lines.
-#
-# To add lines to a ratcheted file: remove lines from it, or decompose it into
-# sub-routers (per Phase 226 / Phase 238) and lower its cap in the same commit.
-# Lowering a cap is always fine. Raising one needs a written carve-out here.
-#
-# fix(#836): the dict is keyed by PATH, not filename, and no longer holds routers
-# only. The router-glob gate below scans `**/router.py`, so the largest backend
-# modules — ingest/metadata.py, ingest/tasks_common.py, maps/schemas.py,
-# api/main.py — were ungated simply because of their names, and ingest/router.py
-# sat a few lines under the 1500 default cliff where the next feature would trip
-# a gate its author had never seen. All five are now ratcheted exact.
-#
-# History of the previous caps, kept because it records why each file is large:
-#   maps/router.py    1610 → 1700 → 1800 → 1900. Phase 1047 bulk-delete, then PR #118
-#     builder polish took it to 2107; extracting _router_helpers.py brought it back.
-#     Icon/sprite assets and public sharing/export now live in composed sub-routers;
-#     media/layer mutation routes remain in the main router.
-#   search/router.py  1515 → 1600 → 1640 → 1700. OGC record metadata (#315), then the
-#     record_type/sort_by allowlist + to_filters() chokepoint (#317 A2). The OGC
-#     Records array-query contract and explicit GeoJSON response schemas add the
-#     final 21 lines after protocol helpers were extracted to records_protocol.py.
-#   standards/stac/router.py entered the allowlist at 1547 for the virtual
-#     unassigned Collection, deterministic multi-membership selection, and HTTP
-#     Link parity required by the 2026-07-12 compliance remediation.
-#   tiles/router.py   1500 → 1660 → 1850 → 1920 → 2050 → 2090 → 2329. fix(#1429) bought
-#     the generation dimension in the tile cache key: `_generation_table_key`, the
-#     dataset-id parameter threaded through `_cluster_cache_table_key`, and
-#     `_evict_dataset_meta` plus its listener registration, which is what stops a
-#     freed table name from serving its successor under the deleted dataset's
-#     visibility. Raster meta TTLCache
-#     (1176 PERF-002), SET LOCAL ROLE binding (1209-03 DP-02), cloud fairness/metering
-#     seams (1213-06), the cold-tier seam (1214-04), terrainrgb nodata (#186), and
-#     empty-tile Cache-Control (#430 V-03). NOTE: `_check_cold_rehydrate` is pinned to
-#     this module by the overlay's 1214-05 static AST proof, so the tile_seams.py split
-#     must update the overlay in lockstep.
-#   api/main.py 1846 -> 1883. fix(#1778 codex r2): +37 for
-#     `install_api_query_deadline` and the note under it. The query deadline
-#     moved off the `get_db` dependency onto the engine this process owns,
-#     because handlers open request-scoped sessions directly through
-#     `async_session()` in more than twenty modules -- `GET /stac/collections`
-#     runs three aggregates that way -- and a per-dependency binding covered
-#     none of them. Most of the addition is why it runs at import rather than
-#     in the lifespan (`do_connect` only fires for connections opened after
-#     registration), why the engine is late-bound (fix(#909)), and why the
-#     worker, which never imports this module, must stay excluded.
-#   api/main.py 1796 -> 1846. fix(#1778): +50 across two audit findings. The
-#     /health/live route (liveness, no dependency probes) and the paragraph
-#     saying why the container healthcheck and the frontend's depends_on had to
-#     stop targeting /health: it probes the cache, which the API is built to
-#     survive, so a Valkey outage marked the container unhealthy and took the
-#     UI down with it. The rest is the note on _rate_limit_handler explaining
-#     why it must stay a plain def -- slowapi's synchronous middleware silently
-#     discards a coroutine handler and answers the global rate limit with a
-#     bare {"error": ...} and no Retry-After, which is unreachable from any
-#     test that drives a decorated route.
-#   api/main.py 1635 -> 1750. fix(#1666): +115 for three OpenAPI post-processing
-#     passes, joining the four already here. `_normalize_validation_error_contract`
-#     replaces FastAPI's `HTTPValidationError` at every 422 with the problem+json
-#     `ProblemDetail` the app-wide handler actually returns, and
-#     `_drop_unreferenced_validation_models` removes the models once nothing
-#     references them — checked rather than popped, since a dangling `$ref`
-#     breaks SDK generation. `_repair_depends_bound_query_model` republishes the
-#     two `SearchQueryParams` fields that do not survive `Depends()` binding on
-#     `collection_items` (`keywords`, which FastAPI reads as a GET request body,
-#     and the `filter-lang` alias, which pydantic cannot name), copying them from
-#     the sibling operation that declares the same model correctly rather than
-#     restating them. Most of the addition is the rationale for why that route
-#     cannot use the query-parameter-model form the other one now does. The last
-#     13 are the codex P2 round: the reference scan excludes only the candidate,
-#     never both models, so a retained `HTTPValidationError` cannot take the
-#     `ValidationError` it points at down with it.
-#   search/router.py 1468 -> 1483. fix(#1666): +15. `search_datasets_endpoint`
-#     moved to `Annotated[SearchQueryParams, Query()]`, which binds `keywords`
-#     and `filter-lang` natively and retired its raw-query-string reads; the
-#     shared `_checked_filter_lang` that replaced the two duplicated checks costs
-#     more lines than it saves, because the reason the field stays a bare `str`
-#     (a `Literal` would answer 422 where both routes contract to 400) has to be
-#     written down or the next reader tightens it. 1483 -> 1494 for the codex
-#     P2 round: `_resolve_filter_lang` reads the wire instead of the bound value,
-#     because neither binding form sees both accepted spellings, and it keeps
-#     honouring `cql2_filter_lang` — the name the PRE-FIX contract published, so
-#     the only one older generated SDKs send. Plus `_legacy_keywords_body`, which
-#     honours the GET-body `keywords` the pre-fix contract declared and older
-#     generated clients still send — accepted, never republished, since a request
-#     body on a GET is the defect being fixed.
-#   api/main.py 1499 -> 1558. fix(#1518 codex P2): +59 for
-#     `_document_unresolvable_credential_401`, which publishes the 401 that
-#     #1518 made normal runtime behaviour on every credential-aware anonymous
-#     operation. Most of it is the docstring explaining why it targets all
-#     THREE optional dependencies while `_normalize_security_contract` targets
-#     two: a 401 RESPONSE is not a security REQUIREMENT, so the no-security-
-#     schema STAC operations must gain the status without gaining the auth
-#     markers #430 removed.
-#   api/main.py 1558 -> 1573. fix(#1518 codex P2 round 4): +15 of `info.description`
-#     prose. The docs promised a 401 for every unresolvable credential while the
-#     capability lanes deliberately serve one, so the published contract was
-#     wrong about behaviour that is right. It states the three exceptions
-#     instead: logout, a capability that authorized on its own, and a shared-map
-#     link that no credential could have opened.
-#   tiles/router.py 2557 -> 2590. fix(#1518 codex P2 round 4): +33 for
-#     `_resolve_dataset_meta_for_serving`, which routes the vector tile lookup's
-#     404 through `capability_declined`, and for moving the clusterable gate
-#     below authorization. Both ran BEFORE `_authorize_vector_tile_request` —
-#     the tile URL carries a table NAME, so the id the capability needs does not
-#     exist until the lookup returns — and both answered a resource code to a
-#     caller whose credential was dead, while the raster route already answered
-#     401 for the same request shape.
-#   tiles/router.py 2528 -> 2557. fix(#1518 codex P2 round 3): +29 for routing
-#     every capability DECLINE through `capability_declined` instead of a bare
-#     raise, plus wrapping the raster meta lookup. The rule had been applied at
-#     one exit point per handler while each has several no-capability paths, so
-#     an invalid embed token and a missing signed template both answered 403
-#     with the credential rule never running. Going through the helper makes the
-#     ordering structural rather than positional, which is also what lets
-#     test_capability_declines_route_through_the_helper check it statically.
-#   tiles/router.py 2505 -> 2528. fix(#1518 codex P2): +23 for the post-loop
-#     capability pass in the batch token handler. The flag it replaces was only
-#     set on the fallback arm, so a batch of PUBLIC datasets never consulted the
-#     embed token at all and a valid capability was rejected. The pass runs only
-#     when nothing has already established the capability and stops at the first
-#     covered id, so it costs one cached validation on exactly the requests that
-#     need it and nothing on the ones that sent no token.
-#   tiles/router.py 2468 -> 2505. fix(#1518): +37 for the CAPABILITY obligation.
-#     `_authorize_vector_tile_request` and `_resolve_raster_access` are the two
-#     centralised decision points for the six tile handlers, so the rule is
-#     applied there rather than six times; most of the cost is re-indenting the
-#     raster auth arms under an explicit `else` so the control flow SHOWS that
-#     the rule fires only when neither capability authorized, instead of leaving
-#     a reader to infer it from an elif chain. The rest is the batch handler's
-#     post-loop application, which cannot be hoisted because the embed token
-#     authorizes a scope and the loop is what resolves it.
-#   tiles/router.py 2341 -> 2468. fix(#1451): +127 for `_assert_dataset_still_registered`
-#     and its single call site in `_acquire_and_serve_tile`. GH-1443 closed the
-#     half a caller could reach; direct DDL on the `data` schema can still put a
-#     relation under a deleted dataset's name, and the schema-wide default
-#     privilege makes it readable by the tile role with no grant of its own. The
-#     cached authorization is what would carry it, and the #1441 eviction is
-#     process-local, so the catalog gets asked once per tile the pool actually has
-#     to build — never on a cache hit, which is the round-trip _dataset_cache
-#     exists to avoid. Most of the lines are the docstring recording why the check
-#     sits on the pool path and not in _resolve_dataset_meta, since that placement
-#     is the whole difference between this and the option #1451 ruled out. The
-#     codex rounds added the placement itself, which took four and is now the bulk
-#     of the lines. The check sits in each endpoint on the first line past the
-#     byte-cache short-circuit: earlier and the hot path pays for it, later and it
-#     is below the COLD-02 seam (which would wake storage for a deleted dataset)
-#     and below the three bounded resources a tile request takes in order — an
-#     API-pool connection, a FAIR-01 permit, a tile-pool connection — where every
-#     position inverts a pair against a metadata-cache miss and stalls both paths.
-#     Every rejected position is recorded in the docstring, since re-deriving them
-#     is what the four rounds were.
-#   tiles/router.py 2329 -> 2341. fix(#1444): +12 of comment, no code. Both
-#     docstrings that GH-1429 left stating "a freed table name is immediately
-#     redrawable" as a live precondition now say GH-1443 removed it, and each
-#     says why its own mechanism stays anyway (the eviction buys freshness; the
-#     generation key is what keeps a name safe independently of how names are
-#     generated). Leaving them was the worse option — a reader who trusts a
-#     stale precondition unwinds the wrong defence.
+# fix(#435): caps equal current LOC; growth needs decomposition or a documented
+# exception. Lower the cap whenever its module shrinks.
+# fix(#836): full paths cover oversized modules beyond the router.py glob.
+# fix(#1451): tile acquisition order and cache guards are documented at their
+# implementation sites; preserve those invariants when decomposing modules.
+# The Enterprise overlay pins _check_cold_rehydrate to tiles/router.py in its
+# static checks, so moving that function requires a coordinated overlay change.
 _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1873): every cap below re-ratcheted to the file's exact LOC after
     # the tree-wide comment trim; no code moved.
@@ -4910,7 +4754,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # in this module now goes through. Cap 1277 -> 1278, exact.
     # refactor(#2026): +2 — the staging cluster's names now come from
     # `tasks_staging`, so this module's one import block became two.
-    "backend/app/processing/ingest/tasks_vector.py": 1280,
+    "backend/app/processing/ingest/tasks_vector.py": 1267,  # Lowered after readability cleanup.
     # --- entered by the inclusion rule ------------------------------------
     # Crossed 1000 lines adding the "unable to open datasource" friendly-
     # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern
@@ -5840,7 +5684,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # replacing the four nested async_session() pool checkouts in
     # get_collections with sequential reuse of the caller's own session.
     # Cap 1854 -> 1869, exact.
-    "backend/app/standards/stac/router.py": 1865,
+    "backend/app/standards/stac/router.py": 1851,  # Lowered after readability cleanup.
     # Central tenant-bound scope resolution replaced duplicated inline logic.
     # fix(#836): +1 — the RASTER_FAMILY_RECORD_TYPES import that replaces four
     # pasted family literals. Same +1 on the stac and search routers.
@@ -6044,7 +5888,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # usage_accounting context manager, including the two single-round repair
     # calls that had no failure accounting at all, and the map prompt gained
     # the tool-result protocol that says what the fence markers mean.
-    "backend/app/processing/ai/service.py": 999,
+    "backend/app/processing/ai/service.py": 998,  # Lowered after readability cleanup.
     # fix(#1463): crossed the inclusion threshold. The growth is the vector-tile
     # protocol constants and the stale-label repair in generate_distributions,
     # plus the comment recording why the repair has to exist at all: migration
@@ -6068,7 +5912,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # exact.
     # fix(#2007): +17. The distributions endpoint reads the dataset counter a
     # stored tile template is republished at. Cap 883 -> 900, exact.
-    "backend/app/modules/catalog/records/service.py": 900,
+    "backend/app/modules/catalog/records/service.py": 887,  # Lowered after readability cleanup.
     # fix(#1528): crossed the inclusion threshold, and this is the file the
     # inclusion rule's own comment named as one of the two "routers-by-role the
     # glob's filename match cannot see ... watched by nothing until they cross
@@ -6406,7 +6250,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1560, exact.
     # fix(#1988): +1. The `# codeql[py/sql-injection]` marker above the
     # feature-update sink. Cap 1388 -> 1389, exact.
-    "backend/app/modules/catalog/features/service.py": 1389,
+    "backend/app/modules/catalog/features/service.py": 1386,  # Lowered after readability cleanup.
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1334,7 +1334,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     "backend/app/processing/ingest/tasks_raster_replace.py": 996,
     # File/service tasks share publication fencing, heartbeat phases and failure
     # cleanup.
-    "backend/app/processing/ingest/tasks_vector.py": 1190,
+    "backend/app/processing/ingest/tasks_vector.py": 1179,
     # GDAL environments, timeouts, reaping and error sanitization share one process
     # boundary.
     "backend/app/processing/ingest/ogr.py": 1351,
@@ -1361,16 +1361,16 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # Native search and OGC Records share visibility, query parsing and pagination.
     "backend/app/modules/catalog/search/router.py": 1433,
     # STAC endpoints share visibility, extent, lineage and pagination conformance rules.
-    "backend/app/standards/stac/router.py": 1850,
+    "backend/app/standards/stac/router.py": 1828,
     # Authorization, acquisition order and cache rehydration share this route boundary;
     # the Enterprise overlay pins _check_cold_rehydrate here.
     "backend/app/processing/tiles/router.py": 2480,
     # SQL allowlisting and cost validation must share canonical AST resolution.
     "backend/app/platform/sandbox/validator.py": 1691,
     # AI orchestration coordinates tool execution, usage accounting and SSE failures.
-    "backend/app/processing/ai/service.py": 998,
+    "backend/app/processing/ai/service.py": 994,
     # Record children share ownership, ordering and publication-version invariants.
-    "backend/app/modules/catalog/records/service.py": 887,
+    "backend/app/modules/catalog/records/service.py": 877,
     # Export formats share visibility, lineage and private-artifact authorization.
     "backend/app/modules/catalog/datasets/api/router_export.py": 1484,
     # Artifact selection, atomic publication, range reads and eviction share one cache
@@ -1380,7 +1380,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     "backend/app/modules/embed_tokens/service.py": 1030,
     # Feature reads/writes share schema typing, safe SQL and geometry/metadata
     # invariants.
-    "backend/app/modules/catalog/features/service.py": 1386,
+    "backend/app/modules/catalog/features/service.py": 1373,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1268,56 +1268,118 @@ _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
 
 # Caps equal current LOC. Lower them when modules shrink; split or explain growth.
 # Full paths cover oversized modules beyond the router glob.
-# Preserve tile acquisition and cache ordering when decomposing tile modules.
-# The Enterprise overlay pins _check_cold_rehydrate to tiles/router.py in its
-# static checks, so moving that function requires a coordinated overlay change.
 _MODULE_LOC_CAPS: dict[str, int] = {
+    # Manifest reservation, staging and fenced settlement share one apply workflow.
     "backend/app/processing/ingest/manifest_service.py": 1163,
+    # Endpoint parsing, SSRF checks and credential forwarding share one security
+    # boundary.
     "backend/app/platform/service_endpoints.py": 1360,
+    # Pagination and materialization keep credentials and remote page traversal out of
+    # GDAL.
     "backend/app/platform/service_items.py": 777,
+    # ArcGIS sign-in shares destination checks, abuse budgets and deadlines across its
+    # protocol.
     "backend/app/modules/catalog/sources/arcgis_signin.py": 1151,
+    # ArcGIS probing and metadata adapter debt; split protocol helpers before raising.
     "backend/app/modules/catalog/sources/adapters/arcgis.py": 887,
+    # Source API router debt; split discovery, preview and dispatch endpoints before
+    # raising.
     "backend/app/modules/catalog/sources/router.py": 1736,
+    # Adoption DDL mirrors the current schema without importing historical migrations.
     "backend/app/core/db/tenant_adoption_sql.py": 2093,
+    # Adoption coordinates resumable tenant transactions with ownership and ACL repair.
     "backend/app/core/db/tenant_adoption.py": 1258,
+    # Application composition debt; preserve lifespan and middleware ordering when
+    # splitting.
     "backend/app/api/main.py": 1721,
+    # Published map schema debt; separate validation helpers before raising.
     "backend/app/modules/catalog/maps/schemas.py": 1396,
+    # Metadata facade preserves the import and patch surface used by extensions and
+    # callers.
     "backend/app/processing/ingest/metadata.py": 153,
+    # Ingest API router debt; split upload, import and registration endpoints before
+    # raising.
     "backend/app/processing/ingest/router.py": 1830,
+    # Shared task finalization keeps lifecycle and cleanup consistent across ingest
+    # formats.
     "backend/app/processing/ingest/tasks_common.py": 1912,
+    # Reupload coordinates staging, credentials and fenced settlement across
+    # file/service paths.
     "backend/app/processing/ingest/tasks_reupload.py": 1295,
+    # Refresh strategies share access, admission and dispatch rules at this API
+    # boundary.
     "backend/app/modules/catalog/datasets/api/router_refresh.py": 1291,
+    # Config planning, signed dry runs and application share one transaction workflow.
     "backend/app/platform/config_ops/service.py": 1161,
+    # Reconciliation and reapers serve startup, workers and admin cleanup consistently.
     "backend/app/platform/jobs/sweep.py": 1537,
+    # Refresh transitions serve request and worker paths without crossing domain
+    # boundaries.
     "backend/app/platform/refresh/service.py": 929,
+    # Central settings and boot-validation debt; split by configuration domain before
+    # raising.
     "backend/app/core/config.py": 1496,
+    # Config resolution coordinates validation, overrides, caching, audit and side
+    # effects.
     "backend/app/core/persistent_config.py": 943,
+    # Backfill batches share vector/model validation and progress/cancellation
+    # semantics.
     "backend/app/processing/embeddings/backfill.py": 933,
+    # Reupload preview, compatibility and staged commit share an endpoint lifecycle.
     "backend/app/modules/catalog/datasets/api/router_reupload.py": 1472,
+    # VRT creation and regeneration share publication and superseded-object cleanup.
     "backend/app/processing/ingest/tasks_vrt.py": 1690,
+    # Raster conversion, verification and fenced publication share one failure
+    # lifecycle.
     "backend/app/processing/ingest/tasks_raster_replace.py": 996,
+    # File/service tasks share publication fencing, heartbeat phases and failure
+    # cleanup.
     "backend/app/processing/ingest/tasks_vector.py": 1190,
+    # GDAL environments, timeouts, reaping and error sanitization share one process
+    # boundary.
     "backend/app/processing/ingest/ogr.py": 1351,
-    # Archive and GDAL validation remain centralized at the security boundary.
+    # Archive and GDAL content validation remain centralized at the upload security
+    # boundary.
     "backend/app/processing/ingest/validation.py": 1104,
+    # OAuth destination validation, account linking and role reconciliation share one
+    # boundary.
     "backend/app/modules/auth/oauth/service.py": 1111,
+    # Admin mutations share locking and audit outcomes.
     "backend/app/modules/admin/service.py": 1019,
+    # Ingest admission, staging and job settlement share one orchestration boundary.
     "backend/app/processing/ingest/service.py": 1437,
+    # PostGIS refresh coordinates geometry repair, measurement and fenced catalog
+    # updates.
     "backend/app/processing/ingest/tasks_postgis_refresh.py": 979,
+    # Dataset schema debt; split request/response families before raising.
     "backend/app/modules/catalog/datasets/domain/schemas.py": 1510,
+    # Analysis validation, bounded execution and fenced registration share one task
+    # lifecycle.
     "backend/app/processing/analysis/tasks.py": 1421,
+    # Maps API router debt; split endpoint families before raising.
     "backend/app/modules/catalog/maps/router.py": 1507,
+    # Native search and OGC Records share visibility, query parsing and pagination.
     "backend/app/modules/catalog/search/router.py": 1433,
+    # STAC endpoints share visibility, extent, lineage and pagination conformance rules.
     "backend/app/standards/stac/router.py": 1850,
-    # Authorization, acquisition order, and cache rehydration share this route boundary;
-    # the Enterprise overlay statically pins _check_cold_rehydrate here.
+    # Authorization, acquisition order and cache rehydration share this route boundary;
+    # the Enterprise overlay pins _check_cold_rehydrate here.
     "backend/app/processing/tiles/router.py": 2480,
+    # SQL allowlisting and cost validation must share canonical AST resolution.
     "backend/app/platform/sandbox/validator.py": 1691,
+    # AI orchestration coordinates tool execution, usage accounting and SSE failures.
     "backend/app/processing/ai/service.py": 998,
+    # Record children share ownership, ordering and publication-version invariants.
     "backend/app/modules/catalog/records/service.py": 887,
+    # Export formats share visibility, lineage and private-artifact authorization.
     "backend/app/modules/catalog/datasets/api/router_export.py": 1484,
+    # Artifact selection, atomic publication, range reads and eviction share one cache
+    # protocol.
     "backend/app/processing/export/artifact_cache.py": 559,
+    # Embed tokens share origin/scope checks, revocation and cached-denial behavior.
     "backend/app/modules/embed_tokens/service.py": 1030,
+    # Feature reads/writes share schema typing, safe SQL and geometry/metadata
+    # invariants.
     "backend/app/modules/catalog/features/service.py": 1386,
 }
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1,74 +1,16 @@
-"""Layering rules across Phases 212, 213, 214, 222, 223, 224, 225, 226, 230, 231, 232, and 233.
+"""Enforce backend dependency boundaries and size ratchets.
 
-Enforces open-core boundaries closed by:
-- Phase 212 LAYER-01 - core/ must not depend on modules/settings/.
-- Phase 213 LAYER-02 - modules/auth/visibility.py is gone; catalog authorization
-  lives at app.modules.catalog.authorization.
-- Phase 214 IDENT-01..03 - core/ broadened: must not depend on ANY app.modules.*.
-  Cross-domain code does not import the concrete `User` ORM from
-  `app.modules.auth.models` outside the 18-file allowlist (auth/**, admin/**,
-  plus 7 specific files where `User` is used as a SQLAlchemy InstrumentedAttribute
-  holder for SQL queries).
-- Phase 225 PROCESS-02/04 - processing/ must not import from app.modules.catalog.*;
-  all catalog access goes through ProcessingPort (app.core.processing_port).
-- Phase 230 CATPORT-02/04 - catalog/ must not have module-level imports from
-  app.processing.*; all processing access goes through CatalogPort
-  (app.core.catalog_port).
-- Phase 226 AIEXT-03/05 - processing/ai/ must not contain hardcoded
-  `if provider == "anthropic"/"openai_compatible"` dispatch; all provider
-  dispatch goes through `get_ai_provider(name).complete(...)` from
-  `app.platform.extensions`. Pathspec excludes `streaming.py` and
-  `metadata_service.py` per RESEARCH.md Open Questions 1 & 2 (true
-  LLM-token streaming and structured-output APIs are deferred-scope
-  follow-up phases).
-- Phase 231 EMBPROV-04 - the Phase-226 architecture guard
-  test_no_module_level_provider_sdk_imports_in_processing_ai is RENAMED
-  to test_no_module_level_provider_sdk_imports_in_processing, pathspec
-  broadened from backend/app/processing/ai/ to backend/app/processing/,
-  and the embeddings carve-out paragraph removed from the docstring.
-- Phase 232 PERM-05 - known permission/visibility chokepoints must route
-  through PermissionExtension: require_permission(), apply_visibility_filter(),
-  and dataset detail access helpers.
-- Phase 233 WORK-05 - known dataset publication transition chokepoints must
-  route through WorkflowExtension: /status/, /target-status/, and metadata
-  PATCH record_status writes.
-- fix(#1438 F6/F7/F17/F24) - four import-boundary guards broadened past their
-  original scope: processing/'s app.modules.* ban now covers every domain, not
-  just catalog (test_no_processing_imports_other_domains); the private-name/
-  private-module ban covers processing/ and standards/, not just platform/
-  (test_no_private_module_imports_from_app_modules); standards/ carries a
-  frozen, shrink-only (non-zero) app.modules.* surface
-  (test_standards_module_import_surface_does_not_grow), complementing the
-  zero-tolerance app.processing guard in the sibling
-  backend/tests/test_standards_layering.py (added by #1438); and the
-  router-module import ban applies package-wide at module scope, not only
-  inside platform/ (test_no_cross_package_router_imports_at_module_scope).
+Core does not depend on product modules. Processing reaches catalog through
+``ProcessingPort``; catalog reaches processing through ``CatalogPort``.
+Permission, workflow, and provider decisions use their extension seams.
+Private module internals and route modules do not leak across packages.
 
-If a test in this file fails, a forbidden import was reintroduced - the failure
-message names the offending lines for fix-forward.
+Explicit allowlists describe existing debt and must shrink as edges disappear.
+Line-count caps are exact where stated, so a module that shrinks must lower its
+cap and a module that grows must split or document its current exception.
 
-Scope:
-- `from app.modules.*` under `backend/app/core/` (Phase 214 IDENT-01 - broadens
-  Phase 212's settings-only guard)
-- `from app.modules.settings.models` anywhere under `backend/` (Phase 212 D-05
-  deleted-path regression)
-- `from app.modules.auth.visibility` anywhere under `backend/` (Phase 213 LAYER-02)
-- Broader `auth.visibility` reference catch (Phase 213 LAYER-02)
-- PermissionExtension chokepoint delegation (Phase 232 PERM-05)
-- WorkflowExtension publication chokepoint delegation (Phase 233 WORK-05)
-- `from app.modules.auth.models import .*\\bUser\\b` outside the 18-file
-  allowlist (Phase 214 IDENT-02 - pathspec excludes auth/**, admin/**,
-  audit/{models,service}.py, api/main.py, processing/ingest/tasks_raster.py,
-  embed_tokens/service.py, catalog/{maps/service,collections/router,
-  datasets/api/router_export,datasets/domain/helpers,search/service_semantic}.py, and
-  tests/)
-
-Phase 218 will re-run `/oc-audit` to verify Boundary B -> A-, Seam Quality
-C -> B, OSS Surface D -> C grade improvements.
-
-Markers:
-- `@pytest.mark.architecture` - opt-out locally with `pytest -m 'not architecture'`
-  (Phase 212-03 D-07). Runs by default in CI because `addopts` does not exclude it.
+Tests marked ``architecture`` run by default and may be excluded locally with
+``pytest -m 'not architecture'``. Failures name the offending paths or lines.
 """
 
 from __future__ import annotations
@@ -90,7 +32,7 @@ def _discover_repo_roots() -> tuple[Path, Path]:
             return candidate, candidate / "backend"
         if (candidate / "app").is_dir() and (candidate / "tests").is_dir():
             return candidate.parent, candidate
-    # Fallback for the historical backend/tests/test_layering.py layout.
+    # Source-tree fallback when neither host nor container layout is detected.
     return test_file.parents[2], test_file.parents[1]
 
 
@@ -122,7 +64,7 @@ def _has_git_metadata() -> bool:
 
     Subprocess-based `git grep` requires git metadata. Some container test
     invocations may exclude `.git/` via `.dockerignore`; in that case we skip
-    rather than fail (RESEARCH.md Pitfall 4).
+    rather than fail.
     """
     return (REPO_ROOT / ".git").exists()
 
@@ -150,10 +92,7 @@ def _has_pathspec_magic() -> bool:
     return match is not None and int(match.group(1)) >= 13
 
 
-# Module-level evaluation of git availability (Phase 278 TEST-09).
-# Cached once at import time so @pytest.mark.skipif decorators can reference
-# it. Both checks are pure (no side effects beyond a single subprocess call
-# to `git --version`); wrapped in try/except above to never raise at import.
+# Cache git capabilities for module-level skip decorators.
 _GIT_METADATA_AVAILABLE: bool = _has_git_metadata()
 _PATHSPEC_MAGIC_AVAILABLE: bool = _has_pathspec_magic()
 _GIT_METADATA_REASON = "git metadata unavailable; arch test only runs on full clones"
@@ -164,10 +103,7 @@ _PATHSPEC_MAGIC_REASON_GENERIC = (
 
 
 def _git_grep(pattern: str, path: str) -> subprocess.CompletedProcess[str]:
-    # fix(#1182): `-P` (PCRE), never `-E`. POSIX ERE has no `\s`/`\b`/`\w`;
-    # glibc accepts them as GNU extensions but macOS does not, so an `-E`
-    # pattern using them matches nothing there — and a forbidden-pattern
-    # guard reads a universal non-match as a clean pass.
+    # PCRE is required because POSIX ERE does not define \s, \b, or \w.
     return subprocess.run(
         ["git", "grep", "-n", "-P", pattern, "--", path],
         cwd=REPO_ROOT,
@@ -181,8 +117,6 @@ def _git_grep(pattern: str, path: str) -> subprocess.CompletedProcess[str]:
 @pytest.mark.skipif(not _GIT_METADATA_AVAILABLE, reason=_GIT_METADATA_REASON)
 def test_git_grep_guards_use_pcre_and_gnu_escapes_are_live() -> None:
     """The grep-based guards in this file must be able to fail on this host.
-
-    fix(#1182): two halves, because either one alone passes vacuously.
 
     1. No `git grep` argv in this file may use `-E`. Nearly every guard pattern
        here relies on `\\s`, `\\b` or `\\w`, which POSIX ERE does not define;
@@ -229,8 +163,8 @@ def test_git_grep_guards_use_pcre_and_gnu_escapes_are_live() -> None:
 def _resolve_relative_import(path: Path, node: ast.ImportFrom) -> str | None:
     """Resolve an `ImportFrom` node's target to an absolute dotted module name.
 
-    fix(#1438 codex review): `node.module` is only the absolute spelling for a
-    LEVEL-0 (non-relative) import. A relative import — ``from . import X``,
+    `node.module` is absolute only for a level-zero import. A relative import —
+    ``from . import X``,
     ``from ..pkg.mod import X`` — stores the leading dots as `node.level` and
     `node.module` as whatever follows them (``None`` for a bare ``from .
     import``), so a guard that reads `node.module` directly sees
@@ -238,9 +172,7 @@ def _resolve_relative_import(path: Path, node: ast.ImportFrom) -> str | None:
     ``app.platform.jobs.router`` — invisible to any check anchored on the
     ``app.`` prefix. Climbing `node.level - 1` steps up from the FILE's own
     package and appending `node.module` reconstructs the real target.
-    Equivalent to ``test_standards_layering.py::_absolute_module`` — kept as a
-    separate copy rather than a cross-file import, since test modules are not
-    meant to import each other's internals.
+    This local copy avoids coupling test modules through private helpers.
     """
     if node.level == 0:
         return node.module
@@ -369,20 +301,7 @@ def _private_service_import_offenders(
 @pytest.mark.architecture
 @pytest.mark.skipif(not _GIT_METADATA_AVAILABLE, reason=_GIT_METADATA_REASON)
 def test_core_does_not_import_from_any_module() -> None:
-    """`backend/app/core/` must never import from `app.modules.*`.
-
-    Closes Phase 214 IDENT-01 (broadens Phase 212-03's settings-only guard).
-    The `core` layer is the lowest layer; modules (auth, catalog, audit,
-    settings, ...) depend on core, never the reverse. Phase 214's
-    `core/identity.py` is the first new file in `core/` since Phase 212;
-    this test ensures it (and any future core/ files) respect the boundary.
-
-    Subsumes Phase 212-03's `test_core_does_not_import_from_settings_module`
-    - `app.modules.settings` is a subset of `app.modules.*`. The deleted-path
-    regression `test_app_settings_imports_only_via_core_db_models` is kept
-    verbatim because it covers a different invariant (the deleted module
-    PATH, not just the layering rule).
-    """
+    """Core is the lowest layer and must not import product modules."""
     result = _git_grep(
         r"^\s*(from|import)\s+app\.modules\.",
         "backend/app/core/",
@@ -393,8 +312,7 @@ def test_core_does_not_import_from_any_module() -> None:
         pytest.fail(
             "Layering violation: backend/app/core/ contains imports from "
             "app.modules.* (modules must depend on core, not the reverse). "
-            "Phase 214 IDENT-01: core/ is the lowest layer. Offending lines:\n"
-            + result.stdout
+            "core/ is the lowest layer. Offending lines:\n" + result.stdout
         )
     if result.returncode != 1:
         pytest.fail(
@@ -406,12 +324,7 @@ def test_core_does_not_import_from_any_module() -> None:
 @pytest.mark.architecture
 @pytest.mark.skipif(not _GIT_METADATA_AVAILABLE, reason=_GIT_METADATA_REASON)
 def test_app_settings_imports_only_via_core_db_models() -> None:
-    """`AppSetting` must only be imported from `app.core.db.models`.
-
-    Catches reintroduction of the deleted `app.modules.settings.models` path
-    (Phase 212 D-05). Anywhere across `backend/` that still names that module
-    is a regression.
-    """
+    """The deleted settings-model path must not return anywhere in the backend."""
     # Match only import-shaped lines so docstrings/error messages in this
     # file that reference the deleted path do not trigger a self-positive.
     result = _git_grep(
@@ -434,12 +347,7 @@ def test_app_settings_imports_only_via_core_db_models() -> None:
 @pytest.mark.architecture
 @pytest.mark.skipif(not _GIT_METADATA_AVAILABLE, reason=_GIT_METADATA_REASON)
 def test_no_imports_from_auth_visibility() -> None:
-    """`auth.visibility` import path must not appear anywhere under `backend/`.
-
-    Closes Phase 213 LAYER-02: the deleted `app.modules.auth.visibility` path
-    becomes a hard ModuleNotFoundError after this phase - any surviving import
-    is a migration miss. Maps directly to ROADMAP SC#4.
-    """
+    """The deleted auth visibility module must not be imported."""
     result = _git_grep(
         r"^\s*(from|import)\s+app\.modules\.auth\.visibility",
         "backend/",
@@ -468,15 +376,9 @@ def test_no_imports_from_auth_visibility() -> None:
     ),
 )
 def test_no_auth_visibility_module_referenced() -> None:
-    """Broader guard: `auth.visibility` string must not appear as a module reference.
+    """References to the deleted auth visibility path must not return.
 
-    Catches re-exports in `__init__.py` files or indirect references that the
-    import-shaped guard above would miss. Excludes this test file itself via
-    a `:!` pathspec so the regex literal in the guard does not produce a
-    self-positive (Phase 212-03 bug, commit b0bd0c2c — fixed there with an
-    import-anchor; here we use the broader regex deliberately and rely on the
-    pathspec exclusion instead).
-    """
+    Import-shaped lines are checked so this guard does not match its own documentation."""
     result = subprocess.run(
         [
             "git",
@@ -508,13 +410,9 @@ def test_no_auth_visibility_module_referenced() -> None:
 
 @pytest.mark.architecture
 def test_permission_chokepoints_use_extension() -> None:
-    """Phase 232 PERM-05: known permission chokepoints must use PermissionExtension.
+    """Known permission chokepoints delegate to PermissionExtension.
 
-    This guard is intentionally narrow. It seals the two Phase 232 surfaces
-    from the roadmap instead of scanning every auth/catalog file:
-    - ``require_permission()`` delegates capability decisions.
-    - catalog visibility helpers delegate list filtering and detail access.
-    """
+    The guard covers capability checks, visibility filtering, and dataset-detail access."""
     auth_path = _backend_path("app/modules/auth/dependencies.py")
     catalog_path = _backend_path("app/modules/catalog/authorization.py")
 
@@ -530,7 +428,7 @@ def test_permission_chokepoints_use_extension() -> None:
         or ".check_permission(" not in require_permission_block
     ):
         pytest.fail(
-            "Phase 232 PERM-05 invariant violated: require_permission() must "
+            "require_permission() must "
             "delegate capability decisions to PermissionExtension. Expected "
             "get_permission_extension().check_permission(...) in "
             f"{_repo_style_rel(auth_path)}."
@@ -548,7 +446,7 @@ def test_permission_chokepoints_use_extension() -> None:
         or ".filter_visible(" not in apply_visibility_block
     ):
         pytest.fail(
-            "Phase 232 PERM-05 invariant violated: apply_visibility_filter() "
+            "apply_visibility_filter() "
             "must delegate query filtering to PermissionExtension. Expected "
             "get_permission_extension().filter_visible(...) in "
             f"{_repo_style_rel(catalog_path)}."
@@ -563,7 +461,7 @@ def test_permission_chokepoints_use_extension() -> None:
         or ".can_access_dataset(" not in access_block
     ):
         pytest.fail(
-            "Phase 232 PERM-05 invariant violated: dataset detail access must "
+            "dataset detail access must "
             "delegate access decisions to PermissionExtension. Expected "
             "get_permission_extension().can_access_dataset(...) in "
             f"{_repo_style_rel(catalog_path)}."
@@ -572,12 +470,7 @@ def test_permission_chokepoints_use_extension() -> None:
 
 @pytest.mark.architecture
 def test_workflow_publication_chokepoints_use_extension() -> None:
-    """Phase 233 WORK-05: known publication transitions use WorkflowExtension.
-
-    This guard is intentionally narrow. It checks the two publication endpoints
-    plus the metadata PATCH record_status helper, and it does not scan seed,
-    ingest, or factory paths that assign initial record_status values.
-    """
+    """Known dataset publication transitions delegate to WorkflowExtension."""
     router_path = _backend_path("app/modules/catalog/datasets/api/router_data.py")
     metadata_path = _backend_path(
         "app/modules/catalog/datasets/domain/service_metadata.py"
@@ -605,7 +498,7 @@ def test_workflow_publication_chokepoints_use_extension() -> None:
             or mode not in block
         ):
             pytest.fail(
-                "Phase 233 WORK-05 invariant violated: "
+                "publication workflow invariant violated: "
                 f"{label} must delegate publication transitions to "
                 "WorkflowExtension. Expected get_workflow_extension(), "
                 "WorkflowTransitionContext, allowed_transitions(...), "
@@ -626,7 +519,7 @@ def test_workflow_publication_chokepoints_use_extension() -> None:
         or 'mode="metadata_patch"' not in metadata_block
     ):
         pytest.fail(
-            "Phase 233 WORK-05 invariant violated: metadata PATCH record_status "
+            "metadata PATCH record_status "
             "writes must delegate to WorkflowExtension. Expected "
             "get_workflow_extension(), WorkflowTransitionContext, "
             "allowed_transitions(...), on_transition(...), and "
@@ -645,55 +538,9 @@ def test_workflow_publication_chokepoints_use_extension() -> None:
     ),
 )
 def test_cross_domain_does_not_import_user_from_auth_models() -> None:
-    """`from app.modules.auth.models import .*User` must only appear in the allowlist.
+    """Cross-domain code must not bind the concrete auth User ORM.
 
-    Closes Phase 214 IDENT-02. The concrete `User` SQLAlchemy ORM stays
-    inside `auth/`; cross-domain code (catalog, audit, processing, platform,
-    standards) types against `app.core.identity.Identity` (the Protocol
-    alias) instead. Allowlist (D-09 + Pitfall 1 reconciliation):
-
-    - `auth/**`         - owns the model
-    - `admin/**`        - admin endpoints CRUD User rows; read sensitive
-                          fields (password_hash, auth_provider, etc.) NOT
-                          on the Identity Protocol
-    - `audit/models.py` - `Mapped["User"]` relationship (TYPE_CHECKING)
-    - `audit/service.py`- function-scope `select(User.id)` SQL filter
-                          (Pitfall 1 reconciliation - InstrumentedAttribute
-                          use, not parameter annotation)
-    - `api/main.py`     - Base.metadata registration for Alembic discovery
-    - `processing/ingest/tasks_raster.py`
-                          - Procrastinate worker `Base.metadata` registration
-    - `embed_tokens/service.py` - function-scope `select(...User.username...)`
-                                   for admin embed-token list (Pitfall 1)
-    - `catalog/maps/service_{shared,crud,public}.py`
-                          - `User.username.label()` in JOINs/SELECTs
-                            for owner display after maps service decomposition
-                            (Pitfall 1)
-    - `catalog/collections/router.py` - `select(User).where(User.id.in_(actor_ids))`
-                                         for actor enrichment (Pitfall 1)
-    - `catalog/datasets/api/router_export.py` - `select(User).where(User.id == ...)`
-                                                for export header personalization (Pitfall 1)
-    - `catalog/datasets/domain/helpers.py` - `select(User).where(User.id.in_(ids))`
-                                              for batched user resolution (Pitfall 1)
-    - `catalog/search/service_semantic.py` - `select(User).where(User.id.in_(actor_ids))`
-                                              for search-result enrichment (Pitfall 1)
-    - `catalog/records/inherited.py` - `record_audience` predicate target
-                                        (the ORM class the audience predicate
-                                        is written against) plus the
-                                        `select(User.id)` audience-difference
-                                        query (Pitfall 1, feat #1070) — the
-                                        same InstrumentedAttribute use the
-                                        maps service entries above cover
-    - `tests/`          - fixtures construct `User(...)` directly; structurally
-                          valid as Identity at the call site
-
-    The `\\bUser\\b` word-boundary ensures `import UserRole` (no standalone
-    `User`) does NOT trip the guard - `UserRole` stays concrete per D-08.
-    `import Role, User, UserRole` and `import User` and `import ApiKey, User`
-    all DO trip the guard outside the allowlist.
-
-    Maps directly to ROADMAP Phase 214 SC#2.
-    """
+    Auth/admin code and named SQL query sites are explicit exceptions. Type-only annotations use UserIdentity; runtime relationship targets use strings."""
     result = subprocess.run(
         [
             "git",
@@ -729,8 +576,8 @@ def test_cross_domain_does_not_import_user_from_auth_models() -> None:
     if result.returncode == 0:
         pytest.fail(
             "Layering violation: cross-domain code imports the concrete "
-            "`User` ORM from `app.modules.auth.models`. Phase 214 IDENT-02 "
-            "requires cross-domain code to type against "
+            "`User` ORM from `app.modules.auth.models`. "
+            "Cross-domain code must type against "
             "`app.core.identity.Identity` (the Protocol alias) instead. "
             "If this is a legitimate SQL InstrumentedAttribute use, add "
             "the file to the allowlist in this test and document the "
@@ -746,35 +593,9 @@ def test_cross_domain_does_not_import_user_from_auth_models() -> None:
 @pytest.mark.architecture
 @pytest.mark.skipif(not _GIT_METADATA_AVAILABLE, reason=_GIT_METADATA_REASON)
 def test_no_external_imports_of_dataset_domain_submodules() -> None:
-    """Phase 224 DECOUPLE-04: no external module imports the catalog/datasets/
-    domain/service_X sub-modules directly. All consumers must go through the
-    ``app.modules.catalog.datasets.domain.service`` façade.
+    """Dataset callers use the public service facade, never split internals.
 
-    Phase 224 split the 1407-LOC ``service.py`` god-module into 5 cohesive
-    sub-modules (service_create, service_query, service_lifecycle,
-    service_metadata, service_relationships) behind a thin re-export façade.
-    DECOUPLE-01 preserved zero call-site churn — the 22 consumer files in
-    ``backend/app/`` still import from ``service``. This guard fails CI if
-    any module under ``backend/app/`` (excluding the 5 sub-modules + service.py
-    + this test file) starts importing from a sub-module directly,
-    re-introducing the bypass that DECOUPLE-04 forbids.
-
-    Cross-imports BETWEEN the 5 sub-modules are PERMITTED (D-05) — e.g.,
-    ``service_create.py`` imports ``_safe_table_ref`` from
-    ``service_lifecycle`` and ``auto_detect_relationships`` from
-    ``service_relationships``. The sub-modules collaborate as a domain
-    package; only external bypasses are forbidden.
-
-    Allowlist (files allowed to reference service_X paths directly):
-      - The 5 sub-modules themselves (service_create.py, service_query.py,
-        service_lifecycle.py, service_metadata.py, service_relationships.py)
-      - The service.py façade (it re-exports from each sub-module)
-      - This test file (it documents and enforces the invariant)
-
-    Maps to Phase 224 ROADMAP DECOUPLE-04 close gate. Mirrors AUDIT-02
-    (Phase 222) and BILLING-02 (Phase 223) architecture guards.
-    See ``oc-separation-audit-20260430-b.md`` §5 + §7 P0 #1.
-    """
+    The split modules may import each other; the facade re-exports their supported surface. Tests are excluded so they can exercise internals directly."""
     # Pattern matches any of the 5 sub-modules OR the _sql_safety helper.
     # _sql_safety is an internal module (underscore prefix) holding shared
     # SQL-injection-prevention regexes; external callers must reach
@@ -822,7 +643,7 @@ def test_no_external_imports_of_dataset_domain_submodules() -> None:
 
     if offenders:
         pytest.fail(
-            "Phase 224 DECOUPLE-04 invariant violated: external module "
+            "external module "
             "imports from a catalog/datasets/domain/service_X sub-module "
             "directly. All consumers must go through the "
             "`app.modules.catalog.datasets.domain.service` façade. "
@@ -834,14 +655,7 @@ def test_no_external_imports_of_dataset_domain_submodules() -> None:
 
 @pytest.mark.architecture
 def test_no_external_imports_of_maps_private_service_modules() -> None:
-    """Phase 238 BOUND-01: maps callers must use the public service façade.
-
-    Phases 236 and 238 keep `app.modules.catalog.maps.service` as the stable
-    import surface. Focused private modules may collaborate with each other and
-    the façade may re-export them, but production modules outside the service
-    split must not import service_shared/service_crud/service_layers/
-    service_public directly.
-    """
+    """Map callers use the public service facade; split implementation modules remain private."""
     private_modules = {
         "service_shared",
         "service_crud",
@@ -857,7 +671,7 @@ def test_no_external_imports_of_maps_private_service_modules() -> None:
 
     if offenders:
         pytest.fail(
-            "Phase 238 BOUND-01 invariant violated: production code imports "
+            "production code imports "
             "maps private service modules directly. External callers must "
             "import from `app.modules.catalog.maps.service`; only the maps "
             "facade and maps service_*.py modules may import private service "
@@ -867,7 +681,7 @@ def test_no_external_imports_of_maps_private_service_modules() -> None:
 
 @pytest.mark.architecture
 def test_no_external_imports_of_search_private_service_modules() -> None:
-    """Phase 238 BOUND-01: search callers must use the public service façade."""
+    """Search callers use the public service facade; split implementation modules remain private."""
     private_modules = {
         "service_filters",
         "service_facets",
@@ -885,7 +699,7 @@ def test_no_external_imports_of_search_private_service_modules() -> None:
 
     if offenders:
         pytest.fail(
-            "Phase 238 BOUND-01 invariant violated: production code imports "
+            "production code imports "
             "search private service modules directly. External callers must "
             "import from `app.modules.catalog.search.service`; only the search "
             "facade and search service_*.py modules may import private service "
@@ -899,18 +713,12 @@ _ANALYSIS_SQL_FAMILIES = frozenset(
 )
 
 # How many times to re-walk a file propagating `sql = analysis_sql` rebinds.
-# Three covers any chain a reviewer would let through; the loop exits early
-# when nothing new binds, so this is a ceiling rather than a cost.
+# Three covers the supported simple-assignment chains; the loop exits early.
 _BINDING_REBIND_ROUNDS = 3
 
-# The eight modules that legitimately consume the façade. Named so the
-# both-directions test can prove the guard still LETS THEM THROUGH — a refusal
-# assertion cannot notice that a correct import started being rejected.
-#
-# fix(#1589): buffer_marker.py joins them. It renders the geodesic buffer the
-# NL->SQL prompt used to embed, which is why sql_generator.py is still on the
-# list too — it keeps MAX_BUFFER_METERS, so the distance ceiling the prompt
-# quotes is the one the expander enforces.
+# Legitimate facade consumers. The positive-direction check keeps the guard
+# from rejecting them. Buffer rendering and SQL generation share the distance
+# ceiling, so both AI modules consume the facade.
 _ANALYSIS_SQL_CALLERS = (
     "app/modules/catalog/datasets/api/router_analysis.py",
     "app/modules/catalog/datasets/domain/schemas.py",
@@ -965,22 +773,9 @@ def _is_analysis_sql_package(dotted: str) -> bool:
 
 
 def _analysis_sql_facade_bindings(tree: ast.Module) -> set[str]:
-    """Expressions denoting the façade PACKAGE in this file, alias included.
+    """Return expressions bound to the analysis_sql facade, including aliases.
 
-    refactor(#1089 review r2): the structural half of the fix. Round 1 compared
-    an attribute chain's base against the literal string ``analysis_sql``, so
-    ``from app.platform import analysis_sql as sql`` then ``sql.overlay.…``
-    walked past it. Chasing that as a missing case is unwinnable — every alias
-    spelling is a new literal and there are infinitely many. Resolving the name
-    to what it is BOUND to closes the class instead, which is why round 2's
-    table adds aliased twins and they need no new branches.
-
-    Bindings are collected FILE-WIDE rather than per scope, so a function-local
-    ``import … as sql`` is seen. That over-approximates: a name bound to the
-    façade in one function makes ``<name>.overlay`` suspicious anywhere in the
-    file. Deliberate — the error direction for a guard is to flag too much, and
-    the alternative silently under-reports.
-    """
+    Bindings are collected file-wide and through simple assignment forms. This deliberately over-approximates across scopes so the architecture guard fails closed."""
     bound: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -1000,18 +795,7 @@ def _analysis_sql_facade_bindings(tree: ast.Module) -> set[str]:
                 if alias.name == "analysis_sql":
                     bound.add(alias.asname or alias.name)
 
-    # One more hop: `sql = analysis_sql` is two characters from `import … as
-    # sql` and binds exactly the same thing. Iterated because rebinding can
-    # chain; bounded because a fixpoint over a file's assignments is not worth
-    # an unbounded loop in a test.
-    #
-    # fix(#1089 review r3): the rebind pass read ``ast.Assign`` only, so the
-    # ANNOTATED form ``sql: object = analysis_sql`` bound nothing — a
-    # statically resolvable path, so the contract below was overstating.
-    # Closed as a form-space rather than a case: every node that pairs a
-    # target with a value is handled, which is Assign, AnnAssign, the walrus,
-    # and element-wise tuple/list unpacking. Attribute targets fall out for
-    # free, so ``self.sql = analysis_sql`` then ``self.sql.overlay`` is seen.
+    # Propagate simple, annotated, walrus, attribute, and sequence rebindings.
     for _ in range(_BINDING_REBIND_ROUNDS):
         grew = False
         for node in ast.walk(tree):
@@ -1073,57 +857,9 @@ def _unpack_pair(target: ast.expr, value: ast.expr) -> list[tuple[ast.expr, ast.
 
 
 def _analysis_sql_family_bypasses(source: str, rel: str) -> list[str]:
-    """Every reference reaching a family module, as ``rel:lineno: detail``.
+    """Return statically resolvable references to analysis_sql family modules.
 
-    THE CONTRACT: this catches every path to a family module that is
-    STATICALLY RESOLVABLE. It is not, and cannot be, "catches everything" —
-    see the residue at the bottom.
-
-    Two review rounds shaped it, and both were the same mistake at different
-    depths: comparing literal text where a name had to be resolved.
-
-    - r1 matched ``node.module`` alone, so ``from app.platform.analysis_sql
-      import overlay`` walked past — the module IS the façade (allowed) and the
-      imported NAME was never read. That import succeeds at runtime, because
-      the façade imports its submodules and they become package attributes.
-    - r2 matched an attribute chain's base against the literal ``analysis_sql``,
-      so ``from app.platform import analysis_sql as sql`` then
-      ``sql.overlay.…`` walked past. Fixed by resolving bindings
-      (``_analysis_sql_facade_bindings``) rather than by adding alias cases,
-      because the set of spellings is unbounded.
-
-    What is checked, in three passes over one parse:
-
-    1. an import whose dotted path traverses a family — ``import
-       …analysis_sql.overlay``, ``from …analysis_sql.overlay import x``,
-       aliased or not, absolute or relative;
-    2. an import FROM the façade whose imported NAME is a family — ``from
-       …analysis_sql import overlay [as ov]``, mixed freely with real exports;
-    3. an attribute chain ``<expr>.<family>`` where ``<expr>`` is bound to the
-       façade in this file — under any alias, through a plain assignment, and
-       from a function-local import.
-
-    STRUCTURALLY OUT OF REACH, so the next review round can be answered by
-    pointing here instead of re-litigating. No static import analysis sees
-    these, and a branch for the spelled-out case would read as coverage it does
-    not provide:
-
-    - ``getattr(analysis_sql, name)`` — the attribute is a value, not a node.
-    - ``importlib.import_module(path)`` — likewise, and the argument need not
-      be a literal.
-    - anything reached through a data flow this does not model (a family module
-      returned from a function, stashed in a dict, passed as a parameter, or
-      bound by a ``for``/``with`` target — see ``_binding_pairs`` for why those
-      last two stay out).
-
-    Nothing under ``backend/app/`` loads a platform module any of those ways.
-
-    One shape looks like residue and is not: ``from …analysis_sql import *``
-    cannot reach a family at all, because ``__init__`` declares ``__all__`` and
-    no family name is in it. That is a property of the FAÇADE rather than of
-    this matcher, so it is pinned where it is decided — see the ``__all__``
-    assertion in ``test_analysis_sql_facade_guard_sees_every_bypass_shape``.
-    """
+    The scan covers direct and relative imports, names imported from the facade, aliases, and simple rebindings. Dynamic getattr/importlib and general data flow are outside static reach. Star imports are safe because the facade __all__ excludes family names."""
     tree = ast.parse(source)
     facade = _analysis_sql_facade_bindings(tree)
 
@@ -1175,27 +911,9 @@ def _analysis_sql_facade_all_names() -> set[str]:
 
 @pytest.mark.architecture
 def test_no_external_imports_of_analysis_sql_family_modules() -> None:
-    """refactor(#1089): analysis_sql's family modules are reached via the façade.
+    """Analysis SQL consumers use one facade so preview and materialization share renderers.
 
-    ``app.platform.analysis_sql`` exists so the catalog preview path
-    (``datasets/domain/service_analysis.py``) and the processing materialize
-    worker (``processing/analysis/tasks.py``) render IDENTICAL SQL. Catalog
-    cannot import processing and processing cannot import catalog, so before
-    the module existed each path carried its own copy of every statement and
-    they drifted: an approved preview and the dataset it saved could disagree
-    about what the operation meant.
-
-    #1089 split it by operation family — overlay, measure, spatial_join,
-    transform, over a shared core. That is safe only while the façade stays the
-    single import surface. The moment a caller reaches past it, "which renderer
-    does this path use" becomes a per-caller question again, which is the same
-    failure in a new shape. Cross-imports BETWEEN family modules are fine (they
-    are one package and reach each other relatively); only external bypasses
-    are forbidden.
-
-    Walks the tree rather than git-grepping, so an untracked new file is
-    covered on the run that introduces it.
-    """
+    Family modules may import each other internally. External callers must use app.platform.analysis_sql; the AST scan includes untracked files."""
     package_dir = _backend_path("app/platform/analysis_sql")
 
     offenders: list[str] = []
@@ -1214,8 +932,7 @@ def test_no_external_imports_of_analysis_sql_family_modules() -> None:
             f"operation-family modules directly. Use `{_ANALYSIS_SQL_PACKAGE}` "
             "instead — it re-exports every renderer, and keeping it the single "
             "import surface is what stops the preview path and the materialize "
-            "worker from drifting apart on what SQL they run (#1089).\n"
-            + "\n".join(offenders)
+            "worker from drifting apart on what SQL they run.\n" + "\n".join(offenders)
         )
 
 
@@ -1236,38 +953,9 @@ _ANALYSIS_SQL_SURFACE_EXEMPT = {
 
 @pytest.mark.architecture
 def test_analysis_sql_facade_surface_matches_its_declared_api() -> None:
-    """The IMPORTABLE surface equals __all__, exemptions named one by one.
+    """The facade importable surface must equal __all__ plus named exemptions.
 
-    fix(#1089 review r3): #1089 added six per-family `render_*_expr` helpers so
-    each family owns the branch that renders it, kept them out of `__all__`,
-    and imported them publicly anyway. `from app.platform.analysis_sql import
-    render_clip_expr` therefore worked on the branch and failed on main — an
-    API expansion the PR was simultaneously claiming not to make.
-
-    `__all__` was honest and irrelevant: it governs `import *` and states
-    intent, while callers bind to ATTRIBUTES. Nothing was comparing the two,
-    which is how the surface drifted twice without a failing test. This is that
-    comparison. It imports the façade, which is cheap and needs no database —
-    `app.core.geo` pulls only shapely and sqlalchemy.
-
-    The comparison is EXACT, and the exemptions are named one by one with a
-    reason. Resist relaxing it into a predicate — "ignore short names",
-    "ignore anything not callable" — because its whole value is that the next
-    accidental promotion has nowhere to land. An exemption forces someone to
-    write down why; a predicate quietly absorbs the thing it was meant to
-    catch.
-
-    THIS CHECK IS HALF OF THE INVARIANT. Python binds a submodule on its
-    parent package at import, so `analysis_sql.overlay` is a public attribute
-    no matter what this module does — it is exempt here because it is
-    unavoidable, not because it is harmless. What makes it harmless is
-    ``test_no_external_imports_of_analysis_sql_family_modules``, which fails
-    the build if anything outside the package reaches through it. So: this
-    test keeps the DECLARED surface honest, that one keeps the UNAVOIDABLE
-    surface unused, and "the façade is the only import surface" is true
-    because both hold. Neither is sufficient alone, and deleting either one
-    leaves a claim the remaining test does not support.
-    """
+    Exact comparison prevents accidental public helpers. A companion guard forbids external access to unavoidable package-bound submodule attributes; both checks are required."""
     facade = importlib.import_module(_ANALYSIS_SQL_PACKAGE)
 
     public = {name for name in dir(facade) if not name.startswith("_")}
@@ -1418,9 +1106,7 @@ def test_analysis_sql_facade_guard_sees_every_bypass_shape() -> None:
         "a family NAME on an unrelated package": (
             "from app.platform.cache import shared"
         ),
-        # --- r2: the must-pass twins. These are what prove the fix resolves
-        # BINDINGS rather than blacklisting whatever the alias happened to be
-        # called in the reported instance.
+        # Must-pass twins prove binding resolution rather than alias blacklisting.
         "ALIASED façade, ordinary renderer": (
             "from app.platform import analysis_sql as sql\n"
             "x = sql.render_geometry_expr('centroid')"
@@ -1473,705 +1159,49 @@ def test_analysis_sql_facade_guard_sees_every_bypass_shape() -> None:
     assert exported, "the façade's __all__ is empty"
     assert exported.isdisjoint(_ANALYSIS_SQL_FAMILIES), (
         "a family module name is exported in the façade's __all__, so "
-        f"`from {_ANALYSIS_SQL_PACKAGE} import *` now reaches a family: "
+        f"`from {_ANALYSIS_SQL_PACKAGE} import *` reaches a family: "
         f"{sorted(exported & _ANALYSIS_SQL_FAMILIES)}"
     )
 
 
 @pytest.mark.architecture
 def test_decomposed_service_modules_stay_within_size_budgets() -> None:
-    """Phase 238 BOUND-02 + Phase 269 H-05 + Phase 276 CODE-02: decomposed splits stay bounded.
-
-    Originally introduced as the maps/search size-budget guard in Phase 238
-    BOUND-02. Phase 269 (v13.12 H-05) extended coverage to the Phase 224
-    dataset-domain split (`datasets/domain/service_*.py`), which previously
-    had a private-import guard but no companion size cap. Phase 276 CODE-02
-    added processing/ai/chat_*.py coverage when chat_service.py was split
-    into a facade + sub-modules.
-    """
+    """Keep split service modules and their stable facades bounded."""
     facade_line_budgets = {
         "backend/app/modules/catalog/maps/service.py": 100,
         "backend/app/modules/catalog/search/service.py": 80,
-        # fix(#1847): +2, sample_example_values re-exported. Cap 110 -> 112, exact.
         "backend/app/modules/catalog/datasets/domain/service.py": 112,
-        # Phase 276 CODE-02 — chat_service.py is now a facade re-exporting
-        # from chat_*.py sub-modules. 400 was the established Phase-226 cap
-        # for facade modules that retain a meaty orchestrator + system-prompt
-        # builder.
-        # builder-audit follow-up (read-only AI access model): +36 LOC —
-        # build_chat_system_prompt gains a can_edit read-only directive, and
-        # chat_edit_map gains the per-turn allowed-tool guard on the tool
-        # executor + action collector (so a view-only caller cannot execute or
-        # collect a mutating tool). Cap raised 400 -> 440 (~4 LOC headroom).
-        # fix(#525 B-037): +2 LOC — chat_edit_map builds ChatActions per-item
-        # via _build_chat_actions (re-exported here for streaming.py) so one
-        # invalid action drops with a note instead of failing the whole turn.
-        # Cap raised 440 -> 446 (~4 LOC headroom).
-        # fix(#549): +9 LOC — the system prompt now owns verb classification
-        # outright, reading the request's OBJECT (catalog / layer / data / map
-        # appearance) before its verb, so the tool descriptions stop
-        # re-litigating which phrasing wins. Cap raised 446 -> 456.
-        # feat(#1242): +29 LOC — build_chat_system_prompt gains the
-        # can_edit-gated filter_offer_note (offer, never apply, a persistent
-        # set_filter after a query_data result that reads as a simple row
-        # predicate) plus the doc/comment explaining why it is gated and why
-        # it lives here rather than in tools.py. Cap raised 456 -> 485, exact.
-        # fix(#1778): +28 - the provider call is wrapped so a tool loop that
-        # exhausts still records what it spent, and the layer block in the
-        # system prompt now scrubs column names and sample values and is fenced
-        # in an explicit trust boundary the model is told to read as data.
-        # Cap 485 -> 513, exact.
-        # fix(#1778 round 1): +3 - the layer block is fenced by the shared
-        # helper instead of interpolating the marker tags here, so a layer id
-        # or a serialized filter cannot forge a closing tag either.
-        # Cap 513 -> 516, exact.
-        # fix(#1778 round 3): +3 - safe_rows re-exported through the facade
-        # alongside _safe_value, per the module's import contract.
-        # Cap 516 -> 519, exact.
         "backend/app/processing/ai/chat_service.py": 519,
-        # fix(#836): defaults.py is the facade over the extensions-defaults
-        # split (defaults_*.py sub-modules discovered below). Pure re-exports —
-        # a new Default* class costs a few lines here.
-        # fix(#873 review r4): +10 — the two incidental pre-split helper
-        # bindings (defer_async_with_tenant, model_safe_tool_result) restored
-        # as redundant-alias re-exports. Cap 60 -> 70, exact.
-        # fix(#873 review r5): +5 — both helpers added to __all__ so the
-        # pre-split wildcard surface survives too. Cap 70 -> 75, exact.
         "backend/app/platform/extensions/defaults.py": 75,
     }
     private_service_default_line_budget = 350
     private_service_line_budget_allowlist = {
-        # M4 phase-2 grew this from three analysis operations to seven
-        # (#953 spatial_join, #954 measure, #955 select_by_location, #956
-        # intersect). Every rendered statement was pushed down into
-        # app.platform.analysis_sql as it landed, so what remains here is the
-        # preview ORCHESTRATION — which branch feeds which renderer, and how the
-        # positional rows become properties — not SQL. Two folds during the
-        # wave (#955's count builder, #956's preview projection) each bought
-        # one more operation's worth of room before it stopped fitting.
-        # 310 on main + 144 for the four operations = 454, then +9 for the
-        # #1097-review note on why intersect's match_count seeds to 0 rather
-        # than None (an empty overlay is an ANSWER; None is reserved for a
-        # count that could not be computed, and the panel renders those
-        # differently). The per-operation dispatch is now the majority of the
-        # file, so an eighth operation should split that out rather than raise
-        # this again.
-        # Then +12 for the #1097-review fix that moves the exact-count query
-        # inside the preview semaphore: 6 lines of code and the note explaining
-        # that BOTH statements open a sandbox connection, so releasing the slot
-        # between them let a finished preview admit the next caller while still
-        # holding one — the bound stopped bounding the thing it exists for.
-        # This budget is a ceiling rather than an exact ratchet, so a stale
-        # higher number would still pass. Set to the measured value anyway:
-        # the spare line is what the no-headroom rule on _MODULE_LOC_CAPS
-        # calls the seed of the next raise.
-        #
-        # Then +19 for the #1097-review preview-serialization fixes: _json_safe
-        # (a transferred bytea value reaches Pydantic as raw bytes and raises;
-        # encode as to_jsonb's hex form so both endpoints serve the same
-        # representation) and linearizing the select-by-location layer-path
-        # identity lateral, the one pass-through geometry this module renders
-        # itself rather than through render_geometry_expr.
-        #
-        # Then +12 making _json_safe recursive: a bytea[] column comes back as
-        # a LIST of bytes, which the scalar check waved through to the same
-        # 500 (round-14 review). to_jsonb renders that as an array of hex
-        # strings, so recursing with the same scalar encoding keeps the two
-        # endpoints byte-identical.
-        #
-        # fix(#1104): -1 — the select-by-location identity lateral reads the
-        # bare column again; geom_4326 is linearized at ingest now, so the
-        # per-read ST_CurveToLine wrap is gone. Budget 506 -> 505, exact.
-        #
-        # fix(#727): +89 for viewport-scoped previews — resolve_source_
-        # feature_count's bbox-scoped sibling (_resolve_bbox_source_count),
-        # the bbox predicate threaded through build_preview_sql's WHERE
-        # composition, the intersect-branch scope-decision comment, and the
-        # docstring updates on run_analysis_preview explaining both. Budget
-        # 505 -> 594.
-        #
-        # fix(#727 codex P1/P2 round 1): +14 — the bbox count moved from a
-        # bare db.execute before the preview semaphore to execute_safe
-        # inside it (a concurrent-preview pool-exhaustion finding), which
-        # also made it degrade to None on SandboxError instead of exposing a
-        # LIMIT-capped count as an exact total (a second, related finding —
-        # see _resolve_bbox_source_count's docstring for both). Budget
-        # 594 -> 608, exact.
-        #
-        # fix(#727 codex round 2): +2 — the intersect branch now passes
-        # request.bbox through to render_intersect_preview instead of
-        # discarding it (a second review round found the discard left one
-        # operation still clustering previews in gid order despite the
-        # frontend sending bbox uniformly). Budget 608 -> 610, exact.
-        #
-        # fix(#727 codex round 5): +2 — the spatial_join match_count call
-        # site now passes bbox=request.bbox through to
-        # render_spatial_join_match_count, matching intersect's fix (a
-        # third review round found spatial_join's count was the one
-        # remaining place a bbox-scoped source_feature_count was paired
-        # with a whole-dataset match_count). Budget 610 -> 612, exact.
+        # Domain splits retain operation orchestration that spans their narrower helpers.
+        # Preview operations share one sandbox concurrency and serialization boundary.
         "backend/app/modules/catalog/datasets/domain/service_analysis.py": 612,
-        # fix(#1778): +56 over the reviewed 550. The gallery listing's
-        # page-scoped layer counts, and the asset-object lifecycle the maps
-        # module had none of: the row lock that serializes one map's thumbnail
-        # and OG-image replacements, the post-commit re-read that refuses to
-        # delete a key the row still points at, and the best-effort discard the
-        # delete endpoint and both upload handlers share. Most of the growth is
-        # the two docstrings, which carry the part a later reader would
-        # otherwise simplify away: a row lock cannot outlive the commit that
-        # releases it, so the lock and the re-read are two halves of one fix and
-        # neither is redundant. Cap 550 -> 606, exact.
-        # fix(#1778 round 3): +44. new_map_asset_key, whose docstring is the
-        # argument for it: the row lock ends at the commit, so the cleanup that
-        # follows re-reads the row and can still be descheduled between that
-        # read and the delete. A key that is never reused closes that window by
-        # construction rather than by timing. The locked read also moved from
-        # the Map entity to its two columns, and the reason is recorded because
-        # it is easy to undo: every caller has already loaded the map, so an
-        # entity select returns the identity-mapped instance and reads back the
-        # keys from before the wait on the lock. Cap 606 -> 650, exact.
-        # fix(#1778 round 4): +58. The post-commit liveness read moved inside
-        # the best-effort boundary, because it is a database call made after the
-        # caller already committed and a blip in it was turning a durable delete
-        # into a 500. And map_asset_publication, the rollback scope the three
-        # object writers in this package share. Most of it is the two rationales
-        # a later reader would otherwise undo: why skipping the deletes is the
-        # safe side of a failed liveness read, and why the ledger records
-        # physical keys rather than logical ones (map images resolve into the
-        # tenant prefix, sprite icons are deliberately global).
-        # Cap 650 -> 708, exact.
-        # fix(#1778 round 5): +33 — the ledger became MapAssetPublication, whose
-        # settled() moves the rollback boundary onto the commit. Keying it on
-        # "did the block raise" answered a different question from "did the row
-        # commit", so the icon route's post-commit refresh could delete an
-        # object the committed row referenced. The class docstring carries that,
-        # and record() carries the physical-vs-logical rule the two writers
-        # depend on. Cap 708 -> 741, exact.
-        # fix(#1778 round 6): +42 — committing() and outcome_unknown, the mark
-        # that makes an indeterminate commit non-destructive. A connection lost
-        # between PostgreSQL making the commit durable and the acknowledgement
-        # arriving raises for a transaction that DID commit, so the rollback
-        # would delete an object the committed row references. Most of the lines
-        # are the docstring recording the trade, and why the alternative of
-        # verifying from an independent session before deleting was refused: it
-        # is a database call on an error path, over a connection that has just
-        # proven unreliable, to decide a deletion. Cap 741 -> 783, exact.
-        # fix(#1778 round 7): +11 — record()'s docstring now states the ordering
-        # as a rule rather than an aside, including the provider evidence that
-        # deleting a never-written key is a no-op everywhere (local, S3, Azure),
-        # which is what makes recording before the write free.
-        # Cap 783 -> 794, exact.
-        # fix(#1778 round 8): +56 — lock_map_for_asset_write now runs
-        # under SET LOCAL lock_timeout = '2s' and maps a lost race (55P03) to a
-        # 409 instead of hanging, plus the _is_lock_timeout_error helper that
-        # detects it across asyncpg and SQLAlchemy wrapping. Most of the growth
-        # is the docstring addition explaining why an unbounded wait here was a
-        # real problem once the row lock started spanning an object-storage
-        # PUT with minute-scale S3 timeouts. Cap 794 -> 850, exact.
+        # Database commits and object publication/rollback form one asset lifecycle.
         "backend/app/modules/catalog/maps/service_crud.py": 850,
-        # fix(#474, #475): localized ranking/eager loading plus the OGC
-        # ids/externalIds filters cross the default by nine lines. Keep the
-        # carve-out exact so further growth requires another review.
-        # fix(#1855): -78. The search-only filters and the count moved into
-        # service_candidates.py, the selection facets now share. Cap 359 -> 281.
         "backend/app/modules/catalog/search/service_datasets.py": 281,
-        # Phase 1062 CR-04: +13 lines from non-expiring embed-token CSP fix
-        # (or_ IS NULL predicate, _create_non_expiring_embed_token helper).
-        # Cap raised from 575 → 600 to allow ~12 lines of headroom above 588.
-        # Phase 1176 SEC-024: +20 lines for _redact_terrain_config (strip the
-        # private DEM source_dataset_id from shared/public map responses when the
-        # DEM is not a visible layer). Cap raised 600 → 625 (~5 LOC headroom).
-        # #347 (ADM-01): +24 lines — the admin "Published Maps" listing re-keys
-        # on Map (visibility=public) LEFT JOINed to the latest share token per
-        # map (DISTINCT ON) so every published map appears, not just shared ones.
-        # Cap raised 625 → 660 (~11 LOC headroom).
-        # fix(#394) SH-01/B-023: +31 lines — get_shared_map unions embed-token
-        # scoped layers into the visibility-filtered set (SEC-022 capability
-        # parity with the tile path) + tile_version threading. Cap raised
-        # 660 → 720 (~29 LOC headroom).
-        # Hosted opaque-share isolation joins every token operation through
-        # its RLS-visible Map/User parent (+9 LOC). Cap 720 -> 735 leaves
-        # only six lines before the next required split review.
-        # fix(#931): +32. find_public_maps_using_dataset became
-        # find_maps_broken_by_dataset_visibility: an internal map using the
-        # dataset was matched by neither the old query nor its caller's gate,
-        # so the flip succeeded and every signed-in viewer of that map lost
-        # the layer in silence. #930 made the rule a matrix, so the helper
-        # compares the before and after audiences instead of listing
-        # forbidden target values. Cap 735 -> 918, exact.
-        # fix(#1111 review): +19 — precision defers to the conservative
-        # refusal whenever a non-default PermissionExtension is registered:
-        # the stranded-viewer query mirrors only the default's grants+ladder,
-        # so an additive overlay's viewers are invisible to it (#1068 tracks
-        # the seam-aware answer). Cap 918 -> 937, exact.
-        # feat(#1068): -36. The rank table, its per-map reach function and the
-        # three named cut slices are gone: the audience seam answers "who could
-        # read this before, and who can after" directly, and a rank drop was
-        # only ever a proxy for that difference being non-empty. The guard is
-        # shorter than it was before #1111's stopgap and now asks the
-        # authority rather than restating the community ladder at it.
-        # Cap 937 -> 901, exact.
-        # fix(#1126 codex P2): +13 — an unchanged visibility returns before the
-        # authority is asked at all. The rank comparison used to absorb the
-        # no-op (`X < X` is false); without it the fallback named every shared
-        # map, and the seam-answering branch reported an account the overlay
-        # could not classify as stranded by a move that did not happen. Most of
-        # the lines are why it sits above the branch rather than inside one.
-        # Cap 901 -> 914, exact.
-        # fix(#1204): +66 — sortable column headers on the admin Published Maps
-        # table need list_share_tokens to order by more than the map's
-        # created_at. Most of the lines are _share_token_ordering: the sort
-        # allowlist, the NULLS LAST pinning for creator/expires_at (an outer
-        # join makes every linkless map null there), and why the embed count is
-        # ordered by the COALESCE'd expression the cell renders rather than the
-        # raw aggregate (which is NULL, not 0, for a map with no ACTIVE embed
-        # token — and the count never exceeds 1, per the partial unique index).
-        # Cap 914 -> 983, exact.
-        # fix(#1372): +4 — the shared-layer raster tile template carries
-        # ?v=<tile_cache_version>, the segment nginx's raster cache keys on.
+        # Shared-map audience decisions stay behind the permission extension seam.
         "backend/app/modules/catalog/maps/service_public.py": 987,
-        # fix(#1290 review): +5 — PUBLIC_ASSET_KEYS and the guard that reads it.
-        # _build_stac_assets published every dataset_assets row it was handed,
-        # so the first INTERNAL key (archived_original, the pre-conversion
-        # upload kept after a lossy conversion) would have been advertised as a
-        # downloadable asset — a presigned URL on published S3. An allowlist
-        # rather than a skip-list so the next internal key is private by
-        # default. Cap 500 -> 505, exact.
-        # feat(#1281): +7 — project origin health and freshness timestamps
-        # through the visibility-filtered OGC search representation, including
-        # JSON-safe datetime serialization for the OGC and STAC response paths.
-        # Cap 505 -> 512, exact.
-        # fix(#1372 codex r2): +7 — the advertised raster_tiles asset carries
-        # ?v=<tile_cache_version> like every rendered raster template.
-        # fix(#1469): +5 — properties.distributions no longer republishes the
-        # raster/VRT ingest tails' object-storage-key row (unresolvable, and it
-        # exposes the storage layout). One is_publishable_url guard plus the
-        # comment saying why this profile drops the row instead of replacing it
-        # — build_assets already advertises raster access here. Cap 519 -> 524.
-        # feat(#1681): +1 — FlatGeobuf joined _FORMAT_MEDIA alongside every
-        # other export format. Cap 524 -> 525, exact.
-        # feat(export/pmtiles): +1 — PMTiles joined _FORMAT_MEDIA the same
-        # way. Cap 525 -> 526, exact.
-        # fix(#1805 review round 4 P2): +13 — a band whose own stats lack a
-        # nodata key but whose asset-level RasterAsset.nodata column is None
-        # now emits an explicit nodata: null, so the client can tell
-        # "confirmed absent" from "genuinely unavailable" (the latter keeps
-        # the key missing). Cap 526 -> 539, exact.
-        # fix(#1805 review round 5): +9 — res_x/res_y are now surfaced
-        # alongside the lossy gsd (min(abs(res_x), abs(res_y))), so a
-        # client-side grid-alignment check can compare each axis
-        # independently, matching the backend's _check_grid_alignment.
-        # Cap 539 -> 548, exact.
-        # fix(#1778): +11, rebased onto the above rather than the 526 baseline
-        # it was originally measured against. The band array now builds
-        # through the shared `app.core.raster_bands` normalisers, so this
-        # representation stops dropping the colour-interpretation name of
-        # every locally ingested raster (it read a `name` key no producer
-        # writes) and stops emitting empty band entries for a remotely
-        # described COG, while keeping the round-4-P2 explicit-null case
-        # above (moved to sit beside the normaliser call it now depends on).
-        # Cap 548 -> 559, exact.
         "backend/app/modules/catalog/search/service_records.py": 559,
-        # fix(#448): +~40 LOC — query-embedding hot-path deadline (asyncio.wait_for
-        # wrapper) + the gated/approximated vector-only match COUNT in
-        # _run_rrf_merge (perf audit 2026-07-10 §2d). Cap 350 → 390
-        # (~19 LOC headroom above 371). That headroom is now spent (386 LOC).
-        # fix(#625): +9 LOC — the _MIN_SEMANTIC_QUERY_LEN gate that drops
-        # typeahead prefixes before they reach the provider, plus its rationale
-        # comment. Cap 390 → 395, exact: the next addition needs its own review.
-        # fix(#1546): +61 — stored rows now carry the identity of the
-        # configuration that produced them and the vector arm filters on it.
-        # Around fifteen lines are mechanism: `_live_embedding_identity`,
-        # resolving it once below the has_embeddings gate and handing it back
-        # out of `_get_vector_ranks` so the counts filter on what the ranks were
-        # taken under, the query-embedding cache key, and `usable_by_config` at
-        # the three filter sites. The rest is why the cache key had to change
-        # with them — the memoized query vector is a third independent reader of
-        # the configuration, and filtering rows by the live one while serving a
-        # vector made under the previous one moves the bug rather than fixing
-        # it. Cap 395 -> 456.
-        # fix(#1546 review r1, codex P1/P2): +26 — the resolved configuration is
-        # now handed to the PROVIDER as well as used for the filter and the
-        # cache key, so a settings change inside one request cannot produce the
-        # query vector under a configuration the rows are not ranked under; and
-        # the resolution moved inside the FTS fallback guard, where a raising
-        # persistent-config read degrades instead of failing the search. Most of
-        # the lines are the two rationales, including why verify-after-the-fact
-        # was rejected. Cap 456 -> 482, exact.
-        # fix(#1855): -84. The vector arm is resolved once into SemanticArm and
-        # counted through the shared candidate set. Cap 482 -> 398, exact.
-        # fix(#1903): +68 — a claim registry coordinates the SPA's unordered
-        # paired search requests so only one pays the SEC-S11 token (bounded
-        # by TTL + LRU, cross-worker sharing tracked at #2018), and
-        # concurrent identical embeds join one in-flight, shielded provider
-        # call (gated on the same fully-pinned predicate the provider's own
-        # session-read check uses) so an exemption can never fund two paid
-        # calls. Cap 398 -> 466, exact.
-        # fix(#2018): +11. Both claim functions consult the shared store
-        # first, so the pair coordinates across uvicorn workers; the local
-        # registry is the fallback for a store that does not answer, and the
-        # pairing window is derived from that store rather than copied.
-        # fix(#2018 review r2): +4. A store "no key" no longer short-circuits
-        # the local registry: a claim the fallback wrote can outlive the
-        # cooldown, and the store was never given it to answer for.
-        # Cap 477 -> 481, exact.
         "backend/app/modules/catalog/search/service_semantic.py": 481,
-        # fix(#430 V-14): _replace_layers now reconciles layers by id (update-in-place
-        # + create/delete) instead of delete-all-then-recreate, so a PUT preserves
-        # layer UUIDs. +~35 LOC over the 350 default. Cap → 400 (~34 headroom).
         "backend/app/modules/catalog/maps/service_diff.py": 400,
-        # fix(#430 V-17): DatasetMeta/LayerRow now carry dataset visibility+status so the
-        # builder can badge layers hidden from a public map's audience. +~10 LOC
-        # over the 350 default (BA-21 tie-break comment adds a couple more).
         "backend/app/modules/catalog/maps/service_shared.py": 400,
-        # Phase 269 H-05: dataset-domain modules over the 350 default at audit
-        # time. Caps set ~20-30 LOC above current size to allow modest growth
-        # while still tripping CI on substantial regrowth back toward the
-        # original 1407-LOC god module.
-        # Security fix (relationship target authz): +83 LOC for target-visibility
-        # filtering in list_relationships, the get_relationship_datasets loader,
-        # source/target binding in get_related_records, and the public-source
-        # auto-detect guard. Cap raised 480 -> 580 for ~30 LOC headroom.
-        # Phase 1191 GAP-033: +new list_relationships_with_total for the list-envelope
-        # contract ({relationships,total}); list_relationships DRY'd to delegate +
-        # _visible_relationships extracted (shared, fail-closed). Cap 580 -> 595 (~7 LOC headroom).
-        # Smoke-check backlog (#315): +source/target Dataset.id resolution so the
-        # list response returns dereferenceable ids. Smoke-residual follow-up (#315):
-        # +try/except (ProgrammingError->503) around get_related_records table
-        # queries (raster/missing-table guard). Cap 595 -> 620 (~3 LOC headroom).
-        # fix(#1104): +8 — _fetch_target_rows projects the row before to_jsonb
-        # (via live_property_columns) so the curved source `geom` column never
-        # reaches the geometry→jsonb cast, which raises on curves. Cap
-        # 620 -> 628, exact.
-        # fix(#1113 review r10): +7 — the FK match moved inside the projection
-        # against the base table (a relationship may target a column the
-        # projection drops), with the identifier colon-escaped for text().
-        # Cap 628 -> 635, exact.
-        # fix(#1580): +18 — the related-items seed is the anchor ROW now, not a
-        # bare vector, and the pair travels from it into the scoring call. A
-        # list of floats does not say which model or endpoint produced it, so
-        # without carrying the identity this layer could select neighbours in
-        # one vector space and print similarities measured in another. Most of
-        # the lines are the two docstrings saying why the anchor's own pair is
-        # the question here, where both sides are stored rows, rather than the
-        # live configuration's. Cap 635 -> 653, exact.
-        # fix(#1580 review r2): +4 — the anchor read is handed into the
-        # neighbour selection rather than left to be taken again. Two reads of
-        # one record under READ COMMITTED can straddle a commit, and then the
-        # ranking is anchored on a row the scoring never saw. Cap 653 -> 657.
         "backend/app/modules/catalog/datasets/domain/service_relationships.py": 657,
-        # fix(#474): reject primary-language updates that collide with a
-        # translated variant. Cap 460 -> 480 (~9 LOC headroom above 471).
-        # fix(#931): +7. _apply_visibility_change no longer carries its own
-        # `new != public and old == public` gate — that gate is what hid the
-        # internal-map case — and delegates the whole before/after audience
-        # comparison to the maps helper. Cap 480 -> 489, exact.
-        # feat(#1068): +1 — the guard call passes record_id, so the permission
-        # authority can key an audience on the record and not only its dataset.
-        # Cap 489 -> 490, exact.
-        # fix(#1170): -37 — delete the dead update_auto_metadata, the one
-        # geometry_type writer that never probed for geom_4326 (refs #1020).
-        # Cap 490 -> 453, exact.
-        # feat(#1070): +30 — the inherited-keyword disclosure warning at the
-        # metadata chokepoint: after visibility/record_status resolve, one
-        # check of the resolved state warns (never blocks) when keywords
-        # inherited from the analysis source reach beyond that source's
-        # audience. Cap 453 -> 483, exact.
-        # fix(#1178 review): -5 — the check body moved into the shared
-        # inherited_keyword_disclosure_warning helper so the publication
-        # status endpoints run it too. Cap 483 -> 478, exact.
-        # feat(#1472): +1 — the `attribution` entry in _RECORD_FIELD_MAP, which
-        # is all the PATCH needs: the field is a plain scalar on the record, so
-        # _apply_simple_field_assignments already gives it PATCH semantics and
-        # explicit-null clearing. Cap 478 -> 479, exact.
-        # fix(#1746 B2b review r24): +9. `row_count_delta` is null when either
-        # count is unknown rather than a subtraction against a coerced zero,
-        # which invented a delta the size of whichever side was known. The
-        # case that reaches it is a service preview whose collection size the
-        # service never published.
-        # fix(#1847): +31. `sample_example_values` reads the data table on its
-        # own and `reset_attribute` takes the sample as an argument, so the
-        # reset samples before it takes the pair. Cap 488 -> 519, exact.
-        # fix(#1881): -7. The PATCH takes the pair on every body, so the
-        # request-field whitelist and its branch are gone. Cap 519 -> 512, exact.
         "backend/app/modules/catalog/datasets/domain/service_metadata.py": 512,
-        # fix(#435 codex r1): +6 LOC in get_dataset_rows to probe schema existence
-        # before degrading a 42P01 to an empty page. Postgres reports a missing
-        # tenant data schema with the same code as a raster dataset's synthetic
-        # table, so the code alone cannot tell provisioning drift from normal
-        # emptiness. Cap 390 -> 396, no headroom.
-        # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import. Cap 397,
-        # still no headroom.
-        # feat(#765): +7 — the detail response resolves derived_from through
-        # visible_derived_from, so a private source is never disclosed via a
-        # derived dataset. Cap 397 -> 404, still no headroom.
-        # fix(#1103): +15 — the same treatment for the PROSE. Both builders in
-        # this module now resolve lineage_summary through
-        # visible_lineage_summary(ies), which is what stops a derived dataset
-        # from naming a source or mask layer the requester cannot open. The
-        # list builder takes the batch form deliberately: one visibility query
-        # for the page rather than one per row. Cap 404 -> 419, no headroom.
-        # fix(#1290 review): +7 — the public-asset-key boundary. Rows are
-        # filtered where they are FETCHED so an internal key never enters a
-        # payload structure; `GET /datasets/{id}` had been building its assets
-        # straight off the ORM rows and leaked the archived original's href and
-        # filename to every viewer. Cap 419 -> 426, exact.
-        # feat(#1316): +12 — the list and detail builders each now resolve
-        # can_view_dataset_provenance(record, user, user_roles) and pass it
-        # into dataset_to_response, so origin_uri/origin_ref are nulled for
-        # every reader but the owner or an admin. Cap 426 -> 438, exact.
-        # fix(#1436): +5 — the raster asset, VRT source-count, and dataset-asset
-        # fetches each open their own async_session() instead of gathering on
-        # the shared `db` (which asyncpg silently serialized despite the old
-        # "in parallel" comment). Cap 438 -> 443, exact.
-        # fix(#1436 codex r1): -14 — reverted to sequential fetches on the
-        # caller's own session. Per-branch async_session() traded the
-        # serialization bug for a nested pool checkout while the caller's own
-        # connection is held for the rest of the request; per codex, ~13
-        # concurrent raster/VRT detail requests exhaust the default (10 + 3)
-        # pool this way. Three fast point lookups aren't worth that risk.
-        # Cap 443 -> 429, exact.
-        # fix(#1778): +10 — the row browser emits quoted column identifiers.
-        # A column named after a SQL keyword (``desc``, ``order``, ``user`` —
-        # ogr2ogr's DBF output, and nothing renames them on ingest) made every
-        # SELECT and every ILIKE filter a 42601 syntax error, which is in none
-        # of the sqlstate sets this module degrades on, so the endpoint 5xx'd
-        # for that dataset forever. The lines are the import, the two call
-        # sites and the docstring note saying membership is decided on the bare
-        # name so quoting happens at emission. Cap 429 -> 439, exact.
         "backend/app/modules/catalog/datasets/domain/service_query.py": 439,
-        # fix(#1452): first explicit cap for this module — it sat under the
-        # 350 default until the detach landed. +65 over the pre-change 350:
-        # _reap_managed_storage (the reap loop both branches had inline,
-        # extracted when the new conditional pushed delete_dataset past
-        # ruff C901), _relation_exists (the pg_class probe that decides
-        # whether a detach freed the name), and the two decisions delete now
-        # makes with the reasoning behind them: drop-vs-detach, and the
-        # GH-1443 retirement that follows the relation rather than the
-        # dataset. Cap 350 -> 415, exact.
-        # fix(#1456): +36 — the tombstone now carries the freed relation's oid
-        # and the dataset's prior owner. _relation_exists became _relation_oid
-        # (same one probe, now returning the identity), the probe moved ahead
-        # of the drop-vs-detach branch so the DROP path can capture an oid
-        # before the relation is gone, and the two new tombstone fields carry
-        # the reasoning for why they are captured here and nowhere else
-        # (both sources die in this transaction) plus the oid's
-        # one-cluster-lifetime caveat. Cap 415 -> 451, exact.
-        # fix(#1456 codex round 1): +32 — the identity was being collected
-        # everywhere EXCEPT the surviving-detach path, which is the one
-        # GH-1456's window 1 is about. That path now writes a DetachedRelation
-        # instead of discarding what it probed, in a sibling table rather than
-        # the retirement set (whose whole API is set membership), with the
-        # reasoning for the split and for the belt-and-braces oid guard.
-        # Cap 451 -> 483, exact.
-        # fix(#1847): the lock order, its gate and its 409 mapping, and the
-        # job rows ahead of the cascade. Cap 513, exact.
         "backend/app/modules/catalog/datasets/domain/service_lifecycle.py": 513,
-        # Phase 276 CODE-02: chat_*.py sub-modules are all under the 350
-        # default (largest is chat_actions.py at ~245 LOC). No explicit
-        # per-file overrides needed; default applies.
-        # fix(#394) CH-02: +~35 lines — set_label column validation against the
-        # target layer schema (error feedback to the model), the CSS-colorish
-        # sanitizer, and the collector error gate. Cap 350 → 400 (~19 headroom).
-        # fix(#544): +~14 lines — deterministic geom_4326 append before
-        # execution and WKB-column strip after geojson extraction in
-        # _handle_query_data. Cap 400 → 425 (~11 headroom).
-        # fix(#556 review P2): +~8 lines — overlay-row-budget fetch cap when
-        # geometry is appended (constant + conditional row_limit). Cap
-        # 425 → 445 (~12 headroom).
-        # fix(#556 review P2, round 7): +~15 lines — geometry-free COUNT
-        # recovery so the transfer cap doesn't corrupt the documented total
-        # row_count. Cap 445 → 470 (~18 headroom).
-        # fix(#560): +~44 lines — _geom_4326_missing_note helper + graceful
-        # degrade (clean note instead of a generic failure) at both the
-        # model-written and append-retry failure points when a legacy geom-only
-        # table lacks geom_4326. Cap 470 → 530 (~16 headroom).
-        # M4 Phase 5 (run_analysis chat tool): +~11 lines — the dispatch branch,
-        # the collector branch, and the chat_analysis import. The handler itself
-        # was split into the new chat_analysis.py sibling (auto-discovered by the
-        # chat_*.py glob below, ~142 lines under the 350 default) rather than
-        # grown here. Cap 530 → 550 (~14 headroom).
-        # fix(#1778): +31 - the _SANDBOX_BOUNDS table and the comment
-        # enumerating what query_data now passes to the sandbox and, for the
-        # statement timeout and the output-amplification denylist, why it
-        # deliberately does not. Both surfaces sit behind the same
-        # use_ai_chat permission, so the omissions were opt-out by asking the
-        # chatbot. Cap 550 -> 581, exact.
-        # fix(#1778 round 3): +6 - safe_rows on the tabular half of the
-        # query_data payload, at the one point it is handed to a frame, plus
-        # the note saying why it runs after geometry detection and not before.
-        # Cap 581 -> 587, exact.
+        # Chat splits retain tool execution and result-serialization workflows.
         "backend/app/processing/ai/chat_actions.py": 587,
-        # feat(#1241): +18 over the 350 default — _safe_value now emits
-        # integers outside JavaScript's safe range as strings (constant, the
-        # int branch, and the docstring explaining why), so a bigint id
-        # survives the browser's JSON.parse intact instead of arriving rounded
-        # and being written that way into a saved chat-preview snapshot.
-        # Cap 350 → 370 (~17 headroom).
-        # fix(#1778): +50 — non-finite floats now become null and an all-EMPTY
-        # result returns no bbox instead of [inf, inf, -inf, -inf], either of
-        # which used to make the actions frame unparseable (the browser dropped
-        # it silently; the non-streaming endpoint returned 500). Two helpers
-        # were split out to keep _extract_geojson under the complexity gate:
-        # _parse_row_geometry (the per-row parse) and _row_properties (the
-        # property build plus its non-finite count, which feeds one warning per
-        # result rather than one per cell). Cap 370 -> 420, exact.
-        # fix(#1778 round 3): +17 - safe_rows, the tabular sibling of
-        # _safe_value. Round 0 normalized only the GeoJSON property copy, so a
-        # NaN in an ordinary column still reached the SSE frame as a bare token
-        # and the browser dropped the whole frame. Cap 420 -> 437, exact.
-        # fix(#1891): +3. The geometry append folds both table parts through
-        # the sandbox's folded_identifier before comparing. Cap 437 -> 440, exact.
         "backend/app/processing/ai/chat_geojson.py": 440,
-        # fix(#836): extensions-defaults sub-modules over the 350 default at
-        # split time. Caps exact (zero headroom): each class moved verbatim
-        # from the 1815-LOC defaults.py, and regrowth toward another god
-        # module should get its own review.
-        # fix(#1590): +48 — stream and stream_chat_events pinned to explicit
-        # keyword-only signatures matching AIProviderExtension instead of a
-        # bare **kwargs shim, so a missing keyword surfaces at the port
-        # boundary rather than inside _stream_openai_chat. Cap 444 -> 492,
-        # exact.
-        # fix(#1778): +10 - each of the three ToolLoopExhaustedError raise
-        # sites now carries the running token totals, so the caller can bill an
-        # exhausted loop to the daily cap instead of losing it. Cap 492 -> 502,
-        # exact.
-        # fix(#1778 round 1): +18 - the loop is wrapped so EVERY exit stamps
-        # its running token totals, not only the three exhaustion raises. After
-        # round one the provider has been billed, so a later request failure, a
-        # tool executor that raises, or a cancellation must still reach the
-        # daily quota. Cap 502 -> 520, exact.
+        # Default adapters expose explicit extension contracts rather than catch-all shims.
         "backend/app/platform/extensions/defaults_ai_openai.py": 520,
-        # fix(#1778 round 1): first explicit cap, over the 350 default. The
-        # loop is wrapped so every exit stamps its running token totals, and
-        # _run_tool_use_blocks was split out of complete() because that wrapper
-        # pushed it over the complexity gate. Cap 350 -> 372, exact.
         "backend/app/platform/extensions/defaults_ai_anthropic.py": 372,
-        # fix(#1207): +15 — three delegations for the shared presigned-completion
-        # helpers (lock/assemble-check/finalize) the reupload door reaches through
-        # the port. Three lines each, matching the existing entries.
-        # fix(#1213 review r3): +7 — the completability guard's delegation.
-        # fix(#1235 review r3): +5 — the remaining-lifetime delegation, which
-        # the reupload door reaches through the port like every other
-        # processing helper it uses.
-        # fix(#1235 review r8): +5 — the sign-with-deadline delegation. The
-        # reupload door hands this to a worker thread, so the whole callable
-        # has to cross the port rather than just the lifetime number.
-        # feat(#1221): +5 — the raster-replace task delegation, same three-line
-        # shape as its reupload_file/reupload_service siblings. The reupload
-        # commit door picks the executor by record type and reaches all three
-        # through the port.
-        # feat(#1265): +5 — the registered-PostGIS refresh task delegation,
-        # same three-line shape again. The refresh door now picks its executor
-        # by origin kind and reaches this one the same way it reaches
-        # reupload_service.
-        # feat(#1266): +5 — the STAC re-resolution task delegation, the third
-        # instance of that same three-line shape. Cap 440 -> 445.
-        # refactor(stac): +5 — fetch_raster_meta_bulk_without_vrt, the narrower
-        # reading of the raster-meta query the STAC item surface takes. Same
-        # deferred-import shape as its sibling; a separate method rather than a
-        # keyword because widening a port signature is an
-        # EXTENSION_API_VERSION bump. Cap 445 -> 450.
-        # fix(#1546): +11 — resolve_embedding_config_fingerprint, the answer
-        # semantic search needs to tell a stored vector from one made under
-        # another endpoint. Same deferred-import shape as its neighbours;
-        # `modules/catalog/` may not import `app.processing.*`, so it crosses
-        # here. Cap 450 -> 461.
-        # fix(#1546 review r1, codex P1): +17 — the port answers the whole live
-        # configuration rather than its fingerprint alone, and generate_embedding
-        # takes a pinned triple. The comment carries why that is ONE optional
-        # argument and not three keyword ones: `None` is a legitimate resolved
-        # endpoint, so three None defaults could not tell "not pinned" from
-        # "pinned to the client default". Cap 461 -> 478, exact.
-        # fix(#1580): +13, and the code shrank — get_record_embedding stopped
-        # spelling its own query and now shares `get_anchor_embedding_row` with
-        # the ranking helper, so "which row is the anchor" has one answer
-        # instead of two `LIMIT 1` reads that could disagree. The lines are the
-        # two comments: why the anchor's identity travels with its vector, and
-        # why scoping the selection without scoping the distances would have
-        # moved the defect one layer out rather than closing it.
-        # Cap 478 -> 491, exact.
-        # fix(#1580 review r2): +18 — get_nearest_record_ids takes the caller's
-        # anchor as a required keyword, and both queries move to
-        # usable_by_stored_anchor. The lines are the two comments saying why the
-        # stored-vs-stored predicate does not grandfather an unstamped row where
-        # search's does: on the catalog that distinction matters for, a partial
-        # re-embed, the rows still carrying NULL are the old space.
-        # Cap 491 -> 509, exact.
-        # fix(#1590): +60 — pin abort_presigned_multipart_upload,
-        # verify_completed_presigned_upload, and finalize_presigned_object to
-        # CatalogPort's explicit keyword-only signatures instead of a bare
-        # **kwargs shim, so a missing keyword surfaces at the port boundary
-        # rather than deep in the service call.
-        # verify_completed_presigned_upload and finalize_presigned_object
-        # also keep accepting replacing_dataset_id: uuid.UUID | None = None,
-        # a structural superset the Protocol does not declare yet (see the
-        # comments on both methods in core/catalog_port.py — adding it there
-        # is a version bump, not a cleanup). Cap 509 -> 569, exact.
         "backend/app/platform/extensions/defaults_catalog_port.py": 569,
-        # feat(#683): +58 — run_analysis_preview carries a clip mask DATASET
-        # now, which costs a widened signature (one param per line once ruff
-        # wraps it) plus the mask's shape and size gates. Those live here on
-        # purpose: they are the rails router_analysis._load_mask_dataset
-        # applies, and putting them at the port gives every caller the same
-        # refusal instead of an empty preview or an unbounded mask subdivide.
-        # Cap 406 → 470 (~6 headroom).
-        # feat(#1266): +11 — resolve_stac_binding. The STAC refresh strategy
-        # re-reads the item document its asset was published in, and every
-        # byte of that goes through Rule 2's safe client and the #1222 health
-        # classifier, both of which live in the catalog domain. Routing the
-        # ANSWER across the port is what keeps processing/ from importing
-        # catalog for it (the burn-down list's own instruction) and leaves the
-        # worker holding no HTTP client at all. Cap 470 -> 481.
-        # fix(#1266 review round 9): +1 — the resolution takes the item's
-        # recorded id as well, so a catalog whose URLs state no identity can
-        # still have an answer checked against the binding. Cap 481 -> 482.
-        # fix(#1314): +12 — reconcile_distributions, the seam the refresh and
-        # reupload paths cross to bring auto-generated distribution rows in
-        # line with a modality that changed under them. Cap 482 -> 494.
-        # fix(#1443): +5 — get_retired_table_name_orm_class. The retired-name
-        # probe runs inside generate_table_name, which lives in processing/ and
-        # so cannot import the catalog model it needs; this is the same
-        # ORM-class accessor shape as its five neighbours. Cap 494 -> 499,
-        # exact.
-        # fix(#1506): +38 — get_records_without_embeddings became model-aware.
-        # Six lines are the NOT EXISTS and the model resolution; the rest is
-        # the pair of rationales a future reader needs to not undo it: why
-        # "missing" means "missing under THIS model", and why an unresolvable
-        # model returns nothing here while the same sentinel is allowed to
-        # read as zero coverage in admin's stats. Cap 499 -> 537, exact.
-        # fix(#1546): +27 — "missing" narrows once more, from "no vector this
-        # MODEL can use" to "no vector this CONFIGURATION can use", so a row
-        # written against another endpoint is picked up instead of reading as
-        # coverage the search cannot use. Six lines are the fingerprint
-        # resolution and its fail-closed branch; the rest records why an
-        # UNSTAMPED row still counts as covering the record, which is the only
-        # thing keeping an upgrade from turning the next Generate Missing into
-        # a catalog-wide re-embed. Cap 537 -> 564, exact.
-        # fix(#1590): +4 — compute_schema_diff's parameters renamed to match
-        # ProcessingPort's old_feature_count/new_feature_count so a keyword
-        # caller fails against the Protocol, not just the default. Cap
-        # 564 -> 568, exact.
+        # ProcessingPort signatures remain explicit across the catalog boundary.
         "backend/app/platform/extensions/defaults_processing_port.py": 568,
-        # fix(#929): +2 over the 350 default — the creator exemption on the
-        # restricted branch of filter_visible/can_access_dataset plus its
-        # rationale comments. fix(#930): +20 — the internal branch on the same
-        # two functions, whose comments carry why the obvious stricter variant
-        # is wrong (it hides an owner's own draft from the owner). Cap exact,
-        # zero headroom.
-        # feat(#1068): +61 — record_audience, the audience-shaped reading of
-        # the same ladder filter_visible applies per user. Roughly half the
-        # lines are the mapping between the two: which condition over there
-        # each branch here inverts, so the pair can be kept in step by reading
-        # rather than by running the equivalence suite. Cap 372 -> 433, exact.
         "backend/app/platform/extensions/defaults_extensions.py": 433,
-        # fix(#1778): +16 over the 350 default -- _apply_common_filters'
-        # datetime block replaces two bare `.is_(None)` OR-arms (which
-        # unconditionally matched every null-temporal record for ANY
-        # datetime filter) with the same null_temporal & created_at
-        # fallback comparison the already-fixed STAC peer uses, while
-        # preserving the existing open-ended reading for records that do
-        # have one bound set. Cap 350 -> 366, exact.
         "backend/app/modules/catalog/search/service_filters.py": 366,
     }
 
@@ -2185,15 +1215,13 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         )
         for path in sorted(root.glob("service_*.py"))
     )
-    # Phase 276 CODE-02: extend discovery to processing/ai/chat_*.py sub-modules
-    # (the chat_service.py facade is already covered via facade_line_budgets).
+    # Discover chat implementation modules; the facade has its own budget.
     files_to_check.extend(
         _repo_style_rel(path)
         for path in sorted(_backend_path("app/processing/ai").glob("chat_*.py"))
         if path.name != "chat_service.py"
     )
-    # fix(#836): extend discovery to the platform/extensions defaults split
-    # (the defaults.py facade is already covered via facade_line_budgets).
+    # Discover extension defaults implementations; the facade is listed above.
     files_to_check.extend(
         _repo_style_rel(path)
         for path in sorted(
@@ -2215,8 +1243,7 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
 
     if violations:
         pytest.fail(
-            "Phase 238 BOUND-02 / Phase 269 H-05 / Phase 276 CODE-02 "
-            "invariant violated: decomposed service modules "
+            "Decomposed service modules "
             "(maps / search / datasets-domain / processing/ai/chat_*) "
             "exceeded their line-count budgets. Split the module or add a "
             "reviewed explicit cap only when growth is intentional.\n"
@@ -2224,4033 +1251,74 @@ def test_decomposed_service_modules_stay_within_size_budgets() -> None:
         )
 
 
-# fix(#958): lifted to module scope from
-# test_open_core_decomposition_boundaries_stay_clean so the inclusion rule below
-# can ask whether a ceiling gate already watches a module. Plain ceilings, not
-# exact ratchets: these files may shrink freely. Where an entry below says its
-# ratchet "stays exact", that is the author setting the cap flush with the
-# file's current LOC as a convention — no test here enforces the equality.
+# These decomposition ceilings may shrink freely; the inclusion rule uses them
+# to avoid tracking the same module in both cap tables.
 _OPEN_CORE_SIZE_CAPS: dict[str, int] = {
-    # fix(#526 B-044): per-layer minzoom/maxzoom in style.json export,
-    # propagated to companion layers.
-    # fix(#527 B-054/S-05+LB-04): symbol icon-opacity + allow-overlap parity.
-    # fix(v1.6.0 audit): hypso_reversed flows into the color-relief
-    # companion so exported ramps match the builder's Reverse toggle.
-    # fix(#836): +1 for the RASTER_FAMILY_RECORD_TYPES import.
-    # fix(#917): +85 — builtin fill patterns are stripped at export and fall back
-    # to a solid colour. Plain strings only: composites are left as authored,
-    # because MapLibre skips a missing pattern and exposes styleimagemissing to
-    # repair it, while stripping a working expression is unrecoverable (#1069).
-    # Ratchet stays exact.
-    # fix(#910): +37 — the extrusion companion resolves its colour from the
-    # fillColorSaved stash, and the export seeds that stash into `fill-color`
-    # BEFORE #917's strip runs, so a builder-patterned polygon exports the colour
-    # the user chose instead of brand blue (EDIT-05 means paint never carries one).
-    # fix(#910, codex P2): +5 — the seed accepts an explicit `fill-color: null` too.
-    # fix(#1069): +56 — the read-side bound on malformed stored style values.
-    # Writes are shape-checked now, but that does nothing about the rows already
-    # in the database, and a serializer that descends into one of them 500s the
-    # SHARED style endpoint from stored data rather than from the request. Two
-    # guards, because the two stages that read stored paint are separate: the
-    # per-layer serialize loop in `build_maplibre_style`, and the emitted-layer
-    # pass now split out as `_validate_emitted_layer` — which is where #1054's
-    # intermediate revision actually walked `fill-pattern` composites. Roughly
-    # half the lines are the write-up of why the catch is a named data-shape
-    # tuple and not `Exception`: `_tile_url_for_layer` raises RuntimeError with
-    # no tenant context, and swallowing that would turn a fail-closed refusal
-    # into a quietly missing layer in a hosted export.
-    # fix(#1372): +5 — exported raster/DEM sources carry ?v=<tile_cache_version>
-    # so external MapLibre consumers roll the shared nginx cache on replace.
-    # fix(#1472 review): +9 — dataset_attribution on exported sources. Placed on
-    # _source_for_layer's common tail rather than in each branch, so vector,
-    # raster, and raster-dem carry it and a fourth source type cannot be added
-    # without it. Cap 1620 -> 1629, exact.
-    # fix(#1472 review): +12 — HTML-escape the exported credit. The style spec's
-    # `attribution` is an HTML string the consuming application renders, so this
-    # export hands a third party a context we do not control; the lines are
-    # mostly the note recording that the write guard already keeps `<`/`>` out,
-    # which leaves this escaping the ampersand and covering a value written
-    # before that guard existed. Cap 1629 -> 1641, exact.
-    # fix(#1626): +53 — `_fold_master_opacity` applies `layer.opacity` to the
-    # primary fill/line layer on export. Mostly its docstring: it records why the
-    # export multiplies instead of emitting the v6 `-layer-opacity` keys (they
-    # abort the style load on maplibre-gl < 6, verified against 5.24.0) and the
-    # metadata handshake that keeps a GeoLens round trip lossless. Plus the
-    # allowlist note saying the two keys are left out on purpose, and (#1631
-    # review) the note on the pre-existing absent-at-master-1 divergence the
-    # fold deliberately leaves alone. Cap 1641 -> 1703.
-    # fix(#1778): +7 — `_layer_metadata` emits popup_config, which had no export
-    # at all, so a map's popup configuration was dropped by any export/import
-    # cycle and the import side had nothing to read. Cap 1703 -> 1710.
-    # fix(#1778 round 3): +9 — the export's zoom no-op conditions read the
-    # shared BUILDER_MIN_ZOOM / BUILDER_MAX_ZOOM instead of repeating 0 and 22,
-    # so the two directions of the round trip cannot drift. Cap 1710 -> 1719.
-    # fix(#2007): +7. The raster and vector templates carry the publication
-    # counter both cache layers key on, through the one shared builder.
-    # Cap 1590 -> 1597, exact.
     "backend/app/modules/catalog/maps/style_json.py": 1597,
-    # fix(#1626): +50 — `_restore_master_opacity` undoes the export fold from
-    # `metadata.geolens.feature_opacity` and maps a v6 `-layer-opacity` key onto
-    # `layer.opacity` (number) or drops it with a warning (expression); plus
-    # (#1631 review) BUILDER_FEATURE_OPACITY_DEFAULTS, the mirror of the
-    # frontend's OPACITY_DEFAULTS the fold starts from when paint has none.
-    # Cap 450 -> 500.
-    # fix(#1778): +6 — the master-opacity read goes through finite_number so a
-    # stored 0.0 survives import, plus the comment saying what the truthiness
-    # read cost (the folded paint key was popped in the same pass, so the
-    # document's own record of the 0 went with it). Cap 500 -> 506.
-    # fix(#1778): +49 — `_restore_zoom_range` reads the spec minzoom/maxzoom the
-    # export promotes from the builder-private layout keys, and
-    # `_popup_config_from_import` reads back the popup settings the export half
-    # of this fix started emitting. Most of it is the two docstrings: why the
-    # 0/22 no-ops must not be written back as explicit keys, and why a
-    # malformed popup config is dropped rather than raised on (MapLayerInput
-    # would 400 the whole document over one layer). Cap 506 -> 555.
-    # fix(#1778 round 1): +25 — MapStyleImportLayerLimitError and the per-map
-    # limit applied to the layers that will become rows, which is the count
-    # apply_layer_diff later compares against, so the import door and the save
-    # path refuse at the same number. Cap 555 -> 580, exact.
-    # fix(#1778 round 3): +57 — BUILDER_MIN_ZOOM / BUILDER_MAX_ZOOM mirrored
-    # from map-sync.ts and shared with the export, plus the clamp that keeps a
-    # restored minimum below the maximum the builder can render. Most of it is
-    # the docstring: MapLibre hides a layer at zoom >= maxzoom, so a minimum at
-    # or above the substituted 22 imported cleanly into a layer that could never
-    # be drawn, and clamping is the only repair the builder can honour.
-    # Cap 580 -> 637, exact.
     "backend/app/modules/catalog/maps/style_import.py": 605,
     "backend/app/modules/catalog/maps/style_sanitizers.py": 192,
-    # fix(getgeolens.com#86 review): +6 — the icon-asset and sprite-index GETs
-    # gained per-route `responses={403: FORBIDDEN_RESPONSE}` overrides; they
-    # are read-gated (icon asset) or unauthenticated (sprite index), so the
-    # router's inherited write-flavored 403 misdescribed their actual cause.
-    # Cap 126 -> 132, exact.
-    # fix(#1440): +10 — the sprite-index override above only reworded the 403; the
-    # sprite JSON and PNG routes take no auth at all, so no 401/403/409 can
-    # occur regardless of description. FastAPI's router `responses=` merge is
-    # additive along the whole include chain (an ancestor's key always shows
-    # through unless a route sets that same key itself), so a same-file
-    # sibling router nested under the maps router's ERROR_RESPONSES_WRITE
-    # would still leak those keys. All four sprite routes moved to
-    # `sprites_router`, mounted with ERROR_RESPONSES_PUBLIC directly on
-    # api_router (api/router.py) as a sibling of the maps router rather than
-    # a descendant. Cap 132 -> 142, exact.
-    # fix(#1778 round 4): +7 — the icon upload publishes the object and its row
-    # inside one rollback scope. It is the third write-object-then-commit-row
-    # site in the package and the only one whose write and commit sit in
-    # different functions, so the comment records why the ledger is threaded
-    # through create_icon_asset. Cap 142 -> 149.
-    # fix(#1778 round 5): +4 — the publication settles on the commit and the
-    # refresh moved below the scope, which is the case that found the boundary
-    # bug. Cap 149 -> 153.
-    # fix(#1778 round 6): +3 — the icon commit is marked before it is awaited,
-    # the same as the two image handlers. Cap 153 -> 156.
     "backend/app/modules/catalog/maps/router_assets.py": 149,
-    # fix(#526 B-048): the card-route SPA-redirect fallback shell.
-    # fix(#819): visibility-check owner-or-admin gate + rationale docstring.
-    # fix(#1518 codex P2 round 3): 398 -> 404. +6 to apply the rule once, ahead
-    # of all three arms. It had run only after a SUCCESSFUL unpack, so a missing
-    # (404) or revoked (410) link answered a caller whose credential was dead
-    # without ever telling them.
-    # fix(#1518): 387 -> 398. +11 for the CAPABILITY obligation on the shared-map
-    # endpoint: it takes the deferring dependency so the embed token is judged
-    # first, unpacks the capability verdict get_shared_map now reports, and
-    # re-applies the fail-closed rule when nothing was authorized by it. The
-    # verdict comes from the service because that is where the scope is
-    # resolved; re-deriving it here would be a second lookup that could
-    # disagree with the first.
-    # fix(#1672): +32 — the style.json export route's 200 response is now
-    # documented in the decorator: an open object schema pointing at the
-    # MapLibre style spec plus the sprite array-form guarantee, replacing the
-    # empty {} schema a generated client could misread (sprite string vs
-    # array). Deliberately description-heavy, zero logic added. Then +4
-    # (codex r1): additionalProperties: true, or openapi-typescript closes
-    # the open object to Record<string, never>. Cap 436 -> 440, exact.
     "backend/app/modules/catalog/maps/router_sharing.py": 430,
     "backend/app/modules/catalog/search/query_params.py": 205,
     "backend/app/modules/catalog/search/router_saved.py": 97,
-    # fix(#821): +14 lines — admin key mint accepts expires_at (audit
-    # detail + response) and maps the inactive-owner mint refusal to 409.
-    # fix(#875): +7 lines — admin key mint accepts scope, and surfaces it
-    # in the audit detail, the create response, and the list item.
-    # fix(#1204): +20 lines — the published-maps listing takes sort/order as
-    # closed enums, with the descriptions that say which columns are absent
-    # (link status) and why.
-    # fix(#1778): +4 lines — POST /admin/api-keys/
-    # documents the 409 it raises for a pending/suspended/deactivated
-    # target user, closing a gap the repaired OpenAPI-contract gate surfaced.
-    # fix(#1778): +4 lines — GET /admin/api-keys/ orders by created_at desc so
-    # the LIMIT-capped page is deterministic across refetches.
-    # fix(#1805 review round 4 P2): +5 lines — created_at DESC alone ties on
-    # equal timestamps and each page is a separate query; id DESC added as a
-    # secondary key for a total, reproducible order across pages.
     "backend/app/modules/admin/router_operations.py": 323,
-    # PRIV-1: +7 lines — GET /settings/branding/ also resolves and returns
-    # PRIVACY_URL, so the login/register privacy-policy link is admin
-    # configurable instead of a hardcoded getgeolens.com URL.
-    # PRIV-1 (pre-review): +18 — the reader re-checks a stored/env privacy_url
-    # against the shape rule and drops (+ logs) an unsafe one instead of
-    # serving it as a login-page <a href>; a stored value can predate the
-    # check or bypass PersistentConfig.set()'s validation entirely.
-    # feat(#1691): +2 — restrict_public_visibility rides the public
-    # feature-flags bundle so the UI can hide the Public option for
-    # non-admins. Cap 175 -> 177.
     "backend/app/modules/settings/router_public.py": 175,
 }
 
 
-# fix(#435): caps equal current LOC; growth needs decomposition or a documented
-# exception. Lower the cap whenever its module shrinks.
-# fix(#836): full paths cover oversized modules beyond the router.py glob.
-# fix(#1451): tile acquisition order and cache guards are documented at their
-# implementation sites; preserve those invariants when decomposing modules.
+# Caps equal current LOC. Lower them when modules shrink; split or explain growth.
+# Full paths cover oversized modules beyond the router glob.
+# Preserve tile acquisition and cache ordering when decomposing tile modules.
 # The Enterprise overlay pins _check_cold_rehydrate to tiles/router.py in its
 # static checks, so moving that function requires a coordinated overlay change.
 _MODULE_LOC_CAPS: dict[str, int] = {
-    # fix(#1873): every cap below re-ratcheted to the file's exact LOC after
-    # the tree-wide comment trim; no code moved.
-    # fix(#1814): first entry. The lines bought the reserve/stage/bind split of
-    # one create-and-queue function, its two fenced settlement exits, the quota
-    # preflight, the staging deadline, and the reset-and-retry settlement.
-    # fix(#1888): +16. The staged-entry settlement reads the row's status on
-    # its own transaction and reaps the staged copy once a committed attempt
-    # left the row failed, best effort. Cap 1130 -> 1146, exact.
-    # fix(#2017): +15. Bounds the admit-plus-bind step under its own deadline and fix(#1953): +1 merged; re-measured after both landed. Cap 1152, exact.
-    # fix(#2032): +11. `_classify_dataset` refuses a metadata.crs that names
-    # no spatial_ref_sys row, so a dry run reports it. Cap 1152 -> 1163, exact.
     "backend/app/processing/ingest/manifest_service.py": 1163,
-    # fix(#1770 round 43 P1): crossed _RATCHET_INCLUSION_LOC on the XML
-    # streaming preflight (`_xml_preflight`, `MAX_DOCUMENT_ATTRIBUTES`,
-    # `MAX_DOCUMENT_DEPTH`) that closes the attribute-bomb/deep-nesting-bomb/
-    # text-bomb class `structural_elements`'s per-element byte-scan could not
-    # see -- a single tag carrying an enormous number of attributes, or a
-    # document nested one element inside another thousands of times over,
-    # both stayed under the element budget while costing real memory or
-    # real recursion. Most of the added lines are the docstring explaining
-    # why the byte-scan stays as a cheap first pass rather than being
-    # replaced outright, and why the preflight has to refuse an entity
-    # declaration itself (it runs on raw `expat`, before `defusedxml`'s own
-    # `forbid_dtd` ever gets a turn).
-    # fix(#1770 round 44 P2): +13. `_parsed_json` now also catches
-    # `RecursionError` (a JSON depth bomb raises that, not `ValueError`, and
-    # was escaping every except chain that named only the latter). Cap
-    # 1042 -> 1055, exact.
-    # fix(#1770 round 46 P2): +61. `_OGCAPI_OPERATION_RELS` split into
-    # `_LANDING_RELS`/`_COLLECTION_RELS`, `_ogcapi_link_hrefs` gained a
-    # `rels` parameter, and the four `_check_ogcapi` call sites gained a
-    # `# fix` comment each explaining which document type they scope to.
-    # Most of the added lines are the docstring tracing which document type
-    # dereferences which rel, and why a collections listing page/entry
-    # dereference neither. Cap 1055 -> 1116, exact.
-    # fix(#1770 round 46b): +29. The pre-trigger audit's four fixes: the
-    # module comment correcting which paths actually reach `_COLLECTION_
-    # RELS` (none of preview/worker do; only the probe, which never passes
-    # a collection), naming the actual structural tests that now guard the
-    # rel scoping, and a one-line "deliberate no-op" comment at each of the
-    # two `frozenset()` call sites. Cap 1116 -> 1145, exact.
-    # fix(#1770 round 47): +113. Three closed classes: `bounded_service_url`/
-    # `bounded_parse_qsl`/`MAX_SERVICE_HREF_BYTES`/`MAX_QUERY_FIELDS` (the P1
-    # advertised-href/query-field-count bound, wired into `_next_page` and
-    # `_assert_same_origin`), `_wfs_operation_hrefs`'s walk made iterative
-    # (no depth of its own to exceed) with a `RecursionError` last line of
-    # defense in `_check_wfs`, and `MAX_DOCUMENT_DEPTH` lowered 1,000 -> 256
-    # with a comment correcting round 43's own claim. Most of the added
-    # lines are the docstrings recording why each bound is the number it is.
-    # Cap 1145 -> 1258, exact.
-    # fix(#1770 round 47b): +52. The pre-trigger audit's P1 (`HrefTooLongError`,
-    # a `ValueError` subclass so the length refusal gets its own wording at
-    # every catch site with no new except clause required at the ones that
-    # don't bother) and the low-priority fixes: a warning on `_next_page`'s
-    # silent stop, and a docstring note on `_wfs_operation_hrefs`'s own
-    # O(breadth) stack-memory tradeoff. Cap 1258 -> 1310, exact.
-    # fix(#1770 round 47c): +6. `_capabilities_url` moved from
-    # `max_num_fields=` back to `# parse_qs: unbounded` -- see the
-    # function's own docstring for why round 47b's bound here was wrong.
-    # Net growth is the corrected, longer docstring. Cap 1310 -> 1316,
-    # exact.
-    # fix(#1770 rebase audit nit): +1. The marker line sat at exactly 88
-    # chars; split the `parse_qs` call onto its own line so the trailing
-    # `# parse_qs: unbounded` comment has room. Cap 1316 -> 1317, exact.
-    # fix(#1770 rebase audit nit): +2. `_capabilities_url`'s docstring now
-    # distinguishes `/probe`'s fresh schema field from preview/the worker's
-    # persisted `origin_ref["url"]`, the same fix `adapters/wfs.py::build_
-    # capabilities_url`'s docstring already got. Cap 1317 -> 1319, exact.
-    # fix(#1770 round 49 P3): +11. Corrected the `_check_ogcapi` listing-walk
-    # comment that claimed the probe's own `/collections` pagination is
-    # "credential-free exploration" -- it is not; `_check_ogcapi` shares the
-    # caller's real `headers`, and the soft stop is safe because `_next_page`
-    # itself refuses a cross-origin/unparseable `next`, not because the
-    # pages are anonymous. Cap 1319 -> 1330, exact.
-    # fix(#1828): +551. `_check_wfs` reads the layer's DescribeFeatureType,
-    # built byte for byte as the driver builds it, and refuses a schema
-    # `include` off the origin; `require_wfs_layer` at the spawn points. 1881.
-    # chore(#1873): review-history comments trimmed. Cap 1881 -> 1385, exact.
     "backend/app/platform/service_endpoints.py": 1360,
-    # fix(#1770): first entry, crossed _RATCHET_INCLUSION_LOC on the
-    # completeness-predicate unification. `_page_proves_complete` is the one
-    # function round 41's full-walk-only proof and round 42's sampled-preview
-    # mirror of it both call now, and `_end_of_chain`/`_sample_truncated` are
-    # the extractions that keep `_walk_pages` itself under ruff's C901
-    # ceiling rather than adding another exemption (the same reason
-    # `_resolve_conformance` was pulled out of `probe_ogcapi` in #1746).
-    # Most of the added lines are the docstrings recording the round 38-42
-    # history so a future reader does not re-derive it from the diff.
-    # fix(#1770): +8. The items-page JSON parse also catches
-    # `RecursionError` now, same reasoning as `service_endpoints.py::
-    # _parsed_json`. Cap 1033 -> 1041, exact.
-    # fix(#1770): +49. Two closed classes: every advertised-href
-    # site (`_advertised_items_href`/`_with_page_size`/`_next_href`) now
-    # runs through `bounded_service_url`/`bounded_parse_qsl`, and
-    # `_walk_pages`'s per-feature re-serialisation catches `UnicodeEncode
-    # Error` from an unpaired JSON surrogate escape rather than letting it
-    # escape as an internal exception. Cap 1041 -> 1090, exact (`ruff
-    # format` wrapped one `urljoin(base, bounded_service_url(...))` call
-    # onto three lines after the round-47 diff landed).
-    # fix(#1770): +16. `HrefTooLongError` handling at the three
-    # `bounded_service_url` catch sites, each getting its own wording
-    # distinct from the generic "unparseable" refusal. Cap 1090 -> 1106,
-    # exact.
-    # chore(#1873): review-history comments trimmed. Cap 1106 -> 797, exact.
     "backend/app/platform/service_items.py": 777,
-    # fix(#1758): the ArcGIS sign-in protocol, which crossed 1000 lines over
-    # nine review rounds. What the growth bought, in order: the two-phase
-    # split that resolves WHERE a password would go before any lock or budget
-    # is taken (r7), host canonicalization so two spellings of one destination
-    # are one bucket rather than two (r5), the delegate bound that stops a
-    # discovery document redirecting the credential to an unrelated host (r9),
-    # and the no-redirect rules on both the discovery GET and the credential
-    # POST (r4, r9). Roughly a third of the file is the comments explaining
-    # those, which is deliberate: every one of them is a security property a
-    # future reader would otherwise "simplify" away.
-    #
-    # Kept as one module because it is one protocol and the phases share the
-    # error vocabulary. The clean split when it next grows is the host cluster
-    # (_numeric_ipv4, canonical_host, canonical_portal_host, portal_host,
-    # _is_trusted_delegate), which would need to raise ValueError and let this
-    # module map it, since ArcGISSignInError lives here.
-    # fix(#1758 codex r10/r11): +62 lines. The two-phase split gained a per-phase
-    # deadline so the caller's ledger insert and audit commit sit outside any
-    # cancellation scope, and the identity the limits key on became the
-    # token service's authority AND web-adaptor path, because two Enterprise
-    # portals can share a hostname and be separate account stores.
-    # fix(#1758 codex r12-r17): +149 lines. One httpx.URL is now the single normalized
-    # form the scope, the delegate check and the POST destination all read,
-    # because urlsplit kept dot segments that httpx removes, and a URL that
-    # still argues with itself after normalization is refused rather than
-    # repaired, and every URL in the module now takes that one road. r14
-    # added the decompression-bomb refusal: identity encoding asked for, raw
-    # transport bytes capped, a compressed answer refused unread. r15 refused
-    # port zero, which is falsey and so aliased the real :443 budget. r16
-    # made a redirect the SSRF hook rejects during DISCOVERY fall back rather
-    # than refuse, since the hook fires on every 3xx whether or not it is
-    # followed. r17 decodes to a fixed point instead of for four passes, and
-    # refuses a stable form still carrying an encoded separator.
-    # fix(#1775): +40. `signin_user_key`, the keyed digest that carries the
-    # per-caller budget now that it is counted from the ledger rather than
-    # from audit_logs (reserve-then-settle commits the attempt before the
-    # credential POST and writes the audit row after it, so a cancelled
-    # request leaves no audit row to count), and AUDIT_CANCELLED, the outcome
-    # of an attempt whose POST was interrupted. Cap 1253 -> 1293, exact.
-    # fix(#1775 audit): +8. AUDIT_CANCELLED's comment now says which external
-    # cancellation actually reaches the route and which does not — a worker
-    # shutdown does, a client disconnect does not, because it arrives as an
-    # `http.disconnect` message a non-streaming route never reads and the one
-    # `cancel()` in BaseHTTPMiddleware ends a sibling wait rather than the
-    # downstream coroutine — and why the reservation makes the path safe
-    # whichever it is. An earlier revision of this comment asserted the
-    # opposite, which is why it now cites the line it was checked against.
-    # Cap 1293 -> 1301, exact.
-    # fix(#1858): +11. The capped read's JSON parse also catches
-    # `RecursionError` now (a depth bomb fits inside `_MAX_RESPONSE_BYTES`,
-    # and the decoder gives up on a stack overflow rather than a
-    # `ValueError`), with the arithmetic recorded so nobody re-derives which
-    # of the two bounds actually holds. A duplicated, unreachable copy of the
-    # same try/except is deleted in the same edit, which is why the net is
-    # smaller than the comment. Cap 1301 -> 1312, exact.
     "backend/app/modules/catalog/sources/arcgis_signin.py": 1151,
-    # feat(C2) / fix(#1840): crossed _RATCHET_INCLUSION_LOC when the ArcGIS
-    # credential moved out of the request URL and into a header. What the
-    # growth bought, in one list: the version gate Esri's own `currentVersion`
-    # spelling needs (`parse_arcgis_current_version`, where 10.5.1 reports as
-    # `10.51` and a float comparison gets two releases the wrong way round),
-    # the one transport chooser (`arcgis_request_auth`) so no read decides for
-    # itself where the credential goes, one bounded reader
-    # (`read_arcgis_json`) with the two query-form fallbacks a real deployment
-    # needs -- a pre-10.5.1 server's 499 envelope and a Web Adaptor's 401/403
-    # before ArcGIS is ever reached -- plus `build_arcgis_layer_info_url` and
-    # the fold of the third hand-rolled count query into
-    # `build_arcgis_count_query_url` (#1755 item 14). Most of the added lines
-    # are the comments carrying the measurements those decisions rest on;
-    # without them the next reader re-derives the Esri version encoding and
-    # the web-tier case from scratch. Cap set at 1015, exact.
-    # fix(#1858): +33. `_arcgis_parsed_json` is the one place both of this
-    # module's remote-body parses go through, so a JSON depth bomb becomes
-    # the `EndpointCheckFailedError` every caller already handles instead of
-    # a `RecursionError` no caller catches. Most of the lines are the
-    # docstring recording why `ValueError` is deliberately left alone.
-    # Cap 1015 -> 1048, exact.
-    # fix(#1858 audit P2-2): +26. Comments only. Four best-effort clauses
-    # here catch `ValueError` and therefore `SSRFError`, and each now says
-    # why a refused hop stays a degrade rather than being raised: the read
-    # establishes one optional fact and the adapter answers without it. The
-    # rule and its converse are stated once at `_fetch_count` and referred to
-    # from the other three. Cap 1048 -> 1074, exact.
     "backend/app/modules/catalog/sources/adapters/arcgis.py": 887,
-    # feat(#1746 B2b): first explicit entry for this file, which rode the 1500
-    # default until the service-auth wave. #1758 added the ArcGIS sign-in
-    # endpoint and its rate-limit wiring, and this lane added the credential
-    # conversion at the probe and preview doors, the CRS fallback's own
-    # credential handling, and the cross-origin endpoint check after detection
-    # (review r13). Ratcheted rather than decomposed because the split that
-    # pays here is connector-versus-service, which is #1755 item 13's queue
-    # and bigger than any one lane. Cap 1500 -> 1528, exact.
-    # fix(#1746 B2b review r14): +33. `_probe_credential_line` composes the
-    # line the endpoint check sends, bound to the format detection just
-    # established, because reading a protected service's description
-    # anonymously learned nothing and approved it. The rest is the second
-    # refusal code on the same handler and the note on why the log line reads
-    # `origin` defensively. Cap 1528 -> 1561, exact.
-    # fix(#1746 B2b review r24): +9. `/probe` passes a monotonic deadline to
-    # the endpoint check. It had omitted one, so the check ran unbounded and a
-    # description delivered slowly but steadily across up to twenty listing
-    # pages held an API request open for as long as the service liked.
-    # fix(#1746 B2b review r27): +9. The door no longer decides from the URL
-    # text whether a credential's method can be carried; it binds by method
-    # alone and `service_carries_method` answers the transport question after
-    # detection. The lines are the comment recording why reading the URL there
-    # was wrong, since `/FeatureServer/wfs` is a WFS and the door had refused
-    # it a credential it supports.
-    # fix(#1770 round 40 P2): +4. The credentialed CRS fallback fetch's
-    # `error=str(exc)` becomes `error=redact_exception_text(exc)`, plus the
-    # new import. Cap 1579 -> 1583, exact.
-    # fix(#1770 round 43 P1): +28. `_fetch_ogcapi_collection_srid` now reads
-    # through `bounded_probe_read` under `DEFAULT_CHECK_TIMEOUT` instead of a
-    # bare `client.get`, the same shape round 41 already gave the four probe
-    # adapters -- new imports (`json`, `urlencode`, `bounded_probe_read`,
-    # `OGC_JSON_ACCEPT`), the query folded into the URL since the helper
-    # takes no `params=`, the `asyncio.timeout` wrapper, and a widened except
-    # clause plus its comment. Cap 1583 -> 1611, exact.
-    # fix(#1770 round 44 P1/P2): +18. The ArcGIS layer-preview except clause
-    # widened for `EndpointCheckFailedError`/`TimeoutError` (P1, ArcGIS
-    # reads now bounded), the CRS-fallback except clause gained
-    # `RecursionError` (P2, JSON depth bomb), plus their comments. Cap
-    # 1611 -> 1629, exact.
-    # fix(#1770 rebase onto main, post-#1820/#1821): re-pinned by direct
-    # `wc -l` measurement of the post-rebase file, not arithmetic on either
-    # side's number. #1820 (merged first) removed 28 lines from this file
-    # reserving the ArcGIS sign-in attempt before the mint; this lane's own
-    # rounds 45 through 47c added lines back on top through the normal
-    # ArcGIS-bound/non-dict-guard/conformance-seed fixes. Net: 1629 -> 1625,
-    # exact.
-    # fix(#1770 round 49 P3): +14. The mid-probe `SSRFError` handler no
-    # longer reflects `SSRFResolutionError`'s interpolated redirect-target
-    # hostname into the 400 body or the persisted audit reason -- both now
-    # carry a fixed policy string; the raw text stays in the server-side log
-    # line only. Cap 1625 -> 1639, exact.
-    # fix(#1755 item 9): +141. `_preview_refusal_response` and
-    # `_run_service_preview_or_refuse` map every typed refusal
-    # `run_service_preview` and its callees can raise to a coded 4xx before
-    # `preview_service_layer`'s broad `except Exception`, so a future edit
-    # that breaks one of those callees' "raises only HTTPException" contracts
-    # degrades to a coded 4xx instead of a 500. Cap 1639 -> 1780, exact.
-    # fix(#1840 audit round 1): +11. `_probe_credential_line` gates on
-    # `requires_header_token_policy` rather than on `build_credential_header`
-    # answering None, plus the import and the docstring paragraph saying why
-    # the two stopped being equivalent when lane C2 taught the builder to
-    # compose an ArcGIS header for the httpx transport. Cap 1780 -> 1791,
-    # exact.
-    # fix(#1858 audit P2-1): +40. `_refuse_preview` is extracted from
-    # `_run_service_preview_or_refuse` so the ArcGIS preview branch, which
-    # never went through that function, answers a refused redirect hop the
-    # way the WFS and OGC API branches of the same door already do, instead
-    # of reporting `ogrinfo_failed` for a tool that never ran. The extraction
-    # is net-neutral; the lines are the helper's own docstring and the new
-    # clause's comment. Cap 1791 -> 1831, exact.
-    # fix(#1848): +18. Both doors hand the pooled connection back before their
-    # network work, which costs the release itself, its comment and the
-    # `user_id` local the rollback's expiry makes necessary. Codex round 1
-    # moved each release above `validate_url_for_ssrf`, whose `getaddrinfo`
-    # wait is the first of the two waits, and the preview needs a second
-    # release because its duplicate-source query re-acquires in between.
-    # Cap 1831 -> 1849, exact.
-    # fix(#1825): +52. A cancellation clause on both settlement writes, and
-    # the reservation id threaded to all three finaliser call sites.
-    # Cap 1849 -> 1901, exact.
     "backend/app/modules/catalog/sources/router.py": 1736,
-    # fix(#998): the DDL ported from migration 0019 so tenant-ownership adoption
-    # is reachable forward-only at head. Almost all of it is SQL text, and it is
-    # one artifact on purpose — the module is reviewed line-by-line against
-    # 0019_tenant_provisioning_boundary.py, which splitting the blocks across
-    # files would make harder, not easier. The Python that drives it and the
-    # report types already live in tenant_adoption.py and
-    # tenant_adoption_report.py.
-    # fix(#998 codex r44/r45): +200 — refuse creator-shaped memberships
-    # retained by other logins (an ADMIN-only edge can re-arm itself), refuse
-    # boundary-function and provisioner grant-option ACL entries a foreign
-    # grantor issued (unrevokable by the repair, which would otherwise
-    # silently no-op every run), count foreign grantors in the early-return
-    # guard so canonical-but-foreign tenants reach the refusal, and render
-    # the default-privilege remedy one statement per object kind.
-    # fix(#998 codex r46-r49): +268 — extended statistics and collations transferred, the six rarer owned kinds refused, so no owned object kind in a tenant schema is unhandled — generated multiranges excluded on all
-    # three type surfaces; schema-less default privileges counted in the
-    # fast-path guard and refused cluster-wide for the provisioner (the
-    # per-tenant pass never runs with zero tenants).
-    # fix(#1913): +2 — the anchor on the member-judgement clause, which now
-    # resolves a gateway member by oid so a role dropped since the scan is
-    # skipped rather than raised.
     "backend/app/core/db/tenant_adoption_sql.py": 2093,
-    # fix(#998): the tool the DDL above serves — the catalog reads that decide
-    # whether anything is left to do, the steps that close the gap, and the
-    # operator CLI. Already decomposed three ways (report types and the success
-    # predicate in tenant_adoption_report.py, the ported DDL in
-    # tenant_adoption_sql.py); the remainder is one read per object the adoption
-    # boundary covers, and each is a single SQL statement that has to see the
-    # whole object at once.
-    # fix(#998): +130 — read side mirrors every apply-side ownership surface — run the provisioner grant-option guard
-    # before the plain revokes it protects; mirror the multirange and
-    # schema-less default-privilege refusals on the read side so the dry run
-    # cannot call adopted what --apply stops on.
-    # chore(#1873): review-history comments trimmed. Cap 1303 -> 1276, exact.
     "backend/app/core/db/tenant_adoption.py": 1258,
-    # fix(#836): the five path-gated additions. Caps are exact (zero headroom),
-    # matching the #435 convention: growth needs a reviewed carve-out here,
-    # shrinking must lower the cap in the same commit.
-    # fix(#1240, #651): +4 — import shutdown_worker_metrics and call it in the
-    # lifespan shutdown block so a recycled uvicorn worker drops its
-    # prometheus_client multiprocess mmap files instead of leaving a stale
-    # series for the next scrape to keep summing. Cap 1292 -> 1296, exact.
-    # fix(#1240, #651 review round 2): +9 — start/cancel metrics_sweep_task
-    # (sweep_dead_worker_metrics) alongside the existing pool/memory
-    # background tasks, so an OOM-killed/SIGKILLed worker's multiprocess
-    # gauge files get reaped even though its own graceful shutdown hook
-    # never ran. Cap 1296 -> 1305, exact.
-    # feat(#1268): +8 — start and cancel the refresh-metrics loop beside the
-    # existing pool/memory/sweep tasks. Half the lines are the comment saying
-    # why the refresh lifecycle is observed in the API at all when the worker
-    # is what executes it: the worker serves no /metrics endpoint, so a
-    # counter incremented there is written to a file nothing reads.
-    # Cap 1305 -> 1313, exact.
-    # fix(#1277 review round 2): +24 — the stale-jobs sweeper also re-arms
-    # refresh credentials whose task is still queued. Round 1 tried to bound
-    # the credential lifetime with a constant derived from JOB_TIMEOUT_SECONDS;
-    # the heartbeat means no constant bounds a healthy long import, so the
-    # bound is now renewal and this loop is what drives it. Most of the lines
-    # are the comment explaining why the interval constant is imported from the
-    # credential module (the TTL arithmetic depends on it, so there is one of
-    # it) and why the renewal needs no try of its own. Cap 1313 -> 1337, exact.
-    # fix(#1277 review round 3): the tenant-scoped renewal landed here first.
-    # fix(#1277 review round 4): -58 — and moved straight back out to
-    # platform/refresh/credentials.py, because the worker has to host the same
-    # renewal and cannot import the API app module. main.py is a thin caller
-    # again, so the cap drops below where round 3 left it.
-    # Cap 1390 -> 1332, exact.
-    # fix(#1315): -2 — init_tile_cache() and its import move into the shared
-    # bootstrap(). The lifespan owning a second copy is how the API and the
-    # worker ended up with different tile-cache states in the first place.
-    # Cap 1332 -> 1330, exact.
-    # +20 — the periodic _stale_jobs_sweeper loop now also sweeps exports/ on
-    # every cycle, not just once at boot: export residue from a hard process
-    # death (SIGKILL, OOM) used to sit until the next restart. The sweep +
-    # conditional log live in a small top-level _sweep_orphaned_exports_and_log
-    # helper (with the Path import it needs) rather than inline in the loop,
-    # so the extra branch does not push lifespan's McCabe complexity past its
-    # gate. Cap 1330 -> 1350, exact.
-    # fix(#1435 codex round 1): +12 — the periodic sweep runs continuously
-    # rather than only at a restart, so it needs a wider age threshold than
-    # the boot-time callers (a directory's mtime does not advance while
-    # ogr2ogr keeps writing the file inside it or a client keeps streaming it
-    # out) — otherwise any export whose total lifetime exceeds 1 hour gets
-    # deleted out from under it on the next 5-minute cycle, guaranteed.
-    # Cap 1350 -> 1362, exact.
-    # fix(#1435 codex round 5): +24 — sweep_orphaned_exports does synchronous
-    # directory traversal + shutil.rmtree; unlike the boot-time callers,
-    # which run before the event loop serves traffic, the periodic caller
-    # runs on a live server every few minutes and was calling it inline,
-    # stalling request handling for the duration. Now runs via
-    # run_in_thread_draining through a small positional-only wrapper
-    # (age_threshold_seconds is keyword-only on sweep_orphaned_exports, and
-    # the helper only forwards *args). Cap 1362 -> 1386, exact.
-    # +3 — one-line comment at the periodic call site stating why the two
-    # boot-time callers deliberately stay synchronous, so a future review
-    # round reads the asymmetry as intentional rather than a missed sibling.
-    # Cap 1386 -> 1389, exact.
-    # fix(#1470): +77 — _register_standards_head_routes, the derived-route pass
-    # that makes HEAD answer wherever the CORS preflight advertises it, and
-    # _clone_api_route, the ~25-kwarg route copy it now shares with
-    # _add_trailing_slash_aliases (which previously spelled that list inline).
-    # HEAD was 405 on all 48 standards GET routes; deriving both surfaces from
-    # standards_api_path is what stops them drifting again, and is why this is
-    # one pass here rather than 48 decorator edits across five routers.
-    # Cap 1389 -> 1466, exact.
-    # fix(#1485): +4 — the boot-time setup_logging() call gains
-    # production=settings.is_production, which selects the plain traceback
-    # formatter so an exception cannot pin the event loop rendering frame
-    # locals with rich. Over 88 columns as one line, hence four.
-    # Cap 1466 -> 1470, exact.
-    # fix(#1518): +29 — 23 lines of API description telling a client what a
-    # rejected credential does, and 6 in _normalize_security_contract for the
-    # second optional-identity dependency. The description is the only in-repo
-    # home for that contract (it is `info.description` in the committed
-    # openapi.json and the rendered /docs page), and the answer could not be
-    # written down before #1518 because it depended on which router you hit.
-    # Cap 1470 -> 1499, exact.
-    # fix(#1540 review P2): +20 — image/tiff joins starlette's default gzip
-    # exclusions, and the comment says why it is a correctness fix rather than a
-    # CPU one: the middleware compresses a 200 and skips a 206, so one strong
-    # ETag named gzip bytes on the full download and raw bytes on every range,
-    # and a client resuming the encoded representation could splice raw bytes at
-    # encoded offsets. Cap 1573 -> 1593, exact.
-    # fix(#1532 review r7): +15 — the periodic staging sweeper also reclaims
-    # atomic-write scratch files now. `LocalStorageProvider.put` writes through
-    # `<name>.<hex>.tmp` and renames, so a process killed mid-write leaves one
-    # under whatever prefix it was writing: COGs, originals, VRTs, map assets.
-    # This sweeper is the right home because it already walks the staging tree
-    # on a schedule and needs no `init_storage`, unlike anything storage-backed.
-    # Cap 1593 -> 1608, exact.
-    # fix(#1532 review r9): +14 — the export route stops being gzipped. #1532
-    # made it sliceable under a strong ETag naming the RAW bytes, so a
-    # compressed 200 beside a raw 206 is the splice fix(#1540) already closed
-    # for COGs.
-    # fix(#1532 review r11): +4 net. That exclusion was by MEDIA TYPE, which
-    # also silenced compression on feature GeoJSON and the admin and audit CSV
-    # streams — endpoints that serve one representation and never a range, so it
-    # bought no safety and cost real bandwidth. It is scoped to the export PATH
-    # now, through a middleware in its own module; `image/tiff` stays a
-    # media-type exclusion because there the type and the route are the same
-    # set. Cap 1622 -> 1626, exact.
-    # fix(#1532 review r14): +2 — the scratch reclaimer now rides this loop's
-    # 300 s cadence but keeps its own, so a replica walks the whole staging root
-    # once per horizon instead of every five minutes. Two lines of docstring say
-    # why the two passes on this line differ; the guard itself lives beside the
-    # function it guards, in staging.py. Cap 1626 -> 1628, exact.
-    # fix(#1596): +7 of comment, no code. The anonymous CORS wildcard now has a
-    # second surface (catalog search), which the derived-HEAD pass keyed on
-    # standards_api_path does not cover. Five lines in that function's docstring
-    # say the omission is deliberate and why it does not reopen #1470 — the
-    # middleware advertises GET, OPTIONS there, so nothing promises a HEAD no
-    # route registers. The other two widen the production CORS warning, which
-    # told an operator only standards reads were open to any browser origin.
-    # Cap 1628 -> 1635, exact.
-    # fix(#1746): +13 — the boot-time and periodic sweeps now also call
-    # sweep_stale_gdal_header_files, reclaiming the GDAL bearer-header
-    # tempfile ogr.py's finally block misses on a SIGKILL/OOM. Cap 1757 ->
-    # 1770, exact.
-    # fix(#1746 codex r1): +19 — `sweep_stale_jobs_once` runs the terminal-row
-    # token purge ONCE per pass, in its own bare session with its own
-    # best-effort handler, instead of once per tenant inside the loop below.
-    # Mostly the comment recording why the queue table is not a tenant's.
-    # Re-measured on the rebase across #1751, which raised the same cap.
-    # Cap 1770 -> 1789, exact.
-    # fix(#1746 codex r2): +7 — both of those sweeps now default to the
-    # container tmpfs rather than taking the staging volume. The lines are the
-    # comments recording why: staging is persistent and backup-entrypoint.sh
-    # tars it every cycle, so a crash-orphaned Authorization header there can
-    # reach a backup, while /tmp is a per-container 512m tmpfs. Re-baselined on
-    # the rebase across #1753, which raised the same cap for the token purge.
-    # Cap 1789 -> 1796, exact.
-    # fix(#1770 round 44 P2): +14. `CredentialScrubASGIMiddleware` registered
-    # as the innermost middleware, plus the import and the comment on why it
-    # has to be registered first and be a plain ASGI callable. Cap
-    # 1883 -> 1897, exact.
-    # fix(#1845): +6. The published description of the deprecated `?api_key=`
-    # lane now states the read-only restriction the resolver enforces, in both
-    # places a client reads it: the auth section of the API description and
-    # the ApiKeyQuery security scheme. Cap 1897 -> 1903, exact.
-    # fix(#1856 item 2): +9 for the conformance list in the API description.
-    # It claimed the OAS 3.0 classes while the served document is OpenAPI 3.1,
-    # and named three of the five families /api/conformance advertises. Cap
-    # 1903 -> 1912, exact.
-    # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1962, exact.
-    # fix(#1847): the handler docstring states its contract. Cap 1962 -> 1959.
-    # fix(#2018): +5. The rate-limit storage decision is made at import,
-    # before setup_logging, so the lifespan flushes its queued notices into
-    # the configured stream. Cap 1716 -> 1721, exact.
     "backend/app/api/main.py": 1721,
-    # fix(#1005): +4 — MapSummaryResponse gains thumbnail_updated_at, the
-    # thumbnail cache version split out of updated_at. Ratchet stays exact.
-    # fix(#910): +1 on top of that, the fillColorSaved entry in the authoritative
-    # builder camelCase->snake_case table.
-    # fix(#1069): +62 — the write-time shape check on `paint`/`layout`. Those
-    # fields were bounded by serialized size alone, so `{"fill-pattern":
-    # {"stops": 1}}` persisted and waited to raise inside whatever serializer
-    # next descended into it. Only `stops` is checked, because it is the one
-    # shape checkable without a per-property paint table (per-property
-    # validation is the raster paint-key-allowlist problem, tracked separately).
-    # Most of the lines are the docstring recording that scope decision and why
-    # `style_config` is deliberately excluded — the builder writes its own
-    # `stops` there in a different shape, so checking it would 422 every
-    # line-gradient save. Ratchet stays exact.
-    # fix(#1109 review): -10 — the nested-dict walker is gone; the check reads
-    # direct property values only, because a `stops` key inside an expression
-    # operand is data, not a legacy function. Cap 1379 -> 1369, still exact.
-    # feat(#1472): +8 — dataset_attribution on the three layer read models
-    # (DatasetMetaKwargs, MapLayerResponse, SharedLayerResponse) plus the notes
-    # recording that the shared/embed response carries it deliberately: that is
-    # the surface a source's display obligation most needs to reach, because it
-    # is the one shown to people outside the instance. Cap 1369 -> 1377, exact.
-    # fix(#1672): +19 — MapSpriteEntry model and the sprite union
-    # (str | list[MapSpriteEntry]), so exported styles (which always emit the
-    # array form) round-trip through /maps/import instead of 422ing.
-    # Cap 1377 -> 1396, exact.
-    # fix(#1778): +28 — `filter` picks up the byte cap the other open JSONB
-    # columns carry. The byte check moved into `_reject_oversize_json` so the
-    # dict and list callers share one policy, and `_validate_filter_field`
-    # records the ordering that matters: the grammar validator carries the
-    # nesting bound and has to run first, because `json.dumps` recurses and a
-    # RecursionError is not something Pydantic turns into a 422.
-    # Cap 1396 -> 1424, exact.
-    # fix(#1778): +27 — the style-import door picks up `max_length=
-    # _MAX_LAYERS_PER_MAP` like its three siblings, with the comment saying
-    # what its absence cost (an over-cap imported map that apply_layer_diff
-    # then refused to save), and MapStyleImportSummary gains add_warning plus
-    # the truncation counter, because one warning per unmatched source over an
-    # unbounded `sources` object put the whole list in the 201 response.
-    # Cap 1424 -> 1451, exact.
-    # fix(#1778 round 1): +14 — _MAX_STYLE_DOCUMENT_LAYERS replaces the per-map
-    # cap on the raw `layers` array, which counted the companions an export
-    # emits and so refused valid GeoLens documents from about 50 polygons up.
-    # The lines are the derivation: four style layers per logical layer, worst
-    # case, measured, times the per-map cap, plus headroom for the layers an
-    # import skips. Cap 1451 -> 1465, exact.
-    # fix(#1963): +5. MapLayerResponse carries `publication_version`, the
-    # counter the style document's signed tile scope binds. Cap 1391 -> 1396,
-    # exact.
     "backend/app/modules/catalog/maps/schemas.py": 1396,
-    # fix(#1042): decomposed. The file reached 2151 lines with five carve-outs
-    # on this cap, each one a correctness fix that had to argue for its lines:
-    # #888 (+117, shift a 0..360 source instead of clipping it, plus the clip
-    # accounting), #899 codex r1 (+23, the angular-unit half of that guard —
-    # 14 stock SRIDs are GEOGCS in grads, where -360 is not a whole turn),
-    # #906 (+83, the degenerate-envelope guard: 4415 of 8500 stock SRIDs
-    # collapse the safe envelope under ST_Transform and the clip then emptied
-    # the table silently), #934 (+52, the seam-aware extent-producer override),
-    # #961 review (+29, the anchor on `_GEOGRAPHIC_SRTEXT_RE` documented as
-    # load-bearing), and then #1104/#1113's eight rounds (+124, the
-    # geom_4326-is-always-linear invariant and its BYO-column enforcement).
-    # #958 named the pattern — the ratchet taxing correctness work on a module
-    # nobody had time to split — and filed #1042 to split it.
-    #
-    # Every one of those clusters now has its own file, so the next carve-out
-    # argues against a few hundred lines instead of two thousand:
-    # metadata_sql (60), metadata_quality (190), metadata_projection (266),
-    # metadata_attributes (352), metadata_mercator (361), metadata_geometry
-    # (424), metadata_extent (633). None is near the 1000-line inclusion
-    # threshold, so none needs an entry here yet. What is left below is the
-    # re-export façade every existing importer and mock.patch target resolves
-    # against. Cap 2151 -> 144, exact.
-    # fix(#1738): +10 — the re-exports the repair path resolves against
-    # (rederive_geom_4326, the Geom4326Repair it returns, and its three
-    # outcome constants) plus their __all__ entries. Cap 144 -> 154, exact.
-    # fix(#1738 round 1): +4 — probe_geom_4326 and the Geom4326State it
-    # returns, split out so the caller can tell a non-spatial table from a
-    # repairable one BEFORE resolving the SRID. Cap 154 -> 158, exact.
     "backend/app/processing/ingest/metadata.py": 153,
-    # ingest/router.py is also scanned by the router-glob gate; this exact
-    # ratchet overrides its 1500 default so the remaining runway to the cliff
-    # cannot be spent silently.
-    # fix(#1186): -20 — _stamp_raster_metadata gave up its download-and-
-    # validate half. It exists to set the `file_type` discriminator, and
-    # bundling a full-object CRS download into that is what kept
-    # complete_presigned_upload from calling it at all. `crs_missing` is
-    # derived in ingest_raster now, from metadata that task already reads.
-    # Cap 1493 -> 1473, still exact.
-    # fix(#1202): +74 — _validate_presigned_content, so the presigned door
-    # enforces the same content contract as the direct one. Most of it is the
-    # docstring recording WHICH bytes the probe carries and why that is
-    # faithful: the header window the magic-byte branch reads, plus the
-    # trailing PAR1 magic for .parquet. That reasoning is the load-bearing
-    # part — a check added to validate_file_content that reads the middle of a
-    # file would pass vacuously here. Cap 1473 -> 1547, exact.
-    # fix(#1202 review): +62 — freeze-first. Validating the staging key was a
-    # TOCTOU: the client keeps a working presigned PUT URL for it until expiry,
-    # so checked bytes could be swapped for garbage before preview read them.
-    # Completion now snapshots to a key no presign endpoint ever issued a URL
-    # for and judges THAT (_frozen_staging_key plus the copy/verify/validate
-    # ordering). The lines are mostly the two comments recording why the ORDER
-    # is the fix and which object each failure branch may delete — get either
-    # wrong and the race is back with the guard still apparently in place.
-    # Cap 1547 -> 1609, exact.
-    # fix(#1202 review r2): +45 — three findings, all the same shape as the
-    # first two rounds (client-writable state re-entering after a check).
-    # One-shot completion keyed off `file_path`; a pre-copy size fast path so
-    # an oversize object is not copied just to be rejected; and draining the
-    # freeze copy so a disconnect cannot abandon the SDK thread mid-write.
-    # The comments carry which of the three is the security boundary (only
-    # the post-copy verify) — deleting the wrong one reads as a cleanup.
-    # Cap 1609 -> 1654, exact.
-    # fix(#1202 review r3): +18 — both findings were "the failure path leaves
-    # state the retry path cannot proceed from". Multipart assembly is skipped
-    # when the staging object already exists (for S3 that is an iff for
-    # CompleteMultipartUpload having succeeded, so a retry no longer presents a
-    # spent upload id), and the staging delete moved after the commit so a
-    # rolled-back commit does not strand the retry with the bytes gone. Both
-    # comments carry the invariant, not the mechanic. Cap 1654 -> 1672, exact.
-    # fix(#1202 review r5): +26 — the one-shot guard was an UNLOCKED read, so
-    # two overlapping completions both passed it and raced over the same
-    # deterministic frozen key, letting the loser's refusal delete state the
-    # winner had already accepted. Completion now re-fetches the row FOR
-    # UPDATE before reading anything the guard depends on. The rest is the
-    # comment explaining why get_job_or_404 deliberately stays unlocked.
-    # Cap 1672 -> 1698, exact.
-    # fix(#1202 review r5b): +5 — the sweep comment named its reapers and went
-    # stale the moment the raster tail was added. It now points at
-    # `owned_presigned_staging_key` as the grep-able registry and records that
-    # the stale purge is a backstop only (it exempts the newest complete job
-    # per dataset). Cap 1698 -> 1703, exact.
-    # fix(#1202 review r9): +14 — the locked re-fetch became
-    # `lock_presigned_job`, whose docstring records that the property is
-    # TWO-part: the SELECT must lock AND the read must be fresh. Without
-    # populate_existing the lock serialized without informing, and the r5 test
-    # pinned only the first half, which is why the second survived four
-    # rounds. Extracting it also stops a test reimplementing the call and
-    # passing while the handler diverges. Cap 1703 -> 1717, exact.
-    # fix(#1207): -194 — the completion sequence moved to presigned.py so the
-    # reupload door could share it. Ratchet DOWN in the same commit, per the
-    # no-headroom rule. Cap 1717 -> 1523, exact.
-    # fix(#1213 review r3): -8 — the one-shot block became a call to the
-    # shared require_completable_presigned_job, which owns both facts.
-    # fix(#1233): +7 — the cancel branch no longer deletes the assembled
-    # object, and the comment records why: the upload id is already spent, so
-    # that object is the only record assembly succeeded and the retry's only
-    # way past it.
-    # fix(#1235 review r3): +10 — both signing sites anchor their expiration
-    # to the job deadline, with the comment recording why the part loop
-    # computes it once (later parts inherit the earlier deadline, which is
-    # conservative in the right direction).
-    # fix(#1235 review r4): +1 — the TTL call moved above the multipart branch
-    # so a job with no usable lifetime left is refused before an upload id is
-    # ever initiated, which trades two in-branch computations for one hoisted
-    # one plus the comment saying why the placement matters.
-    # fix(#1235 review r5): +9 — the part loop recomputes the TTL per
-    # signature (once-before-the-loop expired later parts PAST the deadline),
-    # and the multipart except block re-raises HTTPException so the lifetime
-    # refusal survives as a 409 instead of being reported as a storage outage.
-    # fix(#1235 review r8): -2 — signing moved behind sign_url_with_deadline,
-    # which took the per-site reasoning comments with it into presigned.py.
-    # Ratchet DOWN in the same commit, per the no-headroom rule.
-    # fix(#1235 review r9): +8 — the single-PUT branch re-raises HTTPException
-    # so the in-thread lifetime refusal stays a 409 there too, as it already
-    # did on the other three signing paths.
-    # fix(#1327): -15 — add_vrt_source/remove_vrt_source stage their intended
-    # member set on the VrtGeneration row instead of writing vrt_source_links,
-    # so the MAX(position) lookup, both link INSERT/DELETE statements, the
-    # separate COUNT(*) and position reads, and the two compensating rollback
-    # statements are all gone; the endpoints gained the fix(#1327) notes that
-    # say where the member set now lives, kept out of the docstrings because
-    # FastAPI publishes those into openapi.json. Ratchet DOWN in the same
-    # commit, per the no-headroom rule. Cap 1548 -> 1537, exact.
-    # fix(#1327 codex P1): +8 — both staged dispatch sites say why they defer
-    # the staged task name rather than the legacy one. Cap 1537 -> 1545, exact.
-    # fix(getgeolens.com#86 review): +5 — get_upload_config gained a per-route
-    # `responses={403: FORBIDDEN_RESPONSE}` override; it only requires
-    # authentication, not the router's write-flavored default. Cap 1545 ->
-    # 1550, exact.
-    # Collapsed the add/remove VRT-source defer-rollback closures onto the
-    # shared make_vrt_regeneration_failed_rollback factory in defer_guard.py
-    # instead of hand-rolling the same eight-field revert twice with only
-    # comment/statement-order differences between them (-7 net). Landed
-    # concurrently with the responses={403:...} addition above; recounted
-    # after merge rather than picking either side's number. Cap 1550 ->
-    # 1543, exact.
-    # fix(#1682 codex r3): +4 — the DB-failure fallback for allowed upload
-    # extensions became a function reading settings.allowed_extensions_list
-    # instead of an eight-entry literal that had drifted two formats behind.
-    # Most of the growth is the docstring recording why a narrower fallback is
-    # not a safer one. Cap 1543 -> 1547, exact.
-    # feat(#1691): +37 — the check_public_visibility_allowed gate at the five
-    # visibility-writing handlers (commit, fan-out, register, bulk register,
-    # VRT create), each a local import (PROCESS-02/04) plus one call and the
-    # comment saying which surface it closes. Cap 1547 -> 1584, exact.
-    # fix(#1709 review r2 P1): +16 — commit_fan_out's terminal transition is
-    # a fenced CAS via finalize_fan_out_parent instead of a blind attribute
-    # write, keyed on the attempt id captured with the pending check; the
-    # all-failed branch no longer writes 'pending' back. The lines are the
-    # capture, the call, and the comments recording why the blind writes
-    # could overwrite a committed cancel. Cap 1584 -> 1600, exact.
-    # fix(#1709 review r5 P1): +17 — the terminal transition moved BEFORE the
-    # dispatch loop (claim_fan_out_parent) so it is the mutex for the whole
-    # fan-out: a cancel either wins before any child exists or 409s against
-    # the terminal parent, closing the fast-child window the round-2
-    # post-loop shape left open. The lines are the claim call, its 409
-    # rendering, and the comment carrying the two-serialization argument.
-    # Cap 1600 -> 1617, exact.
-    # feat(#1705): +189 — upload_from_url, the URL variant of POST
-    # /ingest/upload. The handler lives here rather than a sibling module
-    # because the PROCESS-02/04 burndowns (auth.dependencies, quota.service)
-    # may only shrink; the fetch mechanics themselves are in url_fetch.py.
-    # The lines are the Rule 2 sequencing — SSRF gate, safe-client fetch,
-    # streamed size cap, staged-file sniff — plus the same cleanup-ownership
-    # comments the direct upload path carries. #1705 and #1709 both raised
-    # this cap from the same 1584 baseline in parallel, so the value is
-    # measured off the MERGED file rather than taken from either lane (the
-    # two lanes' import-region edits overlap, so the deltas do not simply
-    # add). Cap 1617 -> 1808, exact.
-    # fix(#1708 codex P1/P2): +40 — the pre-fetch commit that releases the
-    # pool connection for the download's lifetime (plus the failed-fetch
-    # stamping that replaces the rollback it gave up), the byte-clamp on the
-    # override filename, and the codeql[py/path-injection] markers at the
-    # staging open/unlink sites. Cap 1775 -> 1815, exact.
-    # fix(#1708 codex r2): +86 — the download now rides the RUNNING lease
-    # (status='running' + started_at before the pre-fetch commit) so the
-    # stale-pending sweep cannot fail an in-progress fetch at a legal 61s
-    # pending_job_timeout_seconds; both post-fetch transitions became
-    # guarded CAS UPDATEs from 'running' only, with the zero-row case
-    # surfaced as a 409; filename derivation moved into _url_import_filename
-    # inside the guarded path (urlparse ValueError on malformed authorities
-    # was an unhandled 500); _raster_stamped_metadata split out pure so the
-    # CAS can persist the same stamp without dirtying the ORM row. Cap
-    # 1815 -> 1908, exact.
-    # fix(#1708 codex r4): +20 — the SSRF gate moved above the handler's DB
-    # work AND the dependency-phase transaction is committed first, so the
-    # validator's unbounded getaddrinfo never overlaps a checked-out pool
-    # connection (auth deps query on the same request-cached session, so a
-    # reorder alone released nothing). Cap 1908 -> 1928, exact.
-    # fix(#1708 codex r5): +45 — control characters (NUL/C0/DEL) refused at
-    # filename derivation before any job row exists, and the failure path
-    # extracted into _settle_failed_url_import so a raising cleanup can
-    # never preempt the failure CAS (the stuck-running shape, not just the
-    # NUL instance); the post-success unlink went best-effort for the same
-    # reason. Cap 1928 -> 1973, exact.
-    # fix(#1708 codex r6): +12 — the completion CAS stamps
-    # user_metadata.staged_at so stale_pending_clauses restarts the pending
-    # review window at staging completion instead of letting the download
-    # time eat it. Cap 1973 -> 1985, exact.
-    # fix(#1708 codex r7): +84 — the S3-mode completions of both families:
-    # the staging put moved into _put_staging_object/_stage_put_bounded (a
-    # bounded WAIT with abandonment, since the drained boto3 thread absorbs
-    # cancellation and an asyncio.timeout would not bound wall time) with
-    # _abandoned_put_reaper deleting a late-landing object, and the byte-
-    # quota check moved below the put so the post-stage transaction holds a
-    # connection only for quota reads + CAS + commit. Cap 1985 -> 2069,
-    # exact.
-    # fix(#1708 codex r8): +40 — the stage clock now starts BEFORE the
-    # preflight SSRF DNS, which is bounded at the call site with wait_for
-    # (the one long operation still outside every deadline), and
-    # _stage_put_bounded installs the abandonment reaper on ANY exit that
-    # leaves the put task running — including the waiter itself being
-    # cancelled mid-wait, which previously escaped before the timeout
-    # branch installed it. Cap 2069 -> 2109, exact.
-    # fix(#1708 codex r9): +14 — staging-path setup hoisted ABOVE the
-    # running-commit (a read-only parent used to raise between the commit
-    # and the settlement guard, stranding a running row for the lease), and
-    # the INVARIANT comment at the seam: nothing executable may sit between
-    # the running-commit and the guarded try. Cap 2109 -> 2123, exact.
-    # fix(#1708 codex r10): +45 — _effective_stream_cap: the fetch's byte
-    # cap becomes min(instance upload max, caller's remaining core byte
-    # quota), refusing at submission when nothing remains and threading a
-    # quota-shaped refusal detail through fetch_url_to_path so both cap
-    # sites (declared Content-Length and mid-stream count) name the quota
-    # when the quota is what is capping. The post-stage byte-charged check
-    # stays authoritative. Cap 2123 -> 2168, exact.
-    # fix(#1708 codex r11): +73 — the ambiguous-commit reconciliation: the
-    # final running->pending commit goes through the _commit_staged_
-    # transition seam, and _settle_failed_url_import probes a FRESH session
-    # first (_url_import_transition_landed) — when the commit durably landed
-    # despite a raised acknowledgement, settlement stands down instead of
-    # deleting bytes a live pending row points at. Probe failure errs
-    # toward standing down: orphaned bytes are sweepable, deleted catalog
-    # data is not. Cap 2168 -> 2241, exact.
-    # fix(#1708 codex r12): +54 — the last unbounded operation on the
-    # request path, on the failure route that fires when S3 is degraded.
-    # An abandoned put raises _StagePutAbandoned, and settlement then skips
-    # the synchronous remote delete entirely (the late-put reaper already
-    # owns that key, and a delete issued now would race the in-flight
-    # upload); every other failure bounds its delete by what remains of the
-    # request budget. Cap 2241 -> 2295, exact.
-    # fix(#1708 codex r13): +37 — the joint budget became genuinely joint.
-    # The fetch's bound is now min(FETCH_MAX_SECONDS, stage_deadline - now)
-    # via _remaining_fetch_budget, so time spent by auth, preflight DNS and
-    # the config/quota transaction is deducted from it instead of the fetch
-    # starting a fresh 480s clock; a budget already under the floor refuses
-    # promptly rather than opening a doomed connection. Most of the growth
-    # is the INVARIANT comment at the deadline's definition, which a future
-    # phase added to this handler inherits. Cap 2295 -> 2332, exact.
-    # fix(#1708 codex r14): +68 — the r11 ambiguous-commit probe was scoped
-    # to EVERY post-staging failure, so ordinary rejections opened a second
-    # session while still holding their own transaction (the r2/r7
-    # connection family, reopened by a settlement path that grew) and
-    # inherited the probe's deliberate assume-landed default, skipping
-    # cleanup. Settlement now rolls back FIRST, and the probe fires only
-    # for an exception carrying the marker _commit_staged_transition_
-    # guarded stamps. A cancelled put task also reaches its deleter now
-    # (task.exception() raises on a cancelled task). Cap 2332 -> 2400,
-    # exact.
-    # fix(#1708 codex r15): +26 — the landed stand-down deletes the LOCAL
-    # copy when the row references an S3 key (nothing downstream can
-    # discover a path no row names, so it leaked one file per ambiguous
-    # commit) and keeps it when the row references the local file itself.
-    # Most of the growth is the comment making that asymmetry read as
-    # intent rather than an oversight. Cap 2400 -> 2426, exact.
-    # fix(#1708 codex r16): +14 — the INVARIANT comment at the deadline's
-    # initialization now states what the joint clock does NOT cover (auth
-    # and dependency-phase work run before this handler body; the
-    # post-stage transaction runs after the budget), replacing wording
-    # that claimed auth time was deducted. A comment describing a
-    # protection the code does not implement is the class AGENTS.md calls
-    # out, so the correction is the point of the change. Cap 2426 -> 2440,
-    # exact.
-    # fix(#1708 codex r17): +1 — the stage budget is derived per request
-    # from the configured db_pool_timeout (see stage_total_budget_seconds)
-    # rather than hardcoded, so raising that operator-settable value
-    # shrinks the budget instead of silently breaking the proxy invariant.
-    # Cap 2440 -> 2441, exact.
-    # fix(#1708 codex r18): +4 — the INVARIANT comment now enumerates the
-    # request's THREE pool checkouts (auth, pre-fetch, post-stage) instead
-    # of the two r17's derivation assumed, and points at the named constant
-    # that carries the count so the arithmetic stays checkable against the
-    # code. Cap 2441 -> 2445, exact.
-    # fix(#1708 codex r19): +37 — _preflight_dns_budget, so the preflight
-    # follows the INVARIANT's own rule (min(own ceiling, remaining)) rather
-    # than a bare ceiling. Harmless while the budget is healthy, wrong in
-    # the floored regime, where a 1s budget could still spend 30s resolving
-    # before anything refused; an exhausted clock now refuses with the
-    # budget's message before any job row exists. Cap 2445 -> 2482, exact.
-    # fix(#1708 codex r20): +29 — comment only. The running-state commit is
-    # deliberately NOT covered by the ambiguous-commit probe, and the
-    # reasoning is recorded at the site: nothing is staged yet, the row
-    # blocks nothing (checked against every active-job predicate: the
-    # backfill unique index, the per-user analysis cap, the manifest
-    # in-flight check, the reupload lookup, and quota), and the running
-    # lease already owns it. An unexplained asymmetry is what invites the
-    # next round, so the trade is written down with its expiry condition.
-    # Cap 2482 -> 2511, exact.
-    # RECONCILED at the #1708/#1709 merge: both PRs raised this cap in
-    # parallel off the same 1584 baseline — #1709 to 1617 (the fan-out
-    # parent claim moving before dispatch), #1708 to 2511 (everything
-    # above). Neither number survives having both applied, so the cap is
-    # measured off the merged file rather than composed from either lane's
-    # arithmetic. 2511 + #1709's 33 = 2544, exact.
-    # fix(#1708 CodeQL triage): +1 — the codeql[py/path-injection] marker on
-    # _cleanup_saved_upload's Path branch. The URL flow reaches that shared
-    # helper (from _settle_failed_url_import) with an S3 KEY STRING, which is
-    # what made the pre-existing sink alert; the marker records that the Path
-    # branch only ever receives a staging-rooted path. Cap 2544 -> 2545, exact.
-    # fix(#1708 codex r25): +20 — the floored-budget refusal moved to
-    # immediately after the deadline is derived, before preflight DNS and the
-    # config/quota transaction. Deliberately the SAME _remaining_fetch_budget
-    # call the pre-fetch check makes, so the two can never disagree about what
-    # "too small to start" means; most of the lines are the comment recording
-    # that the floor promised a PROMPT refusal the ordering did not deliver.
-    # Cap 2545 -> 2565, exact.
-    # fix(#1746 codex r1): +17 — the header-token check moved ahead of the
-    # metadata write in commit_import. The refusal already existed one call
-    # deeper, but `service_auth_required` was committed in between and
-    # permanently blocks POST /jobs/{id}/retry, so a rejected token left a
-    # still-pending job that could never be replayed. Most of the lines are the
-    # comment recording that, and why `service_type` is readable before the
-    # merge. Cap 2565 -> 2582, exact.
-    # feat(#1746 B2b): +20 — `commit_import` converts the structured `auth`
-    # object the way the other four doors do, judges it against the job's own
-    # service format before the metadata write, and hands the resulting
-    # credential to `queue_ingest_job` rather than a bare token. Most of the
-    # lines are the comment saying why `auth` joins `token` in the model_dump
-    # exclusion: user_metadata is a durable JSONB column and that dump is a
-    # whitelist by omission. Cap 2582 -> 2602, exact.
-    # fix(#1846, GHSA-hrf5-v3cq-frx5): +14. `preview_file` lets one refusal
-    # class past the generic "may be malformed or unsupported" handler: the
-    # schema check's message is server-authored, names what was refused and
-    # says what to upload instead, and the preview is where a presigned upload
-    # first meets a whole-file check. Cap 2602 -> 2616, exact.
-    # fix(#1848): +50. `upload_file` commits the job before the spooled body
-    # is staged and binds through a guarded UPDATE that stamps `staged_at`; the
-    # lines are the guard helper, the two guarded writes and the 409.
-    # refactor(#1711): -26. `_cleanup_saved_upload` belongs to service.py: it
-    # is a shared staging helper, not a router one. Cap 2665 -> 2639, exact.
-    # refactor(#1711): -459. The URL-import staging cluster — budget, bounded
-    # put, settlement — lives in url_import_staging.py; the route handler and
-    # its filename/metadata helpers stay. Cap 2639 -> 2180, exact.
-    # fix(#1955): the VRT source doors admit through the shared per-dataset
-    # lock and refuse with the coded `dataset_busy` body. fix(#2016): the
-    # fan-out door reports a lost undo instead of hiding it behind a 202.
-    # fix(#1953): the failure sinks route through ADR-002's door.
-    # feat(#1710): `upload_from_url` validates, commits a 'running' job row and
-    # defers `fetch_url`; the download, staged-file sniff, S3 staging put,
-    # byte-quota recheck and the running->pending settlement moved to
-    # processing/ingest/tasks_url_fetch.py, taking the proxy-deadline budget
-    # with them. RECONCILED: four PRs moved this cap from different baselines,
-    # so the value is MEASURED on the merged file, never composed.
-    # fix(#2032): +11. The import commit door refuses an srid_override that
-    # names no spatial_ref_sys row. Cap 1819 -> 1830, exact.
     "backend/app/processing/ingest/router.py": 1830,
-    # fix(#888): +25 — the `mercator_clip` StagingResult field and the
-    # `_append_mercator_clip_warning` emitter that keeps the three ingest call
-    # sites a single statement each (`reupload_file` is already at the C901
-    # complexity ceiling, so the branch cannot live inline). Ratchet stays exact.
-    # fix(#1018): +40 — `_ingest_vector_into_staging` has no caller in `app/`;
-    # every call site is a test. The added lines say so at the definition and
-    # map what it mirrors, because silent drift is what makes a test-only copy
-    # dangerous rather than merely unused. fix(#1018 review) corrected that
-    # map and cost most of the lines: the staging steps are NOT forked here,
-    # they are the real `_run_staging_pipeline` — but production reaches that
-    # only on re-upload, while new vector ingest reruns the same eight steps
-    # inline in `_finalize_ingest`, so the sequence has three sites. The same
-    # correction fixes `_run_staging_pipeline`'s own docstring, which claimed
-    # `_ingest_vector_into_staging` was the "new ingests" caller.
-    # Ratchet stays exact.
-    # fix(#1202 review r5b): +32 — `reap_presigned_staging_object`, the shared
-    # sweep. The vector tail had it inline; raster needed the same block, and
-    # two copies of a best-effort delete in a PR about doors that drifted
-    # would have been the same mistake one level down. Cap 1671 -> 1703, exact.
-    # fix(#1207): +4 — the terminal-status guard folded into
-    # reap_presigned_staging_object from three identical copies in the task
-    # tails, which also kept reupload_file under the complexity ceiling.
-    # fix(#1213 review r2): +57 — reap_downloaded_staging_source, extracted
-    # from the vector tail so the reupload tail could share it. That block
-    # reaps the object the task DOWNLOADED from, which after a presigned
-    # completion is the frozen copy; the reupload tail shipped without it.
-    # fix(#1213 review r4): +9 — the reaper's guard keyed off the path rewrite,
-    # which never happens when the download itself raises, so a terminal
-    # failure skipped the sweep. The `staging/` prefix is the real
-    # storage-key signal; the docstring records why the rewrite check was
-    # wrong and why the prefix is sufficient.
-    # fix(#1213 review r6): +23 — the failed-source retention semantics (an
-    # ordinary import stays retryable while its source exists, so only the
-    # reupload caller reaps on failure) plus draining both terminal reapers so
-    # a cancellation cannot skip the sweep that follows. Most of it is the
-    # docstring correcting r4's claim, which cited the wrong authority.
-    # feat(#1218): +20 — IngestContext gains origin_ref (the typed per-origin
-    # payload the finalize pipeline writes) and _finalize_ingest stamps the
-    # system-managed origin pointer in the same transaction that creates the
-    # dataset. Most of it is the field's comment recording why the caller
-    # supplies the payload rather than this module inferring one.
-    # Cap 1796 -> 1816, exact.
-    # fix(#1218 review): +32 — _apply_reupload_swap restamps the origin
-    # binding and last_refreshed_at, so the stored ref keeps describing where
-    # the CURRENT bytes came from after a reupload changes the origin kind.
-    # Most of it is the comment explaining why the kind is derived rather than
-    # hardcoded to upload (a service reupload must stay a service origin) and
-    # that #1220's executor takes both writes over, and why the timestamp is a
-    # Python datetime rather than func.now() (a SQL expression leaves the
-    # attribute expired, so the next read lazy-loads). Cap 1816 -> 1850, exact.
-    # fix(#1222 review): +11 — the swap stamps last_checked_at for service and
-    # STAC origins, because set_dataset_origin clears probe state on restamp
-    # and this swap IS a contact with the origin. The comment carries why
-    # source_health is NOT written here (the vocabulary belongs to the
-    # probe's classifier). Cap 1850 -> 1861, exact. +7 more: first ingest
-    # stamps the same contact for service/STAC origins — the import fetched
-    # from the origin too, and a fresh service dataset otherwise reported
-    # "never contacted" until manually probed. Cap 1861 -> 1868, exact.
-    # feat(#1219): +6 — _apply_reupload_swap now RETURNS the DatasetVersion it
-    # created, flushed so its id is populated, because the refresh run row
-    # links to that id. Resolving it at the call site by (dataset_id,
-    # version_number) instead would be a second way to name one row.
-    # Cap 1868 -> 1874, exact. fix(#1274 review): +6 — the failure finalizer's
-    # attempt fence now admits `pending`, because a failure BEFORE the claim
-    # (the worker-time SSRF refusal) must still finalize the job it owns; the
-    # comment carries why attempt-id equality, not status, is the fence.
-    # Cap 1874 -> 1880, exact.
-    # fix(#1277 review): +9 — the shared failure sink redacts before it
-    # persists. This one function fans out to three sinks (the durable
-    # error_message, the log record, the notification reason), so the comment
-    # has to say why the redaction belongs here rather than at each of them,
-    # and why the exception itself is left unmodified for callers that
-    # dispatch on its type. Cap 1880 -> 1889, exact.
-    # fix(#1290 review): +13 — _archive_original_file reports whether the
-    # archive landed and accepts the uploaded filename. The raster tails call
-    # it to satisfy ADR-002 Decision 7 when a conversion was lossy, so for them
-    # the outcome is a decision input (do not delete the staged upload unless
-    # the durable copy exists) rather than a breadcrumb, and `file_path` is a
-    # temp download on object storage so the name had to come from the caller.
-    # Cap 1889 -> 1902, exact.
-    # feat(#1266): +66 — stamp_failed_origin_health, the guarded dataset-side
-    # health write a failed refresh makes. It arrived with #1313 as a private
-    # helper inside the registered-PostGIS strategy; the STAC strategy needs
-    # precisely the same write, and a copy would have been a THIRD spelling of
-    # the binding guard beside _record_failed_origin_contact in
-    # tasks_reupload. Moved here rather than duplicated, so the two strategies
-    # share one implementation and #1313's file shrank by the same lines.
-    # Cap 1902 -> 1968, exact.
-    # fix(#1314): +26 — _apply_reupload_swap reconciles the auto-generated
-    # distribution rows when the swap changes the dataset's modality. Most of
-    # the lines are the note recording what this deliberately does NOT fix on
-    # this path (record_type, filed as #1361) so the asymmetry is a decision
-    # rather than an oversight. Cap 1968 -> 1994, exact.
-    # fix(#1314 review round 2): +28 — the demote needs positive evidence that
-    # the relation is not spatial, because a spatial reupload of an empty file
-    # measures None while its geom column is still there. Most of the lines are
-    # the note saying why the sampled value is not that evidence, which is the
-    # same trap #1313 fell into on the refresh path. Cap 1994 -> 2022, exact.
-    # fix(#1373 x #1361): +97 — the effective-geometry precedence and the
-    # record_type derivation MOVED here from tasks_postgis_refresh (which
-    # already imports from this module, so the dependency runs the right way)
-    # and _apply_reupload_swap now resolves both. Roughly half the lines are
-    # the three helpers and their docstrings arriving intact — that file shrank
-    # by 68 — and the rest is the swap's own note recording why the sampled
-    # geometry type is not evidence about the COLUMN, and why record_type must
-    # consume the RESOLVED value or an empty spatial reupload flips a still-
-    # spatial dataset to `table`. Cap 2022 -> 2119, exact. +8 more: the note
-    # recording what this swap still does NOT retire when it de-spatializes a
-    # dataset (the synthetic `geom` attribute row, filed as #1380), so the
-    # remaining asymmetry with the refresh path is a decision. Cap 2119 ->
-    # 2127, exact. +12 more (#1382 review r1): a generic empty column over a
-    # dataset nothing had ever measured resolved to None and classified a
-    # spatial relation as tabular, so the precedence falls back to the generic
-    # sentinel; the lines are the note recording that `GEOMETRY` is how the
-    # rest of the codebase already spells "spatial, subtype unknown".
-    # Cap 2127 -> 2139, exact. fix(#1380): +39 — the note above becomes the
-    # thing it described. `_retire_geometry_attribute_row` MOVED here from
-    # tasks_postgis_refresh (which shrank by 10) and both de-spatializing
-    # paths call it, so the synthetic `geom` attribute row is retired once
-    # rather than by whichever path remembered to. Most of the lines are the
-    # docstring recording why `refresh_attribute_metadata` is right to leave
-    # that row alone for every other caller, and why the null check lives
-    # inside the helper. Cap 2139 -> 2178, exact.
-    # feat(#1472): +29 — `apply_manifest_record_metadata`, the read-back for the
-    # manifest metadata `manifest_job_metadata` had been writing into the job
-    # ledger and nobody consumed. It lives here rather than in either tail
-    # because the vector tail (below) and the raster tail (tasks_raster, which
-    # already imports `_parse_temporal_fields` from this module) both need it
-    # and would otherwise each grow their own copy. Most of the lines are the
-    # docstring recording why only the manifest-namespaced keys are copied:
-    # title/summary/visibility reach the record through create_dataset's own
-    # arguments on every ingest path, so touching them here would change
-    # non-manifest ingests, and why `record` is duck-typed rather than annotated
-    # `Record` (the annotation would add the processing -> modules.catalog edge
-    # ProcessingPort exists to keep out). Cap 2178 -> 2207, exact.
-    #
-    # fix(#1542): +4 — one `task_app.import_paths` entry for the queued admin
-    # embedding backfill, plus the three-line comment saying why that task
-    # module lives under modules/admin/ (it emits the run's audit events, which
-    # processing/ may not import) rather than beside the backfill it runs.
-    # Cap 2207 -> 2211, exact.
-    # fix(#1675): +81 — run_paged_arcgis_service_fetch, the guarded
-    # resultOffset paging loop extracted from tasks_vector so the refresh
-    # executor pages large ArcGIS layers with the same no-progress guard
-    # instead of trusting GDAL driver paging. Then +16 (codex r2): the
-    # growth check became exact — a server capping responses below its
-    # advertised page size returned SOME rows per page while the offset
-    # skipped records, so positive growth alone could swap a truncated
-    # copy. Cap 2211 -> 2308, exact.
-    # fix(#1682 codex r1): +3 — the DBF field-name-truncation warning in the
-    # shared reupload helper is keyed on the derived source_format instead of
-    # the .zip suffix, plus the import and the comment saying why (a File
-    # Geodatabase arrives in a .zip and has no DBF). Cap 2308 -> 2311, exact.
-    # fix(#1746): +69 — the shared token purge both service tasks now run on
-    # their terminal failure path: `purge_queued_job_arg` (a best-effort
-    # `args - 'token'` UPDATE against the task's own procrastinate row) and
-    # the `purge_token_on_failure` decorator that absorbs the JobContext
-    # procrastinate passes in so the tasks keep their existing signatures.
-    # Two thirds of it is comments — why deleting the key is safe (retry=0,
-    # so the first exception is the terminal one) and why the wrapper catches
-    # Exception rather than BaseException. Cap 2311 -> 2380, exact.
-    # fix(#1778): +14 — `_cleanup_staging_on_failure` skips the DROP when it is
-    # handed an empty staging-table name, which is what makes it usable by the
-    # raster and VRT tails that have no staging table. Most of it is the
-    # docstring saying what the four hand-rolled copies were each missing (the
-    # redaction backstop, the pending-inclusive fence, the ingest_failed
-    # notification) and why an empty name skips rather than logs a cleanup
-    # failure on every VRT build failure. Cap 2380 -> 2395, exact.
-    # fix(#1778 codex r2): +31 — `_cleanup_staging_on_failure` writes and
-    # commits the failure row BEFORE it attempts the staging DROP, and the drop
-    # rolls back its own wreckage. A DDL error aborts the whole PostgreSQL
-    # transaction, so with the drop first a lock or statement timeout took the
-    # failure write down with it and the job sat `running` with no reason. Most
-    # of the lines are the docstring and comment stating that the order is the
-    # contract. Cap 2395 -> 2426, exact.
-    # fix(#1778 codex r6): +21 — `_job_phase_session` takes an optional
-    # `lock_and_statement_timeout_ms`, applied via `SET LOCAL` BEFORE its own
-    # SELECT rather than leaving a caller to set it after entering the
-    # context manager, where it could not protect that SELECT from stalling
-    # behind a lock the row's own later write would never see (e.g. an
-    # ACCESS EXCLUSIVE table lock). `None` by default, so every other caller
-    # of this shared helper is unchanged. Cap 2426 -> 2447, exact.
-    # fix(#1778 audit r11): +23, rebased onto the above rather than the 2426
-    # baseline it was originally measured against. `_job_phase_session` also
-    # gains `require_status`, an independent optional status predicate that
-    # joins the attempt fence, addressing a coexisting gap: an (id, attempt)
-    # -only match still admitted a row the stale sweep had already failed on
-    # a heartbeat timeout, with no retry having rotated the attempt token
-    # yet, so a worker only paused could resume and write whatever that
-    # phase writes. The two parameters are independent and both now live on
-    # the same signature. Almost all of the growth is the docstring stating
-    # which phases must pass which. Cap 2447 -> 2470, exact.
-    # fix(#1778 audit r12): +25. `require_status`'s SELECT now takes `FOR NO
-    # KEY UPDATE`, closing the TOCTOU a plain status check left open: the
-    # sweep could still fail a row in the window between the read and the
-    # phase's first put, since a SELECT is not a lock. Most of the growth is
-    # the docstring stating why `NO KEY UPDATE` over plain `UPDATE`, and
-    # pointing at the sweep-side fixes that now have to contend with this
-    # lock instead of racing past it. Cap 2470 -> 2495, exact.
-    # fix(#1738 round 1): +38 — bump_tile_cache_version_atomic, the sibling of
-    # Dataset.bump_tile_cache_version for a writer that holds no row lock.
-    # Most of it is the docstring arguing why the lock is not the fix: the
-    # feature-edit routers roll the counter through a plain read-modify-write
-    # and never take one, so one side locking does not serialize a race the
-    # other side is not playing. Cap 2495 -> 2533, exact.
-    # fix(#1770 round 43 P2): +8. `_bind_task_log_context` now also resets
-    # the credential-secret registry (`core/service_tokens.register_
-    # credential_secret`) at the same boundary it already clears structlog's
-    # own contextvars, so a re-used worker cannot scrub a later job's log
-    # lines with an earlier job's secret. Cap 2533 -> 2541, exact.
-    # fix(#1846, GHSA-hrf5-v3cq-frx5): +5. The upload-safety gauntlet gained
-    # the SQLite schema check beside the archive checks, for the same reason:
-    # what a file instructs is as much a property of the upload as its shape.
-    # Cap 2541 -> 2546, exact.
-    # fix(#1846 review round 4): +5. Same thread offload as the ogr.py sites,
-    # with the comment saying why a linear walk still does not belong on the
-    # loop. Cap 2546 -> 2551, exact.
-    # fix(#1755 item 11): +30. `cleanup_step`, the one helper the seven ingest
-    # task modules now route every `finally`-block cleanup step through, plus
-    # the docstring stating the two things it must never do: replace the
-    # exception the block is already propagating, and swallow the
-    # `CancelledError` a worker shutdown delivers. It replaces two private
-    # copies that had grown in tasks_vector.py and tasks_reupload.py, whose
-    # bodies differed only in the task name in their docstrings.
-    # Cap 2551 -> 2581, exact.
-    # fix(#1847): the lock order, its gate and its 409 mapping. Cap 2601, exact.
-    # fix(#1847): the cache-bump docstring states its contract. Cap 2601 -> 2596.
-    # fix(#1902): the atomic bump moved to platform/catalog_locks. Cap 2596 -> 2559.
-    # fix(#1911): the reupload swap bumps atomically under the lock. Cap 2559 -> 2558.
-    # fix(#1917): +19 — the swap restores the lock_timeout it installed, so it
-    # stops clamping the catalog-lock wait; its budget constants moved to
-    # module scope to be testable. Cap 2558 -> 2577, exact.
-    # fix(#1921): +66 — the post-swap catalog wait gets its own budget, a
-    # restore, and events telling an expired budget from a lost deadlock.
-    # Cap 2577 -> 2643, exact.
-    # fix(#1950): +25 — the shared failure helper arms the job-row budget after
-    # its own rollback, and an expiry there is logged and swallowed so the caller
-    # re-raises the ingest failure instead. Cap 2643 -> 2668, exact.
-    # fix(#1950 codex r2-r5): +55 — `load_job_for_error_write`, the guarded job
-    # load the two re-upload tails share, which also ends the transaction on a
-    # miss so the run row they write next is unbudgeted. Cap 2668 -> 2723, exact.
-    # fix(#1755 item 12): -8 and fix(#1953): +2 merged; re-measured after both landed. Cap 2415, exact.
-    # fix(#1710): `purge_queued_job_token` became `purge_queued_job_arg`,
-    # taking the key so a submitted file URL is dropped the way a service
-    # token already was; it delegates to the sweep statement #1755 moved,
-    # so the fact keeps one home. RECONCILED across #1755 and #1953:
-    # measured on the merged file, not summed. Cap 2415 -> 2423, exact.
-    # refactor(#2026): -575. The staging acquisition and cleanup half moved to
-    # `tasks_staging.py` (599 lines, under the inclusion threshold), which also
-    # took five imports nothing left here uses. Cap 2423 -> 1848, exact.
-    # fix(#2039): +52. The manifest read-back copies license and organization
-    # and inserts tags as theme keywords, skipping the ones a re-apply already
-    # wrote; the keyword class comes off the record class the port exposes.
-    # Cap 1848 -> 1899, exact.
-    # fix(#2039 review): +13. The tag de-dup reads the rows the unique index
-    # would collide with, spelled as the index spells them (COALESCE on the
-    # vocabulary), case-folded. Cap 1899 -> 1912, exact.
     "backend/app/processing/ingest/tasks_common.py": 1912,
-    # --- entered by the inclusion rule, feat(#1219 x #1222) ---------------
-    # tasks_reupload crossed 1000 when two independently-reviewed features
-    # met in one file: #1222's failed-contact bookkeeping (spawn-armed
-    # binding-guarded stamp, ~90 lines with its helper and comments) and
-    # #1219's refresh-run integration (run claim on dispatch, run
-    # finalization on both outcomes, the savepoint-scoped run row on the
-    # failure path). Both sides earned their lines in their own reviews;
-    # the sum simply tripped the inclusion threshold. Entered at its
-    # measured size. fix(#1274 review): +4 — the fetch-time SSRF check moved
-    # inside the handled region so its refusal finalizes the job and run
-    # instead of stranding a pending run against the admission index.
-    # Cap 1055 -> 1059, exact.
-    # feat(#1220): +48 — the one-time credential handoff reaches the worker
-    # here. Twenty of those lines are `_resolve_service_token`, extracted
-    # rather than inlined because the claim is one `if` and inlining it
-    # tripped the C901 ceiling on `reupload_service`; the rest is the
-    # `credential_ref` parameter, the docstring paragraph saying which of the
-    # two doors sends which credential shape and why the ref wins when both
-    # are set, and the failure handler's `credential_expired` branch — the one
-    # failure on this path whose fix is "start again with a fresh token"
-    # rather than anything about the origin. Cap 1059 -> 1107, exact.
-    # feat(#1220 self-review): +18 — `_service_refresh_error_code`, which
-    # splits the credential failures into two codes instead of one. An
-    # unreachable credential store is an operator's split-brain config (the
-    # API accepted the token because IT could reach the store) and needs a
-    # different answer than a spent token; the mapping lives in a named
-    # function so a fourth case is an entry rather than another branch inside
-    # the failure handler. Cap 1107 -> 1125, exact.
-    # fix(#1277 review): +14 — the exact-value credential scrub at the top of
-    # the broad handler. This task is the only place that knows the token's
-    # literal value, which is what makes it the redaction an unrecognised echo
-    # cannot evade; the comment records that, and why it mutates the exception
-    # in place rather than raising a replacement (the class is load-bearing for
-    # the error-code mapping below it). Cap 1125 -> 1139, exact.
-    # fix(#1472 review): +12 — apply the manifest ledger's credit line on the
-    # reupload swap. A manifest re-apply with a changed fingerprint classifies
-    # as "update" and lands here rather than on either fresh-ingest tail, so
-    # without it the swap installed new data under the previous manifest's
-    # credit. Most of the lines are the comment recording why this path is the
-    # only reupload one that needs it and why dataset.record is safe to touch
-    # (joinedloaded by the SELECT above it). Cap 1139 -> 1151, exact.
-    # fix: +5 — thread original_filename through _detect_reupload_crs and the
-    # two run_ogrinfo/run_ogr2ogr call sites so a corrupt reupload gets the
-    # same friendly "could not open" message as a fresh upload, instead of
-    # leaking the staging path / GDAL driver dump. Cap 1151 -> 1156, exact.
-    # fix(#1675): +79 — _fetch_service_layer_with_paging_guard: the paging
-    # decision (page-info probe, criteria, paged-vs-single dispatch) for the
-    # refresh executor, module-level so the branches stay out of
-    # reupload_service's complexity budget. Then +10 (codex r1): arm the
-    # origin-contact stamp when the probe's request begins — the probe is
-    # the first outbound contact and can die before any subprocess spawns.
-    # Cap 1156 -> 1245, exact.
-    # feat(tier-1 vector import) + fix(#1682 codex r1): +2 — the source_format
-    # derivation moved to the shared ingest/source_format.py (one import line),
-    # and the DBF-truncation guard gained the comment recording that it is
-    # keyed on the derived format, not the .zip suffix. Cap 1245 -> 1247, exact.
-    # feat(#1676): -5 — `_resolve_service_token`'s body moved out to
-    # platform/refresh/credentials.resolve_worker_credential so `ingest_service`
-    # can redeem the same way. Neither task module may import the other
-    # (tasks_reupload already reaches into tasks_vector at call time, so a
-    # top-level edge back would close a cycle), which is what put the shared
-    # copy in platform/. Ratchet DOWN in the same commit, per the no-headroom
-    # rule. Cap 1247 -> 1242, exact.
-    # fix(#1746): +9 — `reupload_service` takes `pass_context=True` (the only
-    # way a task can learn its own queue-row id) and the
-    # `purge_token_on_failure` wrapper, plus the comment saying what the
-    # context is for. Cap 1242 -> 1251, exact.
-    # fix(#1746): +27 — the auth_required marker on the service swap's
-    # origin_ref (True or absent, never False, so a token-less pull stores the
-    # pre-marker ref shape and no backfill is owed), plus door-aware
-    # auth-failure copy. The old string said "Retry commit", which names a
-    # door neither caller came through: this task serves the refresh endpoint
-    # and the re-upload commit, and never a first import. Cap 1251 -> 1278,
-    # exact.
-    # fix(#1746 codex r1): +5 — the marker comment now states the claim
-    # narrowly ("the last successful pull was MADE with a token"), because the
-    # worker never sees a challenge on the happy path. Cap 1278 -> 1283, exact.
-    # fix(#1778): +8. The pending -> running run transition is committed
-    # before `resolve_file_path` instead of after it, plus the comment saying
-    # why. Holding the `dataset_refresh_runs` row lock across the staging
-    # download made every cancel in that window a 409 that also rolled back the
-    # job cancellation it had already written. Cap 1283 -> 1291, exact.
-    # fix(#1746 B2b review r1): +6 — rebased onto #1778 above. The worker's
-    # authentication-failure copy names the `auth` object rather than the
-    # deprecated `token` field, which always means a bearer credential and so
-    # could not authenticate the basic or named-key origin that produced the
-    # failure. Same finding as the refresh door's 422, one layer down; the
-    # lines are the comment recording that the two messages have to agree.
-    # Cap 1291 -> 1297, exact.
-    # fix(#1755 item 11): +36. `reupload_service`'s `finally` block routes
-    # both cleanup calls through the new shared `_finally_cleanup` helper, so
-    # a heartbeat-stop or staging-drop failure logs (redacted, exc_info)
-    # rather than replacing the ingest exception in flight; the #1753 token
-    # purge still runs, since the helper never re-raises. Cap 1297 -> 1333,
-    # exact.
-    # fix(#1755 item 11, follow-up): -23. The private `_finally_cleanup` copy
-    # moved to `tasks_common.cleanup_step` as a context manager, which is
-    # shorter at every call site than passing a coroutine, and `reupload_file`
-    # gained the same treatment its service sibling already had (5 steps).
-    # Cap 1333 -> 1310, exact.
-    # fix(#1921): +15 — the file path gets the exception-to-error_code mapper
-    # its service sibling already had, and both name a contended catalog row.
-    # Cap 1310 -> 1325, exact.
-    # fix(#1950): +4 — both failure tails bound their job-row load, and
-    # reupload_file's terminal status moved into a `finally` so a bounded write
-    # that raises still reaches the reapers. Cap 1325 -> 1329, exact.
-    # fix(#1950 codex r2): -12 — each tail's pre-helper job load moved to
-    # `tasks_common.load_job_for_error_write`, which arms the budget and
-    # swallows an expiry there. Cap 1329 -> 1317, exact.
-    # fix(#1953): +1 — the import of the one redactor every failure writer
-    # in this module now goes through. Cap 1245 -> 1246, exact.
-    # refactor(#2026): +2 — the staging cluster's names now come from
-    # `tasks_staging`, so this module's one import block became two.
-    # fix(#2031): +16. `_detect_reupload_crs` also refuses a replacement that
-    # would strip the dataset's geometry, and takes the record type that
-    # decides it. Cap 1248 -> 1264, exact.
-    # fix(#2031 review): +31. The refusal became `_assert_geometry_survives`,
-    # shared with the service path, which learns geometry from the staging
-    # table and reached the same swap; it also reads the dataset's recorded
-    # geometry, not just its record type. Cap 1264 -> 1295, exact.
     "backend/app/processing/ingest/tasks_reupload.py": 1295,
-    # --- entered by the inclusion rule, feat(#1266) -----------------------
-    # The refresh door crossed 1000 when it gained its third execution
-    # strategy. Two thirds of the addition is the STAC dispatcher, which is
-    # the service door's ordering with the steps a remote ITEM does not need
-    # removed (no credential, no prior-ingest settings) — the shape is
-    # deliberately the same because the ordering is what keeps a re-upload
-    # that commits mid-admission from having its rebind dispatched from a
-    # pre-swap snapshot. The rest is _resolve_stac_origin and the binding
-    # dataclass, whose comments carry the one asymmetry that decides this
-    # strategy: the asset href says whether the COG is still there, and only
-    # the ITEM href can say where the publisher moved it to. Entered at its
-    # measured size.
-    # fix(#1266 review round 9): +2 — the dispatched STAC binding carries the
-    # item's recorded id, so a re-upload that rebinds mid-admission is caught
-    # by the same equality check as every other field of it.
-    # fix(#1266 review round 10): +28 — the door refuses a STAC binding whose
-    # item identity cannot be verified at all (no recorded id, and item URLs
-    # that state none), before a job or a run row exists. Most of the lines
-    # are the refusal's wording and the comment saying why it is the door's
-    # business: an unverified first answer would be both adopted and recorded
-    # as durable truth, and a caller who learns that immediately can act on
-    # it, where one who learns it from a failed run cannot. Cap 1091 -> 1119.
-    # fix(#1746): +44 — the service_token_required 422, refusing a
-    # credential-less refresh of an origin whose last successful pull needed a
-    # token, before the SSRF resolve and before the run reservation. Extracted
-    # into its own helper rather than three lines in the handler, because
-    # refresh_dataset sits one branch under ruff's C901 ceiling and the repo's
-    # answer to that is extraction. Most of the addition is the docstring
-    # saying why the marker is not a permanent trap: the re-upload dialog with
-    # no token is the path that clears it. Cap 1119 -> 1163, exact.
-    # fix(#1746 codex r1): +37 — the marker records that a token was USED, not
-    # that the origin demanded one, so refusing on it alone locks a user who
-    # imported a public service while holding a token out of every token-less
-    # refresh. The guard now runs ONE token-less probe (through the health
-    # endpoint's own target and probe helpers, both lifted into origin_probe)
-    # and refuses only on an auth challenge; every other outcome falls through
-    # to the worker. Most of the addition is the docstring saying why it fails
-    # open. Cap 1163 -> 1200, exact.
-    # fix(#1746 codex r2): +82 — two corrections to the r1 guard. It probes
-    # only ArcGIS, whose target IS the layer the worker reads; WFS and OGC API
-    # are refused outright, because their probe target is GetCapabilities or
-    # the landing page and a public one of those in front of a protected
-    # GetFeature is an ordinary deployment, so a healthy answer would be
-    # evidence of nothing. And the probe path now releases the session across
-    # the outbound wait and re-reads after it, the way check_source_health
-    # does, so concurrent marked refreshes against a slow origin cannot
-    # exhaust the pool. Most of the addition is the docstring stating which
-    # services can be asked and why, plus the caller contract for the
-    # rollback. Cap 1200 -> 1282, exact.
-    # fix(#1746 codex r3): +62 — the marker is re-checked after the
-    # reservation. A token-less refresh could read an unmarked dataset, pass
-    # the guard, and have an authenticated re-upload of the same origin mark it
-    # inside the reservation window; the binding comparison there cannot see
-    # that, because `_ServiceOrigin` is the worker's binding and the origin did
-    # not move. Detects the TRANSITION rather than re-deciding, so a healthy
-    # ArcGIS probe is not overturned with no new evidence. Most of the addition
-    # is the docstring saying why it is not folded into the binding check and
-    # why it does not probe. Cap 1282 -> 1344, exact.
-    # feat(#1746): +9. The refresh body's structured `auth` object is converted
-    # to one credential at the top of the handler, so every branch below reads
-    # the same value and a method this build cannot carry is refused before any
-    # origin is contacted. Two of the lines are the import and the rest is the
-    # comment saying why the conversion is first. Cap 1344 -> 1353, exact.
-    # feat(#1746 B2b): -8. The post-reservation charset check is now one call
-    # to `wire_credential` against the binding that is actually going to be
-    # dispatched, which both judges the inputs and composes the wire value, so
-    # the hand-rolled refusal block it replaced is gone. Ratcheted down rather
-    # than left with headroom. Cap 1353 -> 1345, exact.
-    # fix(#1746 B2b review r1): +19. The credential is composed AFTER the
-    # write-access gate, because it reads `dataset.source_format` and a refusal
-    # ahead of the gate answered 422 for a dataset the caller may not touch
-    # while a nonexistent one answered 404. And the `service_token_required`
-    # message names the `auth` object rather than only the deprecated `token`,
-    # which always means bearer and so could not authenticate the basic origin
-    # that raised it. Most of the lines are the two comments recording those.
-    # Cap 1345 -> 1364, exact.
-    # fix(#1770 round 35): +10 — the refresh door judges header_auth_job_queue
-    # on the composed credential line, before the store lease may swap it for
-    # a reference, and configures the deferred task's queue with the verdict
-    # so a worker from the release before this PR never dequeues a header
-    # line its own validator cannot parse. Cap 1364 -> 1374, exact.
-    # fix(#1755 item 15): +2 — corrected the `_require_service_token_if_marked`
-    # docstring, which still described the ArcGIS probe reading the layer's
-    # `?f=json`; since #1754 round 6 it reads `<layer>/query` via
-    # `build_arcgis_count_query_url`. Cap 1374 -> 1376, exact.
-    # chore(#1812): -9, the refresh door no longer judges a queue on the composed line
-    # or configures the deferred task with it. Cap 1376 -> 1367, exact.
-    # feat(#1764): +70 — the STAC branch stages a credential through the same
-    # single-use store the service branch uses, and applies the marked-origin
-    # refusal before AND after the reservation, the store-availability check,
-    # and the refusal for a binding recording no catalog to anchor a
-    # credential on. Cap 1221 -> 1291, exact.
     "backend/app/modules/catalog/datasets/api/router_refresh.py": 1291,
-    # fix(#1335): stac_resolve.py's 1040 lines were split along their natural
-    # seams — verdict taxonomy, identity checks, the asset gate (SSRF + COG
-    # probe), and the by-search fallback each moved into a sibling module,
-    # leaving this file as the by-URL entry point plus the façade the split's
-    # external callers and tests still import through. No entry needed below
-    # 1000 lines; see stac_resolve_asset_gate.py etc. for the pieces that
-    # carried the length.
-    # --- entered by the inclusion rule, fix(#958) -------------------------
-    # These five were the ungated modules at or above _RATCHET_INCLUSION_LOC
-    # when the rule was written. They arrive at their measured size with no
-    # carve-out history, because none of them has ever had to argue for a
-    # line: that is the gap #958 was filed about. The next change to any of
-    # them writes the first entry.
-    # fix(#1543): +6 — config import applies the whole batch's post-commit side
-    # effects through apply_side_effects_batch instead of a per-key loop, so its
-    # cache eviction is one step. Four of the six are the widened import; the
-    # other two say why the loop is gone, which matters most here: an import
-    # touches far more keys than a settings PUT, so it held the widest version
-    # of the mismatch window. Cap 1201 -> 1207, exact.
     "backend/app/platform/config_ops/service.py": 1161,
-    # fix(#1335): jobs/router.py's 2047 lines carried the sweep SQL
-    # constants and every stale-job recovery/sweep handler alongside the
-    # plain CRUD routes. The two were split along that seam: the sweep
-    # handlers (fail_stale_jobs, sweep_stale_vrt_assets, the presigned-
-    # staging reapers) and their SQL constants moved to sweep.py, leaving
-    # router.py under the router-glob gate's default 1500-line cap with no
-    # entry needed here. The line-by-line growth history that used to live
-    # on this entry (fix #1236, fix #1322 rounds 1-6, ...) is unchanged and
-    # readable via `git log` on the pre-split file; sweep.py is entered
-    # fresh at its measured size below.
-    # fix(#1249): +9 — the object-driven staging reconciliation is wired in
-    # after the two row-driven reapers, with the comment saying why it is not
-    # folded into StaleCleanupOutcome (that dataclass is a published API and
-    # audit shape). The pass itself lives in its own module,
-    # platform/jobs/staging_reconcile.py, which is under the 1000-line
-    # inclusion threshold and needs no entry. Cap 1366 -> 1375, exact.
-    # fix(#1249 review r4): +4 — the retention purge's survivor query now reads
-    # STATUSES_NEEDING_STAGED_INPUT from jobs/models.py instead of an inline
-    # tuple, because the reconciliation asks the same question and two copies
-    # of "which statuses still need the bytes" drift into a leak in one
-    # direction and a deletion of live input in the other. The lines are the
-    # multi-name import that replaced the single-name one. Cap 1375 -> 1379,
-    # exact.
-    # fix(#1249 review r6): +1 — STAGING_REAPED_FINAL_MARKER moved to
-    # jobs/models.py too. Its presence is what tells the reconciliation the
-    # post-expiry sweep is finished with a key, and a copy of the string in
-    # each module is one rename away from a row that shields an object
-    # forever. Cap 1379 -> 1380, exact.
-    # fix(#1327): +23 — the composition-drift branch keeps its code and gains
-    # the rationale for why it is now near-unreachable: source add/remove stage
-    # their member set and apply it at the artifact swap, so the drift this
-    # branch discriminates is no longer produced by live traffic. The comment
-    # says what the branch still guards (pre-#1327 rows, any future writer of
-    # the link table) so the next reader does not delete a check whose FALSE
-    # side went quiet. Cap 1380 -> 1403, exact.
-    # fix(#1550 review): +86 for `audit_settled_embedding_backfill` and its
-    # three call sites. After a hard kill there is no worker process left to
-    # close an embedding backfill's audit trail, so the actor that settles the
-    # row — this sweep — is the only one that can, and it emits on the caller's
-    # session so the status change and the audit entry commit as one. Most of
-    # the lines are the docstring recording why the trail cannot be closed
-    # anywhere else, and why `audit_emit_durable` would be the wrong tool here.
-    # Cap 1403 -> 1522, exact. The second raise adds
-    # `terminal_backfill_audit_exists`: one operation gets one terminal entry,
-    # whoever writes it first, because three actors can legitimately close the
-    # same run and two of them disagreeing is the defect.
-    # fix(#1556): +77 — the unbound half of the pending sweep gained an ACTION
-    # helper (`stale_pending_unbound_values`) to sit beside the existing clause
-    # helper, so a presigned upload nobody ever bound bytes to settles
-    # `cancelled` at all three sites that can reach it instead of `failed` at
-    # whichever one got there first. Most of the lines are the two predicate
-    # docstrings recording why the class is "presigned marker AND empty
-    # file_path" and not "falsy file_path": a service import with a source_url
-    # is also unbound, and `/jobs/{id}/retry` only offers a `failed` row, so
-    # the broader rule would take a recoverable job's recovery away.
-    # Cap 1522 -> 1599, exact.
-    # fix(#1556 review, codex P2): +54 — the unbound UPDATE returns the status
-    # its CASE chose, so `pending_failed` can stop counting the rows that were
-    # cancelled. Without it the admin cleanup response, its audit event and the
-    # sweeper's log line all still reported an abandoned upload as a failure,
-    # which is the whole thing the split exists to stop. The lines are the new
-    # field plus the docstrings recording why `total_cleaned` excludes
-    # cancellations while `total_affected` includes them, and why the count
-    # reaches the audit event but not the published response model.
-    # Cap 1599 -> 1653, exact.
-    # fix(#1709 review r7 A): +82 — the childless-fanned_out reconciliation:
-    # the r5 early flip (the mutex that closed the fast-child cancel window)
-    # regressed the crash recoverability the old late transition got from the
-    # pending clause, so a parent that died between its flip commit and its
-    # first child commit stranded terminal forever. The clause settles such
-    # parents 'failed' (retry becomes available) behind a 5-minute grace and
-    # a retention-horizon bound; most of the lines are the comment proving
-    # childless-fanned_out is the crash signature and nothing else's, and why
-    # parents past the retention horizon belong to the purge instead.
-    # Cap 1653 -> 1735, exact.
-    # fix(#1709 review r8 A): +17 — the recovery stops advertising a retry
-    # flow that does not exist. The settle now stamps
-    # FAN_OUT_INTERRUPTED_METADATA_KEY (which _retry_capability refuses on —
-    # generic retry would re-queue the multi-layer parent as ONE
-    # default-layer import) and the message names re-upload as the real
-    # path. Cap 1735 -> 1752, exact.
-    # fix(#1709 review r10): +11 — audit_settled_embedding_backfill takes an
-    # optional `settled_by`, so the terminal event names whoever SETTLED the
-    # run: the canceller when a person cancelled it (the arm-3/cross-user
-    # case, matching job.cancel and refresh.cancelled in the same
-    # transaction), and the requester when a sweep settles it, since a lease
-    # expiry is nobody's click. Cap 1752 -> 1763, exact.
-    # fix(#1708 codex r6): +29 — pending age in stale_pending_clauses is
-    # measured from coalesce(user_metadata.staged_at, created_at), so a URL
-    # import whose download consumed part of the configurable pending
-    # timeout gets its full review window back at staging completion, while
-    # every row without the key (all other flows) ages from created_at
-    # exactly as before. Mostly the comment recording why this is a restart
-    # and not an exemption. Cap 1653 -> 1682, exact.
-    # RECONCILED at the #1708/#1709 merge: both raised this cap off the same
-    # 1653 baseline — #1709 to 1763, #1708 to 1682 — so the cap is measured
-    # off the merged file. 1763 + #1708's 29 = 1792, exact.
-    # fix(#1746): +35 — `purge_terminal_job_tokens`, the backstop UPDATE that
-    # strips a leftover `token` from every TERMINAL procrastinate row (the
-    # attempts that never reached the task-side purge: worker killed mid-run,
-    # rows deferred before the fix). Its own coroutine rather than a line in
-    # `fail_stale_jobs`, because that runs once per TENANT in hosted mode and
-    # the queue table has no tenant column — the docstring carries that and
-    # the why-no-index note. Cap 1792 -> 1827, exact.
-    # fix(#1744): +30. `abandoned_presigned_upload` became `abandoned_upload`,
-    # which asks the row whether a dispatch was ever attempted
-    # (`commit_attempted_at`) instead of inferring it from an empty
-    # `file_path` plus a `presigned` marker. Almost all of the lines are the
-    # docstring: why the shape-based carve-out missed the door the demo
-    # actually uses (a direct upload binds an absolute staging path and stamps
-    # no `presigned` marker, so four abandoned uploads reported `failed` with
-    # "never queued"), why the absolute-path class no longer needs a branch of
-    # its own, and why rows predating the stamp reclassify rather than get a
-    # migration, plus the two residual gaps it records (the one-statement
-    # window between a door's own commit and the stamp, and S3-mode direct
-    # uploads landing in the bound half). Cap 1827 -> 1857, exact.
-    # fix(#1778): +134. Two out-of-process reapers for artifacts a hard kill
-    # used to strand forever. `unpublished_storage_keys_from_metadata` reads the
-    # `rasters/`/`originals/` keys a raster tail named on its own job row before
-    # writing them, and `unadopted_analysis_table_from_metadata` plus
-    # `_reap_unadopted_analysis_outputs` do the same for an analysis output
-    # table; both are collected in `fail_stale_jobs` and deleted only after its
-    # commit, alongside the existing stale-generation keys. Roughly half of it
-    # is the docstrings stating why the analysis reap takes its own session.
-    # Cap 1857 -> 1991.
-    # fix(#1778 codex r1): +86. The raster reap gained a survivor check that an
-    # earlier revision argued it did not need: an identical re-upload derives
-    # the same content hash, so a replace's intended keys can BE the live
-    # asset's, and a crash then licensed deleting the raster the dataset was
-    # serving. `_live_referenced_storage_keys` asks the four columns that name
-    # an object, `reap_unpublished_storage_keys` refuses what they return and
-    # deletes nothing at all when the query fails, and both stale-job passes
-    # go through it. Cap 1991 -> 2077.
-    # fix(#1778 codex r4): +23. The retention purge is the LAST actor holding a
-    # pointer to a terminal job's unpublished keys and analysis output table,
-    # so a job that failed on its own and whose best-effort cleanup then failed
-    # once had nothing left looking at it. Its DELETE ... RETURNING already
-    # carried `user_metadata`; the rows now feed the same two post-commit reaps
-    # the running-row sweep feeds, survivor checks included. Cap 2077 -> 2100.
-    # fix(#1778 codex r5): +152. Feeding the reap was not enough, because the
-    # reap runs after the commit and can fail as a whole, and by then the
-    # pointer is gone. The purge now refuses to delete a row that still names
-    # an unreaped artifact, which makes the job row the durable pending-reap
-    # record a retry needs without a new table, and both reapers clear that
-    # record once they have a final answer (deleted, or refused because a live
-    # row names it) so the next pass can purge the row. The survivor query also
-    # went from four IN clauses to one shared array bind, because four binds
-    # per key crossed asyncpg's 32767-argument ceiling at about 8192 keys and
-    # the resulting failure skipped every delete. Cap 2100 -> 2252.
-    # fix(#1778 codex r6): +36. Both arms that clear an artifact record now key
-    # the settle off a NAMED outcome instead of off control flow. The analysis
-    # arm was reading "the call returned" as success, but the callee catches
-    # its own probe and DROP failures, so a failed cleanup stripped the table's
-    # last durable name and orphaned it; the storage arm was correct only by
-    # where a statement sat inside a try block. `STORAGE_KEY_FINAL_OUTCOMES`
-    # and the try/else restructure are most of the growth. Cap 2252 -> 2288.
-    # fix(#1778 codex r7): +14. The analysis reap is keyed on the owning JOB
-    # rather than on a table name two jobs could hold in sequence: it carries
-    # (job, table) pairs, hands the owner to the drop so it can refuse a table
-    # that job did not create, and clears the record by row id. Cap 2288 ->
-    # 2302.
-    # fix(#1778 codex r9): +26. The storage-key record accumulates across
-    # attempts now, so clearing it wholesale would forget keys the pass never
-    # answered for. The clear removes the settled keys one by one and drops the
-    # field only once nothing is owed on it, which is a correlated statement
-    # rather than an operator, and the comment says why the binds are cast and
-    # why it uses jsonb_exists_any over `?|`. Cap 2302 -> 2328, exact.
-    # fix(#1778 codex r10): +46. The analysis output record now accumulates
-    # across attempts too (same shape `unpublished_storage_keys` took in r9),
-    # keyed and cleared by TABLE NAME rather than by job id, because a job
-    # can now name more than one table. `unadopted_analysis_table_from_metadata`
-    # became `unadopted_analysis_tables_from_metadata`, delegating to the
-    # writer's own normaliser so the two cannot disagree about the shape. The
-    # two artifact collections that used to run inside `fail_stale_jobs`
-    # (running-row transitions, and the retention purge's exempted-rows
-    # SELECT) are replaced by one unconditional SELECT after the retention
-    # block, because both could miss a row that owed a reap -- a job that
-    # failed on an earlier pass, or one whose dead attempt's keys were carried
-    # over onto a row that is now its dataset's latest complete job and so
-    # exempt from the purge. `_CLEAR_SETTLED_LIST_SQL` also gained an arm for
-    # the field's pre-PR plain-string shape, which the array-only WHERE clause
-    # had silently excluded from ever clearing. Cap 2328 -> 2374, exact.
-    # fix(#1778 audit r12): +18. The running-jobs UPDATE now reads its
-    # candidates through a `FOR UPDATE SKIP LOCKED` subquery instead of
-    # matching them directly in the UPDATE's own WHERE clause, so a row a
-    # live phase-2 transaction holds locked is excluded from the pass
-    # instead of blocking it, or, if this were guarded by a `lock_timeout`
-    # instead, aborting the entire batch on one busy row. Most of the growth
-    # is the comment stating why a set-based UPDATE cannot use `lock_timeout`
-    # the way a single-row write does. Cap 2374 -> 2392, exact.
-    # chore(#1873): review-history comments trimmed. Cap 2392 -> 1506, exact.
-    # fix(#1755 item 12): +22 — `purge_queue_row_args`, the by-id token
-    # purge the stalled sweep and the task-side purge now share.
-    # Cap 1472 -> 1494, exact.
-    # fix(#1710): the running-lease sweep gains `no_unclaimed_queue_entry`, so
-    # a row whose task is still `todo` is not reaped before a worker takes it;
-    # the terminal backstop and the by-id purge both strip `url` alongside
-    # `token`, the latter through an `arg_key`. Measured on the file rebased
-    # across #1755 item 12, not added up. Cap 1494 -> 1537, exact.
     "backend/app/platform/jobs/sweep.py": 1537,
-    # fix(#1709 review r8 B): first entry — crossed the 1000-line inclusion
-    # threshold at 1010 when refresh.cancelled attribution was corrected to
-    # name the CANCELLING user (cancel_active_run_for_job and
-    # _emit_refresh_cancelled thread `cancelled_by` through; the run row's
-    # immutable triggered_by mis-attributed exactly the arm-3 cross-user
-    # cancel this PR added, and most of the growth is the docstring saying
-    # why the dispatcher's identity belongs to refresh.dispatch instead).
-    # The module also carries #1677's cancel machinery from earlier rounds:
-    # USER_CANCELLED codes, _emit_refresh_cancelled, cancel_active_run_for_job.
     "backend/app/platform/refresh/service.py": 929,
-    # fix(second-opinion review on #1236 review r3): first entry — crossed
-    # _RATCHET_INCLUSION_LOC while adding the belt-and-suspenders
-    # `le=5120` bound on `presigned_multipart_threshold_mb` (the router-side
-    # fixed margin in `_sweep_expired_presigned_staging` is what actually
-    # closes the gap; this Field bound only stops a fresh boot from
-    # configuring past S3's own single-PUT ceiling in the first place).
-    # feat(#947): +52 — the opt-in single-tenant runtime DB role field is
-    # normalized and validated as a safe PostgreSQL identifier, is restricted
-    # to single-tenant mode, and must exactly match DATABASE_URL_OVERRIDE's
-    # login/password. Those checks keep bootstrap/migration credentials
-    # distinct and make a miswired Compose deployment fail before it opens a
-    # pool. Cap 1004 -> 1056, exact.
-    # fix(#1287 review): +35 — validate the explicit migration-object owner
-    # against the migrate service's actual database URL login, so managed DB
-    # reconciliation can install future-object defaults for the right role.
-    # Cap 1056 -> 1091, exact.
-    # fix(#1249): +13 — `staging_orphan_min_age_seconds`, the age an untracked
-    # staging object must reach before the reconciliation sweep may delete it.
-    # Most of the lines are the comment saying what the number is NOT (an
-    # estimate of how long an upload takes — the tracking-row check is what
-    # decides ownership), so nobody later "tunes" it as if it were a transfer
-    # margin. Cap 1091 -> 1104, exact.
-    # fix(#1485): +3 — ENVIRONMENT gained a third behavior (plain traceback
-    # rendering), so the field comment and the `is_production` docstring that
-    # enumerate what the setting controls say so. This setting exists because
-    # security posture was once keyed off a flag documented as log-format only;
-    # an under-documented coupling is the same mistake. Cap 1104 -> 1107, exact.
-    # PRIV-1: +5 — a privacy_url Settings field (env-backed default for the
-    # login/register privacy-policy link) plus its empty-string normalizer
-    # entry. Cap 1107 -> 1112, exact.
-    # PRIV-1 (pre-review): +49 — a shared validate_privacy_url_shape helper
-    # (reused by the admin-write validator and the read-path defense in
-    # modules/settings) plus the field_validator that fails boot on an unsafe
-    # PRIVACY_URL. Both are large because they document why the check exists
-    # and why it lives in core/config.py instead of core/public_urls.py
-    # (avoiding a circular import). Cap 1112 -> 1161, exact.
-    # PRIV-1 (r2 pre-review): +7 — hoisted the urlsplit import to module scope
-    # and rejected embedded tab/newline/CR characters (a documented WHATWG
-    # URL scheme-check bypass) in validate_privacy_url_shape.
-    # Cap 1161 -> 1168, exact.
-    # PRIV-1 (codex r1): +12 — validate_privacy_url_shape now rejects an empty
-    # hostname (a netloc like ":443" passes the earlier netloc-truthy check
-    # but resolves nowhere) and a malformed port (urlsplit leaves the junk
-    # sitting in netloc instead of rejecting it; accessing .port is what
-    # actually validates it, same pattern as validate_database_url_override
-    # above). Cap 1168 -> 1180, exact.
-    # PRIV-1 (codex r2): +28 — the whitespace check widened from tab/CR/LF
-    # only to any whitespace character (a plain space inside a host is a
-    # WHATWG-vs-urlsplit disagreement too), and a new _is_valid_privacy_url_host
-    # allowlist (DNS labels or an IP literal) replaces trusting whatever
-    # urlsplit left in .hostname. Deliberately not a call to
-    # app.core.public_urls.canonical_host_error, which answers a
-    # near-identical question, because that would be the same circular
-    # import validate_privacy_url_shape's own docstring already rules out.
-    # Cap 1180 -> 1208, exact.
-    # PRIV-1 (codex r3): +21 — the DNS-label branch alone accepted a
-    # numeric-last-label host ("999.999.999.999", "1.2.3.4.5", "192.168.1")
-    # that a browser reads as an attempted (and often different-resolving)
-    # IPv4 address, per the WHATWG "ends in a number" rule. That branch now
-    # requires the exact canonical dotted-quad spelling instead of falling
-    # through to the DNS-label check. Cap 1208 -> 1229, exact.
-    # PRIV-1 (codex r4): +20 — the DNS-name branch (case 2) now IDNA-encodes
-    # the hostname before applying the label regex, so a browser-valid
-    # internationalized host like 例え.テスト is accepted rather than rejected
-    # by an ASCII-only regex. Also rejects a label that starts with a
-    # Unicode combining mark, which Python's stdlib "idna" codec (IDNA2003)
-    # encodes without error even though no browser accepts it.
-    # Cap 1229 -> 1249, exact.
-    # PRIV-1 (codex r5): +30 — a label the operator spelled directly as
-    # ACE/"xn--" punycode (not one this function IDNA-encoded itself) must
-    # decode to a real IDN label. "xn--a" decodes to a bare C1 control byte
-    # (U+0080) without raising and round-trips cleanly back to "a", so the
-    # round-trip check alone does not catch it; also rejects a decoded
-    # control/format/surrogate/private-use/unassigned character explicitly.
-    # Cap 1249 -> 1279, exact.
-    # PRIV-1 (codex r6): +44 — a bracketed authority ("[...]") is now
-    # restricted to a plain, unscoped IPv6 literal rather than falling
-    # through to the DNS-name or numeric-last-label branches once
-    # `.hostname` strips the brackets, which otherwise accepted an
-    # IPvFuture literal ([v1.foo]), an IPv4-in-brackets ([1.2.3.4]), and a
-    # scoped IPv6 zone ID ([fe80::1%eth0]). Split into a small
-    # _is_unscoped_ipv6_literal helper to stay under ruff's cyclomatic
-    # complexity limit. Cap 1279 -> 1323, exact.
-    # PRIV-1 (codex r7): +23 — unified the U-label combining-mark check and
-    # the decoded-A-label control-character check into one _check_ulabel
-    # function, called from both sites, so "xn--lsa" (the punycode spelling
-    # of a bare combining mark, which only the A-label check saw) gets the
-    # same verdict as its literal U-label form. Cap 1323 -> 1346, exact.
-    # PRIV-1 (codex r8): -57 (SHRANK) — replaced the hand-rolled DNS-label
-    # regex + _check_ulabel + manual punycode decode/round-trip with one
-    # call to the `idna` package's UTS46 ToASCII (already a direct backend
-    # dependency, pinned in pyproject.toml for a CVE), which enforces the
-    # same rules plus the ones a hand-rolled check missed (U+FE47, which
-    # UTS46 maps to "[" and then rejects). Cap 1346 -> 1289, exact.
-    # PRIV-1 (codex r9): +18 — a single trailing DNS root dot is now
-    # stripped before the numeric-last-label check: `rsplit(".", 1)[-1]`
-    # on "192.168.1." returns "", which skipped the ends-in-a-number branch
-    # entirely and let idna.encode() (DNS syntax only, no IPv4 opinion)
-    # accept "999.999.999.999." and "192.168.1." as ordinary-looking DNS
-    # names. Cap 1289 -> 1307, exact.
-    # PRIV-1 (Ian's own review): +68 — the numeric-last-label check now
-    # runs on the UTS46-mapped ASCII form (idna.encode's output), not the
-    # raw hostname: an ideographic full stop (U+3002, "。") has no ASCII "."
-    # for rsplit to find until mapped, and str.isdigit() is true for a
-    # fullwidth digit ("１"), so the OLD raw-hostname check both missed
-    # "999。999。999。999" (no split point) and wrongly rejected
-    # "１２７.０.０.１" (handed the un-mapped string to IPv4Address). Also
-    # added one docstring paragraph enumerating every place this check is
-    # deliberately stricter than a browser, so a future "browser accepts,
-    # we reject" report is read against that list first. Cap 1307 -> 1375,
-    # exact.
-    #
-    # Ambient AWS credentials: four runtime-injected marker fields
-    # (AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE and the two
-    # AWS_CONTAINER_CREDENTIALS_* forms), the has_ambient_aws_credentials
-    # property that reads them, and the rework of the s3 branch of
-    # validate_provider_settings to accept EITHER a complete static key pair or
-    # an ambient source while still rejecting a half-configured pair. Bought
-    # keyless S3 on EKS (IRSA): the storage layer and derive_gdal_s3_env
-    # already omitted unset keys, so this validator was the only thing forcing
-    # long-lived IAM user keys into a Kubernetes Secret. Cap 1375 -> 1423,
-    # exact.
-    # ogr_connection_string now emits sslrootcert alongside sslmode, matching
-    # the procrastinate_conninfo sibling it had drifted from. Bought working
-    # vector ingest against a managed database under DATABASE_SSL_MODE=
-    # verify-full: ogr2ogr goes through libpq, which cannot see the CA that
-    # only ever reached asyncpg as an SSLContext. Most of the growth is the
-    # comment recording that asymmetry.
-    #
-    # codex review on #1617 then added libpq_value(), which quotes and escapes
-    # every interpolated value in BOTH DSN builders — an unescaped path or
-    # password containing whitespace ends the keyword/value pair early and
-    # yields a malformed DSN. Testing that turned up a second defect in the
-    # same two functions: urlparse does not percent-decode, so they sent the
-    # literal `pass%20word` while the API path (SQLAlchemy, which decodes)
-    # authenticated fine — fixed with unquote() on user/password.
-    # Cap 1423 -> 1501, exact.
-    # fix(#1778): 1501 -> 1509 -> 1511 -> 1513. +12 for
-    # DB_STATEMENT_TIMEOUT_SECONDS and the note saying why the deadline is
-    # applied to the API process's engine rather than as a session default in
-    # database_connect_args: the worker imports the same engine module and runs
-    # single statements for minutes while indexing or reprojecting a freshly
-    # ingested table. Two came from the codex r2 round, which moved it off the
-    # get_db dependency because handlers open request-scoped sessions directly
-    # in more than twenty modules and none of those were covered. The last two
-    # are the r3 round: it is issued as SET LOCAL rather than as a startup
-    # parameter, because standard PgBouncer rejects an unknown one and
-    # DB_USE_EXTERNAL_POOLER=true is a supported topology.
-    #
-    # fix(#1778): +24 more for the boot-time GEOLENS_ADMIN_PASSWORD byte bound
-    # and the BCRYPT_MAX_PASSWORD_BYTES constant it needs. core/ may not import
-    # from app.modules.*, so the number is restated here rather than imported
-    # from password_policy.py; tests/test_oversized_password_1778.py pins the
-    # two together. Cap 1513 -> 1537, exact.
-    # fix(#1770 round 35, rebased onto #1778 above): worker_queues' default
-    # gains "ingest-auth-v2" beside the three original queues, so a worker
-    # built from this release drains the header-auth jobs a rolling deploy's
-    # upgraded API enqueues on it, alongside the comment recording why.
-    # fix(#1770 round 36): the P1 finding was that the round-35 comment was
-    # wrong: both compose files DO set WORKER_QUEUES (their own fallback value
-    # shadows this class default entirely), so they needed the new queue too,
-    # and the correction plus the pointer to the structural test that now
-    # guards it is most of the growth. Re-measured with wc -l after all three
-    # fixes landed together through the rebase. Cap 1537 -> 1562, exact.
-    # fix(#1770 round 47b P2 class): +27. `# parse_qs: unbounded` at the
-    # five `DATABASE_URL_OVERRIDE` `parse_qs` sites -- an operator-supplied
-    # BOOT-TIME env var, never a runtime service-advertised value, so
-    # exempted with a reason rather than bound (see
-    # `test_every_parse_qsl_call_bounds_its_field_count`'s own docstring).
-    # Cap 1562 -> 1589, exact.
-    # fix(#1871): +70 for SECRET_ENCRYPTION_KEY and SECRET_ENCRYPTION_KEY_
-    # PREVIOUS: the two fields, the KNOWN_PUBLIC_CREDENTIALS set the boot guard
-    # checks them against, and the guard itself, which is most of it because
-    # each of its four refusals has to say in its message what the operator got
-    # wrong and how to generate a valid key. Cap 1589 -> 1659, exact.
-    # fix(#1882 audit): +15 refusing SECRET_ENCRYPTION_KEY_PREVIOUS equal to
-    # SECRET_ENCRYPTION_KEY. The chain would hold one key twice, so the
-    # rotation script would report every row rewritten under the key they
-    # already use and then say to retire it. Cap 1659 -> 1674, exact.
-    # fix(#1812): -21. Production on ingest-auth-v2 stops; the default keeps it
-    # as a consumer for one release and the two round comments go. 1674 -> 1653.
-    # feat(#1710): +6 — `url_import_fetch_max_seconds`, the operator ceiling
-    # on one URL-import download now that the fetch runs on the worker and no
-    # proxy or client deadline bounds it. Cap 1479 -> 1485, exact.
-    # fix(#1710 codex r3): +3 — `worker_queues` gains "download" and the note
-    # saying to pin a second worker to it, so a slow origin cannot hold the
-    # only ingest slot. Cap 1485 -> 1488, exact.
-    # fix(#2045): +3 — `uvicorn_workers`, so sandbox_bounds can divide the
-    # external-pooler query budget by the worker count. Cap 1488 -> 1491, exact.
-    # fix(#2045 codex r1): +5 — `sandbox_query_slots`, the explicit per-process
-    # share for API replicas sharing one pooler, plus its blank-to-None entry.
-    # Cap 1491 -> 1496, exact.
     "backend/app/core/config.py": 1496,
-    # fix(#1543): first entry — crossed _RATCHET_INCLUSION_LOC on the change
-    # that gave PersistentConfig a batch eviction. The code is small
-    # (apply_side_effects_batch, plus splitting the process-local half of
-    # apply_side_effects out into a synchronous _apply_local_side_effects so a
-    # batch of them cannot interleave). Most of the lines are the docstring,
-    # and deliberately: it records the two fixes that look right and are not —
-    # reordering the deletes, which mismatches the other way, and evicting
-    # before the commit, which lets a reader repopulate the cache with the
-    # pre-commit value for a full TTL — and the limit of what a writer-side fix
-    # can do, since a reader calling get() once per key still samples at two
-    # instants and can straddle the whole step.
-    # fix(#1543 follow-up): +11 recording which half of #1539's endpoint
-    # residue this closes. #1543 is that residue's named owner, and the split
-    # is not guessable from the code: the eviction span is fixed here, while
-    # the cached-vs-uncached TTL lag that dominates it is not an eviction
-    # problem at all and needs EmbeddingProviderExtension widened. Without the
-    # note the next reader assumes an atomic eviction covered both.
-    # Cap 1007 -> 1018, exact.
-    # PRIV-1: +11 — a PRIVACY_URL PersistentConfig on the "general" tab (not
-    # "branding", which ENTERPRISE_ONLY_TABS gates) for the login/register
-    # privacy-policy link. Cap 1018 -> 1029, exact.
-    # feat(#1691): +13 — the RESTRICT_PUBLIC_VISIBILITY flag (admins-only
-    # `visibility: public`) plus the comment pointing at its shared gate in
-    # catalog/authorization.py. Cap 1029 -> 1042, exact.
-    # fix(#1746 codex r8): +5 — the runtime log-level setter now also calls
-    # apply_http_logger_levels() (logging_config.py) after raising root's
-    # level, so httpx/httpcore's WARNING floor tracks a LOG_LEVEL change made
-    # through the admin settings UI, not just one made at boot.
     "backend/app/core/persistent_config.py": 943,
-    # fix(#1533): first entry — crossed _RATCHET_INCLUSION_LOC on the change
-    # that made the run notice the embedding column moving under it. Two
-    # guards, both small: _live_column_dims (one pg_attribute read, shared with
-    # the pre-flight so a rebuild cannot land between two reads of the same
-    # width) and _structural_width_mismatch (the width the provider ACTUALLY
-    # returned, checked against the width the run pinned, before the insert).
-    # Most of the lines are comment, and they are the part worth keeping. They
-    # record why the baseline is the width the run OBSERVED rather than
-    # EMBEDDING_DIMS — the two legitimately disagree at rest under
-    # ENV_ONLY_CONFIG, so comparing them aborts a healthy run — and why the
-    # column read sits ahead of the endpoint block, which returns None from its
-    # except and would otherwise skip every check below it on exactly the
-    # half-configured install where a column gets altered by hand. The third
-    # note is the one a reader would otherwise re-derive: the obvious symmetry
-    # of running the force path's pre-flight on the non-force path too costs a
-    # provider call per run and breaks the #449 partial-success contract that
-    # test_batch_errors_do_not_stop_backfill and
-    # test_failed_batch_retries_per_record pin.
-    # fix(#1544): the same file also carries the compact-error helpers, whose
-    # docstrings record the ordering invariant two review rounds found the hard
-    # way — the redactor runs first, on the raw string, because truncation and
-    # whitespace collapse each break the pattern it matches on.
-    # fix(#1533 review, codex P2): +55 separating a STRUCTURAL width mismatch
-    # from an ISOLATED one. The first revision stopped the run on any
-    # wrong-width vector, which broke the same #449 isolation the note above
-    # defends: one anomalous vector abandoned every remaining record. The lines
-    # are _AnomalousVectorWidth (counted by the per-record handler rather than
-    # rethrown), the batch check reading agreement ACROSS inputs instead of the
-    # first vector, and the retry check asking storage — one input carries no
-    # agreement, so the evidence has to come from whether the column moved.
-    # The comments carry the part that is not visible in the code: why the
-    # retry-path read is paid at all when the drift check two lines up already
-    # compares the same two widths. Cap 1013 -> 1068, exact.
-    # fix(#1533 review r2, codex P2): +30 for the same lesson one batch size
-    # further in. A single-record batch — any catalog sized 1 mod _BATCH_SIZE —
-    # made "every vector agrees" vacuously true, so one anomalous vector in the
-    # final batch stopped the run. _column_rejects_width splits the fit test
-    # away from what a mismatch MEANS, so the batch rule can demand two vectors
-    # while the retry rule keeps judging one, and the comment says why they
-    # cannot share a predicate: the first attempt at this fix routed one vector
-    # through the batch rule and silently disarmed the retry check.
-    # Cap 1068 -> 1098, exact.
-    # fix(#1533 review r3, codex P2): +37, almost entirely comment. The code is
-    # a reorder — flush the pending rows, THEN run the pre-commit drift check,
-    # THEN commit — on both the batch and the retry path. The check reads
-    # pg_attribute, which locks nothing, so running it before the rows were sent
-    # left a window for an ALTER TABLE to take ACCESS EXCLUSIVE and commit
-    # unseen; widening to an unconstrained vector then let the old-width inserts
-    # succeed and the run report success over a column that had moved. The
-    # flush's RowExclusiveLock is what closes it, and the comment says so at the
-    # call site because the reason a statement sits where it does is invisible
-    # from the statement itself. Cap 1098 -> 1135, exact.
-    # fix(#1533 review r4, codex P2): +10 net. The retry's width judgement asked
-    # "does this vector fit" before "is the column still the pinned one", and
-    # returned early when the vector matched — so a column that moved during the
-    # provider call for the LAST retried record was counted as a bad record
-    # rather than named as drift, there being no next record whose pre-call
-    # check would catch it. It now runs the drift bracket first and reuses
-    # _raise_on_pin_drift rather than phrasing the abort locally, so the module
-    # keeps ONE author of "the column moved". Cap 1135 -> 1145, exact.
-    # fix(#1546): +80. Rows carry the identity of the configuration that
-    # produced them, so both write sites stamp `config_fingerprint` from the
-    # run's PIN rather than from a read at write time, and both moved from an
-    # ORM add to `INSERT ... ON CONFLICT DO UPDATE` — a record whose only row
-    # for the active model came from another configuration is now offered as
-    # missing, and a plain INSERT answers that with a unique violation instead
-    # of a vector. `_upsert_embeddings` and its rationale are most of the
-    # count; the rest is why the stamp comes from the pin, which is the whole
-    # point of the column. Cap 1145 -> 1225, exact.
-    # fix(#1549): +140. The bulk DELETE is gone; `_replace_embeddings` and
-    # `_delete_embeddings_for` remove a batch's old rows inside the transaction
-    # that writes their replacements, so an aborted force run leaves the records
-    # it reached rewritten and the rest exactly as they were rather than leaving
-    # an empty table. The comments carry the two things a reader cannot see from
-    # the statements: why the delete must precede the write and share its
-    # transaction, and why the COMMIT belongs to the caller rather than to that
-    # function (#1579's drift check has to run while the write still holds its
-    # lock). fix(#1581): the batch counts the rows it wrote rather than the
-    # texts it was handed, and hands the unanswered tail to the per-record
-    # retry. fix(#1549 review): +36 more — a strict zip, so a provider that
-    # skips a middle input fails the batch into the alignment-safe per-record
-    # retry instead of pairing a record with someone else's vector; and the
-    # end-of-run reclamation bounded to rows that predate the run, so a vector
-    # the ingest path wrote mid-run survives it. fix(#1583 review): +23 more —
-    # writes stamp `updated_at` with `clock_timestamp()` on BOTH the insert and
-    # the conflict branch, because `now()` is transaction-start time and a batch
-    # that spends a provider call in its transaction would otherwise record a
-    # time from before it asked, which #1583's `updated_at DESC` anchor reads as
-    # the wrong row. fix(#1584 review r1): +9 more — the reclamation cutoff moves
-    # ABOVE the record fetch, because the fetch is the observation it protects
-    # and a cutoff taken after it leaves the whole materialisation window
-    # unguarded. fix(#1584 review r3): +20 more — the reclamation stops asking a
-    # CLOCK whether a row predates the run and asks whether the row is still the
-    # version the run observed, as (record_id, updated_at) pairs. A cutoff got
-    # this wrong in both directions: it deleted fresh vectors whose writer read
-    # a different clock, and spared stale ones stamped ahead of the database by
-    # a pre-release writer, which moving the writers to clock_timestamp() cannot
-    # retroactively fix. The snapshot is narrowed to TITLELESS records, a
-    # superset of what the reclamation can reach, so it is not a copy of the
-    # embeddings table in worker memory. Cap 1225 -> 1475, exact. Then +5: the
-    # one edge that narrowing gives up (a title cleared between the snapshot
-    # and the fetch defers that record's reclamation to the next force run) is
-    # stated where the narrowing is decided. Cap 1475 -> 1480, exact.
-    # fix(#1584 review r4): +47 — an unchanged row is not proof of an unchanged
-    # record. The ingest writer skips its write on an unchanged content hash, so
-    # an editor restoring exactly the content a vector was computed from leaves
-    # the row's version untouched, and version matching alone would reclaim a
-    # vector that is valid again. The reclamation now re-reads each record it is
-    # about to reclaim (`_records_still_empty`, through the port's real loader)
-    # and spares those no longer empty; the content-field extraction the run
-    # and the re-check share moved into `_content_fields`. Cap 1480 -> 1527,
-    # exact.
-    # fix(#1584 review r5): the re-read and the delete hold the record. They
-    # were two statements with a gap, and an editor restoring content in it had
-    # the writer skip on an unchanged hash before the delete took the row.
-    # `_records_still_empty` now locks the chunk's records FOR UPDATE and
-    # `_reclaim_observed_rows` runs re-check, delete and commit per chunk in
-    # one transaction. Cap 1527 -> 1555, exact.
-    # fix(#1709 review r6): +33 — the cooperative per-batch stop: an opaque
-    # should_continue callback polled at each batch boundary before the
-    # provider call, so a user cancel whose best-effort queue abort was lost
-    # costs at most one batch of provider spend instead of the whole
-    # remaining catalog racing a successor run. Kept opaque here (the queued
-    # caller passes a fenced job-row read) because this module knows records
-    # and vectors, not jobs. Cap 1555 -> 1588, exact.
-    # chore(#1873): review-history comments trimmed. Cap 1588 -> 922, exact.
-    # fix(#2025): +15 — the per-batch progress report, an opaque
-    # ``on_progress(processed, total)`` kept opaque like ``should_continue``:
-    # this module knows records and vectors, not job rows. Cap 918 -> 933, exact.
     "backend/app/processing/embeddings/backfill.py": 933,
-    # feat(#1219): first entry — crossed _RATCHET_INCLUSION_LOC, exactly as
-    # the inclusion rule's own comment predicted for this file ("watched by
-    # nothing until they cross 1000. The threshold catches them then"). The
-    # lines bought the refresh run row's creation at DISPATCH: the
-    # create_pending_run call in reupload_commit, the origin-kind decision it
-    # shares with the branch below it, and a defer-guard rollback that
-    # finalizes the run as failed when the queue is unreachable, so a dispatch
-    # that provably never happened does not read as `pending` for an hour.
-    # feat(#1219 amendment): +22 — the dispatch door is now the admission
-    # gate. `uq_refresh_runs_one_active` refuses a second active run per
-    # dataset, and this handler turns that IntegrityError into ADR-002
-    # Decision 5b's 409 `dataset_busy`. The lines are the try/except, the
-    # rollback that keeps the refused job re-committable, and the comment
-    # recording why admission belongs here rather than at the worker's
-    # advisory lock. Cap 1005 -> 1027, exact.
-    # fix(#1274 review): +19 — _require_reupload_source, the guard that
-    # rejects a source-less commit BEFORE the run row reserves the dataset.
-    # Its docstring carries the trap: a presigned job's file_path is an empty
-    # STRING, which the queue-time is-None check cannot see, and the stale
-    # reservation it left blocked every refresh for the bound-job timeout.
-    # Cap 1027 -> 1046, exact.
-    # feat(#1221): +79 — raster replace. The eligibility gate stops refusing
-    # raster_dataset outright and instead constrains it to raster payloads
-    # (plus a service-preview refusal, since nothing fetches a GeoTIFF from a
-    # feature service); the schema-preview endpoint gains an explicit refusal
-    # because a raster has no attribute schema and the ogrinfo call below it
-    # would fail as if the upload were broken; and _dispatch_reupload_task
-    # extracts the three-way defer out of reupload_commit, which the raster
-    # branch pushed past the McCabe gate. Most of the added lines are the
-    # extraction's docstring and the raster branch's comment on why it stays
-    # off the priority queue. Cap 1046 -> 1125, exact.
-    # fix(#1290 review): +10 — both doors swap the creation-shaped
-    # check_upload_quota for check_replacement_quota, which needs the
-    # dataset_id and gets a comment explaining that a replacement creates no
-    # dataset, so refusing it at the count cap locked owners out of replacing
-    # what they already own. Cap 1125 -> 1135, exact.
-    # fix(#1290 review): +8 — both doors pass the dataset OWNER rather than the
-    # requester to the replacement admission, which is the identity the worker
-    # reserves against. Wrapped across lines by the formatter.
-    # Cap 1135 -> 1143, exact.
-    # fix(#1290 review): +6 — the presigned completion door names the dataset
-    # it is replacing, so the finalizer runs replacement-aware admission. It was
-    # the third admission point and still creation-shaped, so an owner at the
-    # dataset-count cap passed the request-time door, uploaded the bytes, and
-    # was refused at completion. Cap 1143 -> 1149, exact.
-    # +2 — the uncommitted-source cleanup helper re-raises CancelledError
-    # instead of swallowing it, mirroring the re-raise convention already used
-    # by the other three CancelledError checks in this file. Cap 1149 -> 1151,
-    # exact.
-    # fix(#1682 codex r3): -7 — the presigned-reupload DB-failure fallback
-    # dropped its nine-entry literal for settings.allowed_extensions_list, so
-    # the two upload doors cannot answer differently. Ratchet DOWN in the same
-    # commit, per the no-headroom rule. Cap 1151 -> 1144, exact.
-    # feat(#1676): +50 — the re-upload commit door leases its service token
-    # through the same one-use Valkey handoff the refresh door has used since
-    # #1220, instead of dispatching it as a durable task argument. Most of the
-    # lines are the staging block and its 503, placed before the commit for the
-    # reason the refresh door places its own there (a store failure rolls the
-    # whole request back rather than stranding a dispatch that can never
-    # authenticate), plus the comment recording why a storeless install falls
-    # back here and is refused at the refresh door. The rest is the discard
-    # wrapper on the defer rollback and the extra dispatch argument.
-    # Cap 1144 -> 1194, exact.
-    # fix(#1709 review r4 P1): +50 — the commit fence in reupload_commit: a
-    # same-value CAS on the job's (pending, attempt_id) pair executed in the
-    # SAME transaction that flushes the DatasetRefreshRun, so a cancel that
-    # lands between the handler's pending read and its commit rolls the run
-    # back into a 409 instead of stranding a pending run bound to a
-    # cancelled job (which held uq_refresh_runs_one_active against every
-    # refresh until the stale-run sweep). Over half the lines are the
-    # comment recording both serializations and why the lock order cannot
-    # deadlock against the cancel endpoint. Cap 1194 -> 1244, exact.
-    # fix(#1746): +38 — reupload_commit applies the strict header-token policy
-    # before it reserves anything, so a WFS/OGC token outside the base64url
-    # charset is refused with the same 422 the refresh door returns instead of
-    # burning its single-use credential and dying in ogr2ogr. Most of the lines
-    # are the comment saying why the check sits ahead of `create_pending_run`
-    # (a token that cannot work must not take the one-active-run admission
-    # slot) and why ArcGIS is exempt. Cap 1244 -> 1282, exact.
-    # feat(#1746): +12. The commit body's structured `auth` object becomes one
-    # credential at the top of the handler and is passed to
-    # `resolve_dispatch_credential` as a credential rather than a bare token.
-    # The rest is the note on why `auth` joins `token` in the model_dump
-    # exclusion: user_metadata is a durable JSONB column and that dump is a
-    # whitelist by omission. Cap 1282 -> 1294, exact.
-    # feat(#1746 B2b): +12. `_service_format` and `_job_service_format` resolve
-    # the origin's canonical format once for both service doors, the commit
-    # door composes its wire value from it before anything is written or
-    # reserved (replacing the hand-rolled charset block), and the service
-    # preview door converts its own `auth` object the way the four siblings
-    # do. Cap 1294 -> 1306, exact.
-    # fix(#1768): +61. `_refuse_if_origin_changed` re-reads the dataset's
-    # origin after the run row takes the one-active-run slot and refuses a
-    # stale `expected_origin_kind` with 409 `origin_changed`. It is a helper
-    # rather than an inline block because two more branches in the handler
-    # crossed the McCabe gate, which is the same reason `_dispatch_reupload_task`
-    # exists. Most of the lines are its docstring: which window the condition
-    # closes, why the reservation is what makes the re-read decisive instead of
-    # one more racing read, and why an absent value asserts nothing.
-    # Cap 1306 -> 1367, exact.
-    # fix(#1770 round 35): the reupload door judges header_auth_job_queue on
-    # the composed line before the store lease, and _dispatch_reupload_task
-    # grows a service_queue parameter so the verdict reaches the configure()
-    # call that used to hardcode the task's own queue. Cap 1367 -> 1386,
-    # exact.
-    # fix(#1846 review round 4): +10. This handler wrapped the preview in
-    # try/finally with no `except`, so a content refusal -- a deliberate 4xx
-    # whose message names the fix -- reached the client as a 500 here while the
-    # sibling `preview_file` mapped it to 422. The lines are that branch and
-    # the comment saying which endpoint it is matching.
-    # Cap 1386 -> 1396, exact.
-    # fix(#1848): +43. Three doors release the pooled connection before their
-    # network or GDAL work; the added lines are the releases, their comments,
-    # and the locals read off the ORM instances the rollback expires. The
-    # audit round added the two compare-and-set writes that keep the
-    # commit-first door from binding onto a row the stale-pending sweep
-    # reclaimed mid-upload, plus their refusal. Codex round 2 added the
-    # `staged_at` stamp to the same bind, which restarts the pending window
-    # for a local upload whose absolute path never reaches the sweep's
-    # completion class. Codex round 3 added the dataset binding to both
-    # guarded writes, because the early commit releases the foreign-key lock
-    # and a dataset deleted mid-upload nulls the job's binding.
-    # Cap 1396 -> 1455, exact.
-    # fix(#1848): +51. The presigned door commits before storage is asked for
-    # anything and binds through the guard; the guard, the refusal and the
-    # bind are helpers the direct door now shares. Cap 1455 -> 1506, exact.
-    # chore(#1812): -18, the reupload door and _dispatch_reupload_task lose the
-    # service_queue verdict, its parameter and the configure() branch. Cap 1506 -> 1488, exact.
-    # fix(#1953): +1 — the import of the one redactor every failure writer
-    # in this module now goes through. Cap 1427 -> 1428, exact.
-    # fix(#2036): +8. The re-upload preview maps an unreadable file to the
-    # import preview's 422 instead of letting it escape as a 500.
-    # Cap 1428 -> 1436, exact.
-    # fix(#2043): +9. The ceiling refusal gets its own except clause, and the
-    # core marker it catches joins this module's import block.
-    # Cap 1436 -> 1445, exact.
-    # fix(#2032): +9. The re-upload commit door refuses an srid_override that
-    # names no spatial_ref_sys row. Cap 1445 -> 1454, exact.
-    # fix(#2031): +13. The preview door refuses a replacement that would strip
-    # the dataset's geometry, which the attribute-only schema diff cannot see.
-    # Cap 1454 -> 1467, exact.
-    # fix(#2043 review): +3. The import of the core ceiling marker wraps.
-    # Cap 1467 -> 1470, exact.
-    # fix(#2031 review): +2. The preview door reads the dataset's recorded
-    # geometry alongside its record type. Cap 1470 -> 1472, exact.
     "backend/app/modules/catalog/datasets/api/router_reupload.py": 1472,
-    # fix(#1218 review): +5 — VRT assembly stamps last_refreshed_at like every
-    # other creation path, so a post-migration VRT does not report null while
-    # a backfilled one carries a timestamp, with a note on why it is a Python
-    # datetime and not func.now(). Cap 1071 -> 1078, exact.
-    # fix(#1290 review): +28 — `last_regenerated_at` is stamped with the instant
-    # the member snapshot was READ rather than the instant the VRT was
-    # published. Most of the added lines are the comment: the field names the
-    # state the artifact was built FROM, so a member replaced during the build
-    # now reports stale instead of being vouched for as healthy, and the
-    # clock-authority finding (both sides are app-side UTC, so no DB round trip
-    # is needed and moving one side alone would break it) has to be written
-    # down where the next reader will look. Cap 1078 -> 1106, exact.
-    # fix(#1290 review, round 10): +12 net — snapshot_member_sources extracted
-    # so BOTH VRT tails read their members through one function that stamps
-    # before it reads. The creation tail had no snapshot at all and the
-    # regenerate tail captured one after its query; putting the order inside
-    # the only function that does the read makes the wrong order unwritable
-    # rather than merely discouraged. Cap 1106 -> 1118, exact.
-    # fix(#1290 review, round 12): +22 — built_from_map plus its persistence in
-    # both tails. Staleness stopped being a timestamp comparison and became a
-    # state one: the published VRT records the member URIs it was assembled
-    # from, and health compares what-is against what-was-built-from. Postgres
-    # cannot stamp commit time from inside a transaction, so no clock scheme
-    # could express "committed after my snapshot" — three rounds of timestamp
-    # fixes each left a window. Cap 1118 -> 1140, exact.
-    # feat(#1267): +10 — the dataset's last_refreshed_at is stamped at the
-    # generation's own completed_at instant, in the same transaction as the
-    # generation swap, so source_freshness (#1224) reads a live signal for a
-    # VRT instead of the creation-time floor forever. Most of the lines are
-    # the comment recording why it reuses generation.completed_at rather than
-    # a fresh now() call. Cap 1140 -> 1150, exact.
-    # fix(#1327): +150 — the compensable-links pattern lives here: two helpers
-    # (staged_source_ids_or_none, apply_staged_source_links) plus the phase-1
-    # switch to the staged member set, the member-still-exists check that fails
-    # a run whose staged source vanished, and the apply inside the publish
-    # transaction. Most of the lines are the reasoning: why NULL means "changes
-    # no membership", why apply is an upsert rather than delete-and-insert, and
-    # why the applied list is the one the build read. Cap 1150 -> 1300, exact.
-    # fix(#1327 codex P1): +44 — a second registered task name,
-    # `regenerate_vrt_staged`, that forwards to the same body. It is the
-    # rolling-deploy gate: a pre-#1327 worker has no such task and fails the
-    # job (procrastinate TaskNotFound) instead of rebuilding from the live
-    # links and reporting success, which would silently drop an accepted add or
-    # remove. Nearly all of the lines are the comment recording why a marker
-    # KWARG could not do this (the old signature ends in `**kwargs`, so an
-    # unknown keyword is swallowed) and where the refused delivery lands.
-    # Cap 1300 -> 1344, exact.
-    # fix(#1329 follow-up): +10 — bump tile_cache_version in the VRT swap
-    # transaction; the third pointer-swap door finally rolls the version.
-    # fix(#1778): +32 — both VRT tails guard their publishing COMMIT with the
-    # shared `publish_commit_landed` probe and reap on what it observed rather
-    # than on a flag set after the await returned, and `ingest_vrt`'s terminal
-    # failure write moves to the shared `_cleanup_staging_on_failure` so a
-    # failed build finally emits `ingest_failed`. The dead `final_status`
-    # string both functions no longer read is gone. Cap 1354 -> 1386, exact.
-    # fix(#1778 codex r1): +56 — both VRT tails STAND DOWN on an observed
-    # publish (return instead of re-raising) and both failure handlers refuse
-    # to run at all once the publish is durable, because the generation write
-    # is not fenced the way the job and asset writes are and `get_vrt_status`
-    # plus the stale-generation sweep read what it stamps. The generation
-    # update also gained its own `status != 'completed'` fence, so the rule is
-    # stated at the write and not only at the caller. Most of the lines are the
-    # two handler comments naming the reader each false failure reaches.
-    # Cap 1386 -> 1442, exact.
-    # fix(#1778 codex r2): +38 — the superseded-generation reap is a named
-    # helper called from both the success path and the stand-down, because it
-    # is the only deletion of the previous generation's artifact and a
-    # stand-down that skipped it stranded bytes no row references and no quota
-    # counts. `ingest_vrt` records that it has nothing to reap on that path.
-    # Cap 1442 -> 1480, exact.
-    # fix(#1778): +16. The storage keys are registered before their puts
-    # rather than after (a cancelled put can have completed), the two in-thread
-    # source reads go through the safe-open-env wrappers in `raster/vrt.py`, and
-    # `create_vrt_dataset` accepts a caller-chosen dataset id so the manifest
-    # tail can name its object keys before phase 2 opens. Cap 1480 -> 1496.
-    # fix(#1778 codex r3): +34. The two safe-env wrappers moved here from
-    # `raster/vrt.py` and call `extract_raster_metadata` / `generate_quicklook`
-    # through this module's globals. Those two names are patch targets for the
-    # VRT integration and source-management suites, and putting the wrappers in
-    # `raster/vrt.py` with function-level imports removed the attributes AND
-    # would have made the patches no-ops once restored. The docstrings say so,
-    # because the next reader will want to move them back. Cap 1496 -> 1530.
-    # fix(#1778 codex r4): +38. `ingest_vrt` puts the VRT and its quicklooks
-    # before the terminal commit and recorded nothing, so a kill in between
-    # lost `written_storage_keys` with the process AND rolled back the dataset
-    # id the keys embed. It now preselects that id and records the intended
-    # keys on the job row first, the way `ingest_raster` does. Most of the
-    # growth is the comment saying why the id is decided outside phase 2.
-    # Cap 1530 -> 1568, exact.
-    # fix(#1778 audit): +7. record_unpublished_storage_keys now reports a
-    # confirmed fence miss rather than silently committing nothing, and this
-    # call site checks it: a miss means a retry has already superseded this
-    # attempt, so it returns before generating quicklooks or ever reaching
-    # phase 2, instead of relying on phase 2's own attempt-fenced load to
-    # catch it downstream. Cap 1568 -> 1575, exact.
-    # fix(#1778 audit r11): +25. Neither of this file's two "phase 2" blocks
-    # goes through `_job_phase_session` (they predate the helper and match
-    # the fence by hand), so both gain `IngestJob.status == "running"`
-    # directly in their own SELECT, matching the sibling tails. The
-    # `ingest_vrt` one closes the same object-storage leak the other raster
-    # tails' phase 2 does; the `regenerate_vrt` one closes a job-completion
-    # race the existing `current_generation_id` check does not cover, since
-    # that field lives on a different row than `ingest_jobs.status` and the
-    # sweep never touches it. Cap 1575 -> 1600, exact.
-    # fix(#1778 audit r12): +28. `ingest_vrt`'s hand-matched phase-2 SELECT
-    # gains `.with_for_update(key_share=True)`, the same TOCTOU close as the
-    # other two raster tails, since its puts sit inside this same session
-    # exactly like theirs do. `regenerate_vrt`'s own phase-2 SELECT is
-    # deliberately left unlocked -- most of the growth here is the comment
-    # explaining why: it loads the job row before a RasterAsset row a few
-    # lines down, and `cancel_job` locks those two in the opposite order for
-    # a vrt_regenerate job specifically to avoid an AB-BA deadlock with this
-    # worker, so locking the job row here first would reopen that cycle. Cap
-    # 1600 -> 1628, exact.
-    # fix(#1755 item 11): +12. Both task tails route every cleanup step
-    # through `cleanup_step`: three in `ingest_vrt`, four in `regenerate_vrt`,
-    # which stops two heartbeats. Cap 1628 -> 1640, exact.
-    # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1653, exact.
-    # fix(#1847): the phase-2 job load locks the row and the lock-order
-    # rationale left the source. Cap 1653 -> 1640, exact.
-    # fix(#1938): +58 — the publish's catalog.records wait gets a budget, a
-    # restore after it, and a classified failure report whose SQLSTATE table
-    # lives in catalog_locks instead. Cap 1640 -> 1698, exact.
-    # fix(#1950): +11 — regenerate_vrt's failure handler bounds its three writes,
-    # which is where its own 15s publish wait lands, and keeps the build failure
-    # as the task's outcome when that bound expires. Cap 1698 -> 1709, exact.
-    # fix(#1950 codex r4): -4 — `ingest_vrt`'s failure tail loads its job row
-    # through `tasks_common.load_job_for_error_write` instead of an inline
-    # unbounded SELECT. Cap 1709 -> 1705, exact.
-    # fix(#1962): +63 and fix(#1953): +1 merged; re-measured after both landed. Cap 1690, exact.
     "backend/app/processing/ingest/tasks_vrt.py": 1690,
-    # --- entered by the inclusion rule, fix(#1937) ------------------------
-    # tasks_raster_replace crossed 1000 bounding its phase-2 catalog wait.
-    # The budget alone is six lines; the rest is what a newly failable wait
-    # owes its reader — a classified warning naming the SQLSTATE, the waited
-    # ms and the budget, an error_code mapper so contention does not report as
-    # a bad raster, and the reset that keeps the quota reservation below it
-    # unbounded. The reporter is a context manager so the acquisition stays a
-    # direct call the #1847 gates can see, and the failure write carries a bound
-    # of its own so phase 2's contention cannot move onto it. Cap 1056, exact.
-    # fix(#1957): -4 and fix(#1953): +1 merged; re-measured after both landed. Cap 994, exact.
-    # refactor(#2026): +2 — the staging cluster's names now come from
-    # `tasks_staging`, so this module's one import block became two.
     "backend/app/processing/ingest/tasks_raster_replace.py": 996,
-    # fix(#1202 review r5): +29 — sweep the presigned staging key at job end.
-    # A completed presigned job points file_path at its frozen copy, so this
-    # reaper never touched the key the client's PUT URL can still recreate.
-    # Ownership comes from owned_presigned_staging_key, which refuses a
-    # fan-out child's inherited parent key. Cap 1058 -> 1087, exact.
-    # fix(#1202 review r5b): -12 — that block moved to
-    # `tasks_common.reap_presigned_staging_object` so the raster tail could
-    # share it. Ratchet DOWN in the same commit, per the no-headroom rule.
-    # Cap 1087 -> 1075, exact.
-    # fix(#1207): +1 — the reap call gained the final_status keyword when the
-    # terminal-status guard moved into the shared helper.
-    # fix(#1213 review r2): -16 — the inline BA-09 block became a call to the
-    # shared helper. Ratchet DOWN in the same commit.
-    # fix(#1213 review r4): -1 — the now-dead file_path argument dropped from
-    # the call. Ratchet DOWN in the same commit.
-    # fix(#1213 review r6): +4 — the caller states its retry semantics.
-    # feat(#1218): +11 — both finalize call sites now pass their origin_ref.
-    # The service one keeps the base URL and layer id as separate keys so a
-    # refresh can re-address the layer without re-parsing the enriched URI.
-    # Cap 1063 -> 1074, exact.
-    # fix(#1218 review r3): +16 — the service ref records the SERVICE-NATIVE
-    # layer identifier via service_layer_identity, so WFS/OGC rows name their
-    # typename instead of storing nothing. Most of it is the comment recording
-    # that build_gdal_source makes id and name mutually exclusive per service,
-    # which is why one key suffices. Cap 1074 -> 1090, exact.
-    # fix: +3 — pass original_filename (job.source_filename) to run_ogrinfo
-    # and run_ogr2ogr so a corrupt vector upload gets a friendly message
-    # instead of GDAL's raw driver-enumeration stderr. Cap 1090 -> 1093, exact.
-    # fix(#1675): -10 — the inline paged loop moved to tasks_common's shared
-    # run_paged_arcgis_service_fetch. Cap 1093 -> 1083, exact.
-    # feat(tier-1 vector import): +2 — source_format is resolved once, before
-    # step 3b instead of after it, because the DBF field-name-truncation
-    # warning is Shapefile-only and a File Geodatabase now arrives in a .zip
-    # too. The derivation itself moved out to ingest/source_format.py, shared
-    # with the reupload path. Cap 1083 -> 1085, exact.
-    # feat(#1676): +32 — `ingest_service` accepts a `credential_ref` and
-    # redeems it once. Nearly all of it is two comments: why the claim sits
-    # AFTER phase 1 (the failure write below is fenced on `status == 'running'`,
-    # which phase 1 is what sets, so claiming earlier would leave a
-    # `credential_expired` failure unrecorded and the job pending until the
-    # stale sweep), and why the failure handler now scrubs the claimed secret
-    # by exact value the way `reupload_service` does — this task holds the
-    # value now, and the pattern layers only match tokens shaped like URLs.
-    # Cap 1085 -> 1117, exact.
-    # fix(#1746): +9 — `ingest_service` takes `pass_context=True` (the only
-    # way a task can learn its own queue-row id) and the
-    # `purge_token_on_failure` wrapper, plus the comment saying what the
-    # context is for. Cap 1117 -> 1126, exact.
-    # fix(#1746): +8 — the auth_required marker on a first service import's
-    # origin_ref, so a token-bearing import is refusable at the refresh door.
-    # One key and the comment saying why the value is True-or-None: absent
-    # means "not known to need auth", which is where every dataset imported
-    # before the marker sits. Cap 1126 -> 1134, exact.
-    # fix(#1746 codex r1): +9 — same narrowing of the marker comment, plus the
-    # note that the refresh door treats the key as a gate and not a verdict.
-    # Cap 1134 -> 1143, exact.
-    # fix(#1778): +18 — the upload-safety exit stops unlinking the file (the
-    # #1290 correction the two raster tails already carry), and both terminal
-    # failure writes move to the shared `_cleanup_staging_on_failure`, so a
-    # failed file or service import emits `ingest_failed` and persists a
-    # redacted message. Net of two hand-rolled UPDATE blocks and two now-unused
-    # IngestJob imports removed; the rest is the comment saying which exit owns
-    # the unlink decision. Cap 1143 -> 1161, exact.
-    # fix(#1778): +48 — `_heartbeat_service_import_progress`'s per-tick session
-    # open/write/commit/close now runs under `asyncio.shield`, split into its
-    # own `_service_import_heartbeat_tick` helper so the loop can shield the
-    # whole thing. A `.cancel()` used to be able to land mid-connect or
-    # mid-commit; asyncpg does not always finish tearing a connection down
-    # cleanly when that happens, and the leftover surfaced later, against
-    # unrelated work, as `ConnectionError: unexpected connection_lost() call`
-    # (test_ingest_progress.py's service-worker-progress test, seen in the
-    # merge queue). Cancellation can now only land at the `asyncio.sleep`
-    # between ticks. Cap 1161 -> 1209, exact.
-    # fix(#1778 codex r2): +36 — the shield alone bounded WHERE a cancel could
-    # land, not HOW LONG draining one could take: a tick stuck on something
-    # with no timeout of its own (another transaction's row lock inside
-    # `session.commit()`) could hang the drain, and with it `ingest_service`'s
-    # own `finally`, forever. `_SERVICE_IMPORT_HEARTBEAT_DRAIN_TIMEOUT_SECONDS`
-    # bounds it; `asyncio.shield` still keeps the tick itself running in the
-    # background on a timeout rather than cancelling it, so its connection
-    # still gets to close cleanly. Cap 1209 -> 1245, exact.
-    # fix(#1778 codex r3): +36 — round 2's drain deadline bounded how long the
-    # caller would WAIT for a stuck tick, but the tick's own connection stayed
-    # checked out and blocked until whatever held the lock let go, so
-    # repeated stalls could still exhaust the pool. `_service_import_
-    # heartbeat_tick` now sets `lock_timeout`/`statement_timeout` on its own
-    # transaction, so a blocked commit fails INSIDE Postgres within a few
-    # seconds and releases its connection the ordinary way; the drain deadline
-    # survives only as a safety net for what a DB-side timeout cannot cover.
-    # Cap 1245 -> 1281, exact.
-    # fix(#1778 codex r6): +3 — the timeouts move into
-    # `_job_phase_session(lock_and_statement_timeout_ms=...)` so they also
-    # cover that helper's own initial SELECT, which used to run before this
-    # function's own `SET LOCAL` calls and could stall behind a lock the row
-    # never got far enough to hit. Cap 1281 -> 1284, exact.
-    # fix(#1778 codex r11): +49 — the tick's own SELECT is a snapshot, not a
-    # lock: if this shielded tick's connection stalls past the caller's
-    # cancellation drain, the caller moves on while the tick is still alive,
-    # and `_finalize_ingest` can commit status="complete"/progress=1.0 (or a
-    # retry can rotate attempt_id) before the tick's own commit runs. An
-    # unconditional ORM commit would then overwrite that finalized row by
-    # primary key with a stale progress. The write is now a single UPDATE
-    # gated on id + attempt_id + status="running" + current_step="ogr2ogr" +
-    # progress still below what it is about to write, matching the
-    # attempt-fenced shape `_finalize_ingest` already uses via
-    # `require_ingest_job_update`; zero rows affected logs at debug and does
-    # nothing. Cap 1284 -> 1333, exact.
-    # fix(#1778 audit r11): +23, rebased onto the above rather than the 1161
-    # baseline it was originally measured against. Both of this file's
-    # "phase 2" call sites (`ingest_file`, `ingest_service`) gain
-    # `require_status="running"` on their `_job_phase_session` load. Neither
-    # writes an untracked storage object -- each phase's own terminal write
-    # already fences on status via `require_ingest_job_update`, so a
-    # fenced-out attempt cannot resurrect a failed row -- but this stops a
-    # paused, not-dead worker from running the whole finalize pipeline
-    # against a doomed row in the first place, for consistency with the
-    # raster tails. Cap 1333 -> 1356, exact.
-    # fix(#1755 item 11): +36. `ingest_service`'s `finally` block routes both
-    # cleanup calls through the new shared `_finally_cleanup` helper, so a
-    # heartbeat-stop or staging-drop failure logs (redacted, exc_info)
-    # rather than replacing the ingest exception in flight; the #1753 token
-    # purge still runs, since the helper never re-raises. Cap 1356 -> 1392,
-    # exact.
-    # fix(#1755 item 11, follow-up): -24. The private `_finally_cleanup` copy
-    # moved to `tasks_common.cleanup_step`, and the two `finally` blocks the
-    # first pass left bare are routed too: `ingest_file`'s five steps, and the
-    # nested one that stops the service-import progress heartbeat, where
-    # awaiting the cancelled task re-raises anything the heartbeat body itself
-    # failed with. Cap 1392 -> 1368, exact.
-    # fix(#1950): +12 — both error-write brackets pass the job-row budget, and
-    # the terminal status moved into a `finally` so a bounded write that raises
-    # still reaches the reapers. Cap 1368 -> 1380, exact.
-    # fix(#1950 codex r2): +17 — the budget also bounds the job load
-    # `_job_phase_session` runs before the helper, so both tails grew the
-    # DBAPIError handler that swallows an expiry. Cap 1380 -> 1397, exact.
-    # fix(#1953): +1 — the import of the one redactor every failure writer
-    # in this module now goes through. Cap 1277 -> 1278, exact.
-    # refactor(#2026): +2 — the staging cluster's names now come from
-    # `tasks_staging`, so this module's one import block became two.
-    "backend/app/processing/ingest/tasks_vector.py": 1267,  # Lowered after readability cleanup.
-    # --- entered by the inclusion rule ------------------------------------
-    # Crossed 1000 lines adding the "unable to open datasource" friendly-
-    # message mapping shared by run_ogrinfo and run_ogr2ogr: the pattern
-    # regexes (GDAL's driver-enumeration line and SQLite's own "file is not
-    # a database"), the per-extension format-label table, and the message
-    # builder, plus the log-then-raise branch duplicated at both call sites'
-    # failure handling (ogrinfo's text-fallback raise and ogr2ogr's raise).
-    # Exact line count at entry.
-    # fix(codex review, #1640): +16 — a third pattern, SQLite's "database
-    # disk image is malformed" (a valid header with a corrupt interior
-    # b-tree page — distinct from "file is not a database", which is a
-    # corrupt header). Empirically confirmed against a real GPKG with a
-    # byte-flipped leaf page. Cap 1073 -> 1089, exact.
-    # fix(#1746): +7 — the GDAL bearer-header tempfile now pins dir=
-    # settings.upload_staging_dir (plus an os.makedirs and a comment
-    # explaining why) so it lands on the staging volume the stale-file
-    # sweep can reach, instead of the system tempdir. Cap 1089 -> 1096, exact.
-    # fix(#1746 codex r2): +8 — that dir is now gdal_header_dir(), the
-    # container tmpfs, not the backed-up staging volume; the os.makedirs went
-    # with it (the helper owns creating its own 0700 directory) and the rest is
-    # the comment saying why a credential file does not belong on a volume
-    # scripts/backup-entrypoint.sh archives. Cap 1096 -> 1104, exact.
-    # feat(#1746 B2b): +74. `_sanitize_authorization_token` became a header
-    # LINE validator, because under plan D9 what crosses the queue is the
-    # finished line rather than a bare token: it checks the shape, the field
-    # name and the value charset, and keeps the base64url charset and the
-    # length floor on the bearer branch alone. Most of the lines are the three
-    # policy constants (each a full sentence, none of them naming any part of
-    # a credential) and the docstring recording which branch may still name an
-    # offending character and why the other branches may not. The rest is the
-    # writer dropping its own `Authorization: Bearer ` prefix and pinning the
-    # Authorization redirect rule on the env that carries the header file.
-    # Cap 1104 -> 1178, exact.
-    # fix(#1746 B2b review r3): +57. A value with no separator is the
-    # PRE-#1770 wire format, and a worker starting on a queue that already
-    # holds authenticated jobs reads exactly that; refusing it would fail every
-    # one of them deterministically at the next deploy and spend the
-    # single-use credential before ogr2ogr started. `_legacy_bearer_line`
-    # composes it through `build_credential_header`, so this module still
-    # produces no header of its own, and the charset it accepts is the one the
-    # previous version already enforced. Most of the lines are the two
-    # docstrings recording that and the `service_format` parameter that keeps
-    # the builder the authority on which formats may carry a header.
-    # Cap 1178 -> 1235, exact.
-    # fix(#1746 B2b review r4): +2. The redirect-rule comment at the header
-    # file's env says which value is set and why it is IF_SAME_HOST rather
-    # than NO: NO drops the credential on a same-host canonical redirect too,
-    # which a protected service answers with a 401. Cap 1235 -> 1237, exact.
-    # fix(#1746 B2b review r13): +14. Before the header file is written, the
-    # source's own service description is checked for an operation endpoint on
-    # another origin: GDAL applies the header file to whatever that document
-    # advertises, and those are fresh requests no redirect rule can see. The
-    # check itself is `platform/service_endpoints.py`, shared with the door,
-    # because the two callers are in layers that may not import each other.
-    # Cap 1237 -> 1251, exact.
-    # fix(#1746 B2b review r14): +5. The endpoint check is handed the finished
-    # header line rather than only the header NAME, because a protected
-    # service answers an anonymous description read with a 401 and the check
-    # then learned nothing, and it is scoped to the layer being imported so a
-    # collection past the listing's first page is still the one checked.
-    # Cap 1251 -> 1256, exact.
-    # fix(#1746 B2b review r16): +36. A protected OGC API collection is read
-    # in-process and handed to ogr2ogr as a local file, because GDAL applies a
-    # header file to every request it makes and an items page names its own
-    # successor, so the credential would follow a service-chosen `next` to any
-    # origin. GDAL 3.10.3 has no per-origin header scope; that was measured.
-    # The reader is `platform/service_items.py`; these lines are the branch,
-    # the argv swap and the extract's cleanup. WFS is untouched.
-    # Cap 1256 -> 1292, exact.
-    # fix(#1746 B2b review r17): +22. One clock now covers the in-process page
-    # walk and the subprocess, because the walk ran before `timeout` began and
-    # the HTTP client's timeout is per inactivity, so a service answering
-    # slowly forever held a worker and then still got the full half-hour. The
-    # lines are the deadline, the remaining-budget arithmetic with its floor,
-    # and arming the origin-contact callback at the first page rather than at a
-    # spawn that no longer happens first.
-    # Cap 1292 -> 1314, exact.
-    # fix(#1746 B2b review r23): +26. The WFS capabilities preflight
-    # authenticates against the origin before the subprocess exists, so it now
-    # arms the origin-contact callback and runs under the caller's deadline;
-    # a 401, malformed XML or cross-origin endpoint used to leave
-    # `last_checked_at` stale. One `fire_once` callback is shared by the page
-    # walk, the preflight and the spawn, so no site has to assume another one
-    # fired it, and the remaining-budget arithmetic moved to just before the
-    # spawn where it accounts for both preflights.
-    # Cap 1314 -> 1340, exact.
-    # fix(#1746 B2b review r24): +2. The materialiser returns a described
-    # extract rather than a bare path, so the preview can report the
-    # collection's own size instead of the sample it was handed.
-    # Cap 1340 -> 1342, exact.
-    # fix(#1770 round 49 P3): +12. `_sanitize_authorization_token`'s D9
-    # (separator-present) branch now calls `register_credential_secret`
-    # on the validated value before returning it -- previously only
-    # `_legacy_bearer_line`'s bare-token branch reached `build_credential_
-    # header`, the registry's only other producer, so the exact-value scrub
-    # pass was inert for the whole worker service-import path on the
-    # format every current job actually uses. Cap 1342 -> 1354, exact.
-    # fix(#1840 audit round 1): +12. `_legacy_bearer_line` asks
-    # `requires_header_token_policy` itself before reaching the builder,
-    # instead of inferring "this format carries no header line" from the
-    # builder answering None -- which stopped being true when lane C2 taught
-    # it to compose an ArcGIS header for the httpx transport. Both call sites
-    # already gate on the same two formats; this is the trust-boundary copy
-    # AGENTS.md requires, and the comment is the argument for keeping both.
-    # Cap 1354 -> 1366, exact.
-    # fix(#1840 audit round 2): +5. That gate moved up to
-    # `_sanitize_authorization_token`'s own entry, because inside
-    # `_legacy_bearer_line` it covered only the BARE-token branch -- a
-    # finished `Authorization: Bearer <tok>` line arriving for an ArcGIS job
-    # walked straight through to the header file. Both shapes refused now, and
-    # the comment at each end says which half it is. Cap 1366 -> 1371, exact.
-    # fix(#1844): +11. `_sanitize_authorization_token` registers the header
-    # LINE rather than the value it carries. `_secret_variants` derives the
-    # bare token, the basic blob and the decoded cleartext only from a secret
-    # containing `": "`, so registering `Bearer <tok>` expanded to nothing and
-    # the worker could not exact-scrub what an origin echoes back. The added
-    # lines are the comment saying why the earlier reasoning (keep the header
-    # NAME out of the registry) is still satisfied by the line.
-    # Cap 1371 -> 1382, exact.
-    # fix(#1844 codex r1): +10. The bearer length and charset checks moved
-    # above the registration, so a line this function REFUSES no longer seeds
-    # the exact-value registry -- `Authorization: Bearer e` used to register
-    # the variant `e` and turn every later log line into redaction markers.
-    # The lines are the guarded branch plus the comment saying which failure
-    # the ordering prevents.
-    # Cap 1382 -> 1392, exact.
-    # fix(#1846, GHSA-hrf5-v3cq-frx5): +25. Every vector GDAL subprocess in
-    # this module now names which drivers may open its source and which may
-    # never be registered, instead of handing a caller-supplied file to the
-    # whole driver set. The lines are the two helper calls per entry point, the
-    # argv restructure that puts the `-if` pairs before the source, and the
-    # comments saying what each clamp is for and why the local and service
-    # variants differ. Cap 1392 -> 1417, exact (rebased onto #1844, which took
-    # the same file 1371 -> 1392; the two changes touch different functions).
-    # fix(#1846 audit round 1): +11. GPKG and SQLite are pointer-following
-    # drivers too, and neither clamp can exclude them, because a GeoPackage is
-    # the primary supported upload format and the file really is one. So the
-    # three staged-upload entry points also read the schema and refuse a
-    # database that names a source outside itself, here rather than only at the
-    # doors, because the preview runs before the door that validates a
-    # presigned upload's whole body. Cap 1417 -> 1428, exact.
-    # fix(#1846 review round 4): +5. The three staged-upload call sites run the
-    # content check through `run_in_thread_draining` instead of inline, so a
-    # schema walk cannot sit on the event loop of the request that uploaded the
-    # file. Cap 1428 -> 1433, exact.
-    # fix(#1828): +6. `run_ogr2ogr_service` refuses a credentialed WFS that
-    # names no layer before the origin check and the spawn. Cap 1433 -> 1439.
-    # fix(#2010): +34. The two local-file spawners share one failure exit that
-    # recognises the class first and composes the reason from the fields that
-    # class may carry, since a driver names the source inside its own prose.
-    # Cap 1307 -> 1341, exact.
-    # fix(#2036): +2. The unable-to-open pattern gains ogrinfo's own one-line
-    # wording, which ogr2ogr's driver enumeration never matched.
-    # Cap 1341 -> 1343, exact.
-    # fix(#2043): +4. The ceiling error also carries the core marker the
-    # re-upload preview catches. Cap 1343 -> 1347, exact.
-    # fix(#2031 review): +4. The text fallback's `Geometry: None` sentinel is
-    # parsed as no geometry, not as a type. Cap 1347 -> 1351, exact.
+    "backend/app/processing/ingest/tasks_vector.py": 1190,
     "backend/app/processing/ingest/ogr.py": 1351,
-    # fix(#1846, GHSA-hrf5-v3cq-frx5): first entry. This module crossed the
-    # 1000-line threshold when the content check landed: the SQLite schema
-    # reader, the archive member walk that identifies members by their bytes
-    # rather than their names, and the shared decompression budget the walk
-    # spends. The comments are most of it, because the two facts that make the
-    # code correct (GDAL identifies on content, and it finds a VRT root by
-    # substring) are the two a future reader would otherwise re-learn the hard
-    # way. Cap set at the exact current count.
-    # fix(#1846 audit round 3): +36. Reading a member to its end makes zipfile
-    # verify the CRC, so a damaged upload raised BadZipFile -- not a
-    # ValueError, which is the shape the upload gauntlet promises and
-    # `tasks_vector` catches. The lines are the conversion at both member
-    # reads, the restored guard on the archive open, and the comment saying
-    # why `validate_zip_safety` could not have caught it on the way past (it
-    # never reads member data). Cap 1016 -> 1052, exact.
-    # fix(#1846 review round 4): +63. The comment strip became a single
-    # left-to-right walk instead of a lazy regex that was quadratic on text
-    # holding many `/*` with no `*/` -- uploader-chosen through a valid schema,
-    # 64 KB was 3.6 s. Most of the lines are the comment recording that the
-    # "standard linear block comment" pattern does NOT fix it, since it looks
-    # like it should. The rest is the schema byte cap and the two
-    # archive-member error classes (password-protected, unsupported method)
-    # that were escaping uncaught. Cap 1052 -> 1115, exact.
+    # Archive and GDAL validation remain centralized at the security boundary.
     "backend/app/processing/ingest/validation.py": 1104,
-    # fix(#1778): +157 for two audit findings that both land in JIT
-    # provisioning. One is the REGISTRATION_ENABLED gate plus its exception
-    # class, so enabling a provider stops being a way to reopen signup while
-    # the Settings screen still reads "off". The other is
-    # _reconcile_mapped_role, which re-applies group_role_mapping on a
-    # returning user's login -- the mapping used to run only on the login that
-    # created the account, so it could grant a role and never revoke one. Most
-    # of the lines are the docstring on that helper stating its four
-    # preconditions, each of which is what stops a login from taking away a
-    # role the IdP said nothing about. Cap 1031 -> 1188, exact.
-    # fix(#1778 codex r1): +61 for three round-1 P1s in the same function. The
-    # role change now goes through AdminService.set_role_from_identity_provider,
-    # so it inherits the last-admin invariant and the key_epoch bump instead of
-    # assigning user.roles directly; a refused demotion writes its own audit row
-    # and the login continues. The verified-email linking branch gets the same
-    # reconciliation the subject-link branch had, and the function docstring
-    # enumerates all three return paths so the next one added cannot miss it.
-    # Cap 1188 -> 1249, exact.
-    # fix(#1778 codex r5): +12. The audit event now fires only on a real change
-    # and carries the previous roles the role update actually started from,
-    # rather than a snapshot this coroutine took before waiting for the lock.
-    # Cap 1249 -> 1261, exact.
     "backend/app/modules/auth/oauth/service.py": 1111,
-    # fix(#1778 codex r1): first entry, crossed _RATCHET_INCLUSION_LOC on the
-    # change that added set_role_from_identity_provider, the public seam the
-    # OAuth group-role reconciliation applies a mapped role through. It exists
-    # so that path is the SAME role change the admin router makes rather than a
-    # second, weaker copy: the admin-lifecycle advisory lock, the last-admin
-    # rule and the key_epoch bump all come from _ensure_not_last_admin and
-    # _update_user_role, which stay private. Most of the lines are the docstring
-    # saying which invariants were missing and why a refusal is not an error for
-    # an IdP-driven caller. 992 -> 1036, exact.
-    # fix(#1778 codex r4): +19. The advisory lock now covers the PROMOTION
-    # branch too. Skipping it was justified by "a promotion cannot threaten the
-    # last-admin invariant", which is true and beside the point: two OAuth
-    # callbacks for one account both entered it unserialized, and
-    # _update_user_role's delete-then-insert collided on the (user_id, role_id)
-    # primary key, failing an otherwise valid login. Cap 1036 -> 1055, exact.
-    # fix(#1778 codex r5): +43 for IdentityRoleOutcome and its docstring.
-    # set_role_from_identity_provider returned a bare bool, so a caller could
-    # not tell "applied" from "was already correct", and the loser of two
-    # concurrent promotions reported a change it had not made. It now reports
-    # applied/changed plus the previous roles read UNDER the lock, which is what
-    # lets the caller audit only a real transition. Cap 1055 -> 1098, exact.
-    # fix(#2025): +9 — the embedding-stats response also carries the run in
-    # flight, the run history and the before-start estimate, composed in
-    # backfill_jobs.py. Cap 1010 -> 1019, exact.
     "backend/app/modules/admin/service.py": 1019,
-    # fix(#1113 review): +15 — register_existing_table linearizes a
-    # pre-existing geom_4326 (savepoint + error contract mirroring the
-    # add_4326_column branch beside it); see linearize_existing_4326.
-    # Cap 1017 -> 1032, still exact.
-    # fix(#1114): +12 — register_existing_table docstring records the
-    # registered-table linear-geometry contract (linearize once at
-    # registration, no post-registration policing). Cap 1032 -> 1044.
-    # feat(#1218): +7 — register_existing_table stamps the postgis origin
-    # pointer (schema-qualified table, no connection detail: gate 2 keeps
-    # external federation out of v1). The URI and the ref's table_name are two
-    # spellings of one fact, so set_postgis_origin composes both and this call
-    # site stays one line. Cap 1044 -> 1051, exact.
-    # fix(#1218 review r2): +8 — the call site passes the _schema it resolved
-    # from the active tenant context instead of dataset.tenant_id, which is
-    # NULL on the ORM instance because the insert trigger fills that column in
-    # the database. The comment records why, so nobody "simplifies" it back to
-    # reading the row. Cap 1051 -> 1059, exact.
-    # fix(#1290 review): +14 — safe_upload_basename, extracted from the two
-    # inline `Path(x).name` copies inside save_upload_file so the
-    # archived-original key derives from the SAME normalization the upload path
-    # applies. Deriving from the raw filename split the key: the logical URI
-    # kept a path component the write stripped, so the counted row pointed at
-    # nothing. Cap 1059 -> 1073, exact.
-    # fix(#1359): +4 — register_existing_table now derives metadata for every
-    # table it registers instead of only the spatial ones, so a non-spatial
-    # registration stops landing with column_info and feature_count NULL. The
-    # added lines are the comment explaining why the branch is gone.
-    # Cap 1073 -> 1077, exact.
-    # fix(#1443): +21 — generate_table_name gains a third collision probe,
-    # against the retired-names table. The two it already had ask what exists
-    # NOW, and a delete clears both, so a deleted dataset's table name was
-    # handed straight to its successor while a tile worker could still be
-    # holding the predecessor's authorization snapshot under that name. Most of
-    # the added lines are the comment carrying that reasoning plus why the
-    # probe is unscoped by tenant (it has to agree with the catalog probe
-    # beside it, and over-collision only costs a suffix). Cap 1077 -> 1098,
-    # exact.
-    # fix(#1444 review): +21 — the same probe repeated in
-    # register_existing_table, which is the one path that takes a table name
-    # from the caller instead of generating it. Without it the whole guarantee
-    # is bypassable through the front door: recreate a physical table under a
-    # deleted public dataset's name, register it as private, and a worker still
-    # holding the predecessor's metadata authorizes anonymously against
-    # `public` while querying the successor's rows. The comment carries why it
-    # refuses rather than renaming the caller's own table. Cap 1098 -> 1119,
-    # exact.
-    # fix(#1444 review round 2): +47 — the suffix walk now keeps every candidate
-    # inside PostgreSQL's 63-byte identifier limit. Retired names accumulate
-    # forever, so a 60-char base genuinely reaches `_100`, which is 64 bytes;
-    # Postgres truncates that onto the same relation as `_10` while the catalog
-    # keeps both untruncated strings, putting two logical names on one table.
-    # The lines are `_with_collision_suffix`, three constants, the bound that
-    # refuses an exhausted namespace instead of emitting a truncatable name,
-    # and the probe prefix that has to be short enough to match a candidate
-    # whose base was trimmed — plus the comments tying those last two together,
-    # because they are only correct as a pair. Cap 1119 -> 1166, exact.
-    # fix(#1444 review round 3): +33 — the retirement probes are tenant-scoped,
-    # mirroring migration 0020's per-tenant uniqueness on datasets.table_name.
-    # Unscoped, one tenant's deletions cost every other tenant suffixes, and
-    # once the round-2 bound landed they could exhaust a shared budget and
-    # refuse a title outright. `_retired_tenant_scope` (own tenant plus the NULL
-    # scope, with the string->UUID coercion made explicit because a
-    # never-matching comparison reads as "nothing is retired") is applied at
-    # both probe sites. The comments carry why NULL binds everywhere: it is the
-    # single-tenant namespace, and where a row retired before a single -> multi
-    # transition sits, since nothing back-stamps this table. Cap 1166 -> 1199,
-    # exact.
-    # fix(#1452): +12 — the `managed` keyword and the docstring paragraph that
-    # says why it is an explicit argument rather than a guess. Registration is
-    # called both by an operator handing over a table they own and by the
-    # analysis materialize path handing over one it just CTAS'd, and delete now
-    # drops only the second; the caller is the only place that knows which.
-    # Cap 1199 -> 1211, exact.
-    # feat(#1676): +48 — `queue_ingest_job`'s service branch leases the token
-    # rather than dispatching it. The 503 branch is the bulk: unlike the two
-    # doors that stage before their commit, this runs after `commit_import` has
-    # already committed the job, so an unreachable store has to finalize the
-    # job row itself before raising or it strands a pending row until the stale
-    # sweep. The rest is the discard on the defer rollback and the comment
-    # saying the state-1/state-3 choice is not this door's to make.
-    # Cap 1211 -> 1259, exact.
-    # fix(#1689 codex r1): +25 — the rolling-deploy skew note. A worker from
-    # the previous generation takes `credential_ref` through `**kwargs` and
-    # discards it, and the review asked for a versioned task name to gate that.
-    # The comment records why the gate is the worse option (Procrastinate fails
-    # its own job on TaskNotFound but nothing writes the ingest_jobs row, so the
-    # user sees a hang instead of a retryable failure) and why the window is
-    # narrower here than at the refresh door, where #1220 accepted the same
-    # trade. Written down so the next review lands on the decision rather than
-    # re-deriving it. Cap 1259 -> 1284, exact.
-    # fix(#1709 review r2 P1): +133 — finalize_fan_out_parent: the fenced
-    # pending->fanned_out CAS, and the lost-CAS reconciliation that cancels
-    # the children this request queued (guarded status CAS, best-effort
-    # queue aborts, per-layer results rewritten to failed) so a cancel that
-    # beat the fan-out mid-loop cannot leave every child importing. Roughly
-    # a third of the lines are the docstring recording why the loser, not
-    # the cancel endpoint, owns that reconciliation — only this side knows
-    # the full child set. Cap 1284 -> 1417, exact.
-    # fix(#1709 review r5 P1): -41 — finalize_fan_out_parent's post-loop
-    # loser-reconciliation is DELETED, not kept as defense-in-depth: with
-    # the flip preceding every child (claim_fan_out_parent), the window it
-    # compensated — children existing while the parent CAS loses — is
-    # unreachable, and dead compensation code reads as a live invariant.
-    # Replaced by the smaller claim/restore pair, restore being the fenced
-    # CR-02 retry contract. Cap 1417 -> 1376, exact.
-    # fix(#1737): +26 for the geometry-column-name probe in
-    # register_existing_table. A spatial table whose geometry is not named
-    # `geom` used to register silently as a non-spatial attribute table; the
-    # probe tells that case apart from the deliberate no-geometry path (#1359)
-    # and refuses with the offending column name. Cap 1376 -> 1402, exact.
-    # fix(#1746): +48 — `_assert_header_token_dispatchable`, called by
-    # `queue_ingest_job` before it stashes anything, so a WFS/OGC token outside
-    # the base64url charset is refused with the same 422 the refresh door
-    # returns instead of burning its single-use credential and dying in
-    # ogr2ogr. It is a named helper rather than an inline block because inline
-    # pushed `queue_ingest_job` past ruff's C901 ceiling; most of the lines are
-    # its docstring, recording the failure it closes and why ArcGIS is exempt.
-    # Cap 1402 -> 1450, exact.
-    # feat(#1746): +15. `queue_ingest_job` takes a `ServiceCredential` in its
-    # own right, so a caller with no HTTP layer can queue an authenticated
-    # ingest without assembling a request body for a door to take apart (plan
-    # D2). Most of the lines are the docstring paragraph recording that, and
-    # why an unsupported method is refused here rather than dispatched as an
-    # anonymous fetch. Cap 1450 -> 1465, exact.
-    # fix(#1744): +17. One `job=` argument at each of this module's five
-    # `defer_with_orphan_guard` call sites, so the guard can stamp
-    # `commit_attempted_at` on the row before the task exists. The kwarg is
-    # required rather than optional precisely so a new dispatch site cannot be
-    # written past it, plus `create_fan_out_jobs` putting the same stamp in
-    # the metadata it commits for each child: that door runs inside a worker
-    # task and its child cannot be recreated by repeating a user action, so it
-    # is the one place the commit-to-dispatch window is worth closing
-    # outright. Cap 1465 -> 1482, exact.
-    # fix(#1774 review, codex P2): +18. `create_fan_out_jobs` resets the
-    # session in its per-layer failure handler. That commit now carries the
-    # child's dispatch marker as well as its row, and a transactional failure
-    # there left the session refusing every later statement, so one layer's
-    # deadlock failed every sibling and stranded the parent `fanned_out` with
-    # no child importing. Cap 1482 -> 1500, exact.
-    # fix(#1774 review r2, codex P2): +13. That reset expires the parent, and
-    # both the next layer and `restore_fan_out_parent_pending` read attributes
-    # off the same instance, so a synchronous read would raise MissingGreenlet
-    # and turn one layer's failure into a 500. The parent is reloaded in the
-    # same breath, and the log line reads a snapshotted id rather than the
-    # instance it just expired. Cap 1500 -> 1513, exact.
-    # feat(#1746 B2b): +25. `job_service_format` is extracted so the queue-time
-    # check and the composition read the same answer, and `queue_ingest_job`
-    # composes the wire value (plan D9) from whichever spelling its caller
-    # used: the structured credential of plan D2, or the flat bearer token the
-    # import-commit door still carries because `ServiceCommitRequest` has no
-    # `auth` object yet. Cap 1465 -> 1490, exact.
-    # fix(#1746 B2b review r1): +9. The legacy-token pre-check runs only when
-    # the flat token is the credential being dispatched: the signature promises
-    # the structured one wins when both are given, and the check judged the
-    # losing one, so a stale legacy token refused a valid credential. Most of
-    # the lines are the comment saying which value is judged where.
-    # Cap 1490 -> 1499, exact.
-    # Rebased across #1774: that branch's three raises (1465 -> 1482 -> 1500
-    # -> 1513) and this one's two (1465 -> 1490 -> 1499) are edits to
-    # different parts of the module, so the merged file carries both. Measured
-    # rather than added up. Cap 1513 -> 1547, exact.
-    # fix(#1770 round 35): +13 — the import door judges header_auth_job_queue
-    # on the line job_service_format/wire_credential just composed, before
-    # the credential-store lease may swap it for a reference, and configures
-    # ingest_service's queue with the verdict. Cap 1547 -> 1560, exact.
-    # fix(#1738): +8 of docstring, no code. register_existing_table's stated
-    # contract was "linearize once, do not police the table afterward", which
-    # a reader could take as "the owner's writes are picked up somehow". They
-    # are not: they are picked up by Refresh, which now re-derives geom_4326.
-    # The paragraph says which writes go stale and what recovers them, so the
-    # next reader does not have to find that out from a broken dataset.
-    # Cap 1560 -> 1568, exact.
-    # fix(#1858): +30. Table discovery and registration now read one
-    # expression for "this is an import staging table", where discovery's
-    # `NOT LIKE '%\\_staging'` matched neither shape
-    # `attempt_scoped_staging_table` produces. The lines are the refusal
-    # itself, its bound parameter, and the comment saying why only the
-    # attempt-scoped shape is refused rather than every `_staging`/`_old`
-    # name, since `generate_table_name` can produce those from a title.
-    # Cap 1568 -> 1598, exact.
-    # chore(#1812): -8, the import door no longer judges a queue on the composed line
-    # or configures ingest_service with it. Cap 1598 -> 1590, exact.
-    # refactor(#1711): +32. `_cleanup_saved_upload`, beside the drain it awaits
-    # and the save it undoes, plus the module logger its body reads and the
-    # provider import its S3 branch makes. Cap 1590 -> 1622, exact.
-    # chore(#1940): -9, the fan-out error path no longer re-imports structlog or
-    # guards on the result; the module binds `logger` unconditionally.
-    # Cap 1622 -> 1613, exact.
-    # fix(#2016): +30. `restore_fan_out_parent_pending` returns its rowcount and
-    # widens the CAS to the row the childless-fanout sweep settled `failed` for
-    # this same attempt, clearing that one marker key. Most of the lines are the
-    # docstring recording why the attempt fence is what makes the wider
-    # predicate safe. Cap 1390 -> 1420, exact.
-    # refactor(#1710): `raster_stamped_metadata` moved here from router.py so
-    # the URL fetch task can reach it without importing an HTTP module.
-    # RECONCILED with #2016 off the same 1390 baseline; measured, not summed.
     "backend/app/processing/ingest/service.py": 1437,
-    # fix(#1738): first entry, crossed _RATCHET_INCLUSION_LOC (842 -> 1019) on
-    # the change that gave this task a repair phase. What the growth bought:
-    # `geom_4326` on a registered table was written once, at registration, and
-    # never re-derived, so an `UPDATE geom`, a DELETE+INSERT reload, or an
-    # `ogr2ogr -overwrite` left rows that every reader filters out — silently
-    # invisible, because `NULL && <envelope>` is NULL. Phase 1.5 re-applies
-    # the invariant from outside the table, which is the only shape that
-    # survives -overwrite dropping it. Most of the added lines are the
-    # docstring and the constant comments carrying the two properties a later
-    # reader would otherwise simplify away: the phase runs BEFORE the
-    # read-only measurement (which declares postgresql_readonly=True precisely
-    # so a write from it fails), and it installs its own statement deadline
-    # because `install_api_statement_timeout` is an API-process concern and a
-    # worker UPDATE on a customer's relation would otherwise be unbounded.
-    # The second bound is the one measurement forced: ADD COLUMN takes ACCESS
-    # EXCLUSIVE, a QUEUED lock request already blocks every reader behind it,
-    # and the first version of this phase sat on that queue for the full five
-    # minutes in a test. `_REPAIR_LOCK_TIMEOUT_MS` gives the position back
-    # after five seconds instead. Cap 842 -> 1061, exact.
-    # fix(#1738 round 1): +43 for two review findings and the defect the first
-    # of them uncovered. The reader GRANT is now re-issued whatever the
-    # geometry turned out to be — it is the third thing -overwrite destroys
-    # and losing it does not depend on the render column needing a rewrite, so
-    # gating it on the re-derive let a recreated table with a generated
-    # geom_4326 pass a refresh unreadable. Probing the columns before
-    # resolving the SRID is what that exposed: Find_SRID RAISES for a table
-    # with no geometry, so every refresh of a registered non-spatial dataset
-    # was a logged repair failure that also skipped the grant. And the version
-    # bump moved to the atomic helper, because this transaction holds no row
-    # lock. Cap 1061 -> 1104, exact.
-    # fix(#1738 round 2): +24 — the GiST index restore moves onto the same
-    # rule as the grant: every outcome where the column exists, not only the
-    # one where it had to be rewritten. `rederive_geom_4326` was the only
-    # caller of the index helper, so an overwrite that recreated the table
-    # with a valid STORED GENERATED `geom_4326` left the dataset with no
-    # spatial index and every `geom_4326 && <envelope>` predicate the readers
-    # issue fell back to a sequential scan. Cap 1104 -> 1128, exact.
-    # fix(#1755 item 11): +2. The `finally` block's heartbeat stop routes
-    # through `cleanup_step`, so a failure in it logs instead of replacing the
-    # refresh exception being propagated. Cap 1128 -> 1130, exact.
-    # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1134, exact.
-    # fix(#1847): phase 3 takes the job row before the datasets row. Cap
-    # 1134 -> 1141, exact.
-    # fix(#1902): the atomic bump comment states its contract. Cap 1141 -> 1137.
-    # fix(#1957): +3 and fix(#1953): +1 merged; re-measured after both landed. Cap 979, exact.
     "backend/app/processing/ingest/tasks_postgis_refresh.py": 979,
-    # --- entered by the inclusion rule, feat(#765) -------------------------
-    # First time this module crosses 1000. main sat at 994, six lines under the
-    # gate, so it was going to fire on whoever added next; it fired here.
-    # +38 — DerivedFromResponse. The provenance reference was typed
-    # dict[str, Any], which OpenAPI renders as additionalProperties: true, and
-    # both SDKs then generate an untyped map — the shape is exactly what a
-    # durable reference exists to carry, so leaving it untyped defeated the
-    # feature (#1045 review). The model's own docstring holds the part worth
-    # keeping: `params` stays untyped deliberately, because it is the
-    # operation's parameter dict AND it is redacted per requester, so a union
-    # of per-operation models would describe a shape visible_derived_from is
-    # free to punch holes in.
-    # +95 — the four analysis operations. Each one adds a value to both
-    # AnalysisOperation Literals, a params field with its bounds, and its row
-    # in _ANALYSIS_PARAM_OWNERS, which is what makes a param submitted to the
-    # wrong operation a 422 instead of a silently ignored key. 1032 -> 1127.
-    # fix(#1097 review): +6 for the mask_dataset_id description, on both
-    # request models. It said the field applied to clip and select_by_location
-    # and was an alternative to `mask`, while the validator requires it for
-    # every intersect and rejects a drawn mask there — so the generated SDK
-    # docs led clients to requests that always 422.
-    # fix(#1097 review): +5 for the match_count description, which said the
-    # field is null for anything but spatial_join and select_by_location while
-    # intersect returns it. This is the SOURCE the SDKs and the hand-typed
-    # frontend mirror are generated from or checked against, so it had been
-    # corrected in the mirror and left wrong here — backwards, and the reason
-    # the wrong text shipped into both SDKs.
-    # feat(#1070): +9 for DatasetResponse.metadata_warnings — the advisory
-    # warnings a metadata PATCH can attach (inherited-keyword disclosure at a
-    # visibility/status change). 1138 -> 1147.
-    # fix(#1178 review): +9 for the same field on StatusUpdateResponse — the
-    # publication status endpoints run the disclosure check too, so their
-    # response carries it. 1147 -> 1156.
-    # fix(#1183): +11 for the two record_status descriptions. Both said
-    # "draft, ready, published" — three values, omitting `internal`, and
-    # phrased as a closed set when `record_status` has no CHECK constraint
-    # and its values come from the workflow extension's status_order(). The
-    # wording now names the seam first and the community default second, so a
-    # reader cannot mistake the list for the contract. This is the SOURCE the
-    # SDKs and api.generated.ts are generated from, and #1184 already shipped
-    # a `^(draft|ready|published)$` validator read straight off it. 1156 ->
-    # 1167.
-    # fix(#727): +38 for AnalysisPreviewRequest.bbox — the field, its
-    # description, and the _validate_bbox field_validator (length, finiteness,
-    # ordering) that gives 422s an actionable message instead of a generic
-    # ST_MakeEnvelope failure. 1167 -> 1205.
-    #
-    # fix(#727 codex P2 round 1): +4 — source_feature_count's description now
-    # names the live-bbox-scoped-count and could-not-be-computed cases, so a
-    # reader of the schema (or the generated SDK docs) sees the same contract
-    # _resolve_bbox_source_count's docstring states. 1205 -> 1209.
-    #
-    # fix(#727 codex round 2): +6 — match_count's description now covers
-    # intersect's bbox-scoped total (it rides the same statement the
-    # geometry preview runs, unlike select_by_location's separate uncapped
-    # count query) now that the intersect branch actually receives bbox.
-    # 1209 -> 1215.
-    # feat(#1218): +56 — the eight read-only source-state fields on
-    # DatasetResponse. Seven mirror the new columns; `origin` is computed at
-    # the boundary rather than stored, so its description has to say so or a
-    # reader will go looking for the column. source_health and
-    # schema_drift_status carry the NULL -> "unknown" projection, which is
-    # only discoverable from the description. Cap 1215 -> 1271, exact.
-    # feat(#1224): +15 — the computed `source_freshness` field. The description
-    # spends its lines on the three things a reader cannot see from the type:
-    # that the value is derived from last_refreshed_at, update_frequency, and
-    # origin rather than stored (so nobody goes looking for a column); that a
-    # non-refreshable origin reads "unknown"; and that it is a different thing
-    # from the quality score's own freshness, which the frontend already
-    # computes under that word. Cap 1271 -> 1286, exact.
-    # feat(#1222): +47 — SourceHealthResponse (the probe endpoint's reply) and
-    # SOURCE_HEALTH_DETAIL_DESCRIPTION. Most of it is description text, and it
-    # earns its place twice over: the three health words have to mean the same
-    # thing here as on VrtSourceHealth or the UI cannot render one legend, and
-    # the detail description has to say OUT LOUD that the field is an
-    # enumerated GeoLens code rather than a message to show verbatim. It is
-    # built from the probe's own DETAIL_CODES instead of retyping the list, so
-    # the schema and the vocabulary cannot drift. Cap 1286 -> 1333, exact.
-    # feat(#1219, #1223): +56 — DatasetRefreshRunResponse and its list
-    # wrapper. Most of the growth is descriptions that state facts a reader
-    # cannot get from the field name: started_at is DISPATCH time (so queue
-    # wait is visible), ingest_job_id nulls out when the job is purged while
-    # the run survives, and the response docstring enumerates the five fields
-    # Decision 4e redacts for third-party readers. Cap 1333 -> 1389, exact.
-    # feat(#1219 amendment): +7 — claimed_at, the third timestamp. started_at
-    # is dispatch, claimed_at is when a worker picked the run up, finished_at
-    # is the outcome; queue wait is only measurable because all three exist
-    # separately, which the field's description has to say or a reader will
-    # assume two of them are redundant. Cap 1389 -> 1396, exact.
-    # feat(#1220): +39 — DatasetRefreshRequest and DatasetRefreshResponse.
-    # The request model is one optional field and most of its lines are the
-    # docstring stating what is NOT in it: no URL, no service type, no layer,
-    # because reading those server-side is the entire feature and a reader
-    # who assumes they were merely defaulted would add them back. The
-    # response carries the run id alongside the job id, and says why — the
-    # run is the durable history row that outlives the job the retention
-    # purge removes. Cap 1396 -> 1435, exact.
-    # feat(#1221): +5 — `stale` joins VrtSourceHealth.status, for a member
-    # whose own raster was replaced after the parent VRT was last built. The
-    # comment is the value: the member probes healthy and it is the PARENT
-    # that needs regenerating, which is the opposite of where `inaccessible`
-    # sends the reader. Cap 1435 -> 1440, exact.
-    # feat(#1316): +14 — origin_uri/origin_ref descriptions now state the
-    # owner-or-admin redaction inline (the same fact the field-level
-    # description already carries for every other gated field in this
-    # module), and DatasetVersionResponse gained a docstring for the same
-    # reason on file_hash/uploaded_by. Cap 1440 -> 1454, exact.
-    # fix(getgeolens.com#86 review): +4 — SourceHealthResponse's docstring
-    # claimed it shared ALL of VrtSourceHealth.status's values, which stopped
-    # being true when fix(#1221) added VrtSourceHealth's VRT-specific `stale`
-    # value without updating this cross-reference. Cap 1454 -> 1458, exact.
-    # fix(#1325): +7 — DatasetRefreshRunResponse.origin_kind's description now
-    # states the door-vs-origin distinction inline (a raster-replace run's
-    # door has no ORIGIN_KINDS counterpart), matching the CHECK constraint
-    # comment in platform/refresh/models.py and the ORIGIN_KINDS docstring in
-    # platform/dataset_origin.py. Cap 1458 -> 1465, exact.
-    # fix(#1325 review): +1 — codex caught the description overclaiming
-    # 'raster' as live behavior ("is the raster-replace door") when
-    # refresh/models.py's own comment on the same constraint says reserved,
-    # not live. Reworded to match: 'raster' is reserved for a future door
-    # label, today's raster-replace runs are still recorded 'upload'. Cap
-    # 1465 -> 1466, exact.
-    # fix(#1325 review round 3): +2 — codex found a second, live divergence
-    # the first reword still implied away: it said raster-replace 'upload'
-    # runs "match the dataset's origin", true only when the dataset's origin
-    # was already 'upload'. A STAC-imported raster's pending or failed
-    # replace run is recorded 'upload' while the dataset's origin stays
-    # 'stac' until the swap succeeds — reworded to drop the equality claim
-    # entirely and name that case. Cap 1466 -> 1468, exact.
-    # -16 — dead-code sweep: DatasetCreate deleted. The request schema had
-    # zero references across backend/cli/mcp/sdks/frontend — creation uses
-    # CreateEmptyDatasetRequest instead. Cap 1468 -> 1452, exact.
-    # feat(#1472): +21 — `attribution` on DatasetResponse and DatasetMeta, plus
-    # the NFC-normalization entry. The lines are mostly the note on the PATCH
-    # field's max_length: 5000 rather than the 1000 its neighbours use, because
-    # ManifestMetadata.attribution is NonEmptyString5000 and the ingest tail
-    # writes it straight to the column, so a 1000 bound here would accept a
-    # manifest value the dataset PATCH then refuses to round-trip.
-    # Cap 1452 -> 1473, exact.
-    # fix(#1472 review): +10 — the markup guard on `attribution`. It is the one
-    # field in this schema that reaches an HTML render context (MapLibre's
-    # attribution control assigns it to innerHTML, and MapLibre's own sanitizer
-    # keeps img/iframe/style), so it is the one that must stay plain text. The
-    # rule itself lives in core.text.reject_html_markup, shared with the
-    # manifest schema; these lines are the field_validator and the note saying
-    # why only this field carries it. Cap 1473 -> 1483, exact.
-    # feat(#1746): +16. The re-upload commit and refresh request models gain
-    # the `auth` object and the validator refusing a body that sets it and the
-    # deprecated `token` at once. Both are imported from the sources schema
-    # rather than restated here, so the four doors cannot describe the same
-    # credential four ways. Cap 1483 -> 1499, exact.
-    # feat(#1746 B2b): +17. `ReuploadServicePreviewRequest` is the fifth model
-    # to carry the `auth` object, declared last like the other four. #1760 left
-    # it out because no transport composed a header for the methods it adds;
-    # with one in place, leaving it out would mean a basic-protected service
-    # could be re-uploaded but not previewed first. Cap 1499 -> 1516, exact.
-    # fix(#1746 B2b review r24): +8. `row_count_delta` is nullable (and still
-    # required), with the reason recorded where the field is declared.
-    # Cap 1516 -> 1524, exact.
-    # fix(#1768): +12. `ReuploadCommitRequest.expected_origin_kind`, typed with
-    # the shared `OriginKind` literal from platform/dataset_origin.py rather
-    # than a second spelling of the vocabulary, plus the description telling a
-    # client author what the field buys and that omitting it is supported.
-    # Cap 1524 -> 1536, exact.
-    # fix(#1847): +5. BulkDeleteResultItem gained an optional `code`, so a
-    # per-item conflict is machine-readable with the same code the
-    # single-delete 409 carries. Cap 1536 -> 1540, exact.
-    # fix(#1755 item 3): -5. The module-local copy of the token rule is gone;
-    # the three models import the shared one. Cap 1540 -> 1535, exact.
     "backend/app/modules/catalog/datasets/domain/schemas.py": 1510,
-    # --- entered by the inclusion rule, feat(#953/#954/#955/#956) ----------
-    # tasks.py crossed 1000 for the first time here because the four operations
-    # are deliberately concentrated rather than spread: it grows by one branch
-    # per operation so the CTAS shape is decided in one place, the same reason
-    # every rendered statement lives in analysis_sql rather than in the preview
-    # path and the worker separately. Splitting either one PER CALLER would
-    # trade size for the drift both were built to prevent, so the growth is the
-    # design working.
-    #
-    # refactor(#1089): analysis_sql left this dict. It crossed 1000 in the same
-    # batch (662 -> 1173, later 1255) and carried the follow-up note this entry
-    # used to hold; the split has now happened. It is a package split by
-    # OPERATION FAMILY — overlay, measure, spatial_join, transform, over a
-    # shared core holding the OFFSET 0 fence, the measured ceilings, the
-    # antimeridian helper and the mask parser — and no file in it reaches the
-    # inclusion threshold, so nothing needs a cap. What survived the move and
-    # still binds: never split it by CALLER. Giving the preview path and the
-    # materialize worker their own rendering modules recreates exactly the
-    # drift the module exists to prevent, and the package docstring says to
-    # reject that proposal on sight. The per-family reasoning the #1097 review
-    # entries recorded here — NON_GROUPABLE_COLUMN_TYPES, INTERNAL_ALIAS_PREFIX
-    # and MAX_IDENTIFIER_LENGTH each landing where more than one guard reads
-    # them — now sits beside the constants themselves in analysis_sql/shared.py
-    # and analysis_sql/spatial_join.py, which is where an edit to them starts.
-    # tasks.py carries growth from BOTH sides of this rebase, so the number is
-    # re-measured rather than taken from either. #1012 added the scoped
-    # work_mem (the SET LOCAL, its budget arithmetic and the boot-time
-    # validator); this branch added one CTAS branch per operation. Each cap was
-    # correct for the tree that produced it and neither is correct for the
-    # merge, which is the conflict doing its job.
-    #
-    # fix(#1097): +40 on top of that, for
-    # _reject_ungroupable_overlay_columns — the worker half of the overlay type
-    # guard. The router validates a catalog SNAPSHOT and a re-upload can
-    # replace the overlay before the job runs, the same window
-    # _reject_output_column_collision beside it exists for. Types rather than
-    # names, because the live name list was already read there and would not
-    # have caught it: the column that breaks the CTAS has an ordinary name.
-    #
-    # fix(#1097): +91 for the live-schema rechecks. Two more guards (the
-    # reserved-alias prefix, and re-checking transferred join fields against the
-    # join layer's live columns) plus _resolve_and_validate_columns, which the
-    # set moved into rather than raising _materialize's C901 threshold: five
-    # checks over two layers share a subject the surrounding job bookkeeping
-    # does not.
-    #
-    # fix(#1097): +21 for re-applying the polygon requirement on the
-    # mask layer at resolve time. The router refuses a non-polygonal mask at
-    # enqueue and a re-upload can change that layer's geometry_type while the
-    # job waits, and nothing downstream notices: the mask matches no rows and
-    # the job dies on "produced no features", pointing the user at their data
-    # instead of at the layer that changed.
-    #
-    # fix(#1097): +22 for the second geometry strength. The mask must
-    # still be polygonal; the JOIN layer must only still be spatial, because a
-    # join counts in any direction — but a re-upload from a non-spatial source
-    # leaves no geom_4326 for render_spatial_join to reference.
-    #
-    # fix(#1097): +20 for _DRAWN_MASK_OPERATIONS and the note on why
-    # mask_source belongs to every operation that can take a drawn mask. The
-    # drawn geometry is deliberately excluded from provenance, so that
-    # discriminator is the only trace a drawn selection leaves — the constant
-    # is duplicated from schemas because PROCESS-02 forbids the import, and a
-    # test pins the two copies together.
-    #
-    # fix(#1097): +3 for linearizing the three pass-through CTAS
-    # geometry columns (measure, spatial_join, select_by_location) so a curved
-    # source row is stored linear — a curved geometry written into the derived
-    # table would fail that layer's tiles and feature reads later.
-    # fix(#1104): -1 — those wraps are gone again; geom_4326 is linear at
-    # ingest, so the pass-through columns read the bare column. Cap
-    # 1450 -> 1449, exact.
-    #
-    # fix(#1097): +62 for the array-element half of the ungroupable
-    # guards. information_schema stores an array column's data_type as
-    # 'ARRAY', so json[]/xml[] passed the exact scalar comparison and failed
-    # the CTAS with 42883 after the queue wait; _ungroupable_type_name reads
-    # udt_name ('_json') as well, and the same check now also covers
-    # dissolve's by_field, which had the identical blind spot plus no live
-    # recheck at all.
-    #
-    # fix(#1099): -36 — _reject_ungroupable_overlay_columns is retired, along
-    # with its call site in _resolve_and_validate_columns. The overlay's
-    # attributes are joined back outside the aggregate now, so a re-upload that
-    # introduces a json column has nothing left to break; leaving the recheck
-    # would have refused, after the queue wait, exactly the layers that issue
-    # set out to admit. _ungroupable_type_name and its ARRAY branch stay —
-    # dissolve's by_field really does group by a user-chosen column. Cap
-    # 1449 -> 1413, exact.
-    # fix(#1452): +7 — managed=True on the output registration, with the note
-    # that this table was CTAS'd here so delete may reclaim it. Without the
-    # flag it is indistinguishable from an operator's registered table and
-    # every analysis output would leak one on delete. Cap 1413 -> 1420, exact.
-    # fix(#1778): +42. The generated output table name is persisted to
-    # `user_metadata` in the transaction that creates the table, and the
-    # probe-then-drop the two fence-miss handlers each carried inline is now one
-    # `drop_unadopted_analysis_output` the stale-job sweeps call too. The
-    # helper's docstring and its identifier re-validation are most of the net
-    # growth; the two inlined copies came out. Cap 1420 -> 1462.
-    # fix(#1778): +33. `drop_unadopted_analysis_output` returns what
-    # it established rather than the same None whether it dropped the table or
-    # failed to. The sweep clears the recorded name on the strength of that
-    # call, and the name is the table's last durable pointer, so a swallowed
-    # failure read as success orphaned the table permanently. The five outcomes
-    # and the note on why a raised probe is "failed" and not "adopted" are the
-    # growth. Cap 1462 -> 1495.
-    # fix(#1778): +79. Output table names are scoped by the job that
-    # creates them, so two jobs can never hold one physical name and the sweep
-    # can verify ownership from the name alone, with no marker, registry or
-    # lock. `analysis_output_table_name` and `analysis_output_table_belongs_to`
-    # plus the ownership gate in the drop are the code; the docstring stating
-    # the interleaving that made a shared name unsafe, and why the scope is by
-    # job and not by attempt, is most of the growth. The gate is a REQUIRED
-    # keyword with no default: the in-worker handlers pass their own id either
-    # way, so an optional one would have bought nothing but a way to forget it.
-    # Cap 1495 -> 1580, exact.
-    # fix(#1778): +122. The scope grows an attempt half — job scoping
-    # alone left a retry able to derive the same name as its predecessor, since
-    # `/jobs/{id}/retry` keeps `IngestJob.id` and only mints a new attempt
-    # token. `analysis_output_table_name` takes both now, and the record
-    # accumulates across attempts (`recorded_analysis_output_tables`,
-    # `append_analysis_output_record`) rather than overwriting, the shape
-    # `unpublished_storage_keys` took in r9 and for the same reason: overwriting
-    # a retry's own field dropped the previous attempt's pointer. The other
-    # half of the growth is `resolve_analysis_output_table`, which
-    # collision-checks the SCOPED candidate against pg_class directly —
-    # `generate_table_name`'s own `_N` walk only ever probed the unscoped base,
-    # so it could hand back a name that scoped straight onto an orphan a
-    # previous attempt of the same job left behind. Cap 1580 -> 1702, exact.
-    # fix(#1778): +23. `analysis_output_table_name` takes an
-    # optional `collision_suffix` now instead of the caller pre-pending `_N`
-    # to `base` and calling it again -- the second trim of an already-trimmed
-    # string threw away the very characters that made one candidate differ
-    # from the next, so a `base` at or past the reservation point made every
-    # walked suffix identical and exhausted the whole `_N` walk instead of
-    # self-healing. The tag is reserved for up front, in the same limit
-    # computation as the scope, the idiom `generate_table_name`'s own
-    # `_with_collision_suffix` already uses. Cap 1702 -> 1725, exact.
-    # chore(#1873): review-history comments trimmed. Cap 1725 -> 1392, exact.
-    # fix(#1957): +31 — both failure tails budget their job write and keep an
-    # expired budget distinct from a fence miss, and the cancel path names
-    # its shield and derives a clamp that fits inside it. Cap 1390 -> 1421,
-    # exact.
     "backend/app/processing/analysis/tasks.py": 1421,
-    # Tenant-owned media now crosses the shared logical-to-physical storage
-    # seam; explicit storage-failure responses keep the runtime/OpenAPI contract
-    # aligned. Keep the ratchet exact after the import/decorator expansion.
-    # fix(#1005): +32 — _record_image_capture, the shared write for both
-    # image-upload endpoints. Its docstring carries the part that is easy to
-    # get wrong: Map.updated_at has onupdate=func.now(), so dropping the
-    # explicit assignment does not stop the bump. Ratchet stays exact.
-    # fix(#941): +8 — the reworded add-layer history summary carries the reason
-    # the immediate-POST and save-diff writers say different things, so a later
-    # refactor does not collapse them. Ratchet stays exact.
-    # fix(getgeolens.com#86 review): +35 — five read-gated GETs (list, single
-    # map, access, thumbnail, og-image) gained per-route
-    # `responses={403: FORBIDDEN_RESPONSE}` overrides; get_map_history_endpoint
-    # keeps the router's write-flavored default since it genuinely requires
-    # edit_metadata + ownership. Cap 1425 -> 1460, exact.
-    # feat(#1691): +9 — the check_public_visibility_allowed gate on the map
-    # update route (a non-admin may not move a map TO public when
-    # restrict_public_visibility is on). Cap 1460 -> 1469, exact.
-    # fix(#1778): +19 — the three call sites that discard a map's stored
-    # thumbnail / OG-image objects, plus the comments recording why each key is
-    # snapshotted before the write commits (after it, every attribute on
-    # map_obj is expired and a lazy refresh would raise) and why the extension
-    # flip strands a key at all. Cap 1469 -> 1488, exact.
-    # fix(#1778 round 1): +9 — the import route answers 422 for the per-map
-    # layer limit, above the generic ValueError arm it subclasses, with the
-    # comment saying why that order is load-bearing. Cap 1488 -> 1497, exact.
-    # fix(#1778 round 2): +12 — the three asset call sites take the row lock
-    # that serializes a map's thumbnail and OG-image replacements, plus the
-    # comments recording what the race produced (a committed URI pointing at an
-    # object the other request had already deleted, both requests 204, the
-    # endpoint 404 from then on) and why the lock is taken after payload
-    # validation rather than at the top of each handler. The 404 for a
-    # concurrently deleted map lives in the helper, not repeated three times.
-    # This crosses the 1500 glob default the allowlist overrides, which is what
-    # this entry is for. The seam if it grows again is the asset surface: the
-    # thumbnail and OG-image routes move to router_assets.py, which already
-    # exists and holds 142 lines. Cap 1497 -> 1509, exact.
-    # fix(#1778 round 3): +1 — the two image keys come from new_map_asset_key,
-    # which never returns a name twice. Cap 1509 -> 1510, exact.
-    # fix(#1778 round 4): +16 — both upload handlers publish the object and the
-    # row that names it inside one rollback scope, so a failure between the put
-    # and the commit does not leave an undiscoverable object under maps/.
-    # Cap 1510 -> 1526, exact.
-    # fix(#1778 round 5): +8 — both handlers settle the publication on the
-    # commit inside _record_image_capture, so a failure after it cannot roll
-    # back an object the committed row names. Cap 1526 -> 1534, exact.
-    # fix(#1778 round 6): +11 — the commit moved out of _record_image_capture so
-    # each handler can mark its publication immediately before awaiting it, and
-    # a commit that made the row durable but never acknowledged it deletes
-    # nothing. Cap 1534 -> 1545, exact.
-    # fix(#1778 round 7): +9 — the ledger entry moved above the write it covers,
-    # with the comment saying why that is free: object storage can durably
-    # accept a PUT and still fail the client, and the key is never reused, so a
-    # rollback delete either cleans up or no-ops. Cap 1545 -> 1554, exact.
-    # fix(#1778 round 9): +18 — lock_map_for_asset_write moved to after storage.put
-    # in both image handlers, so a stalled write no longer holds the map row
-    # locked; previous_key is now read under the lock, after the write, so two
-    # concurrent uploads reap each other's key correctly instead of racing on
-    # a stale read. Most of the growth is the docstring explaining why the
-    # lock has to move rather than just gaining a shorter timeout of its own.
-    # Cap 1554 -> 1572, exact.
     "backend/app/modules/catalog/maps/router.py": 1507,
-    # fix(#474): thread negotiated languages through catalog search, cache keys,
-    # and OGC record serialization; fix(#475) adds Records array-query handling,
-    # including collection IDs, plus response-header and documented 400 parity.
-    # fix(#892): +4 — the per-dataset OGC collection extent moved off a bare
-    # to_shape().bounds read onto extent_to_bbox() so a seam-crossing extent
-    # serves the RFC 7946 west > east bbox. Ratchet stays exact.
-    # fix(#886): -5 — the aggregate collection extent moved off
-    # ST_AsGeoJSON(ST_Envelope(ST_Collect(...))) plus its GeoJSON coordinate
-    # fold onto rollup_bbox_columns()/rollup_bbox(), which also retires the
-    # module's last json import. Cap lowered 1432 -> 1427, still exact.
-    # fix(#1103): +13 — the OGC record's `lineage` property is access-checked
-    # per requester now (the sentence names the titles of the datasets an
-    # analysis output was derived from). The item endpoint keeps the roles
-    # check_dataset_access_or_anonymous already resolved; the list endpoint
-    # takes the batch form, one visibility query per page. Cap 1427 -> 1440,
-    # still exact.
-    # fix(#1290 review): +10 — the public-asset-key boundary. Rows are
-    # filtered where they are FETCHED so an internal key never enters a
-    # payload structure; `GET /datasets/{id}` had been building its assets
-    # straight off the ORM rows and leaked the archived original's href and
-    # filename to every viewer. Cap 1440 -> 1450, exact.
-    # fix(#1372 codex r2): +5 — the collections-list raster tiles link carries
-    # ?v=<tile_cache_version> like every rendered raster template.
-    # fix(#1327): +13 — the OGC record item counts the VRT's live member links
-    # instead of reading the in-flight generation's intended count, so this
-    # surface reports the composition being SERVED like every other one. Most
-    # of the lines are the comment explaining why the generation's own count is
-    # a fact about the attempt, not about the dataset. Cap 1455 -> 1468, exact.
-    # fix(#1671): the two pre-#1666 search compatibility shims are sunset --
-    # `_legacy_keywords_body`, the `_LEGACY_FILTER_LANG_PARAM` fallback, and
-    # the comments that only existed to explain them. Cap lowered
-    # 1536 -> 1489, exact.
-    # fix(#1778): +4 -- deterministic ORDER BY tiebreaker on the paginated
-    # per-dataset OGC collections query. Cap 1489 -> 1493, exact.
-    # fix(#1855): -1. The facets rate-limit note shrank when the endpoint
-    # gained the SEC-S11 limiter. Cap 1493 -> 1492, exact.
-    # fix(#1903): +52 — both search routes gain a claim-registry exempt_when
-    # (bounded, single-use, client-scoped, keyed off the route's own scope
-    # name) so the SPA's unordered paired request pays the SEC-S11 token
-    # once; no override_defaults, since the middleware already charges the
-    # global default unconditionally for this callable-valued limit
-    # (test_semantic_search_rate_limit_1778.py). Cap 1380 -> 1432, exact.
-    # fix(#2007): +1. The advertised raster template is built by the shared
-    # cache-key helper. Cap 1432 -> 1433, exact.
     "backend/app/modules/catalog/search/router.py": 1433,
-    # fix(#474): negotiate localized STAC record text; fix(#475) adds the
-    # unassigned Collection and matching HTTP Link navigation. fix(#506): keep
-    # validated STAC item responses wire-compatible with serializer output.
-    # STAC hardening (roadmap trust batch): collection license aggregated from
-    # member records, item-less collections hidden from the STAC surface
-    # instead of advertising a fabricated global extent, and stac-api-validator
-    # conformance (strict RFC 3339 datetime gate, bbox/intersects exclusivity,
-    # south<=north bbox check, limit clamping). Ratchet stays exact.
-    # fix(#886): -7 — both Collection extent queries drop their four repeated
-    # ST_XMin/ST_YMin/ST_XMax/ST_YMax(ST_Extent(...)) columns for one
-    # rollup_bbox_columns() splat, and _parse_extent_row folds the row through
-    # rollup_bbox(). Cap lowered 1796 -> 1789, still exact.
-    # feat(#765): +44 — _visible_derived_from_id resolves the rel="derived_from"
-    # source against the same published+visible query the item endpoints serve
-    # from, and user/user_roles are threaded to the four item builders that
-    # feed it. Cap 1789 -> 1833, still exact.
-    # fix(#1103): +10 — the STAC item's lineage property is gated the same way
-    # as its derived_from link, on the user/user_roles already threaded here.
-    # Cap 1833 -> 1843, still exact.
-    # fix(#1108 review): +27 — the two item-page loops precompute lineage
-    # visibility for the whole page (one query, mirroring PERF-5's
-    # spatial_extent_geojson) instead of one round trip per item at limit=200.
-    # Cap 1843 -> 1870, still exact.
-    # fix(#1432): -15 — the two inline bbox parsers and
-    # _require_finite_bbox collapse onto the shared parse_bbox, which now takes
-    # the POST list as well as the GET string. Cap 1870 -> 1855, still exact.
-    # refactor(stac): -1 — the raster-asset reads go through CatalogPort, so
-    # the DatasetAsset select and the deferred raster-queries import give way
-    # to port calls. Cap 1855 -> 1854, still exact.
-    # fix(#1778): +15 -- deterministic ORDER BY tiebreakers on the two
-    # paginated item queries, the open-ended interval-datetime fix, and
-    # replacing the four nested async_session() pool checkouts in
-    # get_collections with sequential reuse of the caller's own session.
-    # Cap 1854 -> 1869, exact.
-    "backend/app/standards/stac/router.py": 1851,  # Lowered after readability cleanup.
-    # Central tenant-bound scope resolution replaced duplicated inline logic.
-    # fix(#836): +1 — the RASTER_FAMILY_RECORD_TYPES import that replaces four
-    # pasted family literals. Same +1 on the stac and search routers.
-    # fix(#868): +3 lines for the cluster cache-key SQL-semantics version
-    # ("v2") so deploys that change cluster tile geometry invalidate Valkey.
-    # fix(#892): +2 — the raster tile-token bounds moved onto
-    # extent_to_span_bbox() so a seam-crossing extent cannot feed a negative
-    # span into the maxzoom derivation.
-    # fix(#887): +17 — extent_to_span_bbox reports -180..180 for a two-ring seam
-    # extent, which understates a Pacific raster's resolution by 36x and drops
-    # its maxzoom by five levels, so the honest width now travels alongside the
-    # bounds as an explicit `lon_span` keyword.
-    # Merge of the carve-outs: 2043 base + 3 + 1 + 2 + 17. Ratchet stays exact.
-    # fix(#929 review): -22 — _resolve_raster_access's inline RBAC mirror
-    # replaced with delegation to the permission extension via the port.
-    # fix(#939): +23 — the degrees-vs-metres decision in
-    # _native_resolution_meters moved off `epsg == 4326` onto the stored WKT
-    # (wkt_is_geographic + wkt_has_degree_unit), with the grads fall-through
-    # documented at the site. Ratchet stays exact.
-    # fix(#957): +12 — raster_auth_check dropped out of the OpenAPI schema, and
-    # the note recording that the ROUTE is vestigial while the HANDLER is on the
-    # live raster tile path sits at the decorator so nobody deletes the wrong
-    # half. Ratchet stays exact.
-    # fix(#688): +73 — the raster tile template is signed like its vector
-    # sibling (mint in _build_tile_token_for_dataset, verify in
-    # _resolve_raster_access via _has_tile_signature/_verify_raster_tile_signature).
-    # Before this a client following the contract literally received an
-    # unauthenticated template for a private raster. Ratchet stays exact.
-    # fix(#1372): +6 — the signed raster template also carries
-    # ?v=<tile_cache_version> (outside the signature, like the colormap
-    # params) so nginx's $arg_v cache-key segment rolls on replace.
-    # fix(#1372 codex r3): +19 — the auth check refuses to mark a response
-    # cacheable when its `v` mismatches the dataset's current version, so a
-    # predictable future key can never be pre-warmed with pre-replace bytes.
-    # fix(#1372 codex r4): +12 — the check mirrors nginx's $arg_v semantics
-    # (first occurrence, case-insensitive name), closing the duplicate-param
-    # and name-case parser-disagreement variants of the same pre-warm attack.
-    # fix(#1329): +64 — the raster meta cache key carries the request's `v`, so
-    # the three in-place pointer swaps (reupload, VRT regeneration, STAC
-    # moved-asset refresh) invalidate every api process's snapshot with the
-    # version bump they already do, instead of each process serving the
-    # pre-swap href for a TTL. Most of it is the note recording WHY it is the
-    # request's `v` and not the row's: the row's version arrives through the
-    # same cached snapshot, so it is exactly as stale as the href it would be
-    # guarding.
-    # fix(#1329 codex P1): +13 — the lookup key is the request's `v` but the
-    # STORE key is the resolved row's, so no caller can name the entry it
-    # writes and a predictable future `v` can no longer park a pre-swap
-    # snapshot on the key the swap is about to make legitimate.
-    # fix(#1778): +35 — `_resolve_raster_access` hands its API-pool connection
-    # back before returning, so the caller's Titiler round trip (up to three
-    # attempts at a 30s timeout plus backoff) no longer runs with the catalog
-    # read's transaction open. Most of it is the note recording that the release
-    # belongs in the resolver rather than at either call site, and the correction
-    # to the #1329 cache-key note, which priced a cache-busting `v` as one extra
-    # indexed read and left out the connection that read pinned. Four of the
-    # lines say at the `cols=` call site that the dataset's column set now gates
-    # the cache key, since the handler docstring above it is the published
-    # operation description and saying it there churns every generated SDK.
-    # fix(#1778 codex P1): +14 — that call site now hands `parse_cols_param` the
-    # zoom, the allowlist and the route mode, because validating the names was
-    # not enough: at z >= 10 the zoom default already projects every column, so
-    # every valid subset of a wide table produced one set of bytes under its own
-    # key. The key comes from the effective projection now, and each call site
-    # says which of its inputs decide that.
-    # fix(#1778 codex r2): +26 — pmin/pmax/sigma are now validated only when
-    # the ACTIVE stretch mode reads them (percentile for pmin/pmax, stddev for
-    # sigma), not whenever merely present. frontend/nginx.conf's raster
-    # proxy_cache_key blanks an inactive value out of the cache key so a
-    # random one cannot defeat the cache, and that is only safe if "inactive"
-    # means the SAME thing, ignored, on both sides — otherwise a value nginx
-    # blanks could still turn a cached 200 into what would have been a 422.
-    # Most of the growth is the docstring and Query() description updates
-    # recording that contract for both parameters and the endpoint.
-    # fix(#1778 codex r8): +41 — eff_pmin/eff_pmax/eff_sigma used to be
-    # resolved from "was the parameter merely present", independent of
-    # stretch mode, so an INACTIVE parameter's raw (unvalidated) request
-    # value still reached _fetch_band_statistics/_compute_stretch_rescale.
-    # `?stretch=stddev&pmin=1e309` (inf) reached `int(pmin)` there and
-    # raised an uncaught OverflowError, while nginx — which treats a value
-    # it blanks as harmless — found `1e309` inside its canonical float
-    # grammar and blanked it, sharing a cache key with a plain stddev
-    # request: a cached 200 once warm, a 500 cold. eff_pmin/eff_pmax/
-    # eff_sigma now gate on the SAME activity test the validation below
-    # already used, so an inactive parameter's raw value is never read by
-    # anything, and the validation itself now requires math.isfinite() on
-    # the active path explicitly rather than relying on inf/nan's
-    # comparison behavior to fail the existing bound check.
-    # Ratchet stays exact.
-    # fix(#1770 round 40 P2): +1. The raster tile proxy's two retry-path
-    # `error=str(exc)` sites become `error=redact_exception_text(exc)`,
-    # net +1 after the new import. Cap 2706 -> 2707, exact.
-    # fix(#1770 round 47b P2 class): +14. `max_num_fields=MAX_QUERY_FIELDS`
-    # on the `{fmt}` buried-query recovery parse, the one attacker-reachable
-    # site in this round's sweep (unauthenticated, no source registration
-    # needed), with a `try/except ValueError` degrading to "no buried
-    # params recovered" rather than a raw 500. Cap 2707 -> 2721, exact.
-    # chore(#1873): review-history comments trimmed, and the route docstrings
-    # rewritten as published API descriptions. Cap 2721 -> 2386, exact.
-    # fix(#1928): +18. The signed-template check moved ahead of the vector
-    # path's visibility split, so one signature answers alike on every tile
-    # route and the dataset decides cache scope. Cap 2386 -> 2404, exact.
-    # fix(#1926): +6. The tile-pool acquire is bounded by the pool's command
-    # timeout, so an exhausted pool reaches the 429 the handler already
-    # carries instead of waiting forever. Cap 2404 -> 2410, exact.
-    # fix(#1929): +4. Every malformed tile path answers 400, and the parser
-    # docstring says why a syntactically invalid path discloses nothing the
-    # route's 404s keep back. Cap 2410 -> 2414, exact.
-    # fix(#1926, #1928, #1929): +19. The two published tile descriptions now
-    # state the authorization, malformed-path and 429 answers the code gives
-    # after those three changes. Cap 2414 -> 2433, exact.
-    # fix(#1959 review): +2. Those descriptions name all three 429 cases, and
-    # no longer claim every query failure is a 503 or that the cold-storage 202
-    # reaches a deployment without it. Cap 2433 -> 2435, exact.
-    # fix(#1963): +17. Mint and verify derive the signed scope through the one
-    # shared helper, and both meta snapshots carry the publication counter that
-    # scope binds. Cap 2392 -> 2409, exact.
-    # fix(#2007): +71. The two nginx cache-key params are read through one
-    # helper the edge and the api share, a mismatched one loses the shared
-    # cache on all three routes, and the vector/cluster key carries the
-    # publication counter, off the same snapshot that authorized the request.
-    # Cap 2409 -> 2480, exact.
+    "backend/app/standards/stac/router.py": 1850,
+    # Authorization, acquisition order, and cache rehydration share this route boundary;
+    # the Enterprise overlay statically pins _check_cold_rehydrate here.
     "backend/app/processing/tiles/router.py": 2480,
-    # feat(#565): the SQL sandbox validator crossed 1000 lines across the codex
-    # rounds on the query endpoint: the lexical CTE-scope fix (P1) and its
-    # pg_catalog.pg_user rationale, the declaration-order refinement (P1 r2),
-    # the transitive fan-out cost model (P1 r3) — _resolve_cte plus the
-    # rows/work graph walk that catches a CTE chain multiplying one base table
-    # to N^8 while every per-name count stays at 2 — and the per-row correlated
-    # subquery term (P1 r4, _correlated_scopes/_work_fanout) that costs a
-    # self-join hidden in a scalar/EXISTS/WHERE subquery. P1 r5 extended the
-    # per-row term to JOIN ... ON predicates (a join's ON is not a source), and
-    # P2 r5 taught _resolve_cte that a WITH can be owned by a set operation, not
-    # only a SELECT; P1 r6 unwraps exp.Lateral so a repeated table hidden in a
-    # LATERAL source is costed; P1 r7 adds a LATERAL's own internal per-row work
-    # (its excess over its row count) so a correlated subquery inside a LATERAL
-    # is bounded too; P1 r8 costs a parenthesized FROM join group's rows; and P1
-    # r9 unifies group costing (_group_work/_add_source_excess/_outermost_scopes)
-    # so a group's ON-predicate and internal LATERAL work is a first-class
-    # candidate in the statement-wide max; P1 r10 propagates a CTE reference's
-    # own internal work (an inlined / NOT MATERIALIZED CTE re-executes per outer
-    # row) through _add_source_excess; P1 r11 rejects casts to OID-alias types
-    # (regrole/regclass/…) that resolve catalog names with no table reference;
-    # and P1 r12 matches those casts by normalized name (schema-qualified
-    # pg_catalog.regrole is a DataType, not ObjectIdentifier), folds CTE
-    # identifiers per PostgreSQL quoting so "PG_USER" cannot bind an unquoted
-    # pg_user, and propagates ordinary derived-table excess; and P2 r13
-    # combines sibling per-row subquery/source work by per-table MAX rather than
-    # summing (_merge_max), so two scalar subqueries over one table no longer
-    # false-reject; and P2 r14 splits per-row work into per-INPUT (WHERE/JOIN-ON/
-    # sources) and per-OUTPUT (projection/HAVING/ORDER), collapsing the latter's
-    # multiplier for an ungrouped aggregate (_is_ungrouped_aggregate) so a
-    # projection subquery over an aggregate query is additive, not multiplied;
-    # and P1 r15 keeps a subquery beneath an aggregate ARGUMENT per-input (it
-    # runs per input row) so that reduction cannot hide it; P1 r16 costs
-    # subqueries buried in a non-scope LATERAL (VALUES/function) and adds a
-    # per-STATEMENT bucket (LIMIT/OFFSET, evaluated once, no row multiplier);
-    # and P1 r17/r18 counts a VALUES relation as a fan-out source under ONE
-    # shared key so distinct constant sources combine in the cross-product,
-    # caps VALUES cardinality, threads an endpoint-only extra-blocked-function
-    # set (output-amplifying format/replace/regexp_replace/concat + defensive
-    # siblings), and P1 r19 blocks the `||` (exp.DPipe) concatenation operator
-    # when concat is blocked (chained s||s doubling); P1 r20 adds the
-    # cross-product degree (_XPROD_KEY / _join_is_constrained: distinct tables
-    # cross-joined multiply even at per-table exponent 1) and an output-column
-    # cap (repeated projections amplify response width). P1 r21 makes the join
-    # constraint recursive (an equality inside `... OR TRUE` does not constrain)
-    # and counts composite-constructor value slots / rejects `*` for the width
-    # cap. r22 documents the runtime floor: the fan-out/width model is
-    # best-effort pre-filtering, non-security, because every executed query is
-    # runtime-bounded (advisory lock, semaphore, timeout, reader role, row+byte
-    # caps) — the module docstring and a section anchor state it so cost-model
-    # under-counts are documented, not chased. r23 folds unquoted table
-    # identifiers (DATA.ROADS → data.roads) before the access check so a
-    # PostgreSQL-valid reference is not false-404'd. Most of the added lines are
-    # that rationale. Cap at the exact size.
-    # fix(#1778): +63 — _BLOCKED_NILADIC_KEYWORDS and _check_niladic_keywords,
-    # which reject PostgreSQL's parenless identity keywords. sqlglot gives only
-    # some of them a Func subclass, so `user`, `current_role` and `system_user`
-    # parsed as columns and slipped the allowlist walk entirely; the comments
-    # record that parse-shape dependency so a sqlglot bump does not quietly
-    # reopen it. The rest is the TokenError note at the parse site. Cap
-    # 1871 -> 1934, exact.
-    # chore(#1873): review-history comments trimmed. Cap 1934 -> 1673, exact.
-    # fix(#1892): +21 — _strip_statement_terminator cuts at the first of the
-    # trailing SEMICOLON tokens, so no `;` run can break the executor's LIMIT
-    # wrapper and one inside a literal or comment is left alone. Cap 1670 ->
-    # 1691, exact.
     "backend/app/platform/sandbox/validator.py": 1691,
-    # fix(#1778): crossed the 1000-line inclusion threshold, so it joins
-    # the ratchet at its exact size. The growth is the token accounting on
-    # the two map-generation failure exits (an exhausted or timed-out loop
-    # is billed by the provider and used to record nothing), the fixed
-    # error message replacing raw exception text in the SSE stream, and the
-    # scrubbing of dataset content in the two catalog tool results.
-    # fix(#1778 round 1): +3 - the SSE error branch passes only an explicitly
-    # constructed UserFacingAIError through, so the five deliberate refusals
-    # say so by type instead of every ValueError being trusted (
-    # OpenAICredentialDestinationError is one, and its message IS the endpoint).
-    # fix(#1778 round 2): +11 - every provider call site moved to the shared
-    # usage_accounting context manager, including the two single-round repair
-    # calls that had no failure accounting at all, and the map prompt gained
-    # the tool-result protocol that says what the fence markers mean.
-    "backend/app/processing/ai/service.py": 998,  # Lowered after readability cleanup.
-    # fix(#1463): crossed the inclusion threshold. The growth is the vector-tile
-    # protocol constants and the stale-label repair in generate_distributions,
-    # plus the comment recording why the repair has to exist at all: migration
-    # 0048 is one-shot and the scripted upgrade runs it while the previous
-    # release is still writing rows (#1467), so the template is not the only
-    # place that has to know the old value.
-    # fix(#1463 codex r4): +6 — the same comment recording what the repair does
-    # NOT reach. Both refresh callers gate reconcile on a modality flip, so
-    # naming it a closer for the deploy window was wrong; the correction is
-    # worth more than the six lines. Cap at the exact size; the module is
-    # otherwise a stable set of CRUD helpers over the record's related tables
-    # and is not where new domains should land.
-    # feat(#1681): +10 — the FlatGeobuf export format joined
-    # `_DISTRIBUTION_TEMPLATES` (a download row, matching every other export
-    # format already in that table) plus a docstring update to the row count
-    # it now generates.
-    # feat(export/pmtiles): +9 — PMTiles joined `_DISTRIBUTION_TEMPLATES` the
-    # same way, plus the row-count docstring update.
-    # fix(#1778): +3 -- RecordContact.id tiebreaker on the paginated contacts
-    # list, sort_order being a non-unique server-default. Cap 1026 -> 1029,
-    # exact.
-    # fix(#2007): +17. The distributions endpoint reads the dataset counter a
-    # stored tile template is republished at. Cap 883 -> 900, exact.
-    "backend/app/modules/catalog/records/service.py": 887,  # Lowered after readability cleanup.
-    # fix(#1528): crossed the inclusion threshold, and this is the file the
-    # inclusion rule's own comment named as one of the two "routers-by-role the
-    # glob's filename match cannot see ... watched by nothing until they cross
-    # 1000". It just did.
-    #
-    # What the lines bought: HEAD and byte-range service on
-    # /datasets/{id}/download/cog. A COG exists to be read by range — client
-    # reads the header, fetches only the tiles it needs — and this endpoint
-    # served neither, so GDAL /vsicurl/ could not open it at all (measured:
-    # ERROR 4, not a slow download). The additions are the Range parser and its
-    # RFC 9110 ignore/clamp/416 rules, a chunked range streamer that keeps a
-    # multi-GB range off the heap, the 200/206/416 response shapes, and
-    # _local_cog_response, which exists because folding three representations
-    # into a handler that already branches over three storage backends put
-    # download_cog past ruff's C901 ceiling.
-    #
-    # Roughly half the diff is comment: which starlette behaviour each explicit
-    # header displaces, and why HEAD here carries a Content-Length where the
-    # export route's deliberately omits one. Cap at the exact size. The DCAT
-    # feed handlers above are the natural split if this grows again.
-    #
-    # +93 for the two fix(#1540) review findings. P1 pulled the object stat and
-    # the HEAD response out of _local_cog_response into _cog_object_size /
-    # _cog_headers / _cog_head_response so the `s3` branch can answer HEAD from
-    # metadata instead of redirecting to a URL signed for GET — sharing them is
-    # what makes HEAD provably identical on both backends, and it moved the long
-    # explanatory comments from inline into three docstrings. P2 added
-    # _range_int, which saturates every Range numeric field before int() so a
-    # 4301-digit header cannot raise ValueError into a 500.
-    #
-    # +7, all prose. The double-stat review finding DELETED code — _cog_object_size
-    # now calls size() once and maps its FileNotFoundError to 404 instead of asking
-    # exists() first — and the lines are the paragraph saying why the second
-    # head_object was worth removing: it doubled the round trips and the request
-    # charges on every /vsicurl/ probe, against a design chosen for costing one,
-    # and the gap between the two calls turned a deleted object into a 503.
-    #
-    # +90 for the range validator, which is what finishes the range feature rather
-    # than extending it. _cog_etag publishes the COG's own sha256 as a strong ETag
-    # on every stored-bytes response, and _range_bound_to_this_version evaluates
-    # If-Range so a range resumed across a raster replacement returns the whole
-    # current object instead of a 206 the client appends to a prefix of the COG it
-    # is no longer reading. Ranges without a validator are how two COGs become one
-    # corrupt file with no error anywhere, so the explanation is on the two helpers
-    # and at the branch. If this file grows again, the DCAT feed handlers remain
-    # the natural split.
-    #
-    # +111 for the two halves of that binding the first pass missed. _s3_cog_response
-    # is an extraction, not new branching: the s3 block moved out of download_cog so
-    # it could evaluate If-Range before redirecting, which it has to do because the
-    # bucket does not (MEASURED: a presigned GET answers 206 for a non-matching
-    # If-Range) and a 302 cannot strip the client's Range on the way past. The rest
-    # is _if_none_match_matches and _cog_not_modified, so the ETag this route
-    # publishes can end a revalidation with 304 instead of another multi-GB body.
-    #
-    # +7, all comment. The stale-resume fallback now streams from one get_object
-    # rather than _iter_storage_range over the whole object, which issued a ranged
-    # request per 1 MiB — 5,120 of them for a 5 GiB COG, selectable by any caller
-    # willing to send a stale validator and counted by the rate limiter as one
-    # request. The lines say which of the two streaming helpers belongs where.
-    #
-    # +4 net, and the code went DOWN: `_iter_storage_range` is deleted. Serving a
-    # range by calling get_range per 1 MiB issued an object-store request per
-    # chunk on the ORDINARY path this time, which on an S3 or Azure deployment is
-    # every managed raster's range request. Only the provider can ask for a window
-    # once and stream the answer, so `get_range_stream` is where the bound lives
-    # now; what is left here is the note saying why a helper that turns one range
-    # into N reads was removed rather than retuned.
-    #
-    # +53 for If-Match. A resuming client may spell "only if this is still my
-    # representation" as If-Match rather than If-Range, and honouring one while
-    # ignoring the other left the absent If-Range reading as permission — the
-    # same splice through the other header. _if_match_passes is strong comparison
-    # with * handling, _this_service_owns_the_bytes names the rule that already
-    # governed the remote branch's blank validator row, and the 412 carries the
-    # ETag that IS current so a refused client can restart in one round trip.
-    #
-    # +36 for the last two review findings. If-Match had to be reachable from a
-    # browser (the CORS half is enforced by a test now, not a memory), and the
-    # precondition block had to stat the object before answering: a row whose
-    # bytes are gone answers 404 unconditionally, so a 304 there told a cache its
-    # stale copy was current for a representation that no longer exists. That
-    # stat is handed down through _cog_size_once so a conditional request that
-    # goes on to transfer bytes still measures once, and _managed_key names the
-    # tenant-key seam the block now crosses in a second place.
-    #
-    # fix(#1554): +30, and 3 of them are code. `If-None-Match: *` is evaluated
-    # whatever the row's digest is, because RFC 9110 section 13.1.2 makes the
-    # wildcard a question about whether a representation EXISTS rather than
-    # about which one it is — so a row predating the sha256 column answered a
-    # revalidation by transferring the whole COG. The rest is the reasoning
-    # this route keeps needing on hand: why the wildcard is checked before the
-    # digest and the specific tags after it, why a 304 with no ETag is the
-    # right answer rather than a gap to fill, and why an unconditional 304 is
-    # licensed here at all (this path serves GET and HEAD, and the section
-    # gives `*` a different answer for anything that would create a
-    # representation). Cap 1656 -> 1686, exact.
-    # fix(#1532): -97, the first time this cap has come DOWN. The byte-range
-    # parser moved to app/platform/http/ranges.py because the export download
-    # needs the same one and lives under processing/, which may not import
-    # modules/catalog/. Nothing about the parsing changed; it is the same file's
-    # worth of reasoning, now in a place both callers can reach.
-    # fix(#1532 review r1): -18 more. `_range_bound_to_this_version` followed the
-    # parser into the shared module, because the export route has to evaluate the
-    # same If-Range precondition and a second implementation of strong comparison
-    # is how the two would drift.
-    # fix(#1532 review r9): -81 more, same reason a third time. If-Match,
-    # If-None-Match and the 304 builder went to app/platform/http/ranges.py so
-    # the export download can evaluate the same preconditions against the same
-    # kind of strong ETag. Everything seven review rounds settled travelled with
-    # them; only the home changed. Cap 1686 -> 1490, exact.
-    # fix(#1693): +48. _resolve_download_user's no-auth-signal
-    # case now returns None instead of an unconditional 401 (mirroring
-    # get_optional_user, what /export's dependency already does), so
-    # download_cog's existing check_dataset_access_or_anonymous +
-    # public-visibility gate — previously unreachable for a plain anonymous
-    # GET — actually runs. download_cog's authenticated branch also now
-    # routes its capability check through get_permission_extension() instead
-    # of inlining the matrix lookup, matching export_dataset_endpoint. The
-    # docstring (published OpenAPI description) is left untouched to avoid
-    # openapi.json/SDK/CLI churn; the new None case is explained in a plain
-    # comment instead, same as the file already does for the HEAD/GET
-    # docstring split above it. fix(#1693 codex r1): +10 more —
-    # `if qt:` -> `if qt is not None:` so a present-but-empty ?token= 401s
-    # through the existing PyJWTError path instead of falling through to the
-    # new anonymous return None as if no token were supplied. Cap
-    # 1490 -> 1548, exact.
-    # fix(#1778): +3 lines — download_cog documents the
-    # 412 its If-Match branch raises, closing a gap the repaired
-    # OpenAPI-contract gate surfaced. Cap 1548 -> 1551, exact.
-    # fix(#1778): 1551 -> 1602 -> 1632. +81 for `_cog_presign_seconds` and the
-    # note above it. The s3 branch signed the redirect for a flat 3600 seconds,
-    # which exchanged the 120-second, dataset-scoped, revocable download token
-    # SEC-04 mints for an hour-long bearer URL the bucket will honour after the
-    # grant is revoked. The last 30 are the codex r8 round, which removed the
-    # 60-second floor the first pass had put under the window: a token with one
-    # second left still bought a minute of access to a private COG. Those lines
-    # are the refusal that replaced it and the reason it has to be a refusal,
-    # quoting `require_signable_job_lifetime`, which settled the same question
-    # for the upload doors under #1235.
+    "backend/app/processing/ai/service.py": 998,
+    "backend/app/modules/catalog/records/service.py": 887,
     "backend/app/modules/catalog/datasets/api/router_export.py": 1484,
-    # fix(#1532 review r29): first entry — crossed _RATCHET_INCLUSION_LOC. The
-    # export artifact cache: everything is in the key (stamp, size, digest,
-    # nonce), freshness and reclamation read one publication bound that is a
-    # pure function of the object and clamps both clocks by the edge's request
-    # budget, publication hands a lost race its incumbent, and the sweep, the
-    # budget and the contested rule all read the same listing. Most of the
-    # length is the reasoning from twenty-nine review rounds, kept next to the
-    # rules it justifies. Cap 1020, exact.
-    # fix(#1532) follow-up (#1585): +70 — the selection key becomes URL
-    # segment / version segment, so every version of one URL shares a prefix,
-    # and `url_answered_other_bytes_recently` asks that prefix whether the URL
-    # answered with different bytes inside the last TTL: for that TTL bare
-    # ranges are whole, which is what lets a fresh build honour the leading
-    # Range of a cold GDAL open without reopening the splice, on the hit path
-    # too. Cap 1020 -> 1090, exact.
-    # chore(#1873): review-history comments trimmed. Cap 1090 -> 616, exact.
     "backend/app/processing/export/artifact_cache.py": 559,
-    # fix(#1548 review P2): crossed the inclusion threshold. The growth is
-    # assert_domain_lock_is_enforceable — the write-side precondition that
-    # refuses a domain lock this deployment could never enforce, because
-    # PUBLIC_APP_URL ships defaulted to localhost in both compose files and the
-    # #1531 read-side fix is inert for anyone who leaves it there. Most of the
-    # lines are the docstring, and they are the point: it records why the
-    # serving origin is never INFERRED (every unconfigured source is
-    # caller-controlled, so an inferred self-origin would be satisfiable by
-    # exactly the parties a domain lock excludes) and why the refusal condition
-    # is the narrow one, naming the two weaker predicates that were tried and
-    # what each gets wrong. Cap at the exact size. This module is the embed
-    # token domain end to end — CRUD, the single policy reader both validators
-    # share, and now this precondition — and is not where new domains belong.
-    # fix(#1548 review r2): +16 — get_active_embed_token, so the PATCH handler
-    # can settle whether the token exists BEFORE applying the precondition
-    # above. Asked in the other order, a deployment-level refusal answered for
-    # a stale or concurrently revoked token id and told its owner to go
-    # reconfigure PUBLIC_APP_URL. The router and update_embed_token share the
-    # one query rather than carrying a copy each. Cap 1013 -> 1029, exact.
-    # fix(#1548 review r8): +9 — gate the self-origin candidates on
-    # is_usable_public_origin before normalizing them. The comment is most of
-    # it, and it records why the order matters: _normalize_origin PREPENDS
-    # https:// to anything without an http(s) scheme, so an environment value of
-    # ftp://maps.example.com arrived as the plausible non-loopback origin
-    # https://ftp: and convinced the domain-lock gate the deployment was
-    # configured. Cap 1029 -> 1038, exact.
-    # fix(#1548 review r9): +4 — depend on get_configured_public_app_url and
-    # bail when it is None. get_public_app_url is a RESOLVER: with PUBLIC_APP_URL
-    # unset it derives an app URL from an /api-stripped PUBLIC_API_URL, and a
-    # split app/API deployment then had the API host accepted as a self-origin,
-    # so a lock was issued that every shell request missed. Cap 1038 -> 1042.
-    # fix(#1555): +14, all comment except two lines. _is_localhost_origin now
-    # asks is_loopback_host (app/core/public_urls.py) instead of an enumerated
-    # set of three spellings, because 127.0.0.0/8 is loopback in its entirety
-    # and http://127.0.0.2:8080 was read as a routable public origin — enough
-    # for the gate to issue a domain lock every recipient resolves to their own
-    # machine. The rest records why _LOOPBACK_CLIENT_IPS stays an exact set:
-    # that one GATES the localhost bypass, so a miss there denies, while a miss
-    # in the other ISSUES an unenforceable lock. Cap 1042 -> 1056.
-    # fix(#1778): +44, almost all comment. Revocation now stamps a denial over
-    # the validation-cache entry instead of deleting it, and the validator
-    # publishes its positive entry with set_if_absent, so a request that raced
-    # an uncommitted revoke cannot re-cache the token for the rest of the TTL.
-    # The four eviction sites collapse into one _deny_revoked_embed_tokens
-    # helper; the rest records the interleaving, why deleting the key cannot
-    # close it from either side, and the fail-closed trade a rolled-back
-    # revocation makes. Cap 1056 -> 1100.
-    # fix(#1778 codex r1): +6, all comment. The denial write is
-    # set_authoritative, not set: `set` routes to whichever store the circuit
-    # breaker says is live, so a positive that landed in the in-memory fallback
-    # during an outage survived a denial written after Redis recovered.
-    # Cap 1100 -> 1106, exact.
-    # fix(#1778 codex r3): +52. The fallback and the replay queue are
-    # PROCESS-local and production runs several Uvicorn workers, so a revoke on
-    # one worker during a Redis outage reached no other. Reads and writes of the
-    # validation entry now pass security=True (never answer an authorization
-    # positive from this worker's memory), every positive is stamped with the
-    # cluster-global revocation generation and compared against it on each hit,
-    # and the revoke paths advance that generation. Most of the lines are the
-    # comment on EMBED_TOKEN_POSITIVE_TTL_SECONDS, which names the residual this
-    # bounds rather than closes, plus the note on what an unstamped pre-upgrade
-    # entry does. Cap 1106 -> 1164, exact.
-    # fix(#1778 codex r4): +10 for the comment saying why the generation bump
-    # shares the caller's transaction rather than running ahead of it, and why
-    # a failing bump must not be swallowed. Cap 1164 -> 1174, exact.
-    # fix(#1778 codex r5): +18. An unreadable counter yields a SENTINEL, not a
-    # generation, and two entries stamped with it compared EQUAL. The validator
-    # now refuses to trust or to write anything while the generation is
-    # unusable, so a positive cached during that window cannot outlive a later
-    # revocation. Cap 1174 -> 1192, exact.
-    # fix(#1860): +59. The mint took its dataset snapshot straight off the map's
-    # layers with no visibility filter and ignored who was asking, so a map
-    # owner who lost access to a layer could still freeze it into a fresh
-    # anonymous tile capability of up to 365 days. Adds
-    # _assert_scope_visible_to_minter and its EmbedScopeNotVisibleError, and
-    # moves the snapshot ahead of the revoke block. Most of the lines are the
-    # two docstrings, which carry the parts a later reader would otherwise
-    # simplify away: why the minter is resolved from user_id rather than passed
-    # in (so the row's created_by and the checked identity cannot diverge), and
-    # why the refusal has to precede the revoke (the cache denial it writes is
-    # not rolled back with the transaction). Cap 1192 -> 1254, exact.
-    # fix(#1860 audit P3): +1 for EmbedScopeNotVisibleError's docstring naming
-    # the 403 it is answered with. The maps-router siblings it copies its shape
-    # from answer 403, and the licensing refusal on the same handler answers
-    # 400, so the status is what separates "your deployment cannot do that"
-    # from "you cannot see that data". Cap 1254 -> 1255, exact.
     "backend/app/modules/embed_tokens/service.py": 1030,
-    # fix(#1778): first entry for this module — it crossed the 1000-line
-    # inclusion threshold on the property-filter typing. Property filters used
-    # to bind the raw query-string value, so PostgreSQL had no
-    # `bigint = character varying` operator and every non-text filter failed
-    # with 42883, which the OGC items handler reported as a retryable 503.
-    # The growth is the pg-type -> (parser, database type) table, the parsers
-    # that reject a non-finite float / an out-of-int8-range integer / an
-    # unparseable date, and the extracted `_property_filter_predicates`
-    # (get_features was at ruff's C901 ceiling without it). Roughly half is the
-    # comment recording WHY each numeric family keeps its own database type,
-    # which is a correctness property a future reader would otherwise collapse
-    # into one Float.
-    #
-    # The clean split when it next grows is the banner already in the file:
-    # everything below "Write operations" moves to a sibling module behind a
-    # re-export facade, because `standards/ogc/router.py` and
-    # `standards/stac/router.py` may import `features.service` and nothing
-    # else under features (_STANDARDS_MODULE_IMPORT_SURFACE), and several
-    # tests reach private names through it.
-    #
-    # fix(#1778): +80 for the bounded filtered count. The cached-feature_count
-    # fast path applied only to a COMPLETELY unfiltered request, so one bbox or
-    # property filter put a full filtered COUNT(*) on EVERY page, including the
-    # keyset pages whose whole point is constant-time access. The count now runs
-    # inside a LIMIT and the planner answers past the cap. Most of the growth is
-    # the comment on _FILTERED_COUNT_CAP recording what the cap buys and why the
-    # estimate is never reported below the rows already counted (a `next` link
-    # keyed on `offset + limit < total` would otherwise truncate pagination at
-    # the cap), plus the docstring on _planner_row_estimate saying why it is
-    # deliberately not wrapped in a try/except. Cap 1055 -> 1135, exact.
-    #
-    # fix(#1778): +52 for UnwritablePropertyError and is_writable_feature_column.
-    # A key naming a real column that _COLUMN_NAME_RE rejects used to be
-    # silently skipped by the write loop, so POST and PUT answered 201/200 with
-    # the value never stored, and PUT did not even NULL the column it documents
-    # as nulled. Most of the growth is the exception's docstring listing which
-    # producer of column_info admits which names, because the fix is a
-    # disagreement between two guards and a reader has to see both to keep them
-    # in step. Cap 1135 -> 1187, exact.
-    #
-    # fix(#1778): +197 for the incremental metadata refresh.
-    # `_refresh_count_and_extent` runs one unqualified COUNT(*) + ST_Extent over
-    # the whole table on every single-feature write, plus a second scan over
-    # ST_ShiftLongitude past 180 degrees of width and a third DISTINCT
-    # GeometryType for created datasets; there is no bulk feature endpoint, so a
-    # client digitizing 200 points paid it 200 times. The new pieces are
-    # geojson_bounds / feature_bounds (where the write touched),
-    # _stored_extent_box, _strictly_inside, _merged_created_geometry_type and
-    # _apply_incremental_metadata. Most of the growth is the reasoning each of
-    # them has to carry, because every one is a claim that a scan can be
-    # skipped: why the containment test is STRICT (a row on the boundary may be
-    # the row defining it), why a two-ring seam extent cannot be read as a box
-    # at all, and why the type merge is insert-only (a delete can narrow the
-    # derived type and no merge of the stored value can see that).
-    # Cap 1187 -> 1384, exact.
-    #
-    # fix(#1778 review r1): +107 for two review findings. The page now
-    # over-fetches one row and reports `has_more`, because a `next` link
-    # decided by `offset + limit < total` disappears with a full page on screen
-    # whenever the count is the planner's estimate; whether another row exists
-    # is a fact about rows, so FeaturePage carries it and no router re-derives
-    # one. And the envelope a write overwrites is captured BY the mutating
-    # statement (DELETE ... RETURNING, and a locking CTE for UPDATE) instead of
-    # by an unlocked SELECT before it, with the record row locked before either
-    # metadata path reads the extent. The lines are the two NamedTuples, the
-    # prior-bounds SQL helpers, and the comments recording which race each
-    # closes. Cap 1384 -> 1491, exact.
-    #
-    # fix(#1778 review r2): +16 for the range checks. A caller value can be a
-    # good Python number and still be wrong for the column, and how that failed
-    # depended on which cast the compiler emitted: the property-filter path
-    # answered 200 with zero features, the CQL2 path overflowed a real cast
-    # with SQLSTATE 22003, and a pagination int outside int8 could not be
-    # encoded at all. The lines are the two check calls, the int8 bound on
-    # limit/offset/after_gid, and the comments recording which of those three
-    # shapes each one closes; the tables and the messages live in
-    # core/db/pg_ranges.py, which standards/ogc/filtering.py reads too.
-    # Cap 1491 -> 1507, exact.
-    #
-    # fix(#1778 review r3): +34 for _floor_estimated_total. The r1 floor read
-    # `offset + len(rows)` unconditionally, which invented matches out of the
-    # offset: five features asked for at offset 100 answered an empty page and
-    # reported numberMatched 100, and a keyset page borrowed an offset its own
-    # query had ignored. Extracted rather than narrowed in place, because
-    # get_features was back at ruff's C901 ceiling and because each of the
-    # three conditions is a claim about what a page can PROVE -- an exact count
-    # is never raised, an empty page proves nothing, and a keyset page can
-    # prove only the rows in hand. That reasoning is most of the added lines.
-    # Cap 1507 -> 1541, exact.
-    # fix(#1847): the lock order, its gate and its 409 mapping. Cap 1560, exact.
-    # fix(#1988): +1. The `# codeql[py/sql-injection]` marker above the
-    # feature-update sink. Cap 1388 -> 1389, exact.
-    "backend/app/modules/catalog/features/service.py": 1386,  # Lowered after readability cleanup.
+    "backend/app/modules/catalog/features/service.py": 1386,
 }
 
 
@@ -6258,11 +1326,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
 def test_module_loc_caps_have_no_headroom() -> None:
     """Every ratchet must equal its file's current LOC.
 
-    A cap above the current size is permission to grow. The audit found 13, 3, and 29
-    spare lines in the three largest routers — each one the seed of the next
-    "cap raised to N, decomposition queued" comment.
-
-    Shrinking a file fails this too. Lower the cap in the same commit.
+    Shrinking a file also fails; lower its cap in the same change.
     """
     drift: list[str] = []
     for rel, cap in sorted(_MODULE_LOC_CAPS.items()):
@@ -6278,47 +1342,14 @@ def test_module_loc_caps_have_no_headroom() -> None:
         )
 
 
-# fix(#958): the inclusion rule, so a module's ABSENCE from _MODULE_LOC_CAPS is
-# a decision rather than an oversight.
-#
-#   Every module under backend/app/ at or above _RATCHET_INCLUSION_LOC lines
-#   that no OTHER size gate watches belongs in _MODULE_LOC_CAPS, ratcheted at
-#   its exact LOC.
-#
-# Why a rule and not another hand-picked entry. #836 added the four largest
-# non-routers by hand, which left the dict's membership a judgement nobody
-# wrote down: analysis_sql.py then grew 504 -> 651 through no gate at all, and
-# adding just that one would have ratcheted the 24th-largest ungated module
-# while five modules above 1000 lines stayed free to grow. A threshold is
-# arguable; an unwritten rule is not enforceable.
-#
-# Why 1000. It is where the modules this project has actually had to decompose
-# live (the Phase 226 / 238 / 252 splits all started past it), and the measured
-# distribution has a natural break there: a cluster at 1017-1201, then a gap
-# down to 990. A file below the line is not safe, just cheaper to fix later.
-#
-# Why "no OTHER gate" rather than unconditionally. A module a ceiling gate
-# already watches is not silent — it hits a wall, and whoever hits it ratchets
-# the file in, which is exactly how ingest/router.py got here. Ratcheting them
-# anyway would put exact caps on four routers sitting under the 1500 glob
-# ceiling and on maps/style_json.py, doubling the bookkeeping for files that
-# already fail loudly. This rule is about the modules NOTHING watches.
-#
-# The residue, recorded rather than papered over: a router.py at 1400 still has
-# 100 lines of silent runway under the glob default, and the two routers-by-role
-# the glob's filename match cannot see (datasets/api/router_export.py at 928 and
-# router_reupload.py at 922) are watched by nothing until they cross 1000. The
-# threshold catches them then. #958 also notes that any inclusion rule phrased
-# as "routers are covered by the glob" is inaccurate for exactly that reason,
-# which is why this one is phrased by size.
+# Every module at or above this threshold needs an exact cap unless another
+# size gate already covers it. The threshold catches large nonstandard router
+# names and other modules that filename-based gates miss, without duplicating
+# caps for files already governed by a ceiling.
 _RATCHET_INCLUSION_LOC = 1000
 
-# The globs of test_decomposed_service_modules_stay_within_size_budgets, as
-# (directory, filename prefix) pairs. fix(#958 review): the prefix alone is not
-# the gate. That test globs specific directories, so a `service_*.py` anywhere
-# else is watched by nothing — and a filename-only exemption here would have let
-# such a module past 1000 lines through both gates, defeating the rule this
-# file exists to state. Mirror the directories, not just the names.
+# Mirror the decomposed-module gate's non-recursive directory and prefix globs;
+# a matching filename elsewhere is not covered.
 _DECOMPOSED_MODULE_SCOPES: tuple[tuple[str, str], ...] = (
     ("backend/app/modules/catalog/maps/", "service_"),
     ("backend/app/modules/catalog/search/", "service_"),
@@ -6366,14 +1397,7 @@ def test_module_loc_cap_inclusion_rule_is_complete() -> None:
 
 @pytest.mark.architecture
 def test_decomposition_prefix_exemption_matches_the_gate_that_backs_it() -> None:
-    """The exemption is a directory scope, not a filename prefix.
-
-    fix(#958 review): ``test_decomposed_service_modules_stay_within_size_budgets``
-    globs specific directories, so a ``service_*.py`` outside them is watched by
-    nothing. A filename-only exemption would have let such a module grow past
-    the inclusion threshold through both gates — the exact hole this rule was
-    written to close, wearing a different name.
-    """
+    """Size-gate exemptions match both the directory and filename prefix used by the underlying non-recursive globs."""
     for directory, prefix in _DECOMPOSED_MODULE_SCOPES:
         inside = f"{directory}{prefix}example.py"
         assert _is_watched_by_another_size_gate(inside, f"{prefix}example.py"), (
@@ -6434,17 +1458,9 @@ def test_open_core_decomposition_boundaries_stay_clean() -> None:
 
 @pytest.mark.architecture
 def test_router_orchestrator_modules_stay_within_loc_cap() -> None:
-    """Phase 276 CODE-01: router and orchestrator modules stay <= 1500 LOC.
+    """Router and orchestrator modules stay within the shared ceiling.
 
-    Catches regrowth of large API-edge modules toward the size cliff that
-    triggered the Phase 226 / Phase 238 / Phase 252 decompositions.
-    Allowlisted modules are ratcheted at their current size (see _MODULE_LOC_CAPS).
-
-    Scope: ``backend/app/**/router.py`` (all module + standards routers).
-    Decomposed service modules (``service_*.py``) are covered separately by
-    ``test_decomposed_service_modules_stay_within_size_budgets``; the largest
-    non-``router.py`` modules are path-ratcheted in _MODULE_LOC_CAPS (#836).
-    """
+    Specific decomposed modules use stricter caps elsewhere in this file."""
     DEFAULT_CAP = 1500
     allowlist = _MODULE_LOC_CAPS
 
@@ -6458,11 +1474,11 @@ def test_router_orchestrator_modules_stay_within_loc_cap() -> None:
 
     if violations:
         pytest.fail(
-            "Phase 276 CODE-01 invariant violated: router modules exceeded "
+            "Router modules exceeded "
             "their LOC cap. Either decompose the module (preferred — split "
-            "into a facade + cohesive sub-modules per Phase 226 / Phase 238 "
+            "into a facade and cohesive submodules rather than raising "
             "patterns) or, if growth is intentional, raise the explicit "
-            "allowlist entry with a code review.\n" + "\n".join(violations)
+            "allowlist entry with a current rationale.\n" + "\n".join(violations)
         )
 
 
@@ -6472,39 +1488,13 @@ def test_router_orchestrator_modules_stay_within_loc_cap() -> None:
     not _PATHSPEC_MAGIC_AVAILABLE,
     reason=(
         "git < 2.13 lacks `:!` pathspec exclusion; cannot enforce "
-        "Phase 222 AUDIT-02 invariant via grep-based guard"
+        "the audit-call boundary via its grep-based guard"
     ),
 )
 def test_no_log_action_calls_outside_audit_service() -> None:
-    """Phase 222 AUDIT-02: ``log_action()`` is called only by ``DefaultAuditSink.emit()``.
+    """Only the default audit sink calls log_action directly.
 
-    All 65 historical call sites must route through ``audit_emit()`` instead.
-    Closes the +242% ``log_action`` decentralization regression flagged in
-    ``docs-internal/audits/oc-separation-audit-20260430.md`` §5 (line 224).
-
-    Excluded paths:
-      - ``backend/app/modules/audit/service.py`` — defines ``log_action()``;
-        this is the only application-side caller permitted post-Phase-222.
-      - ``backend/app/platform/extensions/defaults_extensions.py`` —
-        ``DefaultAuditSink.emit()`` calls ``log_action()`` via deferred import
-        (Phase 222 D-04 / option a from AUDIT-02; moved from defaults.py by the
-        #836 facade split). The community-edition default sink is the SOLE
-        consumer of the preserved helper.
-      - ``backend/tests/`` — test seeds (e.g., ``test_lifecycle.py:421, 687``)
-        may construct audit_logs rows directly via ``log_action()`` for
-        deterministic fixture setup. Tests are exempt from the production-code
-        invariant (RESEARCH.md Open Question 3 (b)).
-
-    Pattern matched: ``await log_action(`` — the call shape used by every
-    historical site. The ``await`` anchor avoids tripping on the function's
-    own definition (``async def log_action(``) and on attribute references
-    like ``log_action_helper``.
-
-    Maps directly to Phase 222 ROADMAP SC#4 ("No call site in backend/app/
-    calls log_action() directly — all 65 sites route through
-    get_audit_sink().emit()") — implementation is via the ``audit_emit()``
-    facade introduced in Plan 02.
-    """
+    Production callers use audit_emit so deployments can replace the audit extension. The AST guard checks only call sites, not definitions or documentation."""
     result = subprocess.run(
         [
             "git",
@@ -6525,9 +1515,9 @@ def test_no_log_action_calls_outside_audit_service() -> None:
 
     if result.returncode == 0:
         pytest.fail(
-            "Phase 222 AUDIT-02 invariant violated: log_action() is called "
+            "log_action() is called "
             "outside backend/app/modules/audit/service.py and "
-            "backend/app/platform/extensions/defaults_extensions.py. All 65 historical "
+            "backend/app/platform/extensions/defaults_extensions.py. All "
             "sites must use audit_emit(session, AuditEvent(...)) instead.\n"
             f"Offending lines:\n{result.stdout}"
         )
@@ -6540,36 +1530,15 @@ def test_no_log_action_calls_outside_audit_service() -> None:
 
 @pytest.mark.architecture
 def test_no_core_marketplace_import() -> None:
-    """Phase 223 BILLING-02: ``app.core.marketplace`` does not exist after Phase 223.
-
-    Asserts that:
-      (a) ``import app.core.marketplace`` raises ImportError — the module file
-          ``backend/app/core/marketplace.py`` was deleted in Plan 03 (D-02).
-      (b) No surviving ``from app.core.marketplace`` reference exists anywhere
-          in ``backend/app/`` — the lifespan startup at ``api/main.py:184-203``
-          was rewritten to dispatch through ``BillingExtension.on_startup`` in
-          Plan 02; the import line at ``api/main.py:20`` was deleted in Plan 02.
-
-    The 30-line ``register_marketplace_usage`` function was relocated to the
-    enterprise overlay (geolens-enterprise/geolens_enterprise/billing/__init__.py
-    in Plan 05). The community core has zero AWS Marketplace business logic
-    after this phase.
-
-    Negative-control: any future regression that re-creates the file or
-    re-introduces a ``from app.core.marketplace`` import fails this test
-    immediately at CI time.
-    """
+    """The removed app.core.marketplace module must not return."""
     import importlib
 
     # (a) Importing the module must fail
     try:
         importlib.import_module("app.core.marketplace")
         pytest.fail(
-            "Phase 223 BILLING-02 invariant violated: app.core.marketplace was "
-            "importable. The module file backend/app/core/marketplace.py must be "
-            "deleted (Plan 03 / D-02). The 30-line register_marketplace_usage "
-            "function was relocated to the enterprise overlay's "
-            "MarketplaceBillingExtension class (Plan 05)."
+            "app.core.marketplace must not be importable. "
+            "Marketplace billing belongs in the enterprise overlay."
         )
     except ImportError:
         pass  # Expected: module was deleted
@@ -6585,7 +1554,7 @@ def test_no_core_marketplace_import() -> None:
     if not _has_pathspec_magic():
         pytest.skip(
             "git < 2.13 lacks `:!` pathspec exclusion; cannot enforce "
-            "Phase 223 BILLING-02 invariant via grep-based guard"
+            "the removed marketplace path via its grep-based guard"
         )
 
     result = subprocess.run(
@@ -6606,7 +1575,7 @@ def test_no_core_marketplace_import() -> None:
 
     if result.returncode == 0:
         pytest.fail(
-            "Phase 223 BILLING-02 invariant violated: backend/app/ still "
+            "backend/app/ still "
             "contains a `from app.core.marketplace` or `import app.core.marketplace` "
             "reference. The lifespan dispatch in api/main.py must use "
             "`get_billing_extensions()` and the AWS Marketplace business logic "
@@ -6623,22 +1592,7 @@ def test_no_core_marketplace_import() -> None:
 @pytest.mark.architecture
 @pytest.mark.skipif(not _GIT_METADATA_AVAILABLE, reason=_GIT_METADATA_REASON)
 def test_billing_dispatch_uses_hardcoded_timeout() -> None:
-    """Phase 223 BILLING-04 / D-11: the production dispatch loop hardcodes timeout=10.0.
-
-    D-11 deliberately rejects making the timeout configurable (no
-    ``BILLING_STARTUP_TIMEOUT_SECONDS`` env var, no per-extension override).
-    Today's value is hardcoded; preserving that as a constant in core's
-    dispatch loop is the smallest-diff option and matches the pre-phase-223
-    behavior at the now-deleted line 191 of api/main.py.
-
-    Test fixtures (test_billing_extension.py::_dispatch) accept a parameterized
-    ``timeout`` argument for fast tests, but the PRODUCTION dispatch loop (in the
-    shared ``bootstrap()`` helper since Phase 1206 WORK-01 — formerly api/main.py)
-    MUST use the literal ``timeout=10.0``. This test catches drift between the two.
-
-    Negative-control: any change that wraps the timeout in a settings field
-    or env-var lookup will fail this test (the literal will be missing).
-    """
+    """The billing dispatch loop passes the required literal timeout to every handler invocation."""
     result = subprocess.run(
         [
             "git",
@@ -6647,9 +1601,7 @@ def test_billing_dispatch_uses_hardcoded_timeout() -> None:
             "-P",
             r"asyncio\.wait_for\(ext\.on_startup\(app\), timeout=10\.0\)",
             "--",
-            # Phase 1206 (WORK-01) collapsed the API lifespan + worker bootstrap
-            # into one shared bootstrap() helper, which is where the billing
-            # dispatch loop now lives (moved from the now-deleted api/main.py site).
+            # API lifespan and worker startup share this bootstrap dispatch loop.
             "backend/app/platform/extensions/bootstrap.py",
         ],
         cwd=REPO_ROOT,
@@ -6660,14 +1612,12 @@ def test_billing_dispatch_uses_hardcoded_timeout() -> None:
 
     if result.returncode == 1:
         pytest.fail(
-            "Phase 223 BILLING-04 / D-11 invariant violated: "
+            "Billing dispatch invariant violated: "
             "backend/app/platform/extensions/bootstrap.py does NOT contain the "
             "production BillingExtension dispatch loop with literal "
             "`asyncio.wait_for(ext.on_startup(app), timeout=10.0)`. The "
-            "10-second timeout MUST be hardcoded (D-11 — YAGNI for env-var "
-            "configuration). Either the dispatch loop is missing entirely or the "
-            "literal timeout was changed. (Phase 1206 moved this from api/main.py "
-            "into the shared bootstrap() helper.)"
+            "10-second timeout must remain fixed. Either the dispatch loop is missing or the "
+            "literal timeout was changed."
         )
     if result.returncode not in (0,):
         pytest.fail(
@@ -6676,14 +1626,8 @@ def test_billing_dispatch_uses_hardcoded_timeout() -> None:
         )
 
 
-# fix(#435): burn-down list of function-local `app.modules.catalog` imports inside
-# `backend/app/processing/`. Every entry is a place where processing reaches past
-# ProcessingPort, so an Enterprise/Cloud overlay cannot observe or intercept the call.
-#
-# The list may SHRINK, never grow. Adding an entry means adding a new port bypass —
-# route the behavior through `app.core.processing_port` instead. See
-# `_authorize_metadata_dataset` in `processing/ai/router.py`, migrated to the port's
-# existing `get_dataset` / `check_dataset_access` methods.
+# Existing processing-to-catalog port bypasses. This list may shrink, never
+# grow; new calls route through ProcessingPort so overlays can intercept them.
 _PROCESSING_CATALOG_IMPORT_BURNDOWN: dict[str, set[str]] = {
     "ai/chat_validation.py": {"app.modules.catalog.maps.filter_grammar"},
     "ai/router.py": {
@@ -6716,40 +1660,14 @@ _PROCESSING_CATALOG_IMPORT_BURNDOWN: dict[str, set[str]] = {
     "tiles/router.py": {"app.modules.catalog.datasets.domain.models"},
 }
 
-# fix(#1438 codex review): built from `_backend_path()`/`BACKEND_ROOT`, not
-# `REPO_ROOT / "backend" / ...`. `_discover_repo_roots()` returns `BACKEND_ROOT
-# == REPO_ROOT / "backend"` only in the host layout; in the backend-container
-# layout it also supports, `REPO_ROOT` is `/` and `BACKEND_ROOT` is `/app`, so
-# the `REPO_ROOT`-relative spelling resolved to a nonexistent `/backend/app/
-# processing` and every guard built on it scanned zero files and passed
-# vacuously in-container. Proven both ways: constructing the analogous
-# _STANDARDS_DIR the same (wrong) way and rglob-ing it found 0 files in a
-# simulated container layout; constructing it via BACKEND_ROOT found the
-# files. `_PLATFORM_DIR` below had the identical bug.
+# Resolve from BACKEND_ROOT so host and backend-container layouts scan the same tree.
 _PROCESSING_DIR = _backend_path("app/processing")
 
 
 def _processing_import_edges() -> dict[str, set[str]]:
-    """Every `app.modules.*` import under processing/, at ANY scope.
+    """Collect every app.modules import under processing at any scope.
 
-    fix(#1438 F17): broadened from `app.modules.catalog` so a bypass into ANY
-    product domain (auth, audit, quota, embed_tokens, ...) is visible, not just
-    catalog. `_catalog_import_edges()` and `_other_domains_import_edges()` below
-    are the two ways this gets sliced — kept as separate burndowns rather than
-    one merged list because they lead to different fixes (see
-    `_other_domains_import_edges()`'s docstring).
-
-    Handles two import-syntax gaps (fix #1438 codex review): a RELATIVE import
-    (`from ...modules.auth import X`) is resolved to its absolute path via
-    `_resolve_relative_import()` before the prefix check, rather than reading
-    `node.module` as if it were always already-absolute. And `from app.modules
-    import auth` resolves `node.module` to exactly `"app.modules"` — no
-    trailing segment — which does not itself start with `"app.modules."`;
-    falling back to each imported name as a possible extension catches the
-    target this shape actually reaches (`"app.modules.auth"`) without also
-    recording the bare, non-specific `"app.modules"` for the common shape
-    where `node.module` already spells out the full target.
-    """
+    Relative imports and from-app.modules-import-name forms are resolved to absolute targets before classification."""
     edges: dict[str, set[str]] = {}
     for path in sorted(_PROCESSING_DIR.rglob("*.py")):
         for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
@@ -6783,19 +1701,9 @@ def _catalog_import_edges() -> dict[str, set[str]]:
 
 
 def _other_domains_import_edges() -> dict[str, set[str]]:
-    """The non-catalog subset of `_processing_import_edges()`.
+    """Return processing imports into product domains other than catalog.
 
-    fix(#1438 F17): catalog edges are governed separately, above, by
-    `test_no_processing_imports_catalog` — whose fix directs the reader at
-    ProcessingPort (`app.core.processing_port`). That is correct for catalog:
-    ProcessingPort's surface is dataset/record/map/grant methods. It has no
-    auth, audit, quota, or embed-token surface, so an edge into one of those
-    domains needs a different fix (a scoped port method, a dependency injected
-    at the router layer, or a deferred import) — folding it into the catalog
-    burndown would point the fixer at a port that cannot serve it. Kept as a
-    parallel burndown instead, so each guard's failure message stays true for
-    every edge it lists.
-    """
+    Catalog has its own burn-down and ProcessingPort remedy. Other domains may require a scoped port, router injection, or deferred import, so their diagnostics remain separate."""
     edges: dict[str, set[str]] = {}
     for file, modules in _processing_import_edges().items():
         other_modules = {m for m in modules if not m.startswith("app.modules.catalog")}
@@ -6806,15 +1714,9 @@ def _other_domains_import_edges() -> dict[str, set[str]]:
 
 @pytest.mark.architecture
 def test_no_processing_imports_catalog() -> None:
-    """Phase 225 PROCESS-02/04: processing/ reaches catalog only through ProcessingPort.
+    """Processing reaches catalog through ProcessingPort.
 
-    fix(#435): this guard was a `git grep` for imports starting at column 0, so moving
-    an import inside a function body satisfied it while still bypassing the overlay
-    seam. An AST scan found 30 such function-local imports across 11 files, one
-    reaching into private router helpers and another bypassing the port for dataset
-    authorization. The guard now walks every scope, and the surviving edges are an
-    explicit burn-down list rather than an invisible exemption.
-    """
+    The AST scan covers imports at every scope; named existing edges form a shrink-only burn-down."""
     offenders: list[str] = []
     for file, modules in sorted(_catalog_import_edges().items()):
         allowed = _PROCESSING_CATALOG_IMPORT_BURNDOWN.get(file, set())
@@ -6823,7 +1725,7 @@ def test_no_processing_imports_catalog() -> None:
 
     if offenders:
         pytest.fail(
-            "Phase 225 PROCESS-02/04 invariant violated: backend/app/processing/ "
+            "backend/app/processing/ "
             "imports app.modules.catalog.* outside the burn-down allowlist. Route the "
             "behavior through ProcessingPort (app.core.processing_port) instead of "
             "adding an entry to _PROCESSING_CATALOG_IMPORT_BURNDOWN.\n"
@@ -6850,14 +1752,8 @@ def test_processing_catalog_import_allowlist_is_current() -> None:
         )
 
 
-# fix(#1438 F17): burn-down list of `app.modules.*` imports inside
-# `backend/app/processing/` that reach a product domain OTHER than catalog — the
-# same PROCESS-02/04 bypass the catalog burndown above tracks, widened to every
-# domain now that the guard sees all of `app.modules.` rather than just
-# `app.modules.catalog`. See `_other_domains_import_edges()` for why this stays a
-# separate dict instead of merging into `_PROCESSING_CATALOG_IMPORT_BURNDOWN`.
-#
-# The list may SHRINK, never grow.
+# Existing processing imports into non-catalog product domains. This stays
+# separate because those edges need different ports or injection. Shrink only.
 _PROCESSING_OTHER_DOMAINS_IMPORT_BURNDOWN: dict[str, set[str]] = {
     "ai/query_router.py": {
         "app.modules.audit.service",
@@ -6902,9 +1798,7 @@ _PROCESSING_OTHER_DOMAINS_IMPORT_BURNDOWN: dict[str, set[str]] = {
     "ingest/tasks_vrt.py": {
         "app.modules.quota.service",
     },
-    # refactor(#1711): the `get_user_quota_usage` edge follows
-    # `_effective_stream_cap` into the module the URL-import staging split gave
-    # it. The router keeps the same edge for `check_upload_quota`.
+    # Staging reads current usage to bound its stream; the router checks upload admission.
     "ingest/url_import_staging.py": {
         "app.modules.quota.service",
     },
@@ -6917,17 +1811,9 @@ _PROCESSING_OTHER_DOMAINS_IMPORT_BURNDOWN: dict[str, set[str]] = {
 
 @pytest.mark.architecture
 def test_no_processing_imports_other_domains() -> None:
-    """Phase 225 PROCESS-02/04, broadened past catalog: processing/ reaches every
-    product domain through a port, never `app.modules.*` directly.
+    """Processing does not import product domains directly.
 
-    fix(#1438 F17): `test_no_processing_imports_catalog` held processing/ to a
-    catalog-only boundary, so an equally direct reach into auth, audit, quota, or
-    embed_tokens passed silently. processing/ has exactly one blessed
-    cross-domain seam (ProcessingPort, for catalog); every other `app.modules.*`
-    reference is the same bypass in a different domain. Walks the same
-    AST-at-any-scope collector as the catalog guard (`_processing_import_edges()`),
-    so a function-local import cannot hide from either.
-    """
+    The same all-scope AST collector backs this shrink-only non-catalog burn-down."""
     offenders: list[str] = []
     for file, modules in sorted(_other_domains_import_edges().items()):
         allowed = _PROCESSING_OTHER_DOMAINS_IMPORT_BURNDOWN.get(file, set())
@@ -6972,18 +1858,13 @@ def test_processing_other_domains_import_allowlist_is_current() -> None:
     not _PATHSPEC_MAGIC_AVAILABLE,
     reason=(
         "git < 2.13 lacks `:!` pathspec exclusion; cannot enforce "
-        "Phase 230 CATPORT-04 invariant via grep-based guard"
+        "the catalog-to-processing boundary via its grep-based guard"
     ),
 )
 def test_no_catalog_imports_processing() -> None:
-    """Phase 230 CATPORT-02/04: catalog/ must not import app.processing.*.
+    """Catalog reaches processing only through CatalogPort.
 
-    All processing-owned helper, task, schema, and ORM-class access from
-    backend/app/modules/catalog/ must go through CatalogPort
-    (app.core.catalog_port). Strict zero-hit across module-level imports
-    and function-local imports. Pure `#` comment lines are skipped — code
-    comments may legitimately mention the module name for documentation.
-    """
+    The scan covers module-level and deferred imports while ignoring comment-only references."""
     result = subprocess.run(
         [
             "git",
@@ -7012,7 +1893,7 @@ def test_no_catalog_imports_processing() -> None:
         ]
         if offending:
             pytest.fail(
-                "Phase 230 CATPORT-02/04 invariant violated: "
+                "catalog-to-processing boundary violated: "
                 "backend/app/modules/catalog/ contains a direct reference to "
                 "app.processing.*. All processing access must go through "
                 "CatalogPort (app.core.catalog_port). Offending lines:\n"
@@ -7032,25 +1913,11 @@ def test_no_catalog_imports_processing() -> None:
     not _PATHSPEC_MAGIC_AVAILABLE,
     reason=(
         "git < 2.13 lacks `:!` pathspec exclusion; cannot enforce "
-        "Phase 226 AIEXT-03 invariant via grep-based guard"
+        "the provider-dispatch boundary via its grep-based guard"
     ),
 )
 def test_no_hardcoded_ai_provider_branches() -> None:
-    """Phase 226 AIEXT-03/05: no hardcoded ``if provider ==`` dispatch in processing/ai/.
-
-    SC#3 binding (ROADMAP §Phase 226): ``grep -RE "if .*provider *== *['\"]
-    (anthropic|openai_compatible)" backend/app/processing/ai/`` returns zero
-    hits after the provider-seam migration. Streaming chat now dispatches
-    through ``AIProviderExtension.stream_chat_events(...)`` and metadata
-    drafts use ``AIProviderExtension.structured_complete(...)``.
-
-    Negative-control (D-14): temporarily reintroduce
-    ``if provider == "anthropic":`` in ``processing/ai/sql_generator.py``,
-    run this test, confirm it fails with the offending line surfaced.
-    Revert. Run again, confirm green.
-
-    Maps to AIEXT-03 + AIEXT-05 (REQUIREMENTS.md §Phase 226).
-    """
+    """AI provider dispatch goes through the provider extension rather than provider-name branches."""
     result = subprocess.run(
         [
             "git",
@@ -7069,7 +1936,7 @@ def test_no_hardcoded_ai_provider_branches() -> None:
 
     if result.returncode == 0:
         pytest.fail(
-            "Phase 226 AIEXT-03 invariant violated: hardcoded AI provider "
+            "Hardcoded AI provider "
             "dispatch (`if provider == 'anthropic'/'openai_compatible'`) found "
             "in backend/app/processing/. Replace with "
             "`get_ai_provider(name)` dispatch from "
@@ -7085,21 +1952,9 @@ def test_no_hardcoded_ai_provider_branches() -> None:
 @pytest.mark.architecture
 @pytest.mark.skipif(not _GIT_METADATA_AVAILABLE, reason=_GIT_METADATA_REASON)
 def test_no_module_level_provider_sdk_imports_in_processing() -> None:
-    """oc-audit 2026-05-02 §5 + Phase 231: backend/app/processing/ must not have
-    module-level imports of provider SDKs (anthropic, openai).
+    """Processing does not import provider SDKs at module scope.
 
-    Module-level provider-SDK imports inside ``processing/`` violate the
-    open-core boundary: they couple the AI domain to specific SDK packages
-    at import time, defeating the AIProviderExtension Protocol seam (Phase
-    226). Move imports to function-local scope when needed (mirror Phase
-    225's deferred-import discipline) or place them behind the Protocol in
-    ``app/platform/extensions/defaults.py``.
-
-    Negative-control (Phase 231 D-15): temporarily reintroduce
-    ``from openai import OpenAI`` at the top of
-    ``backend/app/processing/embeddings/helpers.py``, run this test,
-    confirm it fails with the offending line surfaced. Revert.
-    """
+    Provider defaults own SDK imports; processing depends on extension protocols and remains importable without optional SDKs."""
     result = subprocess.run(
         [
             "git",
@@ -7130,32 +1985,16 @@ def test_no_module_level_provider_sdk_imports_in_processing() -> None:
         )
 
 
-# fix(#909): env-sensitive helpers that test fixtures redirect by assigning to
-# the module the fixture actually patches. A module-scope `from <module> import
-# <name>` snapshots the object into the importing module's own namespace, so
-# the fixture's patch never reaches it — and the test silently reads or WRITES
-# the dev database while passing (the #898 export-ogr incident). Call sites
-# must late-bind (`from <module> import <name>` inside the function) so the
-# patched module's current attribute is resolved at call time.
-#
-# Maps patched module -> redirected symbol names. Extend this when a fixture
-# starts redirecting another module-scope-importable helper.
+# Fixture-redirected helpers must be read from the patched module at call time;
+# a module-scope direct import can retain a development-database object.
 _FIXTURE_REDIRECTED_SYMBOLS: dict[str, frozenset[str]] = {
-    # fix(#909 codex review): engine included — the client fixture reassigns
-    # db_module.engine to the test engine, so a module-scope engine binding
-    # escapes the redirect exactly like async_session (the health-service
-    # probe was the live instance).
+    # Both attributes are reassigned by the client fixture.
     "app.core.db": frozenset({"async_session", "engine"}),
     "app.processing.ingest.ogr": frozenset({"build_pg_conn_str"}),
 }
 
-# fix(#909 codex review): the conftest fixture patches the FAÇADE attributes
-# (`app.core.db.engine` / `.async_session`), never the origin module's, so
-# importing these from `app.core.db.session` escapes the redirect at ANY
-# scope — late-binding does not save it, because the attribute it late-binds
-# against was never patched. `app/core/db/rls.py` used to do exactly that and
-# would open a dev-database connection from inside a test. These imports are
-# therefore banned outright and must go through the façade.
+# The fixture patches facade attributes, so imports from their origin module
+# escape the redirect even when late-bound. Always use app.core.db.
 _UNPATCHED_ORIGIN_SYMBOLS: dict[str, frozenset[str]] = {
     "app.core.db.session": frozenset({"async_session", "engine"}),
 }
@@ -7214,16 +2053,10 @@ def _redirect_escaping_imports(tree: ast.AST) -> list[tuple[int, str, str, str]]
 
 @pytest.mark.architecture
 def test_no_imports_that_escape_the_fixture_db_redirect() -> None:
-    """fix(#909): no import path may resolve the un-patched dev-database engine.
+    """No backend import may retain an unpatched development-database object.
 
-    AST-based rather than git grep so untracked files are covered and
-    multi-name import lists (`from app.core.db import async_session,
-    tenant_task`) cannot slip through.
-
-    Negative-control: temporarily add `from app.core.db import async_session`
-    at the top of any module under backend/app/, run this test, confirm it
-    fails with the offending file:line surfaced. Revert. (Automated as
-    test_fixture_redirect_guard_catches_seeded_violation below.)
+    The fixture redirects named facade attributes; direct imports of their
+    definitions escape that redirect.
     """
     app_root = _backend_path("app")
     failures: list[str] = []
@@ -7239,15 +2072,15 @@ def test_no_imports_that_escape_the_fixture_db_redirect() -> None:
 
     assert not failures, (
         "Import(s) that escape the test fixture's database redirect, so the "
-        "test silently reads or writes the DEV database while passing (see "
-        "#909). `module-scope`: late-bind the import inside the function. "
+        "test silently reads or writes the DEV database while passing. "
+        "`module-scope`: late-bind the import inside the function. "
         "`unpatched-origin`: import from the `app.core.db` façade, which is "
         "what the fixture patches:\n" + "\n".join(failures)
     )
 
 
 def test_fixture_redirect_guard_catches_seeded_violation() -> None:
-    """The guard must fail on a seeded module-scope offender (issue #909 §3)."""
+    """The guard must fail on a seeded module-scope offender."""
     seeded = ast.parse(
         "import uuid\n"
         "from app.core.db import Base, async_session\n"
@@ -7260,11 +2093,7 @@ def test_fixture_redirect_guard_catches_seeded_violation() -> None:
 
 
 def test_fixture_redirect_guard_catches_unpatched_origin_at_any_scope() -> None:
-    """fix(#909 codex review): late-binding does NOT rescue an import from
-    ``app.core.db.session``. conftest reassigns ``app.core.db.engine``, not
-    ``app.core.db.session.engine``, so the deferred lookup still resolves the
-    dev-database engine — the shape ``rls.apply_tenancy_rls_from_engine`` had.
-    Both scopes must be reported, and the façade equivalent must not be."""
+    """The fixture redirect guard detects direct imports and aliases at every scope."""
     seeded = ast.parse(
         "from app.core.db.session import engine\n"
         "def late():\n"
@@ -7314,12 +2143,7 @@ def _is_forbidden_manifest_import(module: str) -> bool:
 
 @pytest.mark.architecture
 def test_manifest_apply_backend_has_no_cli_sdk_or_enterprise_imports() -> None:
-    """Phase 243 INGEST-03: backend manifest apply stays backend-local.
-
-    The backend apply path must not import CLI internals, generated SDK clients,
-    or Enterprise-only modules. Community extension ports such as
-    ``app.platform.extensions`` remain allowed.
-    """
+    """Backend manifest apply remains independent of CLI, generated SDK, and Enterprise packages."""
 
     offenders: list[str] = []
     for path in _manifest_backend_files():
@@ -7337,7 +2161,7 @@ def test_manifest_apply_backend_has_no_cli_sdk_or_enterprise_imports() -> None:
 
     if offenders:
         pytest.fail(
-            "Phase 243 INGEST-03 invariant violated: backend manifest apply "
+            "Backend manifest apply "
             "imports CLI, generated SDK, or Enterprise-only modules directly. "
             "Keep manifest apply backend-local and use existing community "
             "extension ports. Offending lines:\n" + "\n".join(offenders)
@@ -7346,7 +2170,7 @@ def test_manifest_apply_backend_has_no_cli_sdk_or_enterprise_imports() -> None:
 
 @pytest.mark.architecture
 def test_manifest_apply_router_uses_upload_permission() -> None:
-    """Phase 243 INGEST-03: manifest apply reuses the existing upload permission."""
+    """Manifest apply uses the existing upload permission."""
 
     router_path = _backend_path("app/processing/ingest/manifest_router.py")
     source = router_path.read_text()
@@ -7367,22 +2191,9 @@ def test_manifest_apply_router_uses_upload_permission() -> None:
 
 @pytest.mark.architecture
 def test_upload_thumbnail_route_uses_json_body() -> None:
-    """Phase 254 SDK-02: PUT /maps/{map_id}/thumbnail/ must use a JSON body
-    (Pydantic model), not a text/plain body.
+    """Thumbnail upload uses a JSON request model rather than an ambiguous string body.
 
-    openapi-python-client rejects ``text/plain`` request bodies and silently
-    drops the endpoint from the generated Python SDK (emitting
-    ``WARNING parsing PUT /maps/{map_id}/thumbnail/``). Phase 254 Plan 01
-    switched the route to a JSON body backed by ``ThumbnailUploadRequest``.
-    This guard prevents silent regression: any future change that switches
-    the route back to a non-JSON body shape fails this test BEFORE
-    ``make sdks`` runs.
-
-    Companion gate: the ``Makefile`` ``sdks:`` target also fails on any
-    ``^WARNING parsing`` line from openapi-python-client (Phase 254 Plan 02
-    Task 1). This source-shape guard fires earlier in the loop, on every
-    ``pytest tests/test_layering.py`` invocation.
-    """
+    The guard checks both positional and keyword-only defaults because FastAPI stores Body metadata there."""
     router_path = _backend_path("app/modules/catalog/maps/router.py")
     if not router_path.exists():
         # Test runs from monorepo root; if path is relative-broken, skip
@@ -7410,7 +2221,7 @@ def test_upload_thumbnail_route_uses_json_body() -> None:
 
     if upload_fn is None:
         pytest.fail(
-            "Phase 254 SDK-02 invariant violated: function "
+            "Thumbnail route function "
             "'upload_thumbnail' not found in "
             "backend/app/modules/catalog/maps/router.py. The route was "
             "renamed or removed; update this guard or restore the route."
@@ -7420,11 +2231,7 @@ def test_upload_thumbnail_route_uses_json_body() -> None:
     # whose default is a Body(...) call with a `media_type` keyword arg
     # set to a non-JSON content type (typically "text/plain").
     #
-    # Phase 254 WR-01: walk both positional defaults AND kwonly defaults,
-    # so a regression that switches `upload_thumbnail` to FastAPI's
-    # keyword-only style (e.g., `*, data_uri: str = Body(..., media_type=...)`)
-    # is also caught. Without this, kwonly args land in
-    # `fn.args.kwonlyargs` / `fn.args.kw_defaults` and slip past the guard.
+    # FastAPI Body metadata may live in positional or keyword-only defaults.
     args = upload_fn.args.args
     defaults = upload_fn.args.defaults
     default_idx = len(args) - len(defaults)
@@ -7466,13 +2273,13 @@ def test_upload_thumbnail_route_uses_json_body() -> None:
                 and kw.value.value != "application/json"
             ):
                 pytest.fail(
-                    "Phase 254 SDK-02 invariant violated: parameter "
+                    "Thumbnail route parameter "
                     f"'{arg.arg}' on upload_thumbnail uses "
                     f"Body(..., media_type='{kw.value.value}'). "
                     "openapi-python-client cannot parse non-JSON request "
                     "bodies and will silently drop the endpoint from the "
                     "Python SDK. Switch to a Pydantic JSON body model "
-                    "(e.g., ThumbnailUploadRequest) per Phase 254 Plan 01."
+                    "such as ThumbnailUploadRequest."
                 )
 
 
@@ -7482,50 +2289,16 @@ def test_upload_thumbnail_route_uses_json_body() -> None:
     not _PATHSPEC_MAGIC_AVAILABLE,
     reason=(
         "git < 2.13 lacks `:!` pathspec exclusion; cannot enforce "
-        "Phase 276 CODE-08 invariant via grep-based guard"
+        "the broad-exception annotation rule via its grep-based guard"
     ),
 )
 def test_no_unjustified_broad_except_sites() -> None:
-    """Phase 276 CODE-08: every ``except Exception:`` site under backend/app/
-    must justify itself with ``# broad: <reason>`` or
-    ``# noqa: BLE001 <reason>`` on the SAME line.
+    """Every broad exception handler in backend/app carries a same-line reason.
 
-    Catches new unjustified broad-except sites at PR time. The intent is
-    not to forbid broad catches — they are sometimes the correct safety
-    net (audit sinks, cache decoders, optional-dependency probes,
-    third-party SDK boundaries) — but to require a one-line justification
-    at the catch site so reviewers can confirm the broad catch is
-    intentional and not accidental swallowing of a real bug.
-
-    Two acceptable styles (both already used in the codebase):
-        except Exception:  # broad: <reason>
-        except Exception:  # noqa: BLE001 <reason>
-
-    Pattern A (``# broad:``) is preferred for new annotations and matches
-    the dominant style across ~138 of 139 sites. Pattern B
-    (``# noqa: BLE001``) is reserved for sites where ruff would otherwise
-    complain about BLE001 (e.g., audit sinks).
-
-    The comment must appear on the SAME line as the ``except`` so this
-    grep-based check can find it via line-by-line scanning. Multi-line
-    comments above the except do NOT satisfy the guard.
-
-    Out of scope: ``backend/tests/`` (test code may swallow exceptions
-    for structural reasons unrelated to production safety) and
-    ``backend/app/processing/ai/router.py`` is NOT exempted — it has
-    its own justified sites.
-
-    Negative-control: temporarily reintroduce ``except Exception:`` (no
-    comment) into a sandbox file under ``backend/app/``, run this test,
-    confirm it fails with the offending line surfaced. Revert.
-
-    Maps to CODE-08 (REQUIREMENTS.md §Phase 276).
-    """
+    Use # broad: for intentional safety boundaries or # noqa: BLE001 where Ruff also needs suppression. Tests are outside this production guard."""
     # Match `except Exception:` and `except Exception as foo:` lines
     # under backend/app/ only (tests/ is out of scope).
-    # fix(#1182): runs under `-P`, so `\w` in the optional `as` group is a real
-    # word class. Under `-E` on macOS it matched nothing, so `except Exception
-    # as foo:` lines were invisible locally while CI caught them.
+    # PCRE is required for the optional `as name` word class on every host.
     result = subprocess.run(
         [
             "git",
@@ -7559,7 +2332,7 @@ def test_no_unjustified_broad_except_sites() -> None:
 
     if violations:
         pytest.fail(
-            "Phase 276 CODE-08 invariant violated: unjustified broad-except "
+            "Unjustified broad-except "
             "sites found. Add `# broad: <reason>` (or `# noqa: BLE001 "
             "<reason>`) on the SAME line as the `except`, OR tighten the "
             "catch to a specific exception class.\n"
@@ -7568,90 +2341,9 @@ def test_no_unjustified_broad_except_sites() -> None:
 
 
 def test_every_parse_qsl_call_bounds_its_field_count() -> None:
-    """fix(#1770 round 47 P1 class, `service_endpoints.py:bounded_parse_qsl`).
+    """Runtime query-string parsing must bound field count.
 
-    `parse_qsl()`/`parse_qs()` have no field-count bound of their own: a
-    service-advertised href can pack millions of short `key=value` pairs
-    into a query string that stays comfortably under every byte/structural-
-    token budget (the separators live inside one JSON string), and either
-    function materialises every pair it finds before a caller's own
-    comprehension or `urlencode()` copies the list again.
-    `bounded_parse_qsl` in `service_endpoints.py` is the one call site every
-    read of a service-advertised query string should share.
-
-    fix(#1770 round 47b P2): round 47's own version of this test greped
-    `parse_qsl\\(` only, missing `parse_qs\\(` -- same unbounded semantics,
-    same `max_num_fields` fix, a different function name. Widened to
-    `parse_qsl?\\(` (the trailing `l` optional), which matches both.
-
-    Not every site gets the bound, and the exceptions are real:
-    `url_redaction.py`'s three sites (fix #2044 review x9 added the third,
-    scanning one already-split query VALUE for an embedded credential) and
-    `preview.py`'s one scrub or resolve the CALLER's own already-bounded
-    input, and a redactor specifically must
-    never itself raise (`max_num_fields` raises `ValueError` past the
-    count, which would turn scrubbing an oversized credential out of an
-    exception message into a crash INSIDE exception handling);
-    `core/config.py`'s five sites all parse `DATABASE_URL_OVERRIDE`, an
-    operator-supplied BOOT-TIME environment variable, never a runtime
-    service-advertised value -- the operator already has arbitrary control
-    over their own deployment, and a `ValueError` there surfaces as the
-    existing boot-time config-validation failure, not a runtime refusal, so
-    bounding it buys no security and a local literal would just duplicate
-    `MAX_QUERY_FIELDS` across a layering boundary `config.py` cannot import
-    across (it has no `app.*` imports at all, and importing `platform.
-    service_endpoints` into it would very likely create an import cycle).
-
-    fix(#2018): `platform/ratelimit.py`'s one site is that same class --
-    `REDIS_URL`, read once at import, where a raise would fail boot rather
-    than refuse a request.
-
-    fix(#1770 round 47c): `adapters/wfs.py::build_capabilities_url` and
-    `service_endpoints.py::_capabilities_url` moved from the BOUND list to
-    this exempted one. Round 47b bound them reasoning `_header_auth_probe`
-    (`probe.py`) catches every `ValueError` from an adapter -- true for the
-    `probe_wfs` caller, but not the only one: `origin_probe.py::service_
-    probe_target` calls `build_capabilities_url` for the periodic health
-    check (`GET /datasets/{id}/health`) with NO surrounding `except
-    ValueError` at all, and `_capabilities_url` is reached from `preview.py`
-    and the worker (`processing/ingest/ogr.py`) through `assert_endpoints_
-    stay_on_origin`, both of which catch only `(CrossOriginEndpointError,
-    EndpointCheckFailedError)`. A `ValueError` past the field count on
-    either function reached three of five real callers as an uncaught
-    exception -- a raw 500 on the health route, an unclassified failure on
-    preview and the worker -- the exact class this whole test exists to
-    close, reintroduced by "one caller checked, the rest assumed" reasoning.
-    Both take the caller's own submitted service URL (`ProbeRequest`/
-    `ServicePreviewRequest` cap it at 2048 chars, ~350 fields of `a=1&` at
-    that length), never a value read out of a THIRD-PARTY response, so
-    exempting them is the correct answer, not auditing five call sites for
-    a bound that was never the fix.
-
-    Every exempted site carries `# parse_qs: unbounded` on the same line,
-    the same same-line-annotation discipline `test_no_unjustified_broad_
-    except_sites` already uses for a broad `except`.
-
-    Every OTHER site must carry `max_num_fields=` -- via `bounded_parse_qsl`
-    itself, a call to it (`bounded_parse_qsl(` also matches the grep, since
-    `bounded_parse_qsl(` contains the substring `parse_qsl(`), or an inline
-    `max_num_fields=` on a native `parse_qs`/`parse_qsl` call where the
-    caller needs that function's own return shape and EVERY real caller
-    already degrades a `ValueError` past the count to a coded refusal
-    (`processing/tiles/router.py`'s buried-query recovery is the one
-    remaining example: attacker-reachable, unauthenticated, and its own
-    `try/except ValueError` degrades to "no buried params recovered") --
-    so a new second call site cannot silently reintroduce the unbounded
-    class the finding named.
-
-    Positive control: this repo has more than zero matching call sites
-    today (asserted below), so an empty match list means the grep pattern
-    itself broke, not that the class is closed.
-
-    Negative-control: temporarily add a bare `parse_qsl(some_query)` call
-    (or `parse_qs(...)`) with neither annotation to a sandbox file under
-    `backend/app/`, run this test, confirm it fails naming the offending
-    line. Revert.
-    """
+    Service-advertised URLs use bounded_parse_qsl or max_num_fields. Explicit # parse_qs: unbounded sites are limited to redaction of already-bounded input and operator-supplied boot configuration, where raising during cleanup or startup is the wrong contract. Both parse_qs and parse_qsl are scanned."""
     result = subprocess.run(
         ["git", "grep", "-n", "-P", r"parse_qsl?\(", "--", "backend/app/"],
         cwd=str(REPO_ROOT),
@@ -7685,7 +2377,7 @@ def test_every_parse_qsl_call_bounds_its_field_count() -> None:
 
     if violations:
         pytest.fail(
-            "fix(#1770 round 47 P1 class) invariant violated: a "
+            "Unbounded query parsing found: a "
             "`parse_qsl(`/`parse_qs(` call site with no field-count bound "
             "and no unbounded justification. Route it through "
             "`bounded_parse_qsl` (`service_endpoints.py`), add "
@@ -7696,14 +2388,8 @@ def test_every_parse_qsl_call_bounds_its_field_count() -> None:
         )
 
 
-# fix(#435): `platform/` is the shared layer beneath `modules/`, but four files import
-# upward into product domains at module scope. Each edge means a product-layer refactor
-# can break platform imports at runtime, so they are enumerated rather than tolerated
-# silently. The list may SHRINK, never grow.
-#
-# Deferred (function-local) imports are out of scope: they are the established D-17
-# discipline for breaking these cycles, and `platform/extensions/defaults.py` is built
-# on them by design.
+# Existing module-scope imports from platform into product modules. Shrink only.
+# Deferred imports remain the supported cycle-breaking seam for default adapters.
 _PLATFORM_MODULE_IMPORT_BURNDOWN: dict[str, set[str]] = {
     # Bootstrap adapters: FastAPI dependency callables must be imported to be used as
     # route dependencies. Resolvable by moving these routers under modules/.
@@ -7723,10 +2409,7 @@ _PLATFORM_MODULE_IMPORT_BURNDOWN: dict[str, set[str]] = {
     },
 }
 
-# fix(#1438 codex review): see the comment on `_PROCESSING_DIR` above — this
-# constant had the identical `REPO_ROOT`-relative bug and is fixed the same
-# way (vacuous-pass in the backend-container layout `_discover_repo_roots()`
-# is meant to support).
+# Resolve from BACKEND_ROOT for both host and backend-container layouts.
 _PLATFORM_DIR = _backend_path("app/platform")
 
 
@@ -7754,13 +2437,7 @@ def _platform_module_level_edges() -> dict[str, set[str]]:
 
 @pytest.mark.architecture
 def test_platform_does_not_import_modules() -> None:
-    """The shared platform layer must not depend upward on product domains.
-
-    fix(#435): `platform/config_ops/service.py` reached into `modules.settings.router`
-    for the private `_ENTERPRISE_ONLY_TABS`. That constant now lives beside the
-    persistent-config registry that defines `PersistentConfig.tab`, so edition policy
-    has a stable owner and decomposing the settings router cannot break config import.
-    """
+    """Platform does not add product-module imports beyond the shrink-only burn-down."""
     offenders: list[str] = []
     for file, modules in sorted(_platform_module_level_edges().items()):
         allowed = _PLATFORM_MODULE_IMPORT_BURNDOWN.get(file, set())
@@ -7775,12 +2452,7 @@ def test_platform_does_not_import_modules() -> None:
         )
 
 
-# fix(#1438 F24): platform/ is not the only layer this rule protects — processing/
-# and standards/ reach into app.modules.* too, and a leading underscore is exactly
-# as fragile from either. `_STANDARDS_DIR` mirrors `_PLATFORM_DIR` / `_PROCESSING_DIR`
-# above (also reused by `_standards_module_import_edges()` further down, for the
-# F7 frozen-surface guard) — built via `_backend_path()`, not `REPO_ROOT`-relative,
-# for the same backend-container-layout reason given on `_PROCESSING_DIR`.
+# Private product-module imports are forbidden from every shared layer.
 _STANDARDS_DIR = _backend_path("app/standards")
 _PRIVATE_MODULE_IMPORT_ROOTS: tuple[Path, ...] = (
     _PLATFORM_DIR,
@@ -7790,24 +2462,9 @@ _PRIVATE_MODULE_IMPORT_ROOTS: tuple[Path, ...] = (
 
 
 def _private_module_import_edges() -> dict[str, set[str]]:
-    """Every import reaching a `_`-prefixed segment under `app.modules.*`, at ANY
-    scope, across platform/, processing/, and standards/.
+    """Collect imports of private app.modules names from protected shared layers.
 
-    Two shapes count, because a leading underscore can sit on either side of the
-    `from X import Y` boundary. `from app.modules.X import _name` marks the NAME
-    private; `from app.modules.X._mod import name` (or `import
-    app.modules.X._mod`) marks the MODULE private, and the imported name can look
-    perfectly public while still being reached through a path that can move or
-    vanish without notice. Resolving each import to its full dotted symbol path
-    and checking every segment after `app.modules` catches both shapes with one
-    rule, rather than two independent checks that could drift apart.
-
-    A RELATIVE import is resolved to its absolute path first (fix #1438 codex
-    review): `node.module` alone is only correct for a level-0 import, so
-    `from ...modules.catalog._private import x` written deep in platform/ or
-    processing/ would otherwise read as module `"modules.catalog._private"`
-    — never reaching the `"app.modules"` prefix check at all.
-    """
+    Relative imports and imported submodule names are resolved before checking underscore-prefixed path segments."""
     offenders: dict[str, set[str]] = {}
     for root in _PRIVATE_MODULE_IMPORT_ROOTS:
         for path in sorted(root.rglob("*.py")):
@@ -7834,16 +2491,8 @@ def _private_module_import_edges() -> dict[str, set[str]]:
     return offenders
 
 
-# fix(#1438 F24): kept separate from _PROCESSING_CATALOG_IMPORT_BURNDOWN even
-# though it lists the same import line (ai/router.py:320) — that dict tracks the
-# catalog-BOUNDARY crossing (fix: route through ProcessingPort); this one tracks
-# the PRIVATE-SYMBOL reach the same import happens to also make (fix: promote the
-# symbols to a public home). Two rules, one import, two reasons. When
-# _PROCESSING_CATALOG_IMPORT_BURNDOWN's "ai/router.py":
-# "app.modules.catalog.maps._router_helpers" entry is retired, this entry must be
-# retired in the same commit — the underlying import is gone either way.
-#
-# The list may SHRINK, never grow.
+# This separately tracks private-symbol use; the same edge may also violate the
+# catalog boundary. Retire both entries together when the import disappears.
 _PRIVATE_MODULE_IMPORT_BURNDOWN: dict[str, set[str]] = {
     "backend/app/processing/ai/router.py": {
         "app.modules.catalog.maps._router_helpers._can_edit_map",
@@ -7854,19 +2503,7 @@ _PRIVATE_MODULE_IMPORT_BURNDOWN: dict[str, set[str]] = {
 
 @pytest.mark.architecture
 def test_no_private_module_imports_from_app_modules() -> None:
-    """No `_`-prefixed name or module reached from app.modules.* outside its own
-    domain, across platform/, processing/, and standards/, at any scope.
-
-    fix(#1438 F24): broadens what was `test_platform_does_not_import_private_
-    module_names` (platform/ only, name-shape only) on two axes. Directory:
-    `platform/config_ops` importing the settings router's private
-    `_ENTERPRISE_ONLY_TABS` was never a platform-only failure mode — the same
-    fragility applies wherever backend/app/ reaches into a product module's
-    internals. Shape: `processing/ai/router.py` imports two functions through
-    `app.modules.catalog.maps._router_helpers` — a private MODULE — and a
-    name-only check cannot see that the path itself, not just the names on it,
-    is marked as liable to move or vanish without notice.
-    """
+    """Platform, processing, and standards do not import product-domain private modules outside the shrink-only burn-down."""
     offenders: list[str] = []
     for file, symbols in sorted(_private_module_import_edges().items()):
         allowed = _PRIVATE_MODULE_IMPORT_BURNDOWN.get(file, set())
@@ -7901,11 +2538,8 @@ def test_private_module_import_allowlist_is_current() -> None:
         )
 
 
-# fix(#836): the platform->processing axis, mirroring _PLATFORM_MODULE_IMPORT_BURNDOWN
-# above. `platform/extensions/defaults_*.py` delegates INTO app.processing by design
-# (the CatalogPort/AI-provider defaults carried 63 such edges at audit time), but only
-# through deferred function-local imports (D-17). The module-scope edges below are the
-# reviewed exceptions. The list may SHRINK, never grow.
+# Platform defaults may delegate into processing through deferred imports.
+# These existing module-scope exceptions are shrink only.
 _PLATFORM_PROCESSING_IMPORT_BURNDOWN: dict[str, set[str]] = {
     # Upload/config API composition: these platform routers queue ingest work and
     # reuse the export Content-Disposition sanitizer. Resolvable by moving the
@@ -7920,13 +2554,7 @@ _PLATFORM_PROCESSING_IMPORT_BURNDOWN: dict[str, set[str]] = {
 
 @pytest.mark.architecture
 def test_platform_processing_imports_stay_deferred() -> None:
-    """Module-scope platform->processing imports are enumerated, not tolerated.
-
-    fix(#836): the layering guard scanned the platform->modules axis but not
-    platform->processing, so the port defaults could accrete module-load-time
-    processing dependencies unnoticed. Deferred (function-local) imports remain
-    the sanctioned mechanism, exactly as on the modules axis.
-    """
+    """Platform may reach processing only through the named deferred-import burn-down."""
     import ast
 
     offenders: list[str] = []
@@ -7957,14 +2585,7 @@ def test_platform_processing_imports_stay_deferred() -> None:
 
 @pytest.mark.architecture
 def test_platform_never_imports_processing_routers() -> None:
-    """No platform file imports a processing router module, at any scope.
-
-    fix(#836): `DefaultCatalogPort.ingest_part_size` imported PART_SIZE from
-    `app.processing.ingest.router` — importing an API-edge module executes route
-    registration as a side effect and couples the platform seam to the router's
-    import graph. Constants and helpers a port needs must live in a service or
-    schema module; only api/main.py composes routers.
-    """
+    """Platform never imports processing router modules at any scope."""
     import ast
 
     offenders: list[str] = []
@@ -7992,24 +2613,11 @@ def test_platform_never_imports_processing_routers() -> None:
         )
 
 
-# fix(#1438 F7): standards/ has two import-boundary guards, and this is the
-# second. `backend/tests/test_standards_layering.py` (added by #1438) holds
-# standards -> app.processing to a strict zero, mirroring the catalog rule
-# (processing-owned ORM classes, queries, and helpers must be reached through
-# CatalogPort). standards -> app.modules got no guard at all: the STAC and OGC
-# routers construct queries directly against catalog ORM classes
-# (datasets/collections/records/search), which is a live, reviewed design
-# choice — those routers exist to expose the catalog through external
-# standards, and a port indirection would not remove the coupling, only hide
-# it. So this is NOT a burn-down toward zero the way the processing guards
-# above are: it is a FROZEN surface. Today's edges are enumerated once so the
-# surface cannot grow silently; shrinking (migrating an edge through
-# CatalogPort) is welcome but not required.
+# Standards expose catalog models directly, so this is a frozen surface rather
+# than a zero-edge rule. New imports are forbidden; migration through CatalogPort
+# may shrink the set. Standards-to-processing remains zero tolerance elsewhere.
 _STANDARDS_MODULE_IMPORT_SURFACE: dict[str, set[str]] = {
-    # fix(#1469): the shared "what may a feed publish" helper the three
-    # DCAT-family serializers now share. Same catalog-ORM edge each of them
-    # already carries, in one file instead of three, and TYPE_CHECKING-only —
-    # it is duck-typed on the Dataset instance at runtime.
+    # Shared feed-publication policy; the model import is type-checking only.
     "distributions.py": {
         "app.modules.catalog.datasets.domain.models",
     },
@@ -8052,14 +2660,7 @@ _STANDARDS_MODULE_IMPORT_SURFACE: dict[str, set[str]] = {
 
 
 def _standards_module_import_edges() -> dict[str, set[str]]:
-    """Every `app.modules.*` import under standards/, at ANY scope.
-
-    Same two shapes handled as `_processing_import_edges()` above (fix #1438
-    codex review): a relative import is resolved to its absolute path before
-    the prefix check, and `from app.modules import X` falls back to each
-    imported name as a possible extension of the bare, non-specific
-    `"app.modules"` `node.module` resolves to.
-    """
+    """Collect standards imports into app.modules at any scope, resolving relative and imported-submodule forms."""
     edges: dict[str, set[str]] = {}
     for path in sorted(_STANDARDS_DIR.rglob("*.py")):
         for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
@@ -8084,15 +2685,7 @@ def _standards_module_import_edges() -> dict[str, set[str]]:
 
 @pytest.mark.architecture
 def test_standards_module_import_surface_does_not_grow() -> None:
-    """standards/ -> app.modules.* is frozen at today's edges, not banned.
-
-    fix(#1438 F7): unlike the processing/platform burndowns elsewhere in this
-    file, `_STANDARDS_MODULE_IMPORT_SURFACE` is not a to-do list — STAC/OGC/DCAT
-    exist to expose the catalog to external standards, so direct ORM access is
-    the design, not debt. What this guards against is the surface growing
-    UNREVIEWED: a new file or a new edge here should be a deliberate addition to
-    the allowlist, not a silent side effect of a router growing a new route.
-    """
+    """Standards-to-product imports may not grow beyond the frozen shrink-only surface."""
     offenders: list[str] = []
     for file, modules in sorted(_standards_module_import_edges().items()):
         allowed = _STANDARDS_MODULE_IMPORT_SURFACE.get(file, set())
@@ -8111,11 +2704,7 @@ def test_standards_module_import_surface_does_not_grow() -> None:
 
 @pytest.mark.architecture
 def test_standards_module_import_surface_is_current() -> None:
-    """The frozen surface must shrink (or stay flat) as edges are migrated.
-
-    A stale entry overstates today's coupling and is a silent licence to
-    reintroduce a since-removed edge later without review.
-    """
+    """The standards import surface contains no stale entries."""
     edges = _standards_module_import_edges()
     stale: list[str] = []
     for file, modules in sorted(_STANDARDS_MODULE_IMPORT_SURFACE.items()):
@@ -8129,11 +2718,7 @@ def test_standards_module_import_surface_is_current() -> None:
         )
 
 
-# fix(#1438 F6): widens test_platform_never_imports_processing_routers (fix #836)
-# past its original platform-only, processing-only shape. That guard stays exactly
-# as written below — it is STRICTER on its own axis (any scope, not just module
-# scope) — this one adds the coverage it never had: every package, importing a
-# router module belonging to any OTHER package.
+# Detect cross-package router imports across all backend packages.
 def _dotted_package(path: Path) -> str:
     """The dotted `app.…` package a file lives in — its containing directory."""
     return ".".join(path.parent.relative_to(BACKEND_ROOT).parts)
@@ -8162,17 +2747,9 @@ def _is_router_module(module: str) -> bool:
 
 
 def _resolves_to_real_module(dotted: str) -> bool:
-    """True when a dotted `app.…` path names a real file or package under backend/.
+    """Return whether a dotted app path names a real module or package.
 
-    fix(#1438 F6 codex review): distinguishes `from app.platform.jobs import
-    router` (imports the `router.py` SUBMODULE — `router` here names a real
-    file) from `from app.core.schemas import router_id_param` (imports an
-    ordinary NAME that happens to start with `router_` — no such file exists).
-    Both are the same AST shape (`ImportFrom(module=X, names=[alias(name=Y)])`);
-    only the filesystem tells them apart. Needed because `_is_router_module()`
-    is a filename heuristic — applying it to every imported NAME without this
-    check would flag the second case as a router import.
-    """
+    This distinguishes imported router submodules from ordinary imported names that happen to start with router_."""
     candidate = BACKEND_ROOT / Path(*dotted.split("."))
     return (
         candidate.with_suffix(".py").is_file() or (candidate / "__init__.py").is_file()
@@ -8190,49 +2767,9 @@ _ROUTER_COMPOSITION_ROOT = frozenset(
 
 
 def _cross_package_router_import_edges() -> dict[str, set[str]]:
-    """Every MODULE-SCOPE import of a router module from outside its own
-    package, across all of backend/app/.
+    """Collect module-scope imports of router modules across package boundaries.
 
-    fix(#1438 F6): importing an API-edge module runs its route registration as
-    a side effect and couples the importer to the router's whole transitive
-    import graph, just to reach one constant or helper function — the exact
-    shape fix(#836) diagnosed, but that guard could only see it for platform/
-    importing app.processing.*. The failure mode is not domain-specific: any
-    package reaching across a boundary for a name that belongs in a service or
-    schema module has the same problem.
-
-    Two import shapes reach a router submodule, and both are checked (fix
-    #1438 F6 codex review): `from app.platform.jobs.router import name` names
-    it as `node.module` directly; `from app.platform.jobs import router` names
-    it as an imported NAME, resolved against the filesystem via
-    `_resolves_to_real_module()` so an ordinary name that merely starts with
-    `router_` is not mistaken for a submodule.
-
-    Module scope only, determined by AST ancestry rather than `col_offset`
-    (fix #1438 F6 codex review): `col_offset != 0` was the established idiom
-    elsewhere in this file, but it also skips an import nested in a top-level
-    `try`/`if` block — indented, so nonzero column, but still executed at
-    module-import time. Walking function bodies to build an exclusion set
-    (mirroring `_redirect_escaping_imports()` above) excludes only imports
-    truly inside a function, which is where the D-17 deferred-import escape
-    hatch used throughout this file actually defers to — it does not run the
-    router's side effects at the importer's import time, so it does not
-    reproduce the bug this guard exists to catch.
-
-    Same-package nesting is not an edge: a domain's ``router.py`` composing
-    its own ``router_*.py`` siblings (e.g. ``catalog/maps/router.py`` including
-    ``catalog/maps/router_assets.py``) is the normal way a domain's API surface
-    is assembled, and neither file is "outside its own package" from the
-    other's perspective.
-
-    A RELATIVE import is resolved to its absolute path first (fix #1438 codex
-    review): `from ...platform.jobs.router import name`, written deep inside
-    `app/modules/catalog/collections/`, stores `node.module ==
-    "platform.jobs.router"` with `node.level == 3` — reading `node.module`
-    directly gives a string that does not start with `"app."` and is silently
-    skipped, the same equivalent-relative-syntax bypass `_resolve_relative_
-    import()` closes for the other three collectors in this file.
-    """
+    Both direct-module and imported-submodule forms are resolved, including relative imports. Function-local imports are deferred and excluded. Same-package router composition and the API composition root are allowed."""
     offenders: dict[str, set[str]] = {}
     for path in sorted(_backend_path("app").rglob("*.py")):
         rel = _repo_style_rel(path)
@@ -8274,20 +2811,8 @@ def _cross_package_router_import_edges() -> dict[str, set[str]]:
     return offenders
 
 
-# fix(#1438 F6): the one edge the enumeration surfaced is flagged here rather
-# than treated as routine reviewed debt. Every OTHER burndown in this file
-# traces to a fix commit that named its tradeoff and accepted it; this edge
-# predates any guard that could see it (source outside platform/, target
-# outside app.processing/ — invisible to both axes fix(#836) checked) and was
-# added in #476 ("harden lifecycle and tenant isolation"), a PR about tenant
-# isolation with nothing suggesting this coupling was a deliberate choice.
-# Seeded so the guard is actionable on today's tree rather than failing on
-# pre-existing, unrelated code — worth a follow-up to move
-# `get_retry_capability` into a plain service module, the way `sweep.py`
-# already did for this same router's other non-route helpers (see
-# app/platform/jobs/router.py's own module docstring).
-#
-# The list may SHRINK, never grow.
+# Existing admin-to-jobs-router edge. Move get_retry_capability to a service
+# module, then remove this shrink-only exception.
 _CROSS_PACKAGE_ROUTER_IMPORT_BURNDOWN: dict[str, set[str]] = {
     "backend/app/modules/admin/router.py": {"app.platform.jobs.router"},
 }
@@ -8335,11 +2860,8 @@ def test_cross_package_router_import_allowlist_is_current() -> None:
         )
 
 
-# fix(#1778 codex r3): every cache read that DECIDES ACCESS must be marked
-# security=True, so the layered provider refuses to answer it from this worker's
-# process-local fallback. The provider cannot tell an authorization decision
-# from a cached listing by looking at the value, so the marking is the contract
-# and this test is what keeps the marking honest.
+# Authorization cache reads use security=True so a process-local fallback
+# cannot serve a stale capability after revocation.
 #
 # Phrased as a per-module rule rather than a repo-wide one on purpose. Sweeping
 # every `cache.get(` in backend/app/ and demanding the flag would be wrong: the
@@ -8391,8 +2913,7 @@ def test_authorization_cache_reads_are_security_scoped() -> None:
             "An authorization cache call is missing security=True, so a layered "
             "provider may answer it from this worker's in-memory fallback. That "
             "fallback cannot see a revoke another Uvicorn worker performed while "
-            "Redis was down (fix(#1778 codex r3)). Offending calls:\n"
-            + "\n".join(offenders)
+            "Redis was down. Offending calls:\n" + "\n".join(offenders)
         )
 
 

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -22,7 +22,11 @@ from app.modules.audit.models import AuditLog
 from app.modules.auth.models import User
 from app.modules.catalog.datasets.domain.models import Dataset, Record
 from app.modules.catalog.maps.models import Map, MapLayer
-from app.modules.catalog.maps.schemas import MapLayerDiffRequest, MapLayerInput
+from app.modules.catalog.maps.schemas import (
+    BasemapConfig,
+    MapLayerDiffRequest,
+    MapLayerInput,
+)
 from app.processing.raster.models import RasterAsset
 
 from tests.factories import create_dataset, create_raster_dataset, get_user_id
@@ -51,26 +55,17 @@ BASEMAP_CONFIG_PAYLOAD = {
 
 
 def test_basemap_config_opacity_defaults_to_one():
-    from app.modules.catalog.maps.schemas import BasemapConfig
-
     cfg = BasemapConfig()
     assert cfg.opacity == 1.0
 
 
 def test_basemap_config_opacity_accepts_valid_range():
-    from app.modules.catalog.maps.schemas import BasemapConfig
-
     assert BasemapConfig(opacity=0.0).opacity == 0.0
     assert BasemapConfig(opacity=0.55).opacity == 0.55
     assert BasemapConfig(opacity=1.0).opacity == 1.0
 
 
 def test_basemap_config_opacity_rejects_out_of_range():
-    import pytest
-    from pydantic import ValidationError
-
-    from app.modules.catalog.maps.schemas import BasemapConfig
-
     with pytest.raises(ValidationError):
         BasemapConfig(opacity=-0.1)
     with pytest.raises(ValidationError):
@@ -78,29 +73,17 @@ def test_basemap_config_opacity_rejects_out_of_range():
 
 
 def test_basemap_config_still_rejects_unknown_fields_with_opacity_set():
-    import pytest
-    from pydantic import ValidationError
-
-    from app.modules.catalog.maps.schemas import BasemapConfig
-
     with pytest.raises(ValidationError):
         BasemapConfig(opacity=0.5, unknown_field=1)
 
 
 def test_basemap_config_background_color_accepts_hex_or_null():
-    from app.modules.catalog.maps.schemas import BasemapConfig
-
     assert BasemapConfig(background_color=None).background_color is None
     assert BasemapConfig(background_color="#f8fafc").background_color == "#f8fafc"
     assert BasemapConfig(background_color="#F8FAFC").background_color == "#F8FAFC"
 
 
 def test_basemap_config_background_color_rejects_invalid_colors():
-    import pytest
-    from pydantic import ValidationError
-
-    from app.modules.catalog.maps.schemas import BasemapConfig
-
     for value in ("red", "#abc", "#1234567", "javascript:alert(1)"):
         with pytest.raises(ValidationError):
             BasemapConfig(background_color=value)
@@ -462,8 +445,6 @@ class TestListMaps:
     async def test_list_maps_as_admin(
         self, client: AsyncClient, admin_auth_header: dict
     ):
-        """GET /maps/ as admin returns maps with total."""
-        # Create a map to ensure at least one exists
         await _create_map(client, admin_auth_header)
 
         resp = await client.get("/maps/", headers=admin_auth_header)
@@ -476,8 +457,6 @@ class TestListMaps:
     async def test_list_maps_as_editor_sees_own(
         self, client: AsyncClient, editor_auth_header: dict
     ):
-        """GET /maps/ as editor returns only their own maps."""
-        # Create a map as editor
         created = await _create_map(client, editor_auth_header, "Editor Own Map")
 
         resp = await client.get("/maps/", headers=editor_auth_header)
@@ -487,14 +466,12 @@ class TestListMaps:
         assert created["id"] in map_ids
 
     async def test_list_maps_unauthenticated(self, client: AsyncClient):
-        """GET /maps/ without auth returns 200 (public maps only)."""
         resp = await client.get("/maps/")
         assert resp.status_code == 200
 
     async def test_list_maps_pagination(
         self, client: AsyncClient, admin_auth_header: dict
     ):
-        """GET /maps/?limit=1 returns at most 1 map."""
         await _create_map(client, admin_auth_header)
         await _create_map(client, admin_auth_header)
 
@@ -512,7 +489,6 @@ class TestListMaps:
 
 class TestGetMap:
     async def test_get_map_success(self, client: AsyncClient, admin_auth_header: dict):
-        """GET /maps/{id} returns the map with layers."""
         created = await _create_map(client, admin_auth_header)
         map_id = created["id"]
 
@@ -526,12 +502,10 @@ class TestGetMap:
     async def test_get_map_not_found(
         self, client: AsyncClient, admin_auth_header: dict
     ):
-        """GET /maps/{random_uuid} returns 404."""
         resp = await client.get(f"/maps/{uuid.uuid4()}", headers=admin_auth_header)
         assert resp.status_code == 404
 
     async def test_get_map_unauthenticated(self, client: AsyncClient):
-        """GET /maps/{id} without auth returns 404 (anonymous access allowed, map not found)."""
         resp = await client.get(f"/maps/{uuid.uuid4()}")
         assert resp.status_code == 404
 

--- a/backend/tests/test_maps.py
+++ b/backend/tests/test_maps.py
@@ -41,7 +41,7 @@ BASEMAP_CONFIG_PAYLOAD = {
     "relief_contrast": "strong",
     "opacity": 0.55,
     "background_color": None,
-    # Phase 1059 BSE-01: sublayer_overrides field added to BasemapConfig
+    # Sublayer_overrides field added to BasemapConfig
     # (jsonb-additive, defaults to None). Existing tests must include the
     # field in their expected payload so equality assertions match the
     # serialized response.
@@ -228,7 +228,7 @@ def test_layer_diff_schema_rejects_invalid_style_payload() -> None:
         )
 
 
-# fix(#1069): `paint` and `layout` were bounded by serialized size alone, so a
+# `paint` and `layout` were bounded by serialized size alone, so a
 # value that is structurally nonsense for the property it sits on persisted and
 # waited to raise inside whatever serializer next descended into it — a 500 on
 # the shared `GET /maps/{id}/style.json` produced by stored data rather than by
@@ -270,7 +270,7 @@ def test_layer_schema_keeps_a_well_formed_legacy_function() -> None:
 
 
 def test_expression_operands_are_not_shape_checked() -> None:
-    """fix(#1109 review): `stops` inside an expression operand is plain data.
+    """`stops` inside an expression operand is plain data.
 
     MapLibre accepts ``["get", "stops", ["literal", {"stops": 5}]]`` — the
     literal object is a lookup subject, not a legacy function, and the
@@ -324,7 +324,7 @@ async def _create_map(
 def _valid_png_data_uri() -> str:
     """Return a small but VALID PNG data URI for thumbnail tests.
 
-    Phase 273 SEC-12: PUT /maps/{id}/thumbnail/ now runs PIL.Image.verify()
+    PUT /maps/{id}/thumbnail/ now runs PIL.Image.verify()
     on the decoded base64 payload. The previous shorthand
     ``iVBORw0KGgo=`` was only the 8-byte PNG magic header — not a complete
     PNG — and is correctly rejected by the verify gate. Tests that just
@@ -511,12 +511,12 @@ class TestGetMap:
 
 
 # ---------------------------------------------------------------------------
-# SEC-A: map READ endpoints must re-authorize each layer's dataset
+# Map READ endpoints must re-authorize each layer's dataset
 # ---------------------------------------------------------------------------
 
 
 class TestMapLayerDatasetVisibilityLeak:
-    """SEC-A (Phase 1170): a public map referencing a PRIVATE dataset must not
+    """A public map referencing a PRIVATE dataset must not
     leak that dataset's metadata or a replayable signed tile URL to anonymous
     callers. The map READ endpoints must filter layers by per-caller dataset
     visibility, mirroring get_shared_map.
@@ -662,7 +662,7 @@ class TestUpdateMap:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """ENH-06 round-trip: a custom legend_title (map-level) and a per-entry
+        """A map title and per-entry legend label both persist across save/reload.
         style_config.legendLabel (layer-level) both persist across save+reload.
 
         Proves the verified storage path end-to-end: the title rides the new
@@ -709,7 +709,7 @@ class TestUpdateMap:
     async def test_update_map_legend_title_empty_clears_override(
         self, client: AsyncClient, admin_auth_header: dict
     ):
-        """ENH-06: an empty/whitespace legend_title clears the override (null)."""
+        """An empty/whitespace legend_title clears the override (null)."""
         created = await _create_map(client, admin_auth_header)
         map_id = created["id"]
 
@@ -1207,7 +1207,7 @@ class TestMapHistory:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """fix(#941): POST /layers and the PATCH save-diff both write
+        """POST /layers and the PATCH save-diff both write
         ``layer.add``, and their summaries must not be collapsed into one.
 
         POST creates the row immediately, so its entry outlives a discarded
@@ -1746,7 +1746,7 @@ class TestDuplicateMap:
         created = await _create_map(client, admin_auth_header, "Thumb Source")
         map_id = created["id"]
 
-        # Set a thumbnail on source (SEC-12: must be a real PNG that
+        # Set a thumbnail on source (it must be a real PNG that
         # PIL.Image.verify() accepts — see _valid_png_data_uri docstring)
         await client.put(
             f"/maps/{map_id}/thumbnail/",
@@ -1872,8 +1872,8 @@ class TestShareToken:
     ):
         """Public maps can create expiring share links.
 
-        builder-audit #338 P1-14: custom share expiration is now an Enterprise-only
-        advanced-sharing control; the mechanism is exercised under Enterprise.
+        Custom share expiration is an Enterprise-only control, so this test
+        exercises it under Enterprise.
         """
         created = await _create_map(client, admin_auth_header)
         map_id = created["id"]
@@ -2229,7 +2229,7 @@ class TestMapLayers:
         test_db_session,
         paint,
     ):
-        """fix(#1069): POST /maps/{id}/layers answers 422, not 201-then-500."""
+        """POST /maps/{id}/layers answers 422, not 201-then-500."""
         admin_id = await get_user_id(test_db_session, "admin")
         ds = await create_dataset(test_db_session, created_by=admin_id)
         created = await _create_map(client, admin_auth_header)
@@ -2249,13 +2249,12 @@ class TestMapLayers:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """fix(#1069): rows written before the write-time check are still stored.
+        """Rows written before the write-time check are still stored.
 
         Shape-validating new writes does nothing about the rows already in the
         database, so the read side has to bound them too. The layer's paint is
         seeded straight into the table — the API would refuse it now — and the
-        serializer is made to descend into it the way #1054's intermediate
-        revision did. The shared style endpoint must answer 200 without that
+        serializer must descend into it. The shared style endpoint must answer 200 without that
         layer rather than 500 for every consumer of the map.
 
         (Asserted on behaviour, not on captured logs: `caplog` sees no structlog
@@ -2344,7 +2343,7 @@ class TestMapLayers:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """RHYD-01: POST /maps/{id}/layers returns real band_count + dem_vertical_units.
+        """POST /maps/{id}/layers returns real band_count + dem_vertical_units.
 
         The add-layer response must surface the RasterAsset metadata immediately
         (no save+reload). Before the get_dataset_meta fix both fields came back
@@ -2711,8 +2710,7 @@ class TestMapLayers:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """builder-audit #338 B-011: DEM hypsometric (color-relief) builder-private
-        keys _hypso-enabled/_hypso-ramp are accepted and moved into
+        """DEM hypsometric builder keys are accepted and moved into
         style_config.builder. Before the fix, saving a DEM layer with the
         Elevation tint enabled hit split_legacy_builder_paint's unknown-key
         guard and 422'd."""
@@ -2748,7 +2746,7 @@ class TestMapLayers:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """fix(HT-14): a partial layer PATCH that omits style_config must NOT
+        """A partial layer PATCH that omits style_config must NOT
         erase the DEM's stored hypsometric builder metadata. The old after-mode
         validator assigned style_config=None into model_fields_set, defeating
         exclude_unset=True, so the builder's own eye-toggle Save ({id, visible})
@@ -2883,7 +2881,7 @@ class TestMapLayers:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """fix(V-14 / #430 codex): a full PUT carrying layer ids updates rows in
+        """A full PUT carrying layer ids updates rows in
         place — the layer UUID survives instead of being regenerated. A layer
         sent WITHOUT an id still creates a fresh row."""
         admin_id = await get_user_id(test_db_session, "admin")
@@ -2931,7 +2929,7 @@ class TestMapLayers:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """fix(#430 codex r12): a full-replace payload repeating the same layer
+        """A full-replace payload repeating the same layer
         id must 422 (PATCH already rejects duplicate ids) — previously the
         by-id reconcile silently collapsed the entries, with the second
         overwriting the first. Two id-less entries stay legal: each creates
@@ -3136,7 +3134,7 @@ class TestMapLayers:
 
 
 class TestMapLayersTrailingSlash:
-    """Phase 280: POST /maps/{id}/layers must accept the trailing-slash form
+    """POST /maps/{id}/layers must accept the trailing-slash form
     directly (no 307 redirect) so host-side fetch callers — Node test
     runners, third-party SDKs, curl clients — never resolve the relative
     Location header against the in-container ``api:8000`` Host.
@@ -3145,7 +3143,7 @@ class TestMapLayersTrailingSlash:
     documented in the GeoLens API guide; the trailing-slash form is a hidden
     alias declared on the same handler. The trailing-slash regression guard
     below is the load-bearing one — it would have caught the 260508-d6i
-    smoke failure (#5, #6). The parity guard ensures both decorators
+    smoke failure. The parity guard ensures both decorators
     stay wired to the same handler with the same response contract.
     """
 
@@ -3254,8 +3252,8 @@ class TestMapLayersTrailingSlash:
         admin_auth_header: dict,
         test_db_session,
     ):
-        """v13.14 fixup: PATCH /maps/{id}/layers/ must also accept the
-        trailing-slash form directly. Phase 280 only fixed POST; this guard
+        """PATCH /maps/{id}/layers/ must accept the trailing-slash form directly.
+        This guard
         covers the sibling PATCH endpoint so future programmatic callers
         don't hit the same 307 / in-container hostname leak.
 
@@ -3315,7 +3313,7 @@ class TestMapThumbnail:
         created = await _create_map(client, admin_auth_header)
         map_id = created["id"]
 
-        # SEC-12: payload must pass PIL.Image.verify() — see
+        # Payload must pass PIL.Image.verify() — see
         # _valid_png_data_uri helper for the rationale.
         resp = await client.put(
             f"/maps/{map_id}/thumbnail/",
@@ -3348,7 +3346,7 @@ class TestMapThumbnail:
     ):
         """Thumbnail refreshes must invalidate map-card thumbnail caches.
 
-        fix(#1005): the cache version moved to its own column. ``updated_at``
+        The cache version moved to its own column. ``updated_at``
         carried both meanings, so the lazy backfill that fires when an owner
         first opens a thumbnail-less map in the builder — a read, editing
         nothing — bumped the map's edit timestamp and reordered the "Last
@@ -3707,7 +3705,7 @@ class TestUpdateShareToken:
     ):
         """PATCH /maps/{id}/share with expires_at returns 200 with updated expiration.
 
-        builder-audit #338 P1-14: expiration is Enterprise-only; mechanism tested here.
+        Expiration is Enterprise-only, so the test uses that edition.
         """
         map_id, original_token = await _make_public_map_with_share_token(
             client, admin_auth_header
@@ -3728,8 +3726,8 @@ class TestUpdateShareToken:
     ):
         """PATCH /maps/{id}/share with expires_at=null removes expiration.
 
-        builder-audit #338 P1-14: the setup step sets a custom expiration, which is
-        Enterprise-only; clearing it (None) is allowed in any edition.
+        The setup step uses Enterprise to set the expiration; clearing it is
+        allowed in any edition.
         """
         map_id, original_token = await _make_public_map_with_share_token(
             client, admin_auth_header
@@ -3757,7 +3755,7 @@ class TestUpdateShareToken:
     ):
         """PATCH with expires_at on a never-expires token adds expiration.
 
-        builder-audit #338 P1-14: expiration is Enterprise-only; mechanism tested here.
+        Expiration is Enterprise-only, so the test uses that edition.
         """
         map_id, original_token = await _make_public_map_with_share_token(
             client, admin_auth_header
@@ -3778,7 +3776,7 @@ class TestUpdateShareToken:
     ):
         """PATCH /maps/{id}/share on a map with no share token returns 404.
 
-        builder-audit #338 P1-14: runs under Enterprise so the expiration edition gate
+        Run under Enterprise so the expiration edition gate
         does not pre-empt the missing-token 404.
         """
         created = await _create_map(client, admin_auth_header)
@@ -3811,7 +3809,7 @@ class TestUpdateShareToken:
     ):
         """Token hint does not change after PATCH (same underlying token).
 
-        builder-audit #338 P1-14: expiration is Enterprise-only; mechanism tested here.
+        Expiration is Enterprise-only, so the test uses that edition.
         """
         map_id, original_token = await _make_public_map_with_share_token(
             client, admin_auth_header
@@ -3849,7 +3847,7 @@ class TestAdminShareTokenListing:
     async def test_admin_published_map_without_share_token_appears(
         self, client: AsyncClient, admin_auth_header: dict
     ):
-        """#347 (ADM-01): a public map with no share link still appears in the admin
+        """A public map with no share link still appears in the admin
         Published Maps listing, with null token fields."""
         unique_name = f"NoLinkPublished_{uuid.uuid4().hex[:6]}"
         created = await _create_map(client, admin_auth_header, name=unique_name)
@@ -4442,17 +4440,15 @@ class TestShowInLegendRoundTrip:
 
 
 # ---------------------------------------------------------------------------
-# Style JSON import round-trip — terrain persistence (NEW-INT-01 regression)
+# Style JSON import round-trip — terrain persistence
 # ---------------------------------------------------------------------------
 
 
 class TestImportStyleJsonTerrain:
     """POST /maps/import must persist terrain_config from imported style JSON.
 
-    Closes NEW-INT-01: prior to this test, the parser correctly populated
-    ImportedStyleMap.terrain_config but the import endpoint never assigned
-    it onto the persisted Map, so STYLEX-02 / FLOW-03 silently broke at the
-    HTTP boundary while parser-level unit tests passed.
+    The parser and HTTP import path must both carry
+    ImportedStyleMap.terrain_config onto the persisted Map.
     """
 
     async def test_import_style_with_top_level_terrain_persists_terrain_config(

--- a/backend/tests/test_search_pagination.py
+++ b/backend/tests/test_search_pagination.py
@@ -1,6 +1,6 @@
 """Pagination stability tests for /search/datasets.
 
-Regression coverage for (#315): the standard (non-RRF) sort path used 6 ORDER BY
+Regression coverage: the standard (non-RRF) sort path used 6 ORDER BY
 branches, none of which had a unique tiebreaker. When many rows tie on the
 sort key (same record_status, updated_at, created_at, title) OFFSET/LIMIT
 returned a non-stable order, so paging the full result set produced duplicate

--- a/backend/tests/test_search_pagination.py
+++ b/backend/tests/test_search_pagination.py
@@ -159,7 +159,6 @@ async def test_pagination_no_dupes_no_drops_across_branches(
     tied_datasets: dict,
     sort_by: str,
 ):
-    """Paging tied rows yields every id exactly once for every sort branch."""
     expected = {str(ds.id) for ds in tied_datasets["datasets"]}
     keyword_tag = tied_datasets["keyword_tag"]
 
@@ -172,9 +171,7 @@ async def test_pagination_no_dupes_no_drops_across_branches(
     )
 
     seen = [pid for pid in paged if pid in expected]
-    # No duplicates across pages.
     assert len(seen) == len(set(seen)), f"duplicate ids paging sort_by={sort_by}"
-    # Full coverage -- no dropped rows.
     assert set(seen) == expected, f"missing/extra ids paging sort_by={sort_by}"
 
 
@@ -189,7 +186,6 @@ async def test_pagination_order_is_stable_across_runs(
     tied_datasets: dict,
     sort_by: str,
 ):
-    """The full paged order is identical across two independent runs."""
     expected = {str(ds.id) for ds in tied_datasets["datasets"]}
     keyword_tag = tied_datasets["keyword_tag"]
 

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -125,14 +125,12 @@ STAC_SEARCH_RESULTS = {
 
 @pytest.fixture
 def mock_stac_ssrf():
-    """Patch SSRF validation on STAC router to allow all URLs."""
     with patch("app.modules.catalog.sources.stac_router.validate_url_for_ssrf") as mock:
         yield mock
 
 
 @pytest.fixture
 def mock_stac_connect():
-    """Patch connect_stac_api to return canned landing page."""
     with patch(
         "app.modules.catalog.sources.stac_router.connect_stac_api",
         new_callable=AsyncMock,
@@ -149,7 +147,6 @@ def mock_stac_connect():
 
 @pytest.fixture
 def mock_stac_collections():
-    """Patch list_stac_collections to return canned collections."""
     with patch(
         "app.modules.catalog.sources.stac_router.list_stac_collections",
         new_callable=AsyncMock,
@@ -172,7 +169,6 @@ def mock_stac_collections():
 
 @pytest.fixture
 def mock_stac_search():
-    """Patch search_stac_items to return canned items."""
     with patch(
         "app.modules.catalog.sources.stac_router.search_stac_items",
         new_callable=AsyncMock,

--- a/backend/tests/test_stac_import.py
+++ b/backend/tests/test_stac_import.py
@@ -384,7 +384,7 @@ async def _create_stac_dataset(
 
     ``origin_uri``/``origin_ref`` default to unset — the shape of a row
     migration 0036 could not backfill — so callers that want a fully-bound
-    (post-#1218) dataset, or one with a deliberately mismatched pair to
+    fully bound dataset, or one with a deliberately mismatched pair to
     reproduce a respelling writer, pass both explicitly.
     """
     import uuid as _uuid
@@ -458,7 +458,7 @@ class TestStacImport:
         assert data["results"][0]["status"] == "created"
         assert data["results"][0]["dataset_id"] is not None
 
-        # fix(#1271 review): no Titiler answered in this environment, so
+        # No Titiler answered in this environment, so
         # fetch_cog_info returned None and nobody can show the origin was
         # contacted — the field stays NULL until a probe settles it. The
         # contacted case is pinned separately below.
@@ -476,7 +476,7 @@ class TestStacImport:
         admin_auth_header: dict,
         mock_stac_ssrf,
     ):
-        """fix(#1764): the item pointer is what a later credentialed refresh
+        """The item pointer is what a later credentialed refresh
         anchors on, so it may not name a host other than the submitted
         catalog. Search already drops such a link; this refuses it for a
         client that did not come from there."""
@@ -511,7 +511,7 @@ class TestStacImport:
         mock_stac_ssrf,
         test_db_session,
     ):
-        """feat(#1764): `url` is the anchor a credentialed refresh reads, and
+        """`url` is the anchor a credentialed refresh reads, and
         `auth_required` is a boolean the wizard sets when the search that
         produced these items carried a credential."""
         from sqlalchemy import select
@@ -590,7 +590,7 @@ class TestStacImport:
         test_db_session,
         mock_stac_ssrf,
     ):
-        """feat(#1692): the served STAC item carries a readable COG href.
+        """The served STAC item carries a readable COG href.
 
         Before this, a by-reference import stored no ``dataset_assets`` row,
         so the item GeoLens re-published exposed exactly one asset — the
@@ -646,7 +646,7 @@ class TestStacImport:
 
         # The served item, read the way a generic client reads it. The
         # remote href passes through resolve_asset_url untouched — it is
-        # not managed storage, so neither presigning nor the GAP-031 proxy
+        # not managed storage, so neither presigning nor the proxy
         # refusal applies — and it sits BESIDE the tiles template, each
         # roled as what it is.
         item = await client.get(f"/stac/items/{dataset_id}", headers=admin_auth_header)
@@ -670,7 +670,7 @@ class TestStacImport:
         test_db_session,
         mock_stac_ssrf,
     ):
-        """feat(#1692): the type echo is optional, like the other echoes.
+        """The type echo is optional, like the other echoes.
 
         An older client — or an item whose asset declares no ``type`` —
         still imports, and still gets the pass-through asset; the row simply
@@ -720,7 +720,7 @@ class TestStacImport:
         admin_auth_header: dict,
         mock_stac_ssrf,
     ):
-        """fix(#1271 review): cog info in hand means Titiler reached the COG
+        """Cog info in hand means Titiler reached the COG
         on GeoLens's behalf — that IS a contact, same contract as
         _finalize_ingest and the reupload swap."""
         with patch(
@@ -773,13 +773,13 @@ class TestStacImport:
         mock_stac_ssrf,
         test_db_session,
     ):
-        """fix(#1334): fetch_cog_info retrieves crs_wkt for a remote asset
+        """Fetch_cog_info retrieves crs_wkt for a remote asset
         the same way it retrieves band_count/dtype, but nothing wrote it onto
         the raster_assets row. The Titiler probe already runs at import
         time; this only asks that its answer be kept, the same way its
         other fields already are.
 
-        fix(#1375): this probe result carries no transform, which is the
+        This probe result carries no transform, which is the
         case where res_x/res_y stay NULL. The sibling test below covers the
         one that does carry it.
         """
@@ -862,9 +862,9 @@ class TestStacImport:
         mock_stac_ssrf,
         test_db_session,
     ):
-        """fix(#1375): remote raster rows showed "Resolution: — x —" and
-        exported no ``gsd``, because #1334 had no source for a resolution it
-        could trust. ``fetch_cog_info`` now reads the affine off
+        """Remote raster rows expose their probed resolution and rotation.
+
+        ``fetch_cog_info`` reads the affine from
         ``/cog/stac``; this asks that the numbers reach the row and the API,
         including the rotation flag, which a remote row could previously
         only report as the column's default ``false``.
@@ -873,7 +873,7 @@ class TestStacImport:
         envelope-division shortcut would have got wrong. 10.0 is the pixel
         size of the same 30°-rotated fixture ``test_cog_info.py`` probes —
         its affine's element 0 is 8.66, and the difference between those two
-        numbers is the #1375 review finding.
+        numbers proves that the pixel vector length is used.
         """
         with patch(
             "app.modules.catalog.sources.stac_router.fetch_cog_info",
@@ -936,7 +936,7 @@ class TestStacImport:
         mock_stac_ssrf,
         test_db_session,
     ):
-        """fix(#1334 review): the item declares one EPSG (4326, stale or
+        """The item declares one EPSG (4326, stale or
         simply wrong) while the probe's own CRS says another (32621) — the
         raster row and the dataset's srid mirror the probe, not the item, so
         RasterAsset.to_stac_properties() cannot publish a proj:code and a
@@ -1009,7 +1009,7 @@ class TestStacImport:
         mock_stac_ssrf,
         test_db_session,
     ):
-        """fix(#884): RFC 7946 §5.2 mandates west > east for a crossing bbox, and
+        """RFC 7946 §5.2 mandates west > east for a crossing bbox, and
         the old code fed [170, -20, -170, -15] straight into
         POLYGON((w s, e s, e n, w n, w s)). That ring is valid but spans longitude
         -170..170: 1700 deg² on the wrong side of the world instead of the
@@ -1101,11 +1101,9 @@ class TestStacImport:
         assert row.hits_south_atlantic is False
         assert row.hits_france is False
 
-        # fix(#1004): the dataset payload's own extent_bbox is the RFC 7946 §5.2
-        # spec form too. It was monotonic under #892, when DatasetMap drew an
-        # unguarded planar ring; #903 added the seam guards, and the span form
-        # then flattened this extent to the globe-spanning pair that made those
-        # guards unreachable.
+        # The dataset payload's own extent_bbox is the RFC 7946 §5.2
+        # spec form too. A monotonic span would flatten this extent into a
+        # globe-spanning pair and make the seam guards unreachable.
         detail = await client.get(f"/datasets/{dataset_id}", headers=admin_auth_header)
         assert detail.status_code == 200
         assert detail.json()["extent_bbox"] == [170.0, -20.0, -170.0, -15.0]
@@ -1116,7 +1114,7 @@ class TestStacImport:
         admin_auth_header: dict,
         mock_stac_ssrf,
     ):
-        """fix(#1286): also the never-refreshed-dataset regression test.
+        """Also the never-refreshed-dataset regression test.
 
         The first import writes ``origin_uri`` and ``origin_ref.asset_href``
         together and nothing touches the binding afterward, so the second
@@ -1158,10 +1156,10 @@ class TestStacImport:
         test_db_session,
         mock_stac_ssrf,
     ):
-        """fix(#1286): a row migration 0036 could not backfill is still caught.
+        """A row migration 0036 could not backfill is still caught.
 
         Neither ``origin_uri`` nor ``origin_ref`` is set — the shape of a row
-        that predates #1218 — so the guard can only catch it through the
+        that predates origin binding, so the guard can only catch it through the
         ``source_url`` fallback branch.
         """
         from tests.factories import get_user_id
@@ -1201,7 +1199,7 @@ class TestStacImport:
         test_db_session,
         mock_stac_ssrf,
     ):
-        """fix(#1286): a respelled origin_uri can no longer open the hole.
+        """A respelled origin_uri can no longer open the hole.
 
         ``origin_ref.asset_href`` names the canonical asset; ``origin_uri``
         is deliberately a different spelling of the same asset (as a
@@ -1356,7 +1354,7 @@ class TestStacAdapter:
 
         from app.modules.catalog.sources.adapters.stac import connect_stac_api
 
-        # fix(#1770 round 41 P1): a real client over a MockTransport, not a
+        # A real client over a MockTransport, not a
         # fully-mocked one -- `connect_stac_api` now reads via `client.stream`,
         # which an `AsyncMock` cannot fake the async-context-manager protocol
         # of. A content-yielding async generator is what a real transport's
@@ -1492,7 +1490,7 @@ class TestStacImportContactSemantics:
         admin_auth_header: dict,
         mock_stac_ssrf,
     ):
-        """fix(#1271 review): a Titiler non-200 is NOT proof the origin was
+        """A Titiler non-200 is NOT proof the origin was
         attempted — the extension allowlist rejects some assets before any
         upstream fetch, and the shapes cannot be told apart without parsing
         Titiler's error bodies. Only proven contact (info in hand) stamps;

--- a/backend/tests/test_unscoped_finding_markers.py
+++ b/backend/tests/test_unscoped_finding_markers.py
@@ -1,7 +1,6 @@
-"""Structural gate for AGENTS.md's inline review-comment convention.
+"""Legacy finding-tag guard for AGENTS.md's Contracts and Comments policy.
 
-A comment or docstring under ``backend/app`` that names a coded finding id
-must carry a ``#issue`` anchor within two lines. Detector: finding_markers.py.
+Plain explanations need no anchor. Retained coded references must be scoped.
 """
 
 from pathlib import Path

--- a/backend/tests/test_vector_quicklook_pure.py
+++ b/backend/tests/test_vector_quicklook_pure.py
@@ -60,20 +60,20 @@ class TestGeoToPixel:
 
 class TestComputePointRadius:
     def test_small_dataset_gets_large_points(self):
-        assert _compute_point_radius(10, 256) == 6.0
-        assert _compute_point_radius(50, 256) == 6.0
+        assert _compute_point_radius(10) == 6.0
+        assert _compute_point_radius(50) == 6.0
 
     def test_medium_dataset_gets_medium_points(self):
-        assert _compute_point_radius(51, 256) == 4.5
-        assert _compute_point_radius(200, 256) == 4.5
+        assert _compute_point_radius(51) == 4.5
+        assert _compute_point_radius(200) == 4.5
 
     def test_large_dataset_gets_small_points(self):
-        assert _compute_point_radius(201, 256) == 3.0
-        assert _compute_point_radius(1000, 256) == 3.0
+        assert _compute_point_radius(201) == 3.0
+        assert _compute_point_radius(1000) == 3.0
 
     def test_huge_dataset_gets_smallest_points(self):
-        assert _compute_point_radius(1001, 256) == 2.0
-        assert _compute_point_radius(1_000_000, 256) == 2.0
+        assert _compute_point_radius(1001) == 2.0
+        assert _compute_point_radius(1_000_000) == 2.0
 
 
 class TestBlankCanvas:

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -1504,8 +1504,8 @@ export interface paths {
          * Get Collection Queryables
          * @description Queryable properties for one feature collection (OGC Features Part 3).
          *
-         *     feat(#1614): derived from the live table schema (never the stored
-         *     column_info snapshot) so the advertised set always matches what `filter=`
+         *     Derived from the live table schema rather than the stored column_info
+         *     snapshot, so the advertised set always matches what `filter=`
          *     on /items validates against. `additionalProperties: false` is what makes
          *     rejecting filters on unlisted properties spec-conformant.
          */
@@ -21108,7 +21108,7 @@ export interface operations {
                 f?: string | null;
                 /** @description Include geometry in response. Set to false for attribute-only queries. */
                 include_geometry?: boolean;
-                /** @description CQL2 filter expression evaluated server-side against this collection's queryables document (feat(#1614), OGC Features Part 3). Combines with bbox and property filters by AND. */
+                /** @description CQL2 filter expression evaluated server-side against this collection's OGC Features Part 3 queryables document. Combines with bbox and property filters by AND. */
                 filter?: string | null;
                 /** @description Filter language: cql2-text (default) or cql2-json. */
                 "filter-lang"?: string;

--- a/sdks/python/geolens/api/ogc_features/get_collection_items_collections_dataset_id_items_get.py
+++ b/sdks/python/geolens/api/ogc_features/get_collection_items_collections_dataset_id_items_get.py
@@ -222,8 +222,8 @@ def sync_detailed(
         include_geometry (bool | Unset): Include geometry in response. Set to false for attribute-
             only queries. Default: True.
         filter_ (None | str | Unset): CQL2 filter expression evaluated server-side against this
-            collection's queryables document (feat(#1614), OGC Features Part 3). Combines with bbox
-            and property filters by AND.
+            collection's OGC Features Part 3 queryables document. Combines with bbox and property
+            filters by AND.
         filter_lang (str | Unset): Filter language: cql2-text (default) or cql2-json. Default:
             'cql2-text'.
         filter_crs (None | str | Unset): CRS of filter geometries. Only CRS84
@@ -307,8 +307,8 @@ def sync(
         include_geometry (bool | Unset): Include geometry in response. Set to false for attribute-
             only queries. Default: True.
         filter_ (None | str | Unset): CQL2 filter expression evaluated server-side against this
-            collection's queryables document (feat(#1614), OGC Features Part 3). Combines with bbox
-            and property filters by AND.
+            collection's OGC Features Part 3 queryables document. Combines with bbox and property
+            filters by AND.
         filter_lang (str | Unset): Filter language: cql2-text (default) or cql2-json. Default:
             'cql2-text'.
         filter_crs (None | str | Unset): CRS of filter geometries. Only CRS84
@@ -386,8 +386,8 @@ async def asyncio_detailed(
         include_geometry (bool | Unset): Include geometry in response. Set to false for attribute-
             only queries. Default: True.
         filter_ (None | str | Unset): CQL2 filter expression evaluated server-side against this
-            collection's queryables document (feat(#1614), OGC Features Part 3). Combines with bbox
-            and property filters by AND.
+            collection's OGC Features Part 3 queryables document. Combines with bbox and property
+            filters by AND.
         filter_lang (str | Unset): Filter language: cql2-text (default) or cql2-json. Default:
             'cql2-text'.
         filter_crs (None | str | Unset): CRS of filter geometries. Only CRS84
@@ -469,8 +469,8 @@ async def asyncio(
         include_geometry (bool | Unset): Include geometry in response. Set to false for attribute-
             only queries. Default: True.
         filter_ (None | str | Unset): CQL2 filter expression evaluated server-side against this
-            collection's queryables document (feat(#1614), OGC Features Part 3). Combines with bbox
-            and property filters by AND.
+            collection's OGC Features Part 3 queryables document. Combines with bbox and property
+            filters by AND.
         filter_lang (str | Unset): Filter language: cql2-text (default) or cql2-json. Default:
             'cql2-text'.
         filter_crs (None | str | Unset): CRS of filter geometries. Only CRS84

--- a/sdks/python/geolens/api/ogc_features/get_collection_queryables_collections_dataset_id_queryables_get.py
+++ b/sdks/python/geolens/api/ogc_features/get_collection_queryables_collections_dataset_id_queryables_get.py
@@ -128,8 +128,8 @@ def sync_detailed(
 
      Queryable properties for one feature collection (OGC Features Part 3).
 
-    feat(#1614): derived from the live table schema (never the stored
-    column_info snapshot) so the advertised set always matches what `filter=`
+    Derived from the live table schema rather than the stored column_info
+    snapshot, so the advertised set always matches what `filter=`
     on /items validates against. `additionalProperties: false` is what makes
     rejecting filters on unlisted properties spec-conformant.
 
@@ -172,8 +172,8 @@ def sync(
 
      Queryable properties for one feature collection (OGC Features Part 3).
 
-    feat(#1614): derived from the live table schema (never the stored
-    column_info snapshot) so the advertised set always matches what `filter=`
+    Derived from the live table schema rather than the stored column_info
+    snapshot, so the advertised set always matches what `filter=`
     on /items validates against. `additionalProperties: false` is what makes
     rejecting filters on unlisted properties spec-conformant.
 
@@ -210,8 +210,8 @@ async def asyncio_detailed(
 
      Queryable properties for one feature collection (OGC Features Part 3).
 
-    feat(#1614): derived from the live table schema (never the stored
-    column_info snapshot) so the advertised set always matches what `filter=`
+    Derived from the live table schema rather than the stored column_info
+    snapshot, so the advertised set always matches what `filter=`
     on /items validates against. `additionalProperties: false` is what makes
     rejecting filters on unlisted properties spec-conformant.
 
@@ -252,8 +252,8 @@ async def asyncio(
 
      Queryable properties for one feature collection (OGC Features Part 3).
 
-    feat(#1614): derived from the live table schema (never the stored
-    column_info snapshot) so the advertised set always matches what `filter=`
+    Derived from the live table schema rather than the stored column_info
+    snapshot, so the advertised set always matches what `filter=`
     on /items validates against. `additionalProperties: false` is what makes
     rejecting filters on unlisted properties spec-conformant.
 

--- a/sdks/typescript/src/client/sdk.gen.ts
+++ b/sdks/typescript/src/client/sdk.gen.ts
@@ -1570,8 +1570,8 @@ export const getCollectionItemFeatureCollectionsDatasetIdItemsFeatureIdGet = <Th
  *
  * Queryable properties for one feature collection (OGC Features Part 3).
  *
- * feat(#1614): derived from the live table schema (never the stored
- * column_info snapshot) so the advertised set always matches what `filter=`
+ * Derived from the live table schema rather than the stored column_info
+ * snapshot, so the advertised set always matches what `filter=`
  * on /items validates against. `additionalProperties: false` is what makes
  * rejecting filters on unlisted properties spec-conformant.
  */

--- a/sdks/typescript/src/client/types.gen.ts
+++ b/sdks/typescript/src/client/types.gen.ts
@@ -15891,7 +15891,7 @@ export type GetCollectionItemsCollectionsDatasetIdItemsGetData = {
         /**
          * Filter
          *
-         * CQL2 filter expression evaluated server-side against this collection's queryables document (feat(#1614), OGC Features Part 3). Combines with bbox and property filters by AND.
+         * CQL2 filter expression evaluated server-side against this collection's OGC Features Part 3 queryables document. Combines with bbox and property filters by AND.
          */
         filter?: string | null;
         /**


### PR DESCRIPTION
## Summary

Backend comments mixed current contracts with issue tags, extraction history and repeated narration. This change removes that noise, removes unused private helpers/arguments and simplifies small equivalent branches. The repository policy now favors concise explanations of non-obvious constraints and keeps provenance in Git, issues and PRs.

## Changes

- Trim backend implementation/test prose while retaining authorization, SQL safety, tenant isolation, session, ingestion and cache invariants.
- Remove about 5,500 lines of historical prose from the architecture guard suite; retain assertions and lower exact source-size caps and marker-debt entries.
- Align AGENTS.md, hook guidance and the ADR reference with the new comment policy. Preserve detection logic and functional annotations.
- Remove internal provenance from diagnostic messages, pytest marker descriptions and two published OGC descriptions. Regenerate OpenAPI, both SDKs and frontend API types; request/response shapes are unchanged.
- Audit dependency usage; no backend dependency changes or additions were warranted.

## Area

- [x] Backend (API, services, models)
- [x] OGC / Standards
- [x] Import / Ingestion
- [x] Docs / Config

## Testing

- [x] Full backend Ruff lint and format checks (1,217 files)
- [x] Architecture, marker, CodeQL, migration and STAC bbox/limit checks: 139 passed; final prose corrections: 115 architecture/marker/CodeQL checks passed
- [x] Finding-marker guard, diff checks and signed commit hooks
- [x] Original behavioral cleanup: catalog 6, core/API 124, processing/standards 45, STAC/OGC 140 and migration 13 focused checks passed
- [x] OpenAPI check, SDK regeneration/drift checks, TypeScript SDK build and 7 tests, frontend generated-type drift check
- [x] Independent QA, Codex findings addressed, and parent review; follow-up production changes are comments/docstrings and explicitly reviewed diagnostic/description strings, with executable structure unchanged
- [x] Original behavioral cleanup: uncached API container build and healthy restart; Playwright MCP catalog, dataset preview/data table and public map smoke passed, map/tiles ready and no console errors

The final prose-only follow-up does not require another container rebuild or browser pass. An initial local Docker outage during the original audit was resolved; the affected tests and complete uncached build passed on retry.

## Checklist

- [x] Existing safety and architecture guards preserved
- [x] No new lint warnings or dependencies
- [x] No secrets or credentials in the diff
- API descriptions and generated documentation change; runtime API shapes, database schema, configuration and UI strings do not.

The known upstream Python image Trivy failure on main is addressed separately by #2061 (rebuilt OS layer: zero critical findings). Related frontend cleanup: #2063.
