### PR TITLE
fix(ops): prevent valid large uploads from exhausting tmpfs

### DIFF
--- a/backend/tests/test_docker_audit_regressions.py
+++ b/backend/tests/test_docker_audit_regressions.py
@@ -218,7 +218,7 @@ def test_production_frontend_has_only_explicit_writable_mounts():
     assert "frontend_cache" in compose["volumes"]
 
 
-def test_frontend_request_bodies_spool_outside_the_bounded_tmpfs():
+def test_frontend_streams_request_bodies_outside_the_bounded_tmpfs():
     compose = _load_compose(PROD_COMPOSE)
     frontend = compose["services"]["frontend"]
     nginx = FRONTEND_NGINX.read_text()
@@ -228,7 +228,9 @@ def test_frontend_request_bodies_spool_outside_the_bounded_tmpfs():
     )
     assert "size=64m" in tmpfs_mount
     assert "frontend_cache:/var/cache/nginx" in frontend["volumes"]
-    assert "client_body_temp_path /var/cache/nginx/client_temp;" in nginx
+    assert "proxy_http_version 1.1;" in nginx
+    assert "proxy_request_buffering off;" in nginx
+    assert "client_body_temp_path" not in nginx
 
 
 def test_frontend_runtime_config_is_materialized_in_tmpfs():

--- a/backend/tests/test_docker_audit_regressions.py
+++ b/backend/tests/test_docker_audit_regressions.py
@@ -218,6 +218,19 @@ def test_production_frontend_has_only_explicit_writable_mounts():
     assert "frontend_cache" in compose["volumes"]
 
 
+def test_frontend_request_bodies_spool_outside_the_bounded_tmpfs():
+    compose = _load_compose(PROD_COMPOSE)
+    frontend = compose["services"]["frontend"]
+    nginx = FRONTEND_NGINX.read_text()
+
+    tmpfs_mount = next(
+        mount for mount in frontend["tmpfs"] if mount.startswith("/tmp:")
+    )
+    assert "size=64m" in tmpfs_mount
+    assert "frontend_cache:/var/cache/nginx" in frontend["volumes"]
+    assert "client_body_temp_path /var/cache/nginx/client_temp;" in nginx
+
+
 def test_frontend_runtime_config_is_materialized_in_tmpfs():
     dockerfile = DOCKERFILE.read_text()
     entrypoint = FRONTEND_ENTRYPOINT.read_text()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -572,8 +572,8 @@ services:
     cap_drop:
       - ALL
     read_only: true
-    # The entrypoint materializes the immutable SPA in /tmp. Nginx keeps its
-    # raster cache and large request-body spool on the disk-backed cache volume.
+    # The entrypoint materializes the immutable SPA in /tmp; nginx keeps its
+    # bounded raster cache on a dedicated writable volume.
     tmpfs:
       - /tmp:size=64m,mode=1777
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -572,8 +572,8 @@ services:
     cap_drop:
       - ALL
     read_only: true
-    # The entrypoint materializes the immutable SPA in /tmp; nginx keeps its
-    # bounded raster cache on a dedicated writable volume.
+    # The entrypoint materializes the immutable SPA in /tmp. Nginx keeps its
+    # raster cache and large request-body spool on the disk-backed cache volume.
     tmpfs:
       - /tmp:size=64m,mode=1777
     ports:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -540,6 +540,10 @@ server {
     }
 
     location /api/ {
+        # Request bodies can be as large as CLIENT_MAX_BODY_SIZE. Keep their
+        # temporary files on the frontend cache volume instead of the 64 MiB
+        # /tmp tmpfs used for runtime configuration and the SPA copy.
+        client_body_temp_path /var/cache/nginx/client_temp;
         resolver ${NGINX_RESOLVER} valid=10s;
         set $upstream_api ${API_UPSTREAM};
         rewrite ^/api/(.*) /$1 break;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -540,14 +540,14 @@ server {
     }
 
     location /api/ {
-        # Request bodies can be as large as CLIENT_MAX_BODY_SIZE. Keep their
-        # temporary files on the frontend cache volume instead of the 64 MiB
-        # /tmp tmpfs used for runtime configuration and the SPA copy.
-        client_body_temp_path /var/cache/nginx/client_temp;
         resolver ${NGINX_RESOLVER} valid=10s;
         set $upstream_api ${API_UPSTREAM};
         rewrite ^/api/(.*) /$1 break;
         proxy_pass $upstream_api;
+        # Forward request bodies as they arrive so the frontend does not keep
+        # a second full copy in its bounded /tmp.
+        proxy_http_version 1.1;
+        proxy_request_buffering off;
         # A3 (#315 follow-up): the FastAPI SecurityHeadersMiddleware already emits
         # X-Frame-Options: DENY. This block has no add_header, so it inherits the
         # server-scope `add_header X-Frame-Options SAMEORIGIN`, which nginx APPENDS


### PR DESCRIPTION
## Summary

Production Nginx buffered large request bodies in the frontend container's 64 MiB `/tmp` tmpfs. A valid 70 MiB upload therefore failed with HTTP 500 even when `CLIENT_MAX_BODY_SIZE` allowed it. Nginx now streams API request bodies to the API service, which owns upload staging and body-size enforcement, while preserving the frontend's read-only root filesystem and bounded `/tmp` tmpfs.

Closes #2057.

## Changes

- Disable Nginx request buffering for `/api/` and use HTTP/1.1 upstream so chunked requests stream too.
- Keep the existing 64 MiB frontend `/tmp` tmpfs and disk-backed raster cache unchanged.
- Add a Compose/Nginx regression test that pins streaming, the read-only mount layout, and the frontend tmpfs limit.

## Area

- [ ] Backend (API, workers, migrations)
- [ ] Frontend (React, UI components)
- [x] Infrastructure (Docker, nginx)
- [ ] Documentation
- [ ] CLI / MCP / SDK

## Testing

- [x] Unit tests pass (`14 passed`: `backend/tests/test_docker_audit_regressions.py`)
- [x] Manual testing completed against the built Nginx container
  - Baseline: a 70 MiB request under an 80 MiB configured limit returned HTTP 500 with `pwrite() \"/tmp/client_temp/0000000001\" failed (28: No space left on device)`.
  - Fixed image: 70 MiB Content-Length and chunked requests both reached the upstream after the first 1 MiB, before the client sent the remainder, and returned HTTP 204.
  - After both 70 MiB requests, frontend `/tmp` used 6.3 MiB for runtime files and `/var/cache/nginx` used 0 bytes.
  - Limit enforcement: an 81 MiB Content-Length request against the 80 MiB limit returned HTTP 413.
- [ ] Playwright e2e tests pass (not applicable: no browser UI behavior changed)

Additional checks:

- Full backend `ruff check .`
- Full backend `ruff format --check .` (1,217 files)
- Frontend Docker build target
- Production Compose config validation
- `backend/tests/finding_markers.py`
- `git diff --check`

## Checklist

- [x] Code follows project conventions
- [x] Tests cover the regression
- [x] No generated files were edited manually
- [x] No schema or public API contract changes
- [x] DCO sign-off included

## TDD Audit

| Test commit | Impl commit | gate_status |
|---|---|---|
| — | `138834606` fix(ops): spool large uploads outside tmpfs | missing |
| — | `118817f5a` fix(ops): stream upload bodies through frontend | missing |

Aggregate: 0 skill, 0 fallback, 0 exempt — 2 missing.

gate_status: skill=0, fallback=0, exempt=0, missing=2
