### PR TITLE
fix(editing): preserve drafts and synchronize edit state

### DIFF
--- a/backend/alembic/versions/0062_record_modified_clock.py
+++ b/backend/alembic/versions/0062_record_modified_clock.py
@@ -3,7 +3,7 @@
 from alembic import op
 
 revision = "0062_record_modified_clock"
-down_revision = "0060_dataset_publication_version"
+down_revision = "0061_refresh_token_families"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0062_record_modified_clock.py
+++ b/backend/alembic/versions/0062_record_modified_clock.py
@@ -1,0 +1,32 @@
+"""Keep record modification times monotonic across concurrent transactions."""
+
+from alembic import op
+
+revision = "0062_record_modified_clock"
+down_revision = "0060_dataset_publication_version"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE OR REPLACE FUNCTION catalog.set_updated_at() RETURNS trigger
+        LANGUAGE plpgsql AS $$
+        BEGIN
+            NEW.updated_at = GREATEST(OLD.updated_at, clock_timestamp());
+            RETURN NEW;
+        END;
+        $$
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        CREATE OR REPLACE FUNCTION catalog.set_updated_at() RETURNS trigger
+        LANGUAGE plpgsql AS $$
+        BEGIN
+            NEW.updated_at = now();
+            RETURN NEW;
+        END;
+        $$
+    """)

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -817,6 +817,23 @@ def _validate_geometry_type(geojson_type: str, dataset_geometry_type: str) -> No
         )
 
 
+def _coerce_temporal_properties(properties: dict, column_info: list[dict]) -> dict:
+    """Convert JSON temporal strings to the native values required by asyncpg."""
+    values = dict(properties)
+    for column in column_info:
+        name = column["name"]
+        pg_type = column.get("type")
+        value = values.get(name)
+        if isinstance(value, str) and pg_type in (
+            "date",
+            "timestamp without time zone",
+            "timestamp with time zone",
+        ):
+            parsed = _property_filter_bind(f"prop_{name}", name, pg_type, value)
+            values[name] = parsed.value
+    return values
+
+
 async def insert_feature(
     db: AsyncSession,
     table_name: str,
@@ -835,6 +852,7 @@ async def insert_feature(
     _validate_geometry_type(geometry.get("type", ""), dataset_geometry_type)
     normalized_geom = _validate_geometry_structure(geometry)
     _reject_unknown_properties(properties, column_info)
+    properties = _coerce_temporal_properties(properties or {}, column_info)
 
     geojson_str = to_geojson(normalized_geom)
 
@@ -885,6 +903,7 @@ async def replace_feature(
     # Replace nulls every known column, so an unwritable one makes
     # the documented semantics unachievable even when the request omits it.
     _reject_unknown_properties(properties, column_info, replaces_all=True)
+    properties = _coerce_temporal_properties(properties, column_info)
 
     geojson_str = to_geojson(normalized_geom)
     geom_expr, geom_4326_expr = _geom_write_exprs(dataset_geometry_type, dataset_srid)
@@ -948,6 +967,7 @@ async def update_feature(
 
     if properties is not None:
         _reject_unknown_properties(properties, column_info)
+        properties = _coerce_temporal_properties(properties, column_info)
         allowed = {c["name"] for c in column_info}
         for key, value in properties.items():
             if key in allowed and _COLUMN_NAME_RE.match(key):

--- a/backend/app/modules/catalog/features/service.py
+++ b/backend/app/modules/catalog/features/service.py
@@ -830,6 +830,13 @@ def _coerce_temporal_properties(properties: dict, column_info: list[dict]) -> di
             "timestamp with time zone",
         ):
             parsed = _property_filter_bind(f"prop_{name}", name, pg_type, value)
+            if (
+                pg_type == "timestamp with time zone"
+                and parsed.value.utcoffset() is None
+            ):
+                raise ValueError(
+                    f"Property {name!r} requires a timestamp with a timezone offset."
+                )
             values[name] = parsed.value
     return values
 

--- a/backend/app/modules/catalog/layers/service.py
+++ b/backend/app/modules/catalog/layers/service.py
@@ -93,9 +93,13 @@ async def create_layer(
         geom_type=geometry_type,
     )
     if columns:
+        seen_columns: set[str] = set()
         for col in columns:
             if not COLUMN_NAME_RE.match(col.name):
                 raise ValueError(f"Invalid column name: {col.name!r}")
+            if col.name in seen_columns:
+                raise ValueError(f"Column {col.name!r} is defined more than once.")
+            seen_columns.add(col.name)
             pg_type = ALLOWED_COLUMN_TYPES[col.type]
             col_defs += f", {_qcol(col.name)} {pg_type}"
 
@@ -278,6 +282,9 @@ async def rename_column(
     Validates names, rejects reserved columns, and ensures the destination
     name is not already in use. Refreshes ``column_info`` and migrates the
     matching ``AttributeMetadata`` row to the new name afterwards.
+
+    Names retained by removed attribute metadata cannot be rename targets;
+    preserving both histories requires distinct names.
     """
     get_catalog_port().validate_table_name(dataset.table_name)
 
@@ -297,6 +304,19 @@ async def rename_column(
         raise ValueError(f"Column {column_name!r} does not exist on this layer.")
     if new_name in existing_names:
         raise ValueError(f"Column {new_name!r} already exists on this layer.")
+
+    retained_attribute = await session.scalar(
+        select(AttributeMetadata.id).where(
+            AttributeMetadata.dataset_id == dataset.id,
+            AttributeMetadata.field_name == new_name,
+            AttributeMetadata.is_current.is_(False),
+        )
+    )
+    if retained_attribute is not None:
+        raise ValueError(
+            f"Column name {new_name!r} has retained metadata from a removed column. "
+            "Choose a different name to preserve that metadata."
+        )
 
     table_ref = get_catalog_port().quote_table(dataset.table_name)
     ddl = f"ALTER TABLE {table_ref} RENAME COLUMN {_qcol(column_name)} TO {_qcol(new_name)}"

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -81,6 +81,14 @@ _LANGUAGE_PATH = Path(
 )
 
 
+async def _touch_record(db: AsyncSession, record: Record, user: Identity) -> None:
+    """Stamp the parent before child writes, in their transaction."""
+    record.updated_at = func.now()
+    record.updated_by = user.id
+    # Acquire the parent write lock before a child lock to match cascading delete.
+    await db.flush()
+
+
 async def _propagate_record_write(
     record_id: uuid.UUID,
     *,
@@ -371,6 +379,7 @@ async def create_contact_endpoint(
     """Create a new contact for a record."""
     record = await _check_record_ownership(db, record_id, user)
     try:
+        await _touch_record(db, record, user)
         contact = await create_contact(
             db,
             record_id,
@@ -414,8 +423,9 @@ async def update_contact_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> ContactResponse:
     """Update a contact."""
-    await _check_record_ownership(db, record_id, user)
+    record = await _check_record_ownership(db, record_id, user)
     try:
+        await _touch_record(db, record, user)
         # fix(#458): exclude_unset, not exclude_none — an explicitly-set
         # null clears the field (the dataset contract); the schema already
         # 422s nulls on non-clearable fields.
@@ -458,8 +468,9 @@ async def delete_contact_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Delete a contact."""
-    await _check_record_ownership(db, record_id, user)
+    record = await _check_record_ownership(db, record_id, user)
     try:
+        await _touch_record(db, record, user)
         await delete_contact(db, contact_id, record_id)
         await db.commit()
     except ValueError:
@@ -588,6 +599,7 @@ async def create_keyword_endpoint(
     """Create a new keyword for a record."""
     record = await _check_record_ownership(db, record_id, user)
     try:
+        await _touch_record(db, record, user)
         kw = await create_keyword(
             db,
             record_id,
@@ -628,8 +640,9 @@ async def delete_keyword_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Delete a keyword."""
-    await _check_record_ownership(db, record_id, user)
+    record = await _check_record_ownership(db, record_id, user)
     try:
+        await _touch_record(db, record, user)
         await delete_keyword(db, keyword_id, record_id)
         await db.commit()
     except ValueError:
@@ -714,6 +727,7 @@ async def create_distribution_endpoint(
     """Create a manual distribution for a record."""
     record = await _check_record_ownership(db, record_id, user)
     try:
+        await _touch_record(db, record, user)
         dist = await create_distribution(
             db,
             record_id,
@@ -765,8 +779,9 @@ async def update_distribution_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> DistributionResponse:
     """Update a distribution (manual only; auto-generated distributions are immutable)."""
-    await _check_record_ownership(db, record_id, user)
+    record = await _check_record_ownership(db, record_id, user)
     try:
+        await _touch_record(db, record, user)
         # fix(#458): exclude_unset, not exclude_none — see update_contact.
         dist = await update_distribution(
             db, distribution_id, record_id, **body.model_dump(exclude_unset=True)
@@ -813,8 +828,9 @@ async def delete_distribution_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Delete a distribution (manual only; auto-generated distributions are immutable)."""
-    await _check_record_ownership(db, record_id, user)
+    record = await _check_record_ownership(db, record_id, user)
     try:
+        await _touch_record(db, record, user)
         await delete_distribution(db, distribution_id, record_id)
         await db.commit()
     except ValueError as e:

--- a/backend/app/modules/catalog/records/router.py
+++ b/backend/app/modules/catalog/records/router.py
@@ -83,6 +83,7 @@ _LANGUAGE_PATH = Path(
 
 async def _touch_record(db: AsyncSession, record: Record, user: Identity) -> None:
     """Stamp the parent before child writes, in their transaction."""
+    # Force an UPDATE for the same actor; the trigger supplies monotonic wall time.
     record.updated_at = func.now()
     record.updated_by = user.id
     # Acquire the parent write lock before a child lock to match cascading delete.

--- a/backend/tests/test_layer_column_ops.py
+++ b/backend/tests/test_layer_column_ops.py
@@ -421,3 +421,39 @@ async def test_column_ddl_recomputes_quality_detail(
     assert after.status_code == 200
     computed_after = after.json()["quality_detail"]["computed_at"]
     assert computed_after > computed_before
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH"])
+async def test_timestamp_writes_preserve_offsets_and_reject_ambiguous_local_time(
+    client: AsyncClient, admin_auth_header: dict, method: str
+):
+    dataset_id = await _create_layer(
+        client, admin_auth_header, title=f"Offset {method}"
+    )
+    changed = await client.patch(
+        f"/layers/{dataset_id}/columns/value/type",
+        json={"new_type": "timestamp"},
+        headers=admin_auth_header,
+    )
+    assert changed.status_code == 200, changed.text
+    collection_url = f"/datasets/{dataset_id}/features/"
+    body = {
+        "geometry": {"type": "Point", "coordinates": [1, 2]},
+        "properties": {"value": "2026-09-12T10:30:00-04:00"},
+    }
+    created = await client.post(collection_url, json=body, headers=admin_auth_header)
+    assert created.status_code == 201, created.text
+    feature_url = f"{collection_url}{created.json()['id']}"
+    url = collection_url if method == "POST" else feature_url
+    accepted = await client.request(method, url, json=body, headers=admin_auth_header)
+    assert accepted.status_code == (201 if method == "POST" else 200), accepted.text
+    assert accepted.json()["properties"]["value"] == "2026-09-12T14:30:00+00:00"
+
+    body["properties"] = {"name": "must not persist", "value": "2026-09-12T10:30"}
+    denied = await client.request(method, url, json=body, headers=admin_auth_header)
+    assert denied.status_code == 400, denied.text
+    assert "timezone offset" in denied.json()["detail"]
+    persisted = await client.get(feature_url, headers=admin_auth_header)
+    assert persisted.json()["properties"]["value"] == "2026-09-12T14:30:00+00:00"
+    assert persisted.json()["properties"]["name"] is None

--- a/backend/tests/test_layer_column_ops.py
+++ b/backend/tests/test_layer_column_ops.py
@@ -55,6 +55,62 @@ async def test_rename_column_to_existing_name_fails(
 
 
 @pytest.mark.anyio
+async def test_rename_column_preserves_a_dropped_names_metadata(
+    client: AsyncClient, admin_auth_header: dict
+):
+    """A retained name is rejected clearly without losing either column's metadata."""
+    dataset_id = await _create_layer(
+        client, admin_auth_header, title="Reuse Dropped Column Name"
+    )
+    inserted = await client.post(
+        f"/datasets/{dataset_id}/features/",
+        json={
+            "geometry": {"type": "Point", "coordinates": [1, 2]},
+            "properties": {"name": "preserved", "value": "removed"},
+        },
+        headers=admin_auth_header,
+    )
+    assert inserted.status_code == 201, inserted.text
+    gid = inserted.json()["id"]
+
+    dropped = await client.delete(
+        f"/layers/{dataset_id}/columns/value", headers=admin_auth_header
+    )
+    assert dropped.status_code == 200, dropped.text
+    before = await client.get(
+        f"/datasets/{dataset_id}/attributes/",
+        params={"include_removed": True},
+        headers=admin_auth_header,
+    )
+    assert before.status_code == 200, before.text
+    attributes = {a["field_name"]: a for a in before.json()["attributes"]}
+    assert attributes["name"]["is_current"] is True
+    assert attributes["value"]["is_current"] is False
+
+    renamed = await client.patch(
+        f"/layers/{dataset_id}/columns/name/name",
+        json={"new_name": "value"},
+        headers=admin_auth_header,
+    )
+    assert renamed.status_code == 400, renamed.text
+    assert "retained metadata" in renamed.json()["detail"]
+    assert "different name" in renamed.json()["detail"]
+
+    persisted = await client.get(
+        f"/datasets/{dataset_id}/features/{gid}", headers=admin_auth_header
+    )
+    assert persisted.status_code == 200, persisted.text
+    assert persisted.json()["properties"] == {"name": "preserved"}
+    after = await client.get(
+        f"/datasets/{dataset_id}/attributes/",
+        params={"include_removed": True},
+        headers=admin_auth_header,
+    )
+    assert after.status_code == 200, after.text
+    assert after.json() == before.json()
+
+
+@pytest.mark.anyio
 async def test_rename_column_reserved_rejected(
     client: AsyncClient, admin_auth_header: dict
 ):
@@ -82,6 +138,71 @@ async def test_alter_column_type_success(client: AsyncClient, admin_auth_header:
     assert resp.status_code == 200, resp.text
     cols = {c["name"]: c for c in resp.json()["columns"]}
     assert cols["value"]["type"].lower().startswith("int")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("column_type", "value", "next_value"),
+    [
+        ("date", "2026-09-12", "2026-09-13"),
+        ("timestamp", "2026-09-12T10:30:00+00:00", "2026-09-13T11:45:00+00:00"),
+    ],
+)
+async def test_feature_temporal_column_round_trips(
+    client: AsyncClient,
+    admin_auth_header: dict,
+    column_type: str,
+    value: str,
+    next_value: str,
+):
+    """JSON temporal values must remain writable after a supported column cast."""
+    dataset_id = await _create_layer(
+        client, admin_auth_header, title=f"Temporal Edit {column_type}"
+    )
+    changed = await client.patch(
+        f"/layers/{dataset_id}/columns/value/type",
+        json={"new_type": column_type},
+        headers=admin_auth_header,
+    )
+    assert changed.status_code == 200, changed.text
+    inserted = await client.post(
+        f"/datasets/{dataset_id}/features/",
+        json={
+            "geometry": {"type": "Point", "coordinates": [1, 2]},
+            "properties": {"value": value},
+        },
+        headers=admin_auth_header,
+    )
+    assert inserted.status_code == 201, inserted.text
+    assert inserted.json()["properties"]["value"] == value
+    feature_url = f"/datasets/{dataset_id}/features/{inserted.json()['id']}"
+    for method in ("PATCH", "PUT"):
+        updated = await client.request(
+            method,
+            feature_url,
+            json={
+                "geometry": {"type": "Point", "coordinates": [2, 3]},
+                "properties": {"value": next_value},
+            },
+            headers=admin_auth_header,
+        )
+        assert updated.status_code == 200, updated.text
+        assert updated.json()["properties"]["value"] == next_value
+
+    invalid = await client.patch(
+        feature_url,
+        json={"properties": {"name": "partial", "value": "not-a-date"}},
+        headers=admin_auth_header,
+    )
+    assert invalid.status_code == 400, invalid.text
+    persisted = await client.get(feature_url, headers=admin_auth_header)
+    assert persisted.json()["properties"] == {"name": None, "value": next_value}
+
+    cleared = await client.patch(
+        feature_url, json={"properties": {"value": None}}, headers=admin_auth_header
+    )
+    assert cleared.status_code == 200, cleared.text
+    assert cleared.json()["properties"]["value"] is None
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1379,8 +1379,8 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     # Embed tokens share origin/scope checks, revocation and cached-denial behavior.
     "backend/app/modules/embed_tokens/service.py": 1030,
     # Feature reads/writes share schema typing, safe SQL and geometry/metadata
-    # invariants.
-    "backend/app/modules/catalog/features/service.py": 1373,
+    # invariants; temporal writes reuse the validated filter parsers.
+    "backend/app/modules/catalog/features/service.py": 1393,
 }
 
 

--- a/backend/tests/test_layering.py
+++ b/backend/tests/test_layering.py
@@ -1380,7 +1380,7 @@ _MODULE_LOC_CAPS: dict[str, int] = {
     "backend/app/modules/embed_tokens/service.py": 1030,
     # Feature reads/writes share schema typing, safe SQL and geometry/metadata
     # invariants; temporal writes reuse the validated filter parsers.
-    "backend/app/modules/catalog/features/service.py": 1393,
+    "backend/app/modules/catalog/features/service.py": 1400,
 }
 
 

--- a/backend/tests/test_layers.py
+++ b/backend/tests/test_layers.py
@@ -144,6 +144,38 @@ class TestCreateLayerRBAC:
 
 
 class TestCreateLayerValidation:
+    async def test_duplicate_column_names_rejected_before_creation(
+        self, client: AsyncClient, editor_auth_header: dict
+    ):
+        """Repeated definitions are a caller error and leave no partial layer."""
+        title = f"Duplicate Columns {uuid.uuid4().hex[:8]}"
+        response = await client.post(
+            "/layers/",
+            json={
+                "title": title,
+                "geometry_type": "Point",
+                "columns": [
+                    {"name": "note", "type": "text"},
+                    {"name": "note", "type": "integer"},
+                ],
+            },
+            headers=editor_auth_header,
+        )
+        assert response.status_code == 400, response.text
+        assert "note" in response.json()["detail"]
+
+        retry = await client.post(
+            "/layers/",
+            json={
+                "title": title,
+                "geometry_type": "Point",
+                "columns": [{"name": "note", "type": "text"}],
+            },
+            headers=editor_auth_header,
+        )
+        assert retry.status_code == 201, retry.text
+        assert retry.json()["table_name"] == title.lower().replace(" ", "_")
+
     async def test_create_layer_invalid_geometry_type(
         self, client: AsyncClient, editor_auth_header: dict
     ):

--- a/backend/tests/test_record_write_modified.py
+++ b/backend/tests/test_record_write_modified.py
@@ -1,0 +1,104 @@
+"""Record subresource changes advance modification metadata atomically."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.modules.catalog.datasets.domain.models import Record
+from tests.factories import create_dataset, get_user_id
+
+
+async def _modified(session, record_id):
+    return (
+        await session.execute(
+            select(Record.updated_at, Record.updated_by).where(Record.id == record_id)
+        )
+    ).one()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("resource", "body", "patch"),
+    [
+        ("contacts", {"role": "author", "name": "Initial"}, {"name": "Changed"}),
+        ("keywords", {"keyword": "initial"}, None),
+        (
+            "distributions",
+            {
+                "distribution_type": "download",
+                "format": "GeoJSON",
+                "url": "https://example.com/data.geojson",
+            },
+            {"title": "Changed"},
+        ),
+    ],
+)
+async def test_subresource_writes_advance_record_modified(
+    client, admin_auth_header, test_db_session, resource, body, patch
+):
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await create_dataset(test_db_session, created_by=admin_id)
+    path = f"/records/{dataset.record_id}/{resource}/"
+    before = await _modified(test_db_session, dataset.record_id)
+
+    response = await client.post(path, json=body, headers=admin_auth_header)
+    assert response.status_code == 201, response.text
+    child_id = response.json()["id"]
+    after = await _modified(test_db_session, dataset.record_id)
+    assert after.updated_at > before.updated_at
+    assert after.updated_by == admin_id
+
+    child_path = f"{path}{child_id}/"
+    if patch is not None:
+        before = after
+        response = await client.patch(child_path, json=patch, headers=admin_auth_header)
+        assert response.status_code == 200, response.text
+        after = await _modified(test_db_session, dataset.record_id)
+        assert after.updated_at > before.updated_at
+        assert after.updated_by == admin_id
+
+    response = await client.delete(child_path, headers=admin_auth_header)
+    assert response.status_code == 204, response.text
+    deleted = await _modified(test_db_session, dataset.record_id)
+    assert deleted.updated_at > after.updated_at
+    assert deleted.updated_by == admin_id
+
+    detail = await client.get(f"/datasets/{dataset.id}", headers=admin_auth_header)
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["updated_at"] == deleted.updated_at.isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+@pytest.mark.anyio
+async def test_rejected_subresource_write_preserves_record_modified(
+    client, admin_auth_header, test_db_session
+):
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await create_dataset(test_db_session, created_by=admin_id)
+    path = f"/records/{dataset.record_id}/contacts/"
+    response = await client.post(
+        path, json={"role": "author", "name": "Initial"}, headers=admin_auth_header
+    )
+    assert response.status_code == 201, response.text
+    child_id = response.json()["id"]
+    before = await _modified(test_db_session, dataset.record_id)
+
+    invalid = await client.patch(
+        f"{path}{child_id}/",
+        json={"role": "not-an-iso-role", "name": "Invalid"},
+        headers=admin_auth_header,
+    )
+    assert invalid.status_code == 400, invalid.text
+    assert await _modified(test_db_session, dataset.record_id) == before
+
+    missing = await client.delete(f"{path}{uuid.uuid4()}/", headers=admin_auth_header)
+    assert missing.status_code == 404, missing.text
+    assert await _modified(test_db_session, dataset.record_id) == before
+    listing = await client.get(path, headers=admin_auth_header)
+    assert listing.status_code == 200, listing.text
+    assert (
+        next(c for c in listing.json()["contacts"] if c["id"] == child_id)["name"]
+        == "Initial"
+    )

--- a/backend/tests/test_record_write_modified.py
+++ b/backend/tests/test_record_write_modified.py
@@ -1,9 +1,15 @@
 """Record subresource changes advance modification metadata atomically."""
 
+import asyncio
+import importlib.util
 import uuid
+from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
-from sqlalchemy import select
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import func, select, text, update
 
 from app.modules.catalog.datasets.domain.models import Record
 from tests.factories import create_dataset, get_user_id
@@ -102,3 +108,109 @@ async def test_rejected_subresource_write_preserves_record_modified(
         next(c for c in listing.json()["contacts"] if c["id"] == child_id)["name"]
         == "Initial"
     )
+
+
+@pytest.mark.anyio
+async def test_older_transaction_cannot_regress_record_modified(
+    client, admin_auth_header, test_db_session, monkeypatch
+):
+    import app.modules.catalog.records.router as record_router
+
+    admin_id = await get_user_id(test_db_session, "admin")
+    dataset = await create_dataset(test_db_session, created_by=admin_id)
+    path = f"/records/{dataset.record_id}/contacts/"
+    older_ready = asyncio.Event()
+    resume_older = asyncio.Event()
+    original_touch = record_router._touch_record
+    calls = 0
+
+    async def pause_first_touch(db, record, user):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            # Authorization has already started this request's transaction.
+            older_ready.set()
+            await asyncio.wait_for(resume_older.wait(), timeout=10)
+        await original_touch(db, record, user)
+
+    monkeypatch.setattr(record_router, "_touch_record", pause_first_touch)
+    older = asyncio.create_task(
+        client.post(
+            path,
+            json={"role": "author", "name": "Older request"},
+            headers=admin_auth_header,
+        )
+    )
+    try:
+        await asyncio.wait_for(older_ready.wait(), timeout=10)
+        newer = await client.post(
+            path,
+            json={"role": "author", "name": "Newer request"},
+            headers=admin_auth_header,
+        )
+        assert newer.status_code == 201, newer.text
+        after_newer = await _modified(test_db_session, dataset.record_id)
+    finally:
+        resume_older.set()
+        older_response = await asyncio.wait_for(older, timeout=10)
+
+    assert older_response.status_code == 201, older_response.text
+    after_older = await _modified(test_db_session, dataset.record_id)
+    assert after_older.updated_at >= after_newer.updated_at
+    listing = await client.get(path, headers=admin_auth_header)
+    assert listing.status_code == 200, listing.text
+    assert {contact["name"] for contact in listing.json()["contacts"]} >= {
+        "Older request",
+        "Newer request",
+    }
+
+
+@pytest.mark.anyio
+async def test_modified_clock_migration_round_trip(test_db_session):
+    path = Path(__file__).parents[1] / "alembic/versions/0062_record_modified_clock.py"
+    spec = importlib.util.spec_from_file_location("record_modified_clock", path)
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    session = test_db_session
+    future = datetime(2099, 1, 1, tzinfo=UTC)
+    dataset = await create_dataset(session, created_by=None, updated_at=future)
+
+    def run_migration(sync_session, direction):
+        context = MigrationContext.configure(sync_session.connection())
+        with Operations.context(context):
+            getattr(migration, direction)()
+
+    try:
+        targets = await session.scalars(
+            text(
+                "SELECT tgrelid::regclass::text FROM pg_trigger "
+                "WHERE tgfoid = 'catalog.set_updated_at()'::regprocedure"
+            )
+        )
+        assert list(targets) == ["catalog.records"]
+        await session.execute(
+            update(Record).where(Record.id == dataset.record_id).values(title="Changed")
+        )
+        assert (await _modified(session, dataset.record_id)).updated_at == future
+
+        await session.run_sync(run_migration, "downgrade")
+        transaction_start = await session.scalar(select(func.now()))
+        await session.execute(
+            update(Record)
+            .where(Record.id == dataset.record_id)
+            .values(updated_at=func.clock_timestamp())
+        )
+        assert (
+            await _modified(session, dataset.record_id)
+        ).updated_at == transaction_start
+
+        await session.run_sync(run_migration, "upgrade")
+        wall_clock = await session.scalar(select(func.clock_timestamp()))
+        await session.execute(
+            update(Record)
+            .where(Record.id == dataset.record_id)
+            .values(title="Restored")
+        )
+        assert (await _modified(session, dataset.record_id)).updated_at >= wall_clock
+    finally:
+        await session.rollback()

--- a/frontend/src/components/dataset/AttributeTable.tsx
+++ b/frontend/src/components/dataset/AttributeTable.tsx
@@ -37,6 +37,7 @@ import { formatNumber } from '@/lib/format';
 import { formatMutationError } from '@/lib/error-map';
 import { coerceAttributeValue } from '@/lib/attribute-values';
 import { Loader2, ArrowUpDown, Settings2, Pencil } from 'lucide-react';
+import { useAuthStore } from '@/stores/auth-store';
 
 // react-table v9 requires row models and sort functions to be registered
 // explicitly (v8 wired getSortedRowModel() as a table option and auto-detected
@@ -180,6 +181,16 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnVisibility, setColumnVisibility] = useState<ColumnVisibilityState>({});
   const updateFeature = useUpdateFeature();
+  const authIdentity = useAuthStore((state) => `${state.sessionEpoch}:${state.user?.id ?? ''}`);
+  const requestScopeRef = useRef({ datasetId, authIdentity });
+  if (
+    requestScopeRef.current.datasetId !== datasetId
+    || requestScopeRef.current.authIdentity !== authIdentity
+  ) {
+    requestScopeRef.current = { datasetId, authIdentity };
+  }
+  const editingCellRef = useRef(editingCell);
+  editingCellRef.current = editingCell;
 
   // Debounce filters to avoid hammering the API on every keystroke
   const debouncedFilters = useDebouncedValue(columnFilters, 300);
@@ -205,7 +216,7 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
   useEffect(() => {
     setEditingCell(null);
     setEditError(null);
-  }, [cursor, activeFilters, pageSize]);
+  }, [datasetId, cursor, activeFilters, pageSize]);
 
   const { data, isLoading, isFetching, isError } = useDatasetRows(
     datasetId,
@@ -219,6 +230,9 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
   }, []);
 
   const handleCellSave = useCallback(async (rowGid: number, column: string, colType: string, newValue: string) => {
+    const submittedDatasetId = datasetId;
+    const submittedScope = requestScopeRef.current;
+    const submittedCell = editingCellRef.current;
     // fix(#458 E-03): the inline editor is a plain text input; coerce to the
     // column's wire type instead of sending a string into a typed column.
     const coerced = coerceAttributeValue(newValue, colType);
@@ -236,17 +250,27 @@ export function AttributeTable({ datasetId, canEdit = false, compact = false }: 
     // before awaiting made that branch unreachable and showed the stale value.
     try {
       await updateFeature.mutateAsync({
-        datasetId,
+        datasetId: submittedDatasetId,
         gid: rowGid,
         properties: { [column]: coerced.value },
       });
+      if (
+        requestScopeRef.current !== submittedScope
+        || editingCellRef.current !== submittedCell
+      ) return;
       setEditingCell(null);
       toast.success(t('attributes.editSaved'));
     } catch (err) {
+      if (
+        requestScopeRef.current !== submittedScope
+        || editingCellRef.current !== submittedCell
+      ) return;
       // fix(#458 E-21): surface the backend's specific reason (geometry-type
       // mismatch, unknown column, …) instead of a generic toast, and keep the
       // editor open so the value can be corrected rather than silently reverting.
-      toast.error(formatMutationError('dataset:attributes.editFailed', err));
+      const msg = formatMutationError('dataset:attributes.editFailed', err);
+      setEditError(msg);
+      toast.error(msg);
     }
   }, [datasetId, updateFeature, t]);
 

--- a/frontend/src/components/dataset/DatasetMap.tsx
+++ b/frontend/src/components/dataset/DatasetMap.tsx
@@ -269,6 +269,13 @@ export const DatasetMap = memo(function DatasetMap({
   const clearDrawing = useDrawingStore((s) => s.clearDrawing);
   const selectedFeature = useDrawingStore((s) => s.selectedFeature);
   const sessionEpoch = useDrawingStore((s) => s.sessionEpoch);
+  const requestScopeRef = useRef({ datasetId, sessionEpoch });
+  if (
+    requestScopeRef.current.datasetId !== datasetId
+    || requestScopeRef.current.sessionEpoch !== sessionEpoch
+  ) {
+    requestScopeRef.current = { datasetId, sessionEpoch };
+  }
 
   // Editable columns (non-system) for the attribute form
   const editableColumns = useMemo(
@@ -337,6 +344,7 @@ export const DatasetMap = memo(function DatasetMap({
     selectFeatureFromMap,
     cleanupOverlayListener,
     resetOverlay,
+    isFeatureMutationPending,
   } = useFeatureEditing({
     mapRef,
     datasetId,
@@ -929,11 +937,15 @@ export const DatasetMap = memo(function DatasetMap({
 
   // Attribute form handlers (new feature creation)
   const handleAttributeSubmit = useCallback(
-    (properties: Record<string, unknown>) => {
+    async (properties: Record<string, unknown>) => {
       if (pendingGeometry) {
-        saveAndRefresh(pendingGeometry, properties);
+        const submittedGeometry = pendingGeometry;
+        const submittedScope = requestScopeRef.current;
+        const saved = await saveAndRefresh(submittedGeometry, properties);
+        if (saved && requestScopeRef.current === submittedScope) {
+          setPendingGeometry((current) => current === submittedGeometry ? null : current);
+        }
       }
-      setPendingGeometry(null);
     },
     [pendingGeometry, saveAndRefresh],
   );
@@ -1092,6 +1104,7 @@ export const DatasetMap = memo(function DatasetMap({
           onDeleteFeature={() => setDeleteConfirmOpen(true)}
           onUndo={undo}
           canUndo={canUndo}
+          isMutating={isFeatureMutationPending}
         />
       )}
 

--- a/frontend/src/components/dataset/InlineEdit.tsx
+++ b/frontend/src/components/dataset/InlineEdit.tsx
@@ -9,6 +9,8 @@ interface InlineEditProps {
   onSave: (newValue: string) => void | Promise<void>;
   as?: 'h1' | 'h2' | 'p' | 'span';
   multiline?: boolean;
+  /** Stage multiline drafts when focus leaves the editor. */
+  saveOnBlur?: boolean;
   className?: string;
   placeholder?: string;
   canEdit?: boolean;
@@ -25,6 +27,7 @@ export function InlineEdit({
   onSave,
   as: Tag = 'span',
   multiline = false,
+  saveOnBlur = false,
   className,
   placeholder = '',
   canEdit = true,
@@ -159,21 +162,18 @@ export function InlineEdit({
 
     if (multiline) {
       return (
-        <div ref={multilineContainerRef}>
+        <div
+          ref={multilineContainerRef}
+          onBlur={(e) => {
+            if (multilineContainerRef.current?.contains(e.relatedTarget as Node)) return;
+            if (saveOnBlur) void save();
+            else cancel();
+          }}
+        >
           <textarea
             ref={inputRef as React.RefObject<HTMLTextAreaElement>}
             value={draft}
             onChange={(e) => handleDraftChange(e.target.value)}
-            // fix(#528 review): don't cancel when focus moves to the editor's
-            // own Save/Cancel buttons — Tab from the textarea used to fire
-            // blur→cancel and unmount the buttons before a keyboard user
-            // could reach them (mousedown-preventDefault only covers pointers).
-            onBlur={(e) => {
-              if (multilineContainerRef.current?.contains(e.relatedTarget as Node)) {
-                return;
-              }
-              cancel();
-            }}
             onKeyDown={handleKeyDown}
             // fix(#438): DS-03 — deliberately shares inputClasses with its
             // sibling <input> so the inline editor looks identical in both modes;

--- a/frontend/src/components/dataset/SchemaEditor.tsx
+++ b/frontend/src/components/dataset/SchemaEditor.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { Trash2, Plus } from 'lucide-react';
@@ -38,6 +38,8 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { useAddColumn, useColumnReferences, useDropColumn } from '@/hooks/use-features';
+import { useAuthStore } from '@/stores/auth-store';
+import { formatMutationError } from '@/lib/error-map';
 
 const ALLOWED_TYPES = ['text', 'integer', 'real', 'boolean', 'date', 'timestamp'] as const;
 const COLUMN_NAME_RE = /^[a-z][a-z0-9_]{0,62}$/;
@@ -58,6 +60,17 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const nameInputId = useId();
   const nameErrorId = useId();
+  const newNameRef = useRef('');
+  const newTypeRef = useRef('text');
+  const addInFlightRef = useRef(false);
+  const authIdentity = useAuthStore((state) => `${state.sessionEpoch}:${state.user?.id ?? ''}`);
+  const requestScopeRef = useRef({ datasetId, authIdentity });
+  if (
+    requestScopeRef.current.datasetId !== datasetId
+    || requestScopeRef.current.authIdentity !== authIdentity
+  ) {
+    requestScopeRef.current = { datasetId, authIdentity };
+  }
 
   const addColumnMutation = useAddColumn();
   const dropColumnMutation = useDropColumn();
@@ -65,6 +78,15 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
   const columnReferences = useColumnReferences(datasetId, confirmDelete);
 
   const displayColumns = columns.filter((c) => !SYSTEM_COLUMNS.has(c.name));
+
+  useEffect(() => {
+    newNameRef.current = '';
+    newTypeRef.current = 'text';
+    setNewName('');
+    setNewType('text');
+    setNameError(null);
+    setConfirmDelete(null);
+  }, [datasetId]);
 
   function validateName(name: string): string | null {
     if (!name) return t('schema.validation.required');
@@ -81,38 +103,59 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
   }
 
   function handleAddColumn() {
+    if (addInFlightRef.current) return;
     const error = validateName(newName);
     if (error) {
       setNameError(error);
       return;
     }
 
+    const submittedDatasetId = datasetId;
+    const submittedName = newName;
+    const submittedType = newType;
+    const submittedScope = requestScopeRef.current;
+    addInFlightRef.current = true;
     addColumnMutation.mutate(
-      { datasetId, column: { name: newName, type: newType } },
+      { datasetId: submittedDatasetId, column: { name: submittedName, type: submittedType } },
       {
         onSuccess: () => {
+          if (requestScopeRef.current !== submittedScope) return;
           toast.success(t('schema.columnAdded'));
-          setNewName('');
-          setNewType('text');
-          setNameError(null);
+          if (
+            newNameRef.current === submittedName
+            && newTypeRef.current === submittedType
+          ) {
+            newNameRef.current = '';
+            newTypeRef.current = 'text';
+            setNewName('');
+            setNewType('text');
+            setNameError(null);
+          }
         },
         onError: (err) => {
+          if (requestScopeRef.current !== submittedScope) return;
           toast.error(err instanceof Error ? err.message : t('schema.addFailed'));
+        },
+        onSettled: () => {
+          addInFlightRef.current = false;
         },
       },
     );
   }
 
   function handleDropColumn(columnName: string) {
+    const submittedScope = requestScopeRef.current;
     dropColumnMutation.mutate(
       { datasetId, columnName },
       {
         onSuccess: () => {
+          if (requestScopeRef.current !== submittedScope) return;
           toast.success(t('schema.columnRemoved'));
           setConfirmDelete(null);
         },
-        // fix(#438): UX-07 — the dropColumn hook raises the error toast.
-        onError: () => {
+        onError: (err) => {
+          if (requestScopeRef.current !== submittedScope) return;
+          toast.error(formatMutationError('dataset:schema.removeFailed', err));
           setConfirmDelete(null);
         },
       },
@@ -223,6 +266,7 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
                 placeholder={t('schema.columnNamePlaceholder')}
                 value={newName}
                 onChange={(e) => {
+                  newNameRef.current = e.target.value;
                   setNewName(e.target.value);
                   if (nameError) setNameError(null);
                 }}
@@ -241,7 +285,13 @@ export function SchemaEditor({ datasetId, columns, open, onOpenChange }: SchemaE
                 </p>
               )}
             </div>
-            <Select value={newType} onValueChange={setNewType}>
+            <Select
+              value={newType}
+              onValueChange={(value) => {
+                newTypeRef.current = value;
+                setNewType(value);
+              }}
+            >
               <SelectTrigger className="w-[130px]" aria-label={t('schema.columnType')}>
                 <SelectValue />
               </SelectTrigger>

--- a/frontend/src/components/dataset/__tests__/AttributeTable.cell-editor.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AttributeTable.cell-editor.test.tsx
@@ -25,9 +25,17 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
+import { act } from '@testing-library/react';
 import { render, screen } from '@/test/test-utils';
 import { AttributeTable } from '@/components/dataset/AttributeTable';
 import { useDatasetRows } from '@/components/dataset/hooks/use-dataset';
+import { useAuthStore } from '@/stores/auth-store';
+
+const updateFeature = vi.hoisted(() => vi.fn());
+vi.mock('@/api/features', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/api/features')>()),
+  updateFeature,
+}));
 
 vi.mock('@/components/dataset/hooks/use-dataset', () => ({
   useDatasetRows: vi.fn(),
@@ -59,6 +67,9 @@ const ROWS_RESPONSE = {
 
 describe('fix(#1628): inline cell editor survives an unrelated re-render', () => {
   beforeEach(() => {
+    updateFeature.mockReset();
+    updateFeature.mockResolvedValue({});
+    useAuthStore.setState({ sessionEpoch: 0, user: null });
     vi.mocked(useDatasetRows).mockReturnValue({
       data: ROWS_RESPONSE,
       isLoading: false,
@@ -115,5 +126,108 @@ describe('fix(#1628): inline cell editor survives an unrelated re-render', () =>
     expect(afterReject).toBe(editor);
     expect(afterReject).toHaveValue('not-a-number');
     expect(afterReject).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('associates a backend rejection with the cell editor', async () => {
+    updateFeature.mockRejectedValueOnce(new Error('Backend rejected value'));
+    const user = userEvent.setup();
+    render(<AttributeTable datasetId="ds-1628" canEdit />);
+
+    await user.click(screen.getByRole('button', { name: '100' }));
+    const editor = screen.getByRole('textbox', { name: 'Edit population for feature 1' });
+    await user.clear(editor);
+    await user.type(editor, '250');
+    await user.keyboard('{Enter}');
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Backend rejected value');
+    expect(screen.getByRole('textbox', { name: 'Edit population for feature 1' }))
+      .toHaveAttribute('aria-describedby', alert.id);
+  });
+
+  it('does not let a dataset A completion close an editor after A is reopened', async () => {
+    let resolveUpdate!: (value: unknown) => void;
+    updateFeature.mockReturnValueOnce(new Promise((resolve) => {
+      resolveUpdate = resolve;
+    }));
+    const user = userEvent.setup();
+    const { rerender } = render(<AttributeTable datasetId="dataset-a" canEdit />);
+
+    await user.click(screen.getByRole('button', { name: '100' }));
+    const firstEditor = screen.getByRole('textbox', { name: 'Edit population for feature 1' });
+    await user.clear(firstEditor);
+    await user.type(firstEditor, '250');
+    await user.keyboard('{Enter}');
+
+    rerender(<AttributeTable datasetId="dataset-b" canEdit />);
+    rerender(<AttributeTable datasetId="dataset-a" canEdit />);
+    await user.click(await screen.findByRole('button', { name: '100' }));
+    await act(async () => {
+      resolveUpdate({});
+    });
+
+    expect(await screen.findByRole('textbox', {
+      name: 'Edit population for feature 1',
+    })).toBeInTheDocument();
+  });
+
+  it('does not let an older cell save close a newer editor in the same dataset', async () => {
+    let resolveUpdate!: (value: unknown) => void;
+    updateFeature.mockReturnValueOnce(new Promise((resolve) => {
+      resolveUpdate = resolve;
+    }));
+    vi.mocked(useDatasetRows).mockReturnValue({
+      data: {
+        ...ROWS_RESPONSE,
+        rows: [
+          { gid: 1, population: 100 },
+          { gid: 2, population: 200 },
+        ],
+        approximate_total: 2,
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useDatasetRows>);
+    const user = userEvent.setup();
+    render(<AttributeTable datasetId="ds-1628" canEdit />);
+
+    await user.click(screen.getByRole('button', { name: '100' }));
+    const firstEditor = screen.getByRole('textbox', { name: 'Edit population for feature 1' });
+    await user.clear(firstEditor);
+    await user.type(firstEditor, '250');
+    await user.keyboard('{Enter}');
+    await user.click(screen.getByRole('button', { name: '200' }));
+
+    await act(async () => {
+      resolveUpdate({});
+    });
+
+    expect(await screen.findByRole('textbox', {
+      name: 'Edit population for feature 2',
+    })).toBeInTheDocument();
+  });
+
+  it('does not let a prior auth session close the current cell editor', async () => {
+    let resolveUpdate!: (value: unknown) => void;
+    updateFeature.mockReturnValueOnce(new Promise((resolve) => {
+      resolveUpdate = resolve;
+    }));
+    const user = userEvent.setup();
+    render(<AttributeTable datasetId="ds-1628" canEdit />);
+
+    await user.click(screen.getByRole('button', { name: '100' }));
+    const editor = screen.getByRole('textbox', { name: 'Edit population for feature 1' });
+    await user.clear(editor);
+    await user.type(editor, '250');
+    await user.keyboard('{Enter}');
+    useAuthStore.setState({ sessionEpoch: 1 });
+    await act(async () => {
+      resolveUpdate({});
+    });
+
+    expect(await screen.findByRole('textbox', {
+      name: 'Edit population for feature 1',
+    })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dataset/__tests__/AttributeTable.cell-editor.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AttributeTable.cell-editor.test.tsx
@@ -145,6 +145,28 @@ describe('fix(#1628): inline cell editor survives an unrelated re-render', () =>
       .toHaveAttribute('aria-describedby', alert.id);
   });
 
+  it.each(['Infinity', '-Infinity', '1e309'])(
+    'keeps invalid numeric input %s editable without sending a mutation',
+    async (raw) => {
+      vi.mocked(useDatasetRows).mockReturnValue({
+        data: { ...ROWS_RESPONSE, columns: [{ name: 'population', type: 'double precision' }] },
+        isLoading: false,
+        isFetching: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useDatasetRows>);
+      const user = userEvent.setup();
+      render(<AttributeTable datasetId="ds-1628" canEdit />);
+      await user.click(screen.getByRole('button', { name: '100' }));
+      const editor = screen.getByRole('textbox', { name: 'Edit population for feature 1' });
+      await user.clear(editor);
+      await user.type(editor, raw);
+      await user.keyboard('{Enter}');
+      expect(await screen.findByRole('alert')).toBeInTheDocument();
+      expect(editor).toHaveValue(raw);
+      expect(updateFeature).not.toHaveBeenCalled();
+    },
+  );
+
   it('does not let a dataset A completion close an editor after A is reopened', async () => {
     let resolveUpdate!: (value: unknown) => void;
     updateFeature.mockReturnValueOnce(new Promise((resolve) => {

--- a/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
+++ b/frontend/src/components/dataset/__tests__/AttributeTable.test.tsx
@@ -157,7 +157,7 @@ describe('AttributeTable editing contracts (E-35/E-39/E-51)', () => {
 
   it('E-51: an open cell edit closes when the row set changes', () => {
     expect(attributeTableSrc).toMatch(
-      /setEditingCell\(null\);\s*setEditError\(null\);\s*\}, \[cursor, activeFilters, pageSize\]\)/,
+      /setEditingCell\(null\);\s*setEditError\(null\);\s*\}, \[datasetId, cursor, activeFilters, pageSize\]\)/,
     );
   });
 });

--- a/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
@@ -105,6 +105,7 @@ vi.mock('@/stores/drawing-store', () => {
   // useDrawingStore.getState() directly (not via the selector hook), the
   // same static-access pattern the real zustand store supports.
   useDrawingStore.getState = () => drawingState;
+  useDrawingStore.subscribe = vi.fn(() => vi.fn());
   return { useDrawingStore };
 });
 

--- a/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DatasetMap.test.tsx
@@ -112,6 +112,11 @@ vi.mock('@/stores/drawing-store', () => {
 // literal per render) so a test can hold onto `terraDrawState.clear` and
 // assert it was invoked by the identity-change cleanup effect.
 const terraDrawState = vi.hoisted(() => ({
+  handleDrawFinish: null as ((feature: {
+    type: 'Feature';
+    geometry: { type: 'Point'; coordinates: number[] };
+    properties: Record<string, unknown>;
+  }) => void) | null,
   setMode: vi.fn(),
   isReady: false,
   addFeatures: vi.fn(),
@@ -125,7 +130,10 @@ const terraDrawState = vi.hoisted(() => ({
 }));
 
 vi.mock('@/components/drawing/hooks/use-terra-draw', () => ({
-  useTerraDraw: () => terraDrawState,
+  useTerraDraw: (_map: unknown, handleDrawFinish: typeof terraDrawState.handleDrawFinish) => {
+    terraDrawState.handleDrawFinish = handleDrawFinish;
+    return terraDrawState;
+  },
   getModeName: () => 'polygon',
   getAvailableModes: vi.fn(() => ['select', 'point', 'linestring', 'polygon']),
 }));
@@ -136,8 +144,9 @@ import { getAvailableModes } from '@/components/drawing/hooks/use-terra-draw';
 // vi.fn() per render) so a test can control WHEN the update mutation
 // resolves, to simulate an identity change while it is in flight.
 const updateFeatureMutateAsync = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+const createFeatureMutateAsync = vi.hoisted(() => vi.fn().mockResolvedValue({}));
 vi.mock('@/hooks/use-features', () => ({
-  useCreateFeature: () => ({ mutateAsync: vi.fn() }),
+  useCreateFeature: () => ({ mutateAsync: createFeatureMutateAsync }),
   useUpdateFeature: () => ({ mutateAsync: updateFeatureMutateAsync }),
   useDeleteFeature: () => ({ mutateAsync: vi.fn() }),
 }));
@@ -165,6 +174,49 @@ describe('DatasetMap interaction state', () => {
     drawingState.isDrawing = false;
     drawingState.activeMode = null;
     drawingState.setDrawing.mockReset();
+    createFeatureMutateAsync.mockReset();
+    createFeatureMutateAsync.mockResolvedValue({});
+  });
+
+  it('does not let an older create completion clear a replacement draft', async () => {
+    let resolveCreate!: (value: unknown) => void;
+    createFeatureMutateAsync.mockReturnValueOnce(new Promise((resolve) => {
+      resolveCreate = resolve;
+    }));
+    render(
+      <DatasetMap
+        bbox={[-10, -10, 10, 10]}
+        tableName="example_table"
+        geometryType="Point"
+        datasetId="dataset-1"
+        columnInfo={[{ name: 'population', type: 'integer' }]}
+        canEdit
+      />,
+    );
+
+    act(() => {
+      terraDrawState.handleDrawFinish?.({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [1, 1] },
+        properties: {},
+      });
+    });
+    fireEvent.change(screen.getByLabelText('population'), { target: { value: '100' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(createFeatureMutateAsync).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      terraDrawState.handleDrawFinish?.({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [2, 2] },
+        properties: {},
+      });
+    });
+    await act(async () => {
+      resolveCreate({});
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
   it('keeps the hero map static until edit mode starts', () => {

--- a/frontend/src/components/dataset/__tests__/DraftEditing.integration.test.tsx
+++ b/frontend/src/components/dataset/__tests__/DraftEditing.integration.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InlineEdit } from '@/components/dataset/InlineEdit';
+import { PendingEditsBar } from '@/components/dataset/PendingEditsBar';
+import { useDraftEditing } from '@/components/dataset/hooks/use-draft-editing';
+import type { DatasetResponse } from '@/types/api';
+
+const mutateAsync = vi.fn();
+vi.mock('@/components/dataset/hooks/use-dataset', () => ({
+  useUpdateDataset: () => ({ mutateAsync }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), message: vi.fn() },
+}));
+
+function DraftEditor() {
+  const drafts = useDraftEditing({
+    datasetId: 'dataset-a',
+    dataset: { summary: 'original' } as DatasetResponse,
+    isGeometryEditDirty: false,
+  });
+  return <>
+    <InlineEdit
+      value={drafts.resolveDraftValue('summary')}
+      onSave={(value) => drafts.stagePendingDraft('summary', value)}
+      onDirtyChange={(dirty) => drafts.handleDraftDirtyChange('summary', dirty)}
+      multiline
+      saveOnBlur
+      allowClear
+    />
+    <PendingEditsBar
+      pendingCount={drafts.pendingCount}
+      onSaveAll={async () => { await drafts.savePendingDrafts(); }}
+      onCancelAll={drafts.discardPendingDrafts}
+      isSaving={drafts.isSaving}
+    />
+  </>;
+}
+
+describe('multiline draft handoff', () => {
+  beforeEach(() => mutateAsync.mockReset().mockResolvedValue({}));
+
+  it.each([false, true])('page Save stages active input, with editor button focus: %s', async (tabToButton) => {
+    const user = userEvent.setup();
+    render(<DraftEditor />);
+    await user.click(screen.getByRole('button', { name: 'original' }));
+    await waitFor(() => expect(screen.getByRole('textbox')).toHaveFocus());
+    await user.clear(screen.getByRole('textbox'));
+    await user.type(screen.getByRole('textbox'), 'new summary');
+    if (tabToButton) await user.tab();
+    await user.click(screen.getByTestId('pending-edits-save'));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledWith({
+      datasetId: 'dataset-a', data: { summary: 'new summary' },
+    }));
+    await waitFor(() => expect(screen.queryByTestId('pending-edits-bar')).not.toBeInTheDocument());
+  });
+
+  it('page Discard removes the active multiline draft', async () => {
+    const user = userEvent.setup();
+    render(<DraftEditor />);
+    await user.click(screen.getByRole('button', { name: 'original' }));
+    await waitFor(() => expect(screen.getByRole('textbox')).toHaveFocus());
+    await user.type(screen.getByRole('textbox'), ' changed');
+    await user.click(screen.getByTestId('pending-edits-cancel'));
+    await waitFor(() => expect(screen.queryByTestId('pending-edits-bar')).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'original' })).toBeInTheDocument();
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/dataset/__tests__/SchemaEditor.test.tsx
+++ b/frontend/src/components/dataset/__tests__/SchemaEditor.test.tsx
@@ -8,10 +8,12 @@
  * - E-50: the drop-column Confirm stays disabled until the map-references
  *   query resolves, so a fast confirm can't outrun the E-06 warning.
  */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi } from 'vitest';
+import { toast } from 'sonner';
 import { SchemaEditor } from '@/components/dataset/SchemaEditor';
 import { useAddColumn, useColumnReferences, useDropColumn } from '@/hooks/use-features';
+import { useAuthStore } from '@/stores/auth-store';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -29,15 +31,20 @@ vi.mock('@/hooks/use-features', () => ({
   useColumnReferences: vi.fn(),
 }));
 
+Object.defineProperty(Element.prototype, 'scrollIntoView', {
+  configurable: true,
+  value: vi.fn(),
+});
+
 const COLUMNS = [
   { name: 'name', type: 'character varying' },
   { name: 'value', type: 'integer' },
 ];
 
-function renderEditor() {
+function renderEditor(datasetId = 'test-ds') {
   return render(
     <SchemaEditor
-      datasetId="test-ds"
+      datasetId={datasetId}
       columns={COLUMNS}
       open
       onOpenChange={vi.fn()}
@@ -48,6 +55,7 @@ function renderEditor() {
 describe('SchemaEditor (E-38/E-49/E-50)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useAuthStore.setState({ sessionEpoch: 0, user: null });
     vi.mocked(useAddColumn).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
@@ -113,5 +121,133 @@ describe('SchemaEditor (E-38/E-49/E-50)', () => {
       screen.getByRole('button', { name: 'common:confirm' }),
     ).toBeEnabled();
     expect(screen.getByText('schema.usedByMaps')).toBeInTheDocument();
+  });
+
+  it('preserves a new column name typed while the previous add is pending', () => {
+    let onSuccess: (() => void) | undefined;
+    const mutate = vi.fn((_variables, options) => {
+      onSuccess = options?.onSuccess;
+    });
+    vi.mocked(useAddColumn).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useAddColumn>);
+    renderEditor();
+
+    const input = screen.getByRole('textbox', { name: 'schema.addColumn' });
+    fireEvent.change(input, { target: { value: 'first_column' } });
+    fireEvent.click(screen.getByRole('button', { name: /schema\.add$/ }));
+    fireEvent.change(input, { target: { value: 'next_column' } });
+    onSuccess?.();
+
+    expect(input).toHaveValue('next_column');
+  });
+
+  it('preserves a changed type while the previous add is pending', async () => {
+    let onSuccess: (() => void) | undefined;
+    vi.mocked(useAddColumn).mockReturnValue({
+      mutate: vi.fn((_variables, options) => {
+        onSuccess = options?.onSuccess;
+      }),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAddColumn>);
+    renderEditor();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'schema.addColumn' }), {
+      target: { value: 'new_column' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /schema\.add$/ }));
+    const typeSelect = screen.getByRole('combobox', { name: 'schema.columnType' });
+    fireEvent.keyDown(typeSelect, { key: 'ArrowDown' });
+    fireEvent.click(await screen.findByRole('option', { name: 'integer' }));
+    onSuccess?.();
+
+    expect(screen.getByRole('combobox', { name: 'schema.columnType' }))
+      .toHaveTextContent('integer');
+  });
+
+  it('ignores an add completion after dataset A is left and reopened', () => {
+    let onSuccess: (() => void) | undefined;
+    vi.mocked(useAddColumn).mockReturnValue({
+      mutate: vi.fn((_variables, options) => {
+        onSuccess = options?.onSuccess;
+      }),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAddColumn>);
+    const { rerender } = renderEditor('dataset-a');
+    const input = screen.getByRole('textbox', { name: 'schema.addColumn' });
+    fireEvent.change(input, { target: { value: 'first_column' } });
+    fireEvent.click(screen.getByRole('button', { name: /schema\.add$/ }));
+
+    rerender(<SchemaEditor datasetId="dataset-b" columns={COLUMNS} open onOpenChange={vi.fn()} />);
+    rerender(<SchemaEditor datasetId="dataset-a" columns={COLUMNS} open onOpenChange={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'schema.addColumn' }), {
+      target: { value: 'current_column' },
+    });
+    onSuccess?.();
+
+    expect(screen.getByRole('textbox', { name: 'schema.addColumn' }))
+      .toHaveValue('current_column');
+  });
+
+  it('ignores an add completion after the auth session changes', () => {
+    let onSuccess: (() => void) | undefined;
+    vi.mocked(useAddColumn).mockReturnValue({
+      mutate: vi.fn((_variables, options) => {
+        onSuccess = options?.onSuccess;
+      }),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAddColumn>);
+    renderEditor();
+    const input = screen.getByRole('textbox', { name: 'schema.addColumn' });
+    fireEvent.change(input, { target: { value: 'new_column' } });
+    fireEvent.click(screen.getByRole('button', { name: /schema\.add$/ }));
+
+    useAuthStore.setState({ sessionEpoch: 1 });
+    onSuccess?.();
+
+    expect(input).toHaveValue('new_column');
+  });
+
+  it('ignores repeated Enter submissions while an add is pending', () => {
+    const mutate = vi.fn();
+    vi.mocked(useAddColumn).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useAddColumn>);
+    renderEditor();
+
+    const input = screen.getByRole('textbox', { name: 'schema.addColumn' });
+    fireEvent.change(input, { target: { value: 'new_column' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+});
+
+
+describe('schema response scope', () => {
+  it.each(['success', 'failure'])('preserves a newer drop confirmation after old %s', (outcome) => {
+    vi.clearAllMocks();
+    let callbacks: { onSuccess: () => void; onError: (error: Error) => void };
+    vi.mocked(useAddColumn).mockReturnValue({ mutate: vi.fn(), isPending: false } as unknown as ReturnType<typeof useAddColumn>);
+    vi.mocked(useDropColumn).mockReturnValue({
+      mutate: vi.fn((_variables, options) => { callbacks = options; }),
+      isPending: false,
+    } as unknown as ReturnType<typeof useDropColumn>);
+    vi.mocked(useColumnReferences).mockReturnValue({ data: { map_count: 0 }, isLoading: false } as unknown as ReturnType<typeof useColumnReferences>);
+    const { rerender } = renderEditor('dataset-a');
+    fireEvent.click(screen.getAllByTitle('schema.removeColumn')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'common:confirm' }));
+    rerender(<SchemaEditor datasetId="dataset-b" columns={COLUMNS} open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getAllByTitle('schema.removeColumn')[1]);
+    act(() => {
+      if (outcome === 'success') callbacks.onSuccess();
+      else callbacks.onError(new Error('Old failure'));
+    });
+    expect(screen.getByRole('button', { name: 'common:confirm' })).toBeInTheDocument();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/dataset/hooks/__tests__/use-draft-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-draft-editing.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useDraftEditing } from '@/components/dataset/hooks/use-draft-editing';
 import type { DatasetResponse } from '@/types/api';
+import { useAuthStore } from '@/stores/auth-store';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -258,7 +259,8 @@ describe('useDraftEditing', () => {
   // for dataset A survived into dataset B's render.
   it('resets staged drafts when datasetId changes', () => {
     const { result, rerender } = renderHook(
-      ({ datasetId, dataset }) => useDraftEditing({ datasetId, dataset, isGeometryEditDirty: false }),
+      ({ datasetId, dataset }) =>
+        useDraftEditing({ datasetId, dataset, isGeometryEditDirty: false }),
       {
         initialProps: {
           datasetId: 'ds-1',
@@ -283,7 +285,8 @@ describe('useDraftEditing', () => {
 
   it('a save after navigating to a different dataset does not send the previous draft', async () => {
     const { result, rerender } = renderHook(
-      ({ datasetId, dataset }) => useDraftEditing({ datasetId, dataset, isGeometryEditDirty: false }),
+      ({ datasetId, dataset }) =>
+        useDraftEditing({ datasetId, dataset, isGeometryEditDirty: false }),
       {
         initialProps: {
           datasetId: 'ds-1',
@@ -326,5 +329,230 @@ describe('useDraftEditing', () => {
       result.current.handleDraftDirtyChange('lineage_summary', false);
     });
     expect(result.current.pendingCount).toBe(0);
+  });
+});
+
+function deferredSave() {
+  let resolve!: (value: unknown) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<unknown>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function renderDraft() {
+  return renderHook(
+    ({ id }) =>
+      useDraftEditing({
+        datasetId: id,
+        dataset: makeDataset({ id, summary: `${id} original` }),
+        isGeometryEditDirty: false,
+      }),
+    { initialProps: { id: 'A' } },
+  );
+}
+
+describe('draft save races', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockReset().mockResolvedValue({});
+  });
+
+  it.each(['success', 'failure'])(
+    'preserves another dataset draft after old save %s',
+    async (outcome) => {
+      const request = deferredSave();
+      mockMutateAsync.mockReturnValueOnce(request.promise);
+      const { result, rerender } = renderDraft();
+      act(() => result.current.stagePendingDraft('summary', 'A submitted'));
+      let saving!: Promise<boolean>;
+      act(() => {
+        saving = result.current.savePendingDrafts();
+      });
+      await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+      rerender({ id: 'B' });
+      act(() => result.current.stagePendingDraft('summary', 'B draft'));
+      await act(async () => {
+        if (outcome === 'success') request.resolve({});
+        else request.reject(new Error('failed'));
+        expect(await saving).toBe(false);
+      });
+      expect(result.current.resolveDraftValue('summary')).toBe('B draft');
+      expect(result.current.pendingCount).toBe(1);
+      expect(result.current.isSaving).toBe(false);
+    },
+  );
+
+  it.each(['new edit', 'A original'])(
+    'preserves input staged during a save: %s',
+    async (laterValue) => {
+      const request = deferredSave();
+      mockMutateAsync.mockReturnValueOnce(request.promise);
+      const { result } = renderDraft();
+      act(() => result.current.stagePendingDraft('summary', 'submitted'));
+      let saving!: Promise<boolean>;
+      act(() => {
+        saving = result.current.savePendingDrafts();
+      });
+      await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+      act(() => result.current.stagePendingDraft('summary', laterValue));
+      await act(async () => {
+        request.resolve({});
+        await saving;
+      });
+      expect(result.current.pendingCount).toBe(1);
+      expect(result.current.resolveDraftValue('summary')).toBe(laterValue);
+      await act(async () => {
+        await result.current.savePendingDrafts();
+      });
+      expect(mockMutateAsync).toHaveBeenLastCalledWith({
+        datasetId: 'A',
+        data: { summary: laterValue },
+      });
+    },
+  );
+
+  it('keeps the submitted value retryable when a reverted in-flight edit fails', async () => {
+    const request = deferredSave();
+    mockMutateAsync.mockReturnValueOnce(request.promise);
+    const { result } = renderDraft();
+    act(() => result.current.stagePendingDraft('summary', 'submitted'));
+    let saving!: Promise<boolean>;
+    act(() => {
+      saving = result.current.savePendingDrafts();
+    });
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    act(() => result.current.stagePendingDraft('summary', 'second edit'));
+    act(() => result.current.stagePendingDraft('summary', 'submitted'));
+    expect(result.current.resolveDraftValue('summary')).toBe('submitted');
+    await act(async () => {
+      request.reject(new Error('failed'));
+      expect(await saving).toBe(false);
+    });
+    expect(result.current.pendingCount).toBe(1);
+    expect(result.current.resolveDraftValue('summary')).toBe('submitted');
+    await act(async () => {
+      await result.current.savePendingDrafts();
+    });
+    expect(mockMutateAsync).toHaveBeenLastCalledWith({
+      datasetId: 'A',
+      data: { summary: 'submitted' },
+    });
+  });
+
+  it('keeps a newer dataset save active when the old request finishes', async () => {
+    const first = deferredSave();
+    const second = deferredSave();
+    mockMutateAsync.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const { result, rerender } = renderDraft();
+    act(() => result.current.stagePendingDraft('summary', 'A draft'));
+    let firstSave!: Promise<boolean>;
+    act(() => {
+      firstSave = result.current.savePendingDrafts();
+    });
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    rerender({ id: 'B' });
+    act(() => result.current.stagePendingDraft('summary', 'B draft'));
+    let secondSave!: Promise<boolean>;
+    act(() => {
+      secondSave = result.current.savePendingDrafts();
+    });
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      first.resolve({});
+      await firstSave;
+    });
+    expect(result.current.isSaving).toBe(true);
+    expect(result.current.pendingCount).toBe(1);
+    await act(async () => {
+      second.resolve({});
+      await secondSave;
+    });
+    expect(result.current.pendingCount).toBe(0);
+  });
+
+  it('preserves unblurred changes after a save', async () => {
+    const request = deferredSave();
+    mockMutateAsync.mockReturnValueOnce(request.promise);
+    const { result } = renderDraft();
+    act(() => result.current.stagePendingDraft('summary', 'submitted'));
+    let saving!: Promise<boolean>;
+    act(() => {
+      saving = result.current.savePendingDrafts();
+    });
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    act(() => result.current.handleDraftDirtyChange('summary', true));
+    await act(async () => {
+      request.resolve({});
+      await saving;
+    });
+    expect(result.current.pendingCount).toBe(1);
+    act(() => {
+      result.current.stagePendingDraft('summary', 'latest input');
+      result.current.handleDraftDirtyChange('summary', false);
+    });
+    await act(async () => {
+      await result.current.savePendingDrafts();
+    });
+    expect(mockMutateAsync).toHaveBeenLastCalledWith({
+      datasetId: 'A',
+      data: { summary: 'latest input' },
+    });
+  });
+
+  it('does not clear drafts after the authentication identity changes', async () => {
+    const request = deferredSave();
+    mockMutateAsync.mockReturnValueOnce(request.promise);
+    const { result } = renderDraft();
+    act(() => result.current.stagePendingDraft('summary', 'old session'));
+    let saving!: Promise<boolean>;
+    act(() => {
+      saving = result.current.savePendingDrafts();
+    });
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    act(() =>
+      useAuthStore.setState({
+        sessionEpoch: useAuthStore.getState().sessionEpoch + 1,
+      }),
+    );
+    act(() => result.current.stagePendingDraft('summary', 'new session'));
+    await act(async () => {
+      request.resolve({});
+      expect(await saving).toBe(false);
+    });
+    expect(result.current.resolveDraftValue('summary')).toBe('new session');
+    expect(result.current.pendingCount).toBe(1);
+  });
+
+  it('rejects a save callback captured before navigation', async () => {
+    const { result, rerender } = renderDraft();
+    const staleSave = result.current.savePendingDrafts;
+    rerender({ id: 'B' });
+    act(() => result.current.stagePendingDraft('summary', 'B draft'));
+    await act(async () => {
+      expect(await staleSave()).toBe(false);
+    });
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+    expect(result.current.pendingCount).toBe(1);
+  });
+
+  it('prevents duplicate saves before blur settles', async () => {
+    const request = deferredSave();
+    mockMutateAsync.mockReturnValueOnce(request.promise);
+    const { result } = renderDraft();
+    act(() => result.current.stagePendingDraft('summary', 'submitted'));
+    let saving!: Promise<boolean>;
+    act(() => {
+      saving = result.current.savePendingDrafts();
+    });
+    await act(async () => {
+      expect(await result.current.savePendingDrafts()).toBe(false);
+    });
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      request.resolve({});
+      await saving;
+    });
   });
 });

--- a/frontend/src/components/dataset/hooks/__tests__/use-draft-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-draft-editing.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useDraftEditing } from '@/components/dataset/hooks/use-draft-editing';
-import type { DatasetResponse } from '@/types/api';
+import type { DatasetResponse, UserResponse } from '@/types/api';
 import { useAuthStore } from '@/stores/auth-store';
 
 vi.mock('react-i18next', () => ({
@@ -354,10 +354,76 @@ function renderDraft() {
   );
 }
 
+function draftUser(id: string): UserResponse {
+  return {
+    id,
+    username: id,
+    email: `${id}@example.com`,
+    is_active: true,
+    status: 'approved',
+    last_login_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+    roles: ['editor'],
+  };
+}
+
 describe('draft save races', () => {
   beforeEach(() => {
     mockMutateAsync.mockReset().mockResolvedValue({});
+    useAuthStore.setState({ user: draftUser('user-A'), sessionEpoch: 0 });
   });
+
+  it('clears staged and dirty metadata after a user switch without an epoch change', async () => {
+    const { result } = renderDraft();
+    act(() => {
+      result.current.stagePendingDraft('summary', 'user A draft');
+      result.current.handleDraftDirtyChange('lineage_summary', true);
+    });
+    const staleSave = result.current.savePendingDrafts;
+    let saving!: Promise<boolean>;
+    act(() => {
+      useAuthStore.setState({ user: draftUser('user-B') });
+      saving = staleSave();
+    });
+    await act(async () => expect(await saving).toBe(false));
+    expect(useAuthStore.getState().sessionEpoch).toBe(0);
+    expect(result.current.pendingCount).toBe(0);
+    expect(result.current.resolveDraftValue('summary')).toBe('A original');
+    await act(async () => {
+      await result.current.savePendingDrafts();
+    });
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it.each(['success', 'failure'])(
+    'preserves the new user draft after the old user save %s without an epoch change',
+    async (outcome) => {
+      const request = deferredSave();
+      mockMutateAsync.mockReturnValueOnce(request.promise);
+      const { result } = renderDraft();
+      act(() => result.current.stagePendingDraft('summary', 'user A submitted'));
+      let saving!: Promise<boolean>;
+      act(() => {
+        saving = result.current.savePendingDrafts();
+      });
+      await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+      act(() => useAuthStore.setState({ user: draftUser('user-B') }));
+      expect(result.current.isSaving).toBe(false);
+      act(() => result.current.stagePendingDraft('summary', 'user B draft'));
+      await act(async () => {
+        if (outcome === 'success') request.resolve({});
+        else request.reject(new Error('failed'));
+        expect(await saving).toBe(false);
+      });
+      expect(result.current.resolveDraftValue('summary')).toBe('user B draft');
+      expect(result.current.pendingCount).toBe(1);
+      await act(async () => expect(await result.current.savePendingDrafts()).toBe(true));
+      expect(mockMutateAsync).toHaveBeenLastCalledWith({
+        datasetId: 'A',
+        data: { summary: 'user B draft' },
+      });
+    },
+  );
 
   it.each(['success', 'failure'])(
     'preserves another dataset draft after old save %s',

--- a/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
+++ b/frontend/src/components/dataset/hooks/__tests__/use-feature-editing.test.ts
@@ -286,6 +286,80 @@ describe('useFeatureEditing — post-mutation cleanup skipped after a stale iden
     expect(useDrawingStore.getState().selectedFeature).toEqual({ gid: 7, tdId: 'td-7', properties: {} });
   });
 
+  it('handleSaveEdit skips cleanup when another dataset is opened while the update is in flight', async () => {
+    useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
+    const update = deferred<unknown>();
+    updateMutateAsync.mockReturnValueOnce(update.promise);
+
+    const removeFeatures = vi.fn();
+    const getSnapshotFeature = vi.fn(() => ({
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [0, 0] },
+      properties: {},
+    }));
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { removeFeatures, getSnapshotFeature });
+
+    const saving = result.current.handleSaveEdit();
+    act(() => {
+      useDrawingStore.getState().setDrawing('ds-2', 'buildings', 'Point');
+      useDrawingStore.getState().setSelectedFeature(
+        { gid: 7, tdId: 'td-7', properties: { dataset: 'ds-2' } },
+        useDrawingStore.getState().sessionEpoch,
+      );
+    });
+    update.resolve({});
+    await act(async () => {
+      await saving;
+    });
+
+    expect(removeFeatures).not.toHaveBeenCalled();
+    expect(map.setFilter).not.toHaveBeenCalled();
+    expect(useDrawingStore.getState().selectedFeature).toEqual({
+      gid: 7,
+      tdId: 'td-7',
+      properties: { dataset: 'ds-2' },
+    });
+  });
+
+  it('handleSaveEdit does not clear a newer selection in the same dataset', async () => {
+    useDrawingStore.getState().setDrawing('ds-1', 'parcels', 'Point');
+    useDrawingStore.getState().setSelectedFeature(
+      { gid: 7, tdId: 'td-7', properties: {} },
+      useDrawingStore.getState().sessionEpoch,
+    );
+    const update = deferred<unknown>();
+    updateMutateAsync.mockReturnValueOnce(update.promise);
+
+    const removeFeatures = vi.fn();
+    const getSnapshotFeature = vi.fn(() => ({
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [0, 0] },
+      properties: {},
+    }));
+    const map = { getLayer: vi.fn(() => true), getFilter: vi.fn(() => null), setFilter: vi.fn(), getSource: vi.fn(() => undefined) } as unknown as MaplibreMap;
+    const { result } = renderEditing(map, { removeFeatures, getSnapshotFeature });
+
+    const saving = result.current.handleSaveEdit();
+    act(() => {
+      useDrawingStore.getState().setSelectedFeature(
+        { gid: 8, tdId: 'td-8', properties: { name: 'new selection' } },
+        useDrawingStore.getState().sessionEpoch,
+      );
+    });
+    update.resolve({});
+    await act(async () => {
+      await saving;
+    });
+
+    expect(removeFeatures).not.toHaveBeenCalled();
+    expect(useDrawingStore.getState().selectedFeature).toEqual({
+      gid: 8,
+      tdId: 'td-8',
+      properties: { name: 'new selection' },
+    });
+  });
+
   it('handleSaveEdit still cleans up normally when the identity has not changed', async () => {
     useDrawingStore.setState({ selectedFeature: { gid: 7, tdId: 'td-7', properties: {} } });
     const removeFeatures = vi.fn();
@@ -804,10 +878,12 @@ describe('useFeatureEditing — stale-failure feedback suppressed (fix #1761 rev
 
     createMutateAsync.mockRejectedValueOnce(new Error('boom'));
 
+    let saved: boolean | undefined;
     await act(async () => {
-      await result.current.saveAndRefresh({ type: 'Point', coordinates: [0, 0] }, {});
+      saved = await result.current.saveAndRefresh({ type: 'Point', coordinates: [0, 0] }, {});
     });
 
+    expect(saved).toBe(false);
     expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
@@ -938,5 +1014,57 @@ describe('useFeatureEditing — stale-failure feedback suppressed (fix #1761 rev
     });
 
     expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+});
+
+
+describe('drawing session return to the same dataset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDrawingStore.getState().setDrawing('ds-1', 'parcels', 'Point');
+  });
+
+  it('ignores create completion after leaving and reopening the drawing target', async () => {
+    const request = deferred<unknown>();
+    createMutateAsync.mockReturnValueOnce(request.promise);
+    const { result } = renderEditing(makeMapWithVectorSource(vi.fn()));
+    let saving!: Promise<boolean>;
+    act(() => {
+      saving = result.current.saveAndRefresh({ type: 'Point', coordinates: [0, 0] }, {});
+    });
+    act(() => {
+      useDrawingStore.getState().setDrawing('ds-2', 'other', 'Point');
+      useDrawingStore.getState().setDrawing('ds-1', 'parcels', 'Point');
+    });
+    await act(async () => {
+      request.resolve({});
+      expect(await saving).toBe(false);
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('ignores a feature fetch after leaving and reopening the drawing target', async () => {
+    const request = deferred<GeoJSONFeature>();
+    vi.mocked(getFeature).mockReturnValueOnce(request.promise);
+    const map = {
+      getLayer: vi.fn(() => true),
+      queryRenderedFeatures: vi.fn(() => [{ id: 9, properties: {} }]),
+      getSource: vi.fn(),
+      setFilter: vi.fn(),
+      getFilter: vi.fn(),
+    } as unknown as MaplibreMap;
+    const { result, opts } = renderEditing(map);
+    let selecting!: Promise<void>;
+    act(() => { selecting = result.current.selectFeatureFromMap(map, FAKE_POINT); });
+    act(() => {
+      useDrawingStore.getState().setDrawing('ds-2', 'other', 'Point');
+      useDrawingStore.getState().setDrawing('ds-1', 'parcels', 'Point');
+    });
+    await act(async () => {
+      request.resolve({ type: 'Feature', id: 9, geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} });
+      await selecting;
+    });
+    expect(opts.clear).not.toHaveBeenCalled();
+    expect(opts.addFeatures).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/dataset/hooks/use-draft-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-draft-editing.ts
@@ -44,12 +44,15 @@ export function useDraftEditing({ datasetId, dataset, isGeometryEditDirty }: Use
   const pendingDraftsRef = useRef<PendingDrafts>({});
   const dirtyFieldsRef = useRef(new Set<PendingDraftField>());
   const sessionEpoch = useAuthStore((state) => state.sessionEpoch);
-  const scope = useMemo(() => ({ datasetId, sessionEpoch }), [datasetId, sessionEpoch]);
+  const userId = useAuthStore((state) => state.user?.id);
+  const scope = useMemo(() => ({ datasetId, sessionEpoch, userId }), [datasetId, sessionEpoch, userId]);
   const scopeRef = useRef<typeof scope | null>(scope);
   scopeRef.current = scope;
   const saveRef = useRef<{ payload?: PendingDrafts } | null>(null);
   const isCurrent = useCallback(
-    () => scopeRef.current === scope && useAuthStore.getState().sessionEpoch === scope.sessionEpoch,
+    () => scopeRef.current === scope
+      && useAuthStore.getState().sessionEpoch === scope.sessionEpoch
+      && useAuthStore.getState().user?.id === scope.userId,
     [scope],
   );
 

--- a/frontend/src/components/dataset/hooks/use-draft-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-draft-editing.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useUpdateDataset } from '@/components/dataset/hooks/use-dataset';
 import type { DatasetResponse, DatasetUpdateRequest } from '@/types/api';
+import { useAuthStore } from '@/stores/auth-store';
 
 export type PendingDraftField =
   | 'summary'
@@ -40,59 +41,64 @@ export function useDraftEditing({ datasetId, dataset, isGeometryEditDirty }: Use
   const [pendingDrafts, setPendingDrafts] = useState<PendingDrafts>({});
   const [dirtyFields, setDirtyFields] = useState<Set<PendingDraftField>>(() => new Set());
   const [isSaving, setIsSaving] = useState(false);
-  // fix(#458 E-17): mirror pendingDrafts in a ref, updated synchronously with the
-  // state. savePendingDrafts blurs the focused input to flush its edit through
-  // stagePendingDraft — the blur event fires synchronously, so the ref carries
-  // that just-staged field, whereas the callback's pendingDrafts closure does not
-  // and used to drop it (then setPendingDrafts({}) discarded it for good).
   const pendingDraftsRef = useRef<PendingDrafts>({});
+  const dirtyFieldsRef = useRef(new Set<PendingDraftField>());
+  const sessionEpoch = useAuthStore((state) => state.sessionEpoch);
+  const scope = useMemo(() => ({ datasetId, sessionEpoch }), [datasetId, sessionEpoch]);
+  const scopeRef = useRef<typeof scope | null>(scope);
+  scopeRef.current = scope;
+  const saveRef = useRef<{ payload?: PendingDrafts } | null>(null);
+  const isCurrent = useCallback(
+    () => scopeRef.current === scope && useAuthStore.getState().sessionEpoch === scope.sessionEpoch,
+    [scope],
+  );
 
-  // fix(#1851): DatasetPage stays mounted across a route change from one
-  // dataset's edit view to another — only `datasetId` changes, not the
-  // component instance — so without this, staged drafts for dataset A
-  // survived into dataset B's render and a subsequent Save PATCHed them onto
-  // B. Reset every time the id changes, including into this hook's first
-  // render for a given id.
-  useEffect(() => {
-    setPendingDrafts({});
+  const resetDrafts = useCallback(() => {
     pendingDraftsRef.current = {};
+    dirtyFieldsRef.current = new Set();
+    setPendingDrafts({});
     setDirtyFields(new Set());
-  }, [datasetId]);
+  }, []);
+
+  useEffect(() => {
+    scopeRef.current = scope;
+    saveRef.current = null;
+    resetDrafts();
+    setIsSaving(false);
+    return () => {
+      if (scopeRef.current === scope) scopeRef.current = null;
+    };
+  }, [scope, resetDrafts]);
 
   const stagePendingDraft = useCallback(
     (field: PendingDraftField, value: string) => {
+      if (!isCurrent()) return;
       const normalizedNext = normalizeDraftValue(value);
-      const currentDatasetValue = normalizeDatasetValue(
-        (dataset?.[field] as string | null | undefined) ?? null,
-      );
-
-      setPendingDrafts((prev) => {
-        const next = { ...prev };
-        if (normalizedNext === currentDatasetValue) {
-          delete next[field];
-        } else {
-          next[field] = normalizedNext;
-        }
-        // Keep the ref in lockstep. Idempotent in prev, so StrictMode's
-        // double-invoke of this updater lands on the same value.
-        pendingDraftsRef.current = next;
-        return next;
-      });
+      const submitted = saveRef.current?.payload?.[field];
+      const next = { ...pendingDraftsRef.current };
+      // Keep the submitted value staged until success; failure must remain retryable.
+      if (submitted === undefined && normalizedNext === normalizeDatasetValue(dataset?.[field])) {
+        delete next[field];
+      } else {
+        next[field] = normalizedNext;
+      }
+      pendingDraftsRef.current = next;
+      setPendingDrafts(next);
     },
-    [dataset],
+    [dataset, isCurrent],
   );
 
-  const handleDraftDirtyChange = useCallback((field: PendingDraftField, isDirty: boolean) => {
-    setDirtyFields((prev) => {
-      const next = new Set(prev);
-      if (isDirty) {
-        next.add(field);
-      } else {
-        next.delete(field);
-      }
-      return next;
-    });
-  }, []);
+  const handleDraftDirtyChange = useCallback(
+    (field: PendingDraftField, isDirty: boolean) => {
+      if (!isCurrent()) return;
+      const next = new Set(dirtyFieldsRef.current);
+      if (isDirty) next.add(field);
+      else next.delete(field);
+      dirtyFieldsRef.current = next;
+      setDirtyFields(next);
+    },
+    [isCurrent],
+  );
 
   const resolveDraftValue = useCallback(
     (field: PendingDraftField) => {
@@ -116,70 +122,56 @@ export function useDraftEditing({ datasetId, dataset, isGeometryEditDirty }: Use
   const pendingCount = pendingFields.size;
 
   const savePendingDrafts = useCallback(async (): Promise<boolean> => {
-    if (!datasetId) return false;
+    if (!datasetId || !isCurrent() || saveRef.current) return false;
 
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
-
-    // Read from the ref, not the closure — it includes the field just staged by
-    // the blur above (fix(#458 E-17)).
-    const entries = Object.entries(pendingDraftsRef.current) as Array<
-      [PendingDraftField, string | null]
-    >;
-    if (entries.length === 0) {
-      return true;
-    }
-
-    const payload = entries.reduce<Record<PendingDraftField, string | null>>((acc, [field, value]) => {
-      acc[field] = value;
-      return acc;
-    }, {} as Record<PendingDraftField, string | null>);
-
+    const request = { payload: undefined as PendingDrafts | undefined };
+    saveRef.current = request;
     setIsSaving(true);
     try {
-      await updateDataset.mutateAsync({ datasetId, data: payload as DatasetUpdateRequest });
-      setPendingDrafts({});
-      pendingDraftsRef.current = {};
-      setDirtyFields(new Set());
-      toast.success(
-        t('affordances.pending.saved', {
-          defaultValue: 'Changes saved.',
-        }),
-      );
-      if (isGeometryEditDirty) {
-        toast.info(
-          t('affordances.pending.geometryHint', {
-            defaultValue: 'Field changes saved. Save geometry changes from the map toolbar.',
-          }),
-        );
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+        await new Promise((resolve) => setTimeout(resolve, 0));
       }
+      if (!isCurrent()) return false;
+
+      // Blur can stage another field before React renders the updated state.
+      const payload = { ...pendingDraftsRef.current };
+      const entries = Object.entries(payload) as Array<[PendingDraftField, string | null]>;
+      if (entries.length === 0) return true;
+      request.payload = payload;
+      await updateDataset.mutateAsync({
+        datasetId,
+        data: payload as DatasetUpdateRequest,
+      });
+      if (!isCurrent()) return false;
+
+      // Clear only submitted values that have not been edited again.
+      const remaining = { ...pendingDraftsRef.current };
+      for (const [field, value] of entries) {
+        if (remaining[field] === value && !dirtyFieldsRef.current.has(field))
+          delete remaining[field];
+      }
+      pendingDraftsRef.current = remaining;
+      setPendingDrafts(remaining);
+      toast.success(t('affordances.pending.saved'));
+      if (isGeometryEditDirty) toast.info(t('affordances.pending.geometryHint'));
       return true;
     } catch {
-      toast.error(
-        t('affordances.pending.saveFailed', {
-          defaultValue: 'Failed to save pending edits.',
-        }),
-      );
+      if (isCurrent()) toast.error(t('affordances.pending.saveFailed'));
       return false;
     } finally {
-      setIsSaving(false);
+      if (saveRef.current === request) {
+        saveRef.current = null;
+        if (isCurrent()) setIsSaving(false);
+      }
     }
-    // pendingDrafts is intentionally not a dep — savePendingDrafts reads the ref,
-    // which stays current without re-creating this callback on every keystroke.
-  }, [datasetId, isGeometryEditDirty, t, updateDataset]);
+  }, [datasetId, isCurrent, isGeometryEditDirty, t, updateDataset]);
 
   const discardPendingDrafts = useCallback(() => {
-    setPendingDrafts({});
-    pendingDraftsRef.current = {};
-    setDirtyFields(new Set());
-    toast.message(
-      t('affordances.pending.canceled', {
-        defaultValue: 'All changes discarded.',
-      }),
-    );
-  }, [t]);
+    if (!isCurrent()) return;
+    resetDrafts();
+    toast.message(t('affordances.pending.canceled'));
+  }, [isCurrent, resetDrafts, t]);
 
   return {
     stagePendingDraft,

--- a/frontend/src/components/dataset/hooks/use-feature-editing.ts
+++ b/frontend/src/components/dataset/hooks/use-feature-editing.ts
@@ -4,7 +4,7 @@
  * Manages: create (with overlay), select, edit geometry, edit attributes,
  * delete, deselect, tile reload, and hide-filter lifecycle.
  */
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useDrawingStore } from '@/stores/drawing-store';
@@ -87,18 +87,27 @@ interface UseFeatureEditingOptions {
   resetHistory: () => void;
 }
 
-/**
- * fix(#1761 review round 7): shared by every mutation's success AND failure
- * path — round 5/6 found catch blocks that skipped the same epoch recheck
- * their own success path already did, so a request that FAILED after an
- * identity change still surfaced its error toast (and, for create, its
- * failed-write UI feedback) to whoever is signed in now. One helper used in
- * all six places (three successes, three failures) instead of six
- * hand-rolled comparisons, so a seventh mutation added later has an
- * unmissable pattern to copy.
- */
-function isStale(epoch: number): boolean {
-  return useDrawingStore.getState().sessionEpoch !== epoch;
+/** A request belongs to one identity and drawing session, even after returning to a dataset. */
+function isStale(
+  epoch: number,
+  targetDatasetId: string | null,
+  generation: number,
+  currentGeneration: number,
+): boolean {
+  const state = useDrawingStore.getState();
+  return generation !== currentGeneration
+    || state.sessionEpoch !== epoch || state.targetDatasetId !== targetDatasetId;
+}
+
+function isSelectionStale(
+  epoch: number,
+  targetDatasetId: string | null,
+  selectedFeature: ReturnType<typeof useDrawingStore.getState>['selectedFeature'],
+  generation: number,
+  currentGeneration: number,
+): boolean {
+  return isStale(epoch, targetDatasetId, generation, currentGeneration)
+    || useDrawingStore.getState().selectedFeature !== selectedFeature;
 }
 
 export function useFeatureEditing({
@@ -122,6 +131,20 @@ export function useFeatureEditing({
   const setSelectedFeature = useDrawingStore((s) => s.setSelectedFeature);
   const clearSelectedFeature = useDrawingStore((s) => s.clearSelectedFeature);
   const setEditDirty = useDrawingStore((s) => s.setEditDirty);
+
+  const drawingGenerationRef = useRef(0);
+  useEffect(() => {
+    // Subscribe synchronously so batched A→B→A transitions cannot look unchanged.
+    const unsubscribe = useDrawingStore.subscribe((state, previous) => {
+      if (state.targetDatasetId !== previous.targetDatasetId || state.isDrawing !== previous.isDrawing) {
+        drawingGenerationRef.current += 1;
+      }
+    });
+    return () => {
+      unsubscribe();
+      drawingGenerationRef.current += 1;
+    };
+  }, []);
 
   const overlayFeaturesRef = useRef<GeoJSON.Feature[]>([]);
   const overlayCleanupRef = useRef<{ off: () => void; clearTimer: () => void } | null>(null);
@@ -164,14 +187,17 @@ export function useFeatureEditing({
 
   /** Create a new feature and refresh tiles. */
   const saveAndRefresh = useCallback(
-    async (geometry: Geometry, properties: Record<string, unknown>) => {
-      if (!datasetId || !tableName) return;
+    async (geometry: Geometry, properties: Record<string, unknown>): Promise<boolean> => {
+      if (!datasetId || !tableName) return false;
       const map = mapRef.current;
 
       // fix(#1761 review round 4): captured before the mutation's await —
       // clearOverlay() below must not erase a NEWER identity's own overlay
       // if this request's identity has since changed.
-      const epoch = useDrawingStore.getState().sessionEpoch;
+      const session = useDrawingStore.getState();
+      const epoch = session.sessionEpoch;
+      const targetDatasetId = session.targetDatasetId;
+      const generation = drawingGenerationRef.current;
 
       // Overlay for instant visibility
       const overlayFeature: GeoJSON.Feature = { type: 'Feature', geometry, properties: properties ?? {} };
@@ -194,7 +220,7 @@ export function useFeatureEditing({
         // here would only be feedback for an identity that is no longer
         // looking, and re-arming the listener below would have nothing
         // useful left to clear.
-        if (isStale(epoch)) return;
+        if (isStale(epoch, targetDatasetId, generation, drawingGenerationRef.current)) return false;
         toast.success(t('map.featureSaved'));
         reloadTiles();
 
@@ -207,7 +233,7 @@ export function useFeatureEditing({
             // again in the gap before the tile-load event (or the 5s
             // fallback) fires, and a second identity may have started
             // their own overlay by then.
-            if (isStale(epoch)) return;
+            if (isStale(epoch, targetDatasetId, generation, drawingGenerationRef.current)) return;
             overlayFeaturesRef.current = [];
             const src = map.getSource('drawn-overlay') as GeoJSONSource | undefined;
             src?.setData(EMPTY_FC);
@@ -230,13 +256,14 @@ export function useFeatureEditing({
             clearTimer: () => clearTimeout(fallbackTimer),
           };
         }
+        return true;
       } catch (err) {
         // fix(#1761 review round 7): the toast is feedback for whoever
         // issued this request — reject it the same way the success branch
         // above already does, or a failed create surfaces A's backend
         // error to B. The overlay-ref filtering below stays unconditional:
         // see its own comment for why it's already safe either way.
-        if (!isStale(epoch)) {
+        if (!isStale(epoch, targetDatasetId, generation, drawingGenerationRef.current)) {
           // fix(#458 E-36): surface the backend's reason (invalid geometry,
           // type mismatch) like the table path does, not a bare "failed".
           toast.error(formatMutationError('dataset:map.featureSaveFailed', err));
@@ -251,6 +278,7 @@ export function useFeatureEditing({
           const src = map.getSource('drawn-overlay') as GeoJSONSource | undefined;
           src?.setData({ type: 'FeatureCollection', features: overlayFeaturesRef.current });
         }
+        return false;
       }
     },
     [datasetId, tableName, mapRef, createFeature, reloadTiles, cleanupOverlayListener, t],
@@ -283,7 +311,10 @@ export function useFeatureEditing({
 
     // fix(#1761 review round 3 P2): captured before the mutation's
     // await — see handleDeleteFeature below for the shared rationale.
-    const epoch = useDrawingStore.getState().sessionEpoch;
+    const session = useDrawingStore.getState();
+    const epoch = session.sessionEpoch;
+    const targetDatasetId = session.targetDatasetId;
+    const generation = drawingGenerationRef.current;
     try {
       await updateFeatureMutation.mutateAsync({
         datasetId,
@@ -297,7 +328,7 @@ export function useFeatureEditing({
       // filters out from under them, and clear THEIR selectedFeature. The
       // write already landed server-side, which is as far as a stale
       // caller's responsibility goes — skip the rest.
-      if (isStale(epoch)) return;
+      if (isSelectionStale(epoch, targetDatasetId, sf, generation, drawingGenerationRef.current)) return;
       toast.success(t('map.featureUpdated'));
       try { removeFeatures([sf.tdId]); } catch { /* already removed */ }
       reloadTiles();
@@ -311,7 +342,7 @@ export function useFeatureEditing({
       // fix(#1761 review round 7): mirror the success branch's recheck —
       // a failed update is feedback for whoever issued it, not whoever is
       // signed in by the time it rejects.
-      if (isStale(epoch)) return;
+      if (isSelectionStale(epoch, targetDatasetId, sf, generation, drawingGenerationRef.current)) return;
       // fix(#458 E-36): keep the backend detail.
       toast.error(formatMutationError('dataset:map.featureUpdateFailed', err));
     }
@@ -327,10 +358,13 @@ export function useFeatureEditing({
     // delete is in flight; applying this success's cleanup then would
     // remove THEIR terra draw feature by a colliding tdId, restore tile
     // filters out from under them, and clear THEIR selectedFeature.
-    const epoch = useDrawingStore.getState().sessionEpoch;
+    const session = useDrawingStore.getState();
+    const epoch = session.sessionEpoch;
+    const targetDatasetId = session.targetDatasetId;
+    const generation = drawingGenerationRef.current;
     try {
       await deleteFeatureMutation.mutateAsync({ datasetId, gid: sf.gid });
-      if (isStale(epoch)) return;
+      if (isSelectionStale(epoch, targetDatasetId, sf, generation, drawingGenerationRef.current)) return;
       toast.success(t('map.featureDeleted'));
       try { removeFeatures([sf.tdId]); } catch { /* already removed */ }
       reloadTiles();
@@ -345,7 +379,7 @@ export function useFeatureEditing({
       // fix(#1761 review round 7): mirror the success branch's recheck —
       // a failed delete is feedback for whoever issued it, not whoever is
       // signed in by the time it rejects.
-      if (isStale(epoch)) return;
+      if (isSelectionStale(epoch, targetDatasetId, sf, generation, drawingGenerationRef.current)) return;
       // fix(#458 E-36): keep the backend detail.
       toast.error(formatMutationError('dataset:map.featureDeleteFailed', err));
     }
@@ -368,7 +402,10 @@ export function useFeatureEditing({
       // identity may have adopted its own new target, whose fresh epoch
       // would otherwise make this stale write look current. See
       // drawing-store.ts's setSelectedFeature doc comment.
-      const epoch = useDrawingStore.getState().sessionEpoch;
+      const session = useDrawingStore.getState();
+      const epoch = session.sessionEpoch;
+      const targetDatasetId = session.targetDatasetId;
+      const generation = drawingGenerationRef.current;
       try {
         await updateFeatureMutation.mutateAsync({ datasetId, gid: sf.gid, properties });
         // fix(#1761 review round 4): recheck immediately after the await,
@@ -376,7 +413,7 @@ export function useFeatureEditing({
         // tiles. setSelectedFeature's own epoch check already refuses the
         // store write on its own, but this validates it BEFORE those other
         // effects run and reports it to the caller via the return value.
-        if (isStale(epoch)) return { applied: false };
+        if (isSelectionStale(epoch, targetDatasetId, sf, generation, drawingGenerationRef.current)) return { applied: false };
         toast.success(t('map.attributesUpdated'));
         setSelectedFeature({ ...sf, properties: { ...sf.properties, ...properties } }, epoch);
         // BUG-042: the geometry handlers (handleSaveEdit/handleDeleteFeature)
@@ -394,7 +431,7 @@ export function useFeatureEditing({
         // an error toast and telling the caller to close would be exactly
         // the same collateral damage the success path already guards
         // against, just via the rejection branch instead of the resolve one.
-        if (isStale(epoch)) return { applied: false };
+        if (isSelectionStale(epoch, targetDatasetId, sf, generation, drawingGenerationRef.current)) return { applied: false };
         // fix(#458 E-36): keep the backend detail.
         toast.error(formatMutationError('dataset:map.attributesUpdateFailed', err));
         return { applied: true };
@@ -468,7 +505,10 @@ export function useFeatureEditing({
       // the same reason as handleEditAttributeSubmit above — a stale
       // resolution here must not be accepted just because someone else's
       // fresh target happens to make the live epoch look unchanged.
-      const epoch = useDrawingStore.getState().sessionEpoch;
+      const session = useDrawingStore.getState();
+      const epoch = session.sessionEpoch;
+      const targetDatasetId = session.targetDatasetId;
+      const generation = drawingGenerationRef.current;
       try {
         const fullFeature = await getFeature(datasetId, gid);
         // fix(#1761 review round 3 P1): recheck IMMEDIATELY after the
@@ -477,7 +517,7 @@ export function useFeatureEditing({
         // addFeatures() below would already have installed the stale
         // geometry on the map, and the rest of this block would go on to
         // select it and hide its tile.
-        if (isStale(epoch)) return;
+        if (isSelectionStale(epoch, targetDatasetId, null, generation, drawingGenerationRef.current)) return;
         clear();
 
         if (!fullFeature.geometry) {
@@ -512,7 +552,7 @@ export function useFeatureEditing({
         // a failed fetch is feedback for whoever clicked the feature, not
         // whoever is signed in (or anonymous) by the time getFeature()
         // rejects.
-        if (isStale(epoch)) return;
+        if (isSelectionStale(epoch, targetDatasetId, null, generation, drawingGenerationRef.current)) return;
         toast.error(t('map.featureLoadFailed'));
       }
     },
@@ -532,5 +572,9 @@ export function useFeatureEditing({
     reloadTiles,
     cleanupOverlayListener,
     resetOverlay,
+    isFeatureMutationPending:
+      Boolean(createFeature.isPending)
+      || Boolean(updateFeatureMutation.isPending)
+      || Boolean(deleteFeatureMutation.isPending),
   };
 }

--- a/frontend/src/components/dataset/tabs/OverviewTab.tsx
+++ b/frontend/src/components/dataset/tabs/OverviewTab.tsx
@@ -352,6 +352,7 @@ export function OverviewTab({
                     allowClear
                     as="p"
                     multiline
+                    saveOnBlur
                     canEdit={capabilities.summary.editable}
                     placeholder={t('inline.noDescription')}
                     className="text-sm leading-7"

--- a/frontend/src/components/dataset/tabs/SourceQualityTab.tsx
+++ b/frontend/src/components/dataset/tabs/SourceQualityTab.tsx
@@ -215,6 +215,7 @@ export function SourceQualityTab({
                   allowClear
                   as="p"
                   multiline
+                  saveOnBlur
                   canEdit={capabilities.lineage_summary.editable}
                   placeholder={t('iso.lineagePlaceholder')}
                   className="text-sm"
@@ -346,6 +347,7 @@ export function SourceQualityTab({
                   allowClear
                   as="p"
                   multiline
+                  saveOnBlur
                   canEdit={capabilities.quality_statement.editable}
                   placeholder={t('iso.qualityStatementPlaceholder')}
                   className="text-sm"
@@ -446,6 +448,7 @@ export function SourceQualityTab({
                   allowClear
                   as="p"
                   multiline
+                  saveOnBlur
                   canEdit={capabilities.attribution.editable}
                   placeholder={t('metadata.attributionPlaceholder')}
                   className="text-sm"
@@ -470,6 +473,7 @@ export function SourceQualityTab({
                   allowClear
                   as="p"
                   multiline
+                  saveOnBlur
                   canEdit={capabilities.usage_constraints.editable}
                   placeholder={t('iso.usageConstraintsPlaceholder')}
                   className="text-sm"
@@ -491,6 +495,7 @@ export function SourceQualityTab({
                   allowClear
                   as="p"
                   multiline
+                  saveOnBlur
                   canEdit={capabilities.access_constraints.editable}
                   placeholder={t('iso.accessConstraintsPlaceholder')}
                   className="text-sm"

--- a/frontend/src/components/drawing/AttributeForm.tsx
+++ b/frontend/src/components/drawing/AttributeForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, type FormEvent } from 'react';
+import { useState, useEffect, useMemo, useRef, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Dialog,
@@ -26,7 +26,7 @@ interface AttributeFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   columns: Column[];
-  onSubmit: (properties: Record<string, unknown>) => void;
+  onSubmit: (properties: Record<string, unknown>) => void | Promise<void>;
   onCancel: () => void;
   initialValues?: Record<string, unknown>;
 }
@@ -66,6 +66,8 @@ export function AttributeForm({
     [columns],
   );
   const isEditing = initialValues !== undefined;
+  const submittingRef = useRef(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [values, setValues] = useState<Record<string, string | boolean>>(() =>
     buildFormValues(editableColumns, initialValues),
@@ -76,6 +78,18 @@ export function AttributeForm({
     setValues(buildFormValues(editableColumns, initialValues));
     // eslint-disable-next-line react-hooks/exhaustive-deps -- reseed the form only when initialValues change; the setters are stable
   }, [initialValues]);
+
+  async function submit(properties: Record<string, unknown>) {
+    if (submittingRef.current) return;
+    submittingRef.current = true;
+    setIsSubmitting(true);
+    try {
+      await onSubmit(properties);
+    } finally {
+      submittingRef.current = false;
+      setIsSubmitting(false);
+    }
+  }
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -93,15 +107,21 @@ export function AttributeForm({
         properties[col.name] = str === '' ? null : str;
       }
     }
-    onSubmit(properties);
+    void submit(properties);
   }
 
   function handleSkip() {
-    onSubmit({});
+    void submit({});
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && submittingRef.current) return;
+        onOpenChange(nextOpen);
+      }}
+    >
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{isEditing ? t('attributeForm.titleEdit') : t('attributeForm.titleNew')}</DialogTitle>
@@ -122,6 +142,7 @@ export function AttributeForm({
                   <Checkbox
                     id={`attr-${col.name}`}
                     checked={values[col.name] === true}
+                    disabled={isSubmitting}
                     onCheckedChange={(checked) =>
                       setValues((v) => ({ ...v, [col.name]: checked === true }))
                     }
@@ -144,6 +165,7 @@ export function AttributeForm({
                   type={htmlType}
                   step={inputType === 'number-int' ? '1' : inputType === 'number-float' ? 'any' : undefined}
                   value={values[col.name] as string}
+                  disabled={isSubmitting}
                   onChange={(e) =>
                     setValues((v) => ({ ...v, [col.name]: e.target.value }))
                   }
@@ -154,14 +176,14 @@ export function AttributeForm({
 
           <DialogFooter>
             {!isEditing && (
-              <Button type="button" variant="outline" onClick={handleSkip}>
+              <Button type="button" variant="outline" onClick={handleSkip} disabled={isSubmitting}>
                 {t('attributeForm.skip')}
               </Button>
             )}
-            <Button type="button" variant="ghost" onClick={onCancel}>
+            <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
               {t('common:cancel')}
             </Button>
-            <Button type="submit">{t('common:save')}</Button>
+            <Button type="submit" disabled={isSubmitting}>{t('common:save')}</Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/frontend/src/components/drawing/AttributeForm.tsx
+++ b/frontend/src/components/drawing/AttributeForm.tsx
@@ -140,7 +140,7 @@ export function AttributeForm({
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {editableColumns.map((col) => {
-            const inputType = getInputType(col.type);
+            const inputType = getInputType(col.type, initialValues?.[col.name]);
 
             if (inputType === 'checkbox') {
               return (

--- a/frontend/src/components/drawing/AttributeForm.tsx
+++ b/frontend/src/components/drawing/AttributeForm.tsx
@@ -12,7 +12,11 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
-import { getAttributeInputType as getInputType } from '@/lib/attribute-values';
+import {
+  formatAttributeInputValue,
+  getAttributeInputType as getInputType,
+  serializeAttributeInputValue,
+} from '@/lib/attribute-values';
 
 /** System columns that should never appear in the attribute form */
 const SYSTEM_COLUMNS = new Set(['gid', 'geom', 'geom_4326']);
@@ -43,7 +47,7 @@ function buildFormValues(
       if (inputType === 'checkbox') {
         init[col.name] = Boolean(initial);
       } else {
-        init[col.name] = String(initial);
+        init[col.name] = formatAttributeInputValue(initial, col.type);
       }
     } else {
       init[col.name] = inputType === 'checkbox' ? false : '';
@@ -104,7 +108,9 @@ export function AttributeForm({
         properties[col.name] = str === '' ? null : Number(str);
       } else {
         const str = raw as string;
-        properties[col.name] = str === '' ? null : str;
+        properties[col.name] = str === ''
+          ? null
+          : serializeAttributeInputValue(str, col.type, initialValues?.[col.name]);
       }
     }
     void submit(properties);
@@ -163,7 +169,13 @@ export function AttributeForm({
                 <Input
                   id={`attr-${col.name}`}
                   type={htmlType}
-                  step={inputType === 'number-int' ? '1' : inputType === 'number-float' ? 'any' : undefined}
+                  step={
+                    inputType === 'number-int'
+                      ? '1'
+                      : inputType === 'number-float' || inputType === 'datetime-local'
+                        ? 'any'
+                        : undefined
+                  }
                   value={values[col.name] as string}
                   disabled={isSubmitting}
                   onChange={(e) =>

--- a/frontend/src/components/drawing/DrawingToolbar.tsx
+++ b/frontend/src/components/drawing/DrawingToolbar.tsx
@@ -43,6 +43,7 @@ interface DrawingToolbarProps {
   onDeleteFeature?: () => void;
   onUndo?: () => void;
   canUndo?: boolean;
+  isMutating?: boolean;
 }
 
 export function DrawingToolbar({
@@ -55,6 +56,7 @@ export function DrawingToolbar({
   onDeleteFeature,
   onUndo,
   canUndo,
+  isMutating = false,
 }: DrawingToolbarProps) {
   const { t } = useTranslation('builder');
   const activeMode = useDrawingStore((s) => s.activeMode);
@@ -133,6 +135,7 @@ export function DrawingToolbar({
             title={t('drawing.saveChanges')}
             aria-label={t('drawing.saveChanges')}
             onClick={onSaveEdit}
+            disabled={isMutating}
           >
             <Check className="h-4 w-4" />
             <span className="hidden sm:inline">{t('common:save')}</span>
@@ -144,6 +147,7 @@ export function DrawingToolbar({
             title={t('drawing.cancelEditing')}
             aria-label={t('drawing.cancelEditing')}
             onClick={onCancelEdit}
+            disabled={isMutating}
           >
             <X className="h-4 w-4" />
             <span className="hidden sm:inline">{t('common:cancel')}</span>
@@ -155,6 +159,7 @@ export function DrawingToolbar({
             title={t('drawing.editAttributes')}
             aria-label={t('drawing.editAttributes')}
             onClick={onEditAttributes}
+            disabled={isMutating}
           >
             <FileEdit className="h-4 w-4" />
             <span className="hidden sm:inline">{t('drawing.editAttributes')}</span>
@@ -166,6 +171,7 @@ export function DrawingToolbar({
             title={t('drawing.deleteFeature')}
             aria-label={t('drawing.deleteFeature')}
             onClick={onDeleteFeature}
+            disabled={isMutating}
           >
             <Trash2 className="h-4 w-4" />
             <span className="hidden sm:inline">{t('common:delete')}</span>

--- a/frontend/src/components/drawing/__tests__/AttributeForm.test.tsx
+++ b/frontend/src/components/drawing/__tests__/AttributeForm.test.tsx
@@ -1,0 +1,76 @@
+import { act, fireEvent, render, screen } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AttributeForm } from '@/components/drawing/AttributeForm';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('AttributeForm submission', () => {
+  it('keeps the form stable and blocks duplicate edits while a save is pending', async () => {
+    const save = deferred();
+    const onSubmit = vi.fn(() => save.promise);
+    render(
+      <AttributeForm
+        open
+        onOpenChange={vi.fn()}
+        columns={[{ name: 'population', type: 'integer' }]}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText('population');
+    const saveButton = screen.getByRole('button', { name: 'common:save' });
+    fireEvent.change(input, { target: { value: '250' } });
+    fireEvent.click(saveButton);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(input).toBeDisabled();
+    expect(saveButton).toBeDisabled();
+    fireEvent.click(saveButton);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      save.resolve();
+      await save.promise;
+    });
+
+    expect(input).toBeEnabled();
+    expect(input).toHaveValue(250);
+  });
+
+  it('blocks Escape dismissal while a save is pending', async () => {
+    const save = deferred();
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AttributeForm
+        open
+        onOpenChange={onOpenChange}
+        columns={[{ name: 'population', type: 'integer' }]}
+        onSubmit={() => save.promise}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'common:save' }));
+    await user.keyboard('{Escape}');
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    await act(async () => {
+      save.resolve();
+      await save.promise;
+    });
+  });
+});

--- a/frontend/src/components/drawing/__tests__/AttributeForm.test.tsx
+++ b/frontend/src/components/drawing/__tests__/AttributeForm.test.tsx
@@ -1,11 +1,22 @@
 import { act, fireEvent, render, screen } from '@/test/test-utils';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { AttributeForm } from '@/components/drawing/AttributeForm';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
+
+const originalTimezone = process.env.TZ;
+
+beforeAll(() => {
+  process.env.TZ = 'America/New_York';
+});
+
+afterAll(() => {
+  if (originalTimezone === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTimezone;
+});
 
 function deferred() {
   let resolve!: () => void;
@@ -16,6 +27,96 @@ function deferred() {
 }
 
 describe('AttributeForm submission', () => {
+  it('hydrates and preserves an unchanged timezone-aware instant', () => {
+    const onSubmit = vi.fn();
+    render(
+      <AttributeForm
+        open
+        onOpenChange={vi.fn()}
+        columns={[{ name: 'observed_at', type: 'timestamp with time zone' }]}
+        initialValues={{ observed_at: '2026-11-01T06:30:00Z' }}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('observed_at')).toHaveValue('2026-11-01T01:30');
+    fireEvent.click(screen.getByRole('button', { name: 'common:save' }));
+    expect(onSubmit).toHaveBeenCalledWith({ observed_at: '2026-11-01T06:30:00Z' });
+  });
+
+  it('hydrates API precision into valid DOM values and preserves full unchanged values', () => {
+    const onSubmit = vi.fn();
+    render(
+      <AttributeForm
+        open
+        onOpenChange={vi.fn()}
+        columns={[
+          { name: 'aware_at', type: 'timestamp with time zone' },
+          { name: 'local_at', type: 'timestamp without time zone' },
+        ]}
+        initialValues={{
+          aware_at: '2026-07-11T14:30:00.123456Z',
+          local_at: '2026-07-11T10:30:00.123456',
+        }}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('aware_at')).toHaveValue('2026-07-11T10:30:00.123');
+    expect(screen.getByLabelText('local_at')).toHaveValue('2026-07-11T10:30:00.123');
+    fireEvent.click(screen.getByRole('button', { name: 'common:save' }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      aware_at: '2026-07-11T14:30:00.123456Z',
+      local_at: '2026-07-11T10:30:00.123456',
+    });
+  });
+
+  it('converts a new local timestamp to an explicit instant but preserves a naive wall clock', () => {
+    const onSubmit = vi.fn();
+    render(
+      <AttributeForm
+        open
+        onOpenChange={vi.fn()}
+        columns={[
+          { name: 'aware_at', type: 'timestamp' },
+          { name: 'local_at', type: 'timestamp without time zone' },
+        ]}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('aware_at'), { target: { value: '2026-07-11T10:30' } });
+    fireEvent.change(screen.getByLabelText('local_at'), { target: { value: '2026-07-11T10:30' } });
+    fireEvent.click(screen.getByRole('button', { name: 'common:save' }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      aware_at: '2026-07-11T10:30-04:00',
+      local_at: '2026-07-11T10:30',
+    });
+  });
+
+  it('leaves an invalid DST-gap wall clock unchanged for backend validation', () => {
+    const onSubmit = vi.fn();
+    render(
+      <AttributeForm
+        open
+        onOpenChange={vi.fn()}
+        columns={[{ name: 'aware_at', type: 'timestamp with time zone' }]}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('aware_at'), { target: { value: '2026-03-08T02:30' } });
+    fireEvent.click(screen.getByRole('button', { name: 'common:save' }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ aware_at: '2026-03-08T02:30' });
+    expect(screen.getByLabelText('aware_at')).toHaveValue('2026-03-08T02:30');
+  });
+
   it('keeps the form stable and blocks duplicate edits while a save is pending', async () => {
     const save = deferred();
     const onSubmit = vi.fn(() => save.promise);

--- a/frontend/src/components/drawing/__tests__/AttributeForm.test.tsx
+++ b/frontend/src/components/drawing/__tests__/AttributeForm.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen } from '@/test/test-utils';
 import userEvent from '@testing-library/user-event';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { AttributeForm } from '@/components/drawing/AttributeForm';
 
 vi.mock('react-i18next', () => ({
@@ -18,6 +18,10 @@ afterAll(() => {
   else process.env.TZ = originalTimezone;
 });
 
+afterEach(() => {
+  process.env.TZ = 'America/New_York';
+});
+
 function deferred() {
   let resolve!: () => void;
   const promise = new Promise<void>((done) => {
@@ -27,6 +31,30 @@ function deferred() {
 }
 
 describe('AttributeForm submission', () => {
+  it.each([
+    ['America/New_York', '0001-01-01T00:00:00Z'],
+    ['Asia/Tokyo', '9999-12-31T23:59:59Z'],
+  ])('preserves an instant outside the supported local year range in %s', (timezone, original) => {
+    process.env.TZ = timezone;
+    const onSubmit = vi.fn();
+    render(
+      <AttributeForm
+        open
+        onOpenChange={vi.fn()}
+        columns={[{ name: 'observed_at', type: 'timestamp with time zone' }]}
+        initialValues={{ observed_at: original }}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText('observed_at');
+    expect(input).toHaveAttribute('type', 'text');
+    expect(input).toHaveValue(original);
+    fireEvent.click(screen.getByRole('button', { name: 'common:save' }));
+    expect(onSubmit).toHaveBeenCalledWith({ observed_at: original });
+  });
+
   it('hydrates and preserves an unchanged timezone-aware instant', () => {
     const onSubmit = vi.fn();
     render(

--- a/frontend/src/components/drawing/__tests__/AttributeForm.test.tsx
+++ b/frontend/src/components/drawing/__tests__/AttributeForm.test.tsx
@@ -121,7 +121,7 @@ describe('AttributeForm submission', () => {
     fireEvent.click(screen.getByRole('button', { name: 'common:save' }));
 
     expect(onSubmit).toHaveBeenCalledWith({
-      aware_at: '2026-07-11T10:30-04:00',
+      aware_at: '2026-07-11T14:30:00Z',
       local_at: '2026-07-11T10:30',
     });
   });

--- a/frontend/src/components/drawing/__tests__/DrawingToolbar.test.tsx
+++ b/frontend/src/components/drawing/__tests__/DrawingToolbar.test.tsx
@@ -135,6 +135,17 @@ describe('DrawingToolbar edit action bar', () => {
     expect(screen.getByLabelText('drawing.editAttributes')).toBeInTheDocument();
     expect(screen.getByLabelText('drawing.deleteFeature')).toBeInTheDocument();
   });
+
+  it('disables edit actions while a feature mutation is pending', () => {
+    drawingState.selectedFeature = { gid: 1, tdId: 'td-1', properties: {} };
+
+    render(<DrawingToolbar geometryType="POINT" onClose={vi.fn()} isMutating />);
+
+    expect(screen.getByLabelText('drawing.saveChanges')).toBeDisabled();
+    expect(screen.getByLabelText('drawing.cancelEditing')).toBeDisabled();
+    expect(screen.getByLabelText('drawing.editAttributes')).toBeDisabled();
+    expect(screen.getByLabelText('drawing.deleteFeature')).toBeDisabled();
+  });
 });
 
 describe('DrawingToolbar callbacks', () => {

--- a/frontend/src/hooks/__tests__/use-features.test.ts
+++ b/frontend/src/hooks/__tests__/use-features.test.ts
@@ -1,6 +1,9 @@
 import { renderHook } from '@/test/test-utils';
 import { vi } from 'vitest';
 import { QueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
 
 vi.mock('@/api/features', () => ({
   createFeature: vi.fn(),
@@ -185,5 +188,24 @@ describe('useDeleteFeature', () => {
     const { result } = renderHook(() => useDeleteFeature());
 
     await expect(result.current.mutateAsync({ datasetId: 'ds-1', gid: 99 })).rejects.toThrow('Not found');
+  });
+});
+
+
+describe('schema error feedback belongs to the current editor', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns add failures without emitting an unscoped toast', async () => {
+    mockAddColumn.mockRejectedValueOnce(new Error('Add failed'));
+    const { result } = renderHook(() => useAddColumn());
+    await expect(result.current.mutateAsync({ datasetId: 'old-dataset', column: { name: 'new_column', type: 'text' } })).rejects.toThrow('Add failed');
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('returns drop failures without emitting an unscoped toast', async () => {
+    mockDropColumn.mockRejectedValueOnce(new Error('Drop failed'));
+    const { result } = renderHook(() => useDropColumn());
+    await expect(result.current.mutateAsync({ datasetId: 'old-dataset', columnName: 'old_column' })).rejects.toThrow('Drop failed');
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/use-features.ts
+++ b/frontend/src/hooks/use-features.ts
@@ -1,11 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query-keys';
-import { formatMutationError } from '@/lib/error-map';
 import { createFeature, updateFeature, deleteFeature } from '@/api/features';
 import { addColumn, dropColumn, getColumnReferences } from '@/api/datasets';
 import type { Geometry } from 'geojson';
-import { toast } from 'sonner';
-import i18n from '@/i18n/i18n';
 import { logger } from '@/lib/logger';
 import type { QueryClient } from '@tanstack/react-query';
 
@@ -118,7 +115,6 @@ export function useAddColumn() {
       qc.invalidateQueries({ queryKey: queryKeys.datasets.attributes(variables.datasetId) });
       invalidateColumnCaches(qc, variables.datasetId);
     },
-    onError: () => { toast.error(i18n.t('dataset:schema.addFailed')); },
   });
 }
 
@@ -138,8 +134,6 @@ export function useDropColumn() {
       qc.invalidateQueries({ queryKey: queryKeys.datasets.attributes(variables.datasetId) });
       invalidateColumnCaches(qc, variables.datasetId);
     },
-    // The hook owns the error toast so SchemaEditor does not duplicate it.
-    onError: (err) => { toast.error(formatMutationError('dataset:schema.removeFailed', err)); },
   });
 }
 

--- a/frontend/src/lib/__tests__/attribute-values.test.ts
+++ b/frontend/src/lib/__tests__/attribute-values.test.ts
@@ -95,6 +95,35 @@ describe('coerceAttributeValue', () => {
 });
 
 describe('timestamp form values', () => {
+  it.each([
+    ['America/New_York', '0001-01-01T00:00:00Z', 'text'],
+    ['America/New_York', '0001-01-01T00:00:00+14:00', 'text'],
+    ['America/New_York', '0001-01-01T00:00:00-12:00', 'datetime-local'],
+    ['Asia/Tokyo', '0001-01-01T00:00:00Z', 'datetime-local'],
+    ['Asia/Tokyo', '9999-12-31T23:59:59Z', 'text'],
+    ['Asia/Tokyo', '9999-12-31T23:59:59-12:00', 'text'],
+    ['Asia/Tokyo', '9999-12-31T23:59:59+14:00', 'datetime-local'],
+    ['America/New_York', '9999-12-31T23:59:59Z', 'datetime-local'],
+  ])('preserves year boundaries in %s for %s', (timezone, original, inputType) => {
+    const previousTimezone = process.env.TZ;
+    process.env.TZ = timezone;
+    try {
+      const colType = 'timestamp with time zone';
+      expect(getAttributeInputType(colType, original)).toBe(inputType);
+      const value = formatAttributeInputValue(original, colType);
+      const input = document.createElement('input');
+      input.type = inputType;
+      input.value = value;
+      expect(input.value).not.toBe('');
+      if (inputType === 'text') expect(value).toBe(original);
+      expect(serializeAttributeInputValue(value, colType, original)).toBe(original);
+      expect(getAttributeInputType('timestamp without time zone', original.slice(0, 19)))
+        .toBe('datetime-local');
+    } finally {
+      process.env.TZ = previousTimezone;
+    }
+  });
+
   it.each(['0001', '0099', '0999'])(
     'keeps historical year %s visible in native datetime inputs and unchanged on save',
     (year) => {

--- a/frontend/src/lib/__tests__/attribute-values.test.ts
+++ b/frontend/src/lib/__tests__/attribute-values.test.ts
@@ -95,6 +95,23 @@ describe('coerceAttributeValue', () => {
 });
 
 describe('timestamp form values', () => {
+  it.each(['0001', '0099', '0999'])(
+    'keeps historical year %s visible in native datetime inputs and unchanged on save',
+    (year) => {
+      for (const colType of ['timestamp with time zone', 'timestamp without time zone']) {
+        const suffix = colType === 'timestamp with time zone' ? 'Z' : '';
+        const original = `${year}-07-11T14:30:00${suffix}`;
+        const local = formatAttributeInputValue(original, colType);
+        const input = document.createElement('input');
+        input.type = 'datetime-local';
+        input.value = local;
+        expect(input.value).not.toBe('');
+        expect(input.value.startsWith(`${year}-`)).toBe(true);
+        expect(serializeAttributeInputValue(local, colType, original)).toBe(original);
+      }
+    },
+  );
+
   it('displays aware instants in browser-local time and submits changed values as instants', () => {
     expect(formatAttributeInputValue('2026-07-11T14:30:00Z', 'timestamp with time zone'))
       .toBe('2026-07-11T10:30');

--- a/frontend/src/lib/__tests__/attribute-values.test.ts
+++ b/frontend/src/lib/__tests__/attribute-values.test.ts
@@ -61,6 +61,34 @@ describe('coerceAttributeValue', () => {
     expect(coerceAttributeValue('12abc', 'real')).toEqual({ ok: false });
   });
 
+  it.each(['Infinity', '-Infinity', '1e309', '-1e309'])('rejects non-finite numeric input %s', (raw) => {
+    for (const type of ['double precision', 'real', 'numeric']) {
+      expect(coerceAttributeValue(raw, type)).toEqual({ ok: false });
+    }
+  });
+
+  it('preserves historical timezone seconds and extra fractional precision', () => {
+    expect(coerceAttributeValue('0999-05-06T07:37:58', 'timestamptz')).toEqual({
+      ok: true,
+      value: '0999-05-06T12:34:00Z',
+    });
+    expect(serializeAttributeInputValue('0999-05-06T07:37:58.123456', 'timestamptz'))
+      .toBe('0999-05-06T12:34:00.123456Z');
+  });
+
+  it.each([
+    ['Asia/Tokyo', '0001-01-01T00:00'],
+    ['America/New_York', '9999-12-31T23:59'],
+  ])('rejects local edits outside the supported UTC year range in %s', (timezone, raw) => {
+    const previousTimezone = process.env.TZ;
+    process.env.TZ = timezone;
+    try {
+      expect(coerceAttributeValue(raw, 'timestamptz')).toEqual({ ok: false });
+    } finally {
+      process.env.TZ = previousTimezone;
+    }
+  });
+
   it('coerces boolean words and rejects others', () => {
     expect(coerceAttributeValue('true', 'boolean')).toEqual({ ok: true, value: true });
     expect(coerceAttributeValue('Yes', 'boolean')).toEqual({ ok: true, value: true });
@@ -73,10 +101,10 @@ describe('coerceAttributeValue', () => {
     expect(coerceAttributeValue(' padded ', 'text')).toEqual({ ok: true, value: ' padded ' });
   });
 
-  it('adds the browser offset to local timezone-aware timestamp edits', () => {
+  it('converts browser-local timezone-aware timestamp edits to UTC', () => {
     expect(coerceAttributeValue('2026-07-11T10:30', 'timestamp with time zone')).toEqual({
       ok: true,
-      value: '2026-07-11T10:30-04:00',
+      value: '2026-07-11T14:30:00Z',
     });
     expect(coerceAttributeValue('2026-07-11T14:30:00+02:00', 'timestamptz')).toEqual({
       ok: true,
@@ -145,7 +173,7 @@ describe('timestamp form values', () => {
     expect(formatAttributeInputValue('2026-07-11T14:30:00Z', 'timestamp with time zone'))
       .toBe('2026-07-11T10:30');
     expect(serializeAttributeInputValue('2026-07-11T11:30', 'timestamp with time zone'))
-      .toBe('2026-07-11T11:30-04:00');
+      .toBe('2026-07-11T15:30:00Z');
   });
 
   it('retains an unchanged aware instant through an ambiguous local time', () => {

--- a/frontend/src/lib/__tests__/attribute-values.test.ts
+++ b/frontend/src/lib/__tests__/attribute-values.test.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect } from 'vitest';
-import { coerceAttributeValue, getAttributeInputType } from '../attribute-values';
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import {
+  coerceAttributeValue,
+  formatAttributeInputValue,
+  getAttributeInputType,
+  serializeAttributeInputValue,
+} from '../attribute-values';
+
+const originalTimezone = process.env.TZ;
+
+beforeAll(() => {
+  process.env.TZ = 'America/New_York';
+});
+
+afterAll(() => {
+  if (originalTimezone === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTimezone;
+});
 
 describe('getAttributeInputType', () => {
   it('maps postgres types to input kinds', () => {
@@ -55,5 +71,81 @@ describe('coerceAttributeValue', () => {
   it('trims date strings but keeps text verbatim', () => {
     expect(coerceAttributeValue(' 2026-07-11 ', 'date')).toEqual({ ok: true, value: '2026-07-11' });
     expect(coerceAttributeValue(' padded ', 'text')).toEqual({ ok: true, value: ' padded ' });
+  });
+
+  it('adds the browser offset to local timezone-aware timestamp edits', () => {
+    expect(coerceAttributeValue('2026-07-11T10:30', 'timestamp with time zone')).toEqual({
+      ok: true,
+      value: '2026-07-11T10:30-04:00',
+    });
+    expect(coerceAttributeValue('2026-07-11T14:30:00+02:00', 'timestamptz')).toEqual({
+      ok: true,
+      value: '2026-07-11T14:30:00+02:00',
+    });
+    expect(coerceAttributeValue('2026-07-11T10:30', 'timestamp without time zone')).toEqual({
+      ok: true,
+      value: '2026-07-11T10:30',
+    });
+  });
+
+  it('rejects local timestamps that JavaScript normalizes across a DST gap', () => {
+    expect(coerceAttributeValue('2026-03-08T02:30', 'timestamp with time zone'))
+      .toEqual({ ok: false });
+  });
+});
+
+describe('timestamp form values', () => {
+  it('displays aware instants in browser-local time and submits changed values as instants', () => {
+    expect(formatAttributeInputValue('2026-07-11T14:30:00Z', 'timestamp with time zone'))
+      .toBe('2026-07-11T10:30');
+    expect(serializeAttributeInputValue('2026-07-11T11:30', 'timestamp with time zone'))
+      .toBe('2026-07-11T11:30-04:00');
+  });
+
+  it('retains an unchanged aware instant through an ambiguous local time', () => {
+    const original = '2026-11-01T06:30:00Z';
+    const local = formatAttributeInputValue(original, 'timestamp with time zone');
+
+    expect(local).toBe('2026-11-01T01:30');
+    expect(new Date(local).toISOString()).toBe('2026-11-01T05:30:00.000Z');
+    expect(serializeAttributeInputValue(local, 'timestamp with time zone', original)).toBe(original);
+  });
+
+  it('keeps timezone-free timestamps as wall-clock values', () => {
+    const original = '2026-07-11T14:30:00';
+    expect(formatAttributeInputValue(original, 'timestamp without time zone'))
+      .toBe('2026-07-11T14:30');
+    expect(serializeAttributeInputValue(
+      '2026-07-11T14:30',
+      'timestamp without time zone',
+      original,
+    )).toBe(original);
+  });
+
+  it('limits display precision while preserving unchanged API precision', () => {
+    const aware = '2026-07-11T14:30:00.123456Z';
+    const naive = '2026-07-11T10:30:00.123456';
+    expect(formatAttributeInputValue(aware, 'timestamp with time zone'))
+      .toBe('2026-07-11T10:30:00.123');
+    expect(formatAttributeInputValue(naive, 'timestamp without time zone'))
+      .toBe('2026-07-11T10:30:00.123');
+    expect(serializeAttributeInputValue('2026-07-11T10:30:00.123', 'timestamp with time zone', aware))
+      .toBe(aware);
+    expect(serializeAttributeInputValue('2026-07-11T10:30:00.123', 'timestamp without time zone', naive))
+      .toBe(naive);
+
+    const subMillisecond = '2026-07-11T14:30:00.000456Z';
+    expect(formatAttributeInputValue(subMillisecond, 'timestamp with time zone'))
+      .toBe('2026-07-11T10:30');
+    expect(serializeAttributeInputValue('2026-07-11T10:30', 'timestamp with time zone', subMillisecond))
+      .toBe(subMillisecond);
+    const naiveSubMillisecond = '2026-07-11T10:30:00.000456';
+    expect(formatAttributeInputValue(naiveSubMillisecond, 'timestamp without time zone'))
+      .toBe('2026-07-11T10:30');
+    expect(serializeAttributeInputValue(
+      '2026-07-11T10:30',
+      'timestamp without time zone',
+      naiveSubMillisecond,
+    )).toBe(naiveSubMillisecond);
   });
 });

--- a/frontend/src/lib/attribute-values.ts
+++ b/frontend/src/lib/attribute-values.ts
@@ -20,6 +20,136 @@ export function getAttributeInputType(colType: string): AttributeInputType {
   return 'text';
 }
 
+function isTimezoneAwareTimestamp(colType: string): boolean {
+  const type = colType.toLowerCase();
+  if (type.includes('without time zone')) return false;
+  // The layer schema API's short `timestamp` type creates TIMESTAMPTZ columns.
+  return type === 'timestamp' || type.startsWith('timestamptz') || type.includes('with time zone');
+}
+
+function hasTimezoneOffset(value: string): boolean {
+  return /(?:z|[+-]\d{2}:?\d{2})$/i.test(value);
+}
+
+function localTimestampWithOffset(raw: string): string | null {
+  const match = raw.match(
+    /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?$/,
+  );
+  if (!match) return null;
+  const [, year, month, day, hour, minute, second = '0', fraction = ''] = match;
+  const milliseconds = Number(fraction.padEnd(3, '0').slice(0, 3));
+  const instant = new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second),
+    milliseconds,
+  );
+  if (Number(year) < 100) instant.setFullYear(Number(year));
+  if (
+    instant.getFullYear() !== Number(year)
+    || instant.getMonth() !== Number(month) - 1
+    || instant.getDate() !== Number(day)
+    || instant.getHours() !== Number(hour)
+    || instant.getMinutes() !== Number(minute)
+    || instant.getSeconds() !== Number(second)
+    || instant.getMilliseconds() !== milliseconds
+  ) return null;
+  const offsetMinutes = instant.getTimezoneOffset();
+  const sign = offsetMinutes <= 0 ? '+' : '-';
+  const absoluteOffset = Math.abs(offsetMinutes);
+  const hours = String(Math.floor(absoluteOffset / 60)).padStart(2, '0');
+  const minutes = String(absoluteOffset % 60).padStart(2, '0');
+  return `${raw}${sign}${hours}:${minutes}`;
+}
+
+function dateTimeLocalValue(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number,
+): string {
+  const pad = (part: number) => String(part).padStart(2, '0');
+  const minuteValue = [
+    year,
+    '-',
+    pad(month),
+    '-',
+    pad(day),
+    'T',
+    pad(hour),
+    ':',
+    pad(minute),
+  ].join('');
+  return second === 0 && millisecond === 0
+    ? minuteValue
+    : `${minuteValue}:${pad(second)}${
+      millisecond === 0 ? '' : `.${String(millisecond).padStart(3, '0')}`
+    }`;
+}
+
+function naiveDateTimeLocalValue(text: string): string | null {
+  const match = text.match(
+    /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?/,
+  );
+  if (!match) return null;
+  const [, year, month, day, hour, minute, second = '0', fraction = ''] = match;
+  return dateTimeLocalValue(
+    Number(year),
+    Number(month),
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second),
+    Number(fraction.padEnd(3, '0').slice(0, 3)),
+  );
+}
+
+/** Convert an API attribute value to the representation required by its HTML input. */
+export function formatAttributeInputValue(value: unknown, colType: string): string {
+  const text = String(value);
+  if (getAttributeInputType(colType) !== 'datetime-local') return text;
+
+  if (!isTimezoneAwareTimestamp(colType)) {
+    return naiveDateTimeLocalValue(text) ?? text;
+  }
+
+  const instant = new Date(text);
+  if (Number.isNaN(instant.getTime())) return text;
+  return dateTimeLocalValue(
+    instant.getFullYear(),
+    instant.getMonth() + 1,
+    instant.getDate(),
+    instant.getHours(),
+    instant.getMinutes(),
+    instant.getSeconds(),
+    instant.getMilliseconds(),
+  );
+}
+
+/** Convert an HTML datetime-local value to the timestamp column's wire representation. */
+export function serializeAttributeInputValue(
+  raw: string,
+  colType: string,
+  initialValue?: unknown,
+): string {
+  if (
+    initialValue !== undefined
+    && initialValue !== null
+    && raw === formatAttributeInputValue(initialValue, colType)
+  ) {
+    return String(initialValue);
+  }
+
+  if (!isTimezoneAwareTimestamp(colType)) return raw;
+  return localTimestampWithOffset(raw) ?? raw;
+}
+
 const TRUE_WORDS = new Set(['true', 't', '1', 'yes', 'y']);
 const FALSE_WORDS = new Set(['false', 'f', '0', 'no', 'n']);
 
@@ -58,9 +188,17 @@ export function coerceAttributeValue(
       return { ok: false };
     }
     case 'date':
-    case 'datetime-local':
-      // ISO strings, same wire shape AttributeForm sends.
       return { ok: true, value: trimmed };
+    case 'datetime-local': {
+      if (!isTimezoneAwareTimestamp(colType)) return { ok: true, value: trimmed };
+      if (hasTimezoneOffset(trimmed)) {
+        return Number.isNaN(new Date(trimmed).getTime())
+          ? { ok: false }
+          : { ok: true, value: trimmed };
+      }
+      const timestamp = localTimestampWithOffset(trimmed);
+      return timestamp === null ? { ok: false } : { ok: true, value: timestamp };
+    }
     default:
       // text keeps the raw, untrimmed value.
       return { ok: true, value: raw };

--- a/frontend/src/lib/attribute-values.ts
+++ b/frontend/src/lib/attribute-values.ts
@@ -10,13 +10,18 @@ export type AttributeInputType =
   | 'datetime-local'
   | 'text';
 
-export function getAttributeInputType(colType: string): AttributeInputType {
+export function getAttributeInputType(colType: string, value?: unknown): AttributeInputType {
   const t = colType.toLowerCase();
   if (t === 'integer' || t === 'bigint') return 'number-int';
   if (['double precision', 'real', 'numeric'].includes(t)) return 'number-float';
   if (t === 'boolean') return 'checkbox';
   if (t === 'date') return 'date';
-  if (t === 'timestamp' || t === 'timestamptz' || t.startsWith('timestamp')) return 'datetime-local';
+  if (t === 'timestamp' || t === 'timestamptz' || t.startsWith('timestamp')) {
+    const localYear = isTimezoneAwareTimestamp(t) ? new Date(String(value)).getFullYear() : NaN;
+    // Preserve the original offset when local conversion exceeds Python's year range.
+    if (localYear < 1 || localYear > 9999) return 'text';
+    return 'datetime-local';
+  }
   return 'text';
 }
 
@@ -113,7 +118,7 @@ function naiveDateTimeLocalValue(text: string): string | null {
 /** Convert an API attribute value to the representation required by its HTML input. */
 export function formatAttributeInputValue(value: unknown, colType: string): string {
   const text = String(value);
-  if (getAttributeInputType(colType) !== 'datetime-local') return text;
+  if (getAttributeInputType(colType, value) !== 'datetime-local') return text;
 
   if (!isTimezoneAwareTimestamp(colType)) {
     return naiveDateTimeLocalValue(text) ?? text;

--- a/frontend/src/lib/attribute-values.ts
+++ b/frontend/src/lib/attribute-values.ts
@@ -76,7 +76,7 @@ function dateTimeLocalValue(
 ): string {
   const pad = (part: number) => String(part).padStart(2, '0');
   const minuteValue = [
-    year,
+    String(year).padStart(4, '0'),
     '-',
     pad(month),
     '-',

--- a/frontend/src/lib/attribute-values.ts
+++ b/frontend/src/lib/attribute-values.ts
@@ -36,7 +36,7 @@ function hasTimezoneOffset(value: string): boolean {
   return /(?:z|[+-]\d{2}:?\d{2})$/i.test(value);
 }
 
-function localTimestampWithOffset(raw: string): string | null {
+function localTimestampAsInstant(raw: string): string | null {
   const match = raw.match(
     /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?$/,
   );
@@ -62,12 +62,10 @@ function localTimestampWithOffset(raw: string): string | null {
     || instant.getSeconds() !== Number(second)
     || instant.getMilliseconds() !== milliseconds
   ) return null;
-  const offsetMinutes = instant.getTimezoneOffset();
-  const sign = offsetMinutes <= 0 ? '+' : '-';
-  const absoluteOffset = Math.abs(offsetMinutes);
-  const hours = String(Math.floor(absoluteOffset / 60)).padStart(2, '0');
-  const minutes = String(absoluteOffset % 60).padStart(2, '0');
-  return `${raw}${sign}${hours}:${minutes}`;
+  if (instant.getUTCFullYear() < 1 || instant.getUTCFullYear() > 9999) return null;
+  // Native conversion retains historical offset seconds; keep sub-millisecond input precision.
+  const utcSeconds = instant.toISOString().split('.')[0];
+  return `${utcSeconds}${fraction ? `.${fraction}` : ''}Z`;
 }
 
 function dateTimeLocalValue(
@@ -152,7 +150,7 @@ export function serializeAttributeInputValue(
   }
 
   if (!isTimezoneAwareTimestamp(colType)) return raw;
-  return localTimestampWithOffset(raw) ?? raw;
+  return localTimestampAsInstant(raw) ?? raw;
 }
 
 const TRUE_WORDS = new Set(['true', 't', '1', 'yes', 'y']);
@@ -184,7 +182,7 @@ export function coerceAttributeValue(
     }
     case 'number-float': {
       const n = Number(trimmed);
-      return Number.isNaN(n) ? { ok: false } : { ok: true, value: n };
+      return Number.isFinite(n) ? { ok: true, value: n } : { ok: false };
     }
     case 'checkbox': {
       const w = trimmed.toLowerCase();
@@ -201,7 +199,7 @@ export function coerceAttributeValue(
           ? { ok: false }
           : { ok: true, value: trimmed };
       }
-      const timestamp = localTimestampWithOffset(trimmed);
+      const timestamp = localTimestampAsInstant(trimmed);
       return timestamp === null ? { ok: false } : { ok: true, value: timestamp };
     }
     default:


### PR DESCRIPTION
## Summary

Editing workflows could lose newer drafts or selections when earlier requests finished, and the page-level Save button did not flush active multiline metadata. Preserve request ownership across dataset/account changes, keep failed creates retryable, and make metadata Save persist active input.

## Changes

- Scope feature, attribute, metadata draft and schema responses to their originating editor session and authenticated user; prevent duplicate submissions and retain newer input even when account rehydration preserves the session epoch.
- Accept supported date/timestamp feature values using existing parsers; reject duplicate initial columns and retained-metadata rename collisions before DDL.
- Update record modification metadata transactionally when contacts, keywords or distributions change.
- Reject non-finite numeric inline edits before JSON serialization can turn them into null.
- Require timezone offsets for timestamptz writes; browser controls preserve local time, DST folds and unchanged fractional precision. Retain four-digit historical years; use original timestamp text when local conversion exceeds supported years 1–9999.
- Migration 0062 makes record modification timestamps monotonic under concurrent transactions. It follows the merged #2065 migration 0061 in a single linear chain.
- No dependencies, static public API/schema changes or new UI strings. The reviewed editing-audit skill/playbook was updated locally in ignored assistant directories.

## Area

- [x] Backend (API, services, models)
- [x] Frontend (UI, components, hooks)
- [x] Tiles / Rendering

## Testing

- Backend: 121 feature/layer tests, 52 concurrency/metadata/tenant-binding tests, 101 record/auth tests, 50 layering tests; Ruff lint/format and finding-marker checks passed.
- Frontend: final integrated full suite 6,202 tests passed, 80.48% line coverage; build, lint and project typecheck passed. Focused suites include 60 schema/feature tests and 40 draft/inline integration tests.
- Playwright MCP against the edited local checkout: disabled-editing denial; date feature creation; inline attribute edit and reload; schema add; active multiline metadata Save and reload; record keyword edit advances modification timestamp. Browser had no application errors after successful workflows; three existing basemap filter warnings remain.
- Additional Playwright MCP: America/New_York inline timestamp edit `10:30` persisted as `14:30 UTC` and survived reload. Disposable datasets removed; original editing flag restored.
- Historical timestamp regression: native datetime inputs retain zero-padded years 0001, 0099 and 0999 for aware and timezone-free columns; 48 focused formatter/form/table tests pass, including year 1 underflow and year 9999 overflow with eastern/western timezones and positive/negative offsets; unchanged wire timestamps remain exact.
- Historical offset/numeric regression: ten tests reproduced incorrect second-level offsets or accepted non-finite values before the fix and pass afterward. Playwright MCP in America/New_York confirmed `0999-05-06T07:37:58.123456` → `0999-05-06T12:34:00.123456Z` exactly; Infinity and numeric overflow are rejected. Real browsers also passed New York/Kiritimati year-boundary input hydration.
- Account-switch regression: all three new unchanged-epoch identity tests failed before the fix and pass afterward; 30 focused draft/hook integration tests pass.
- Final base integration: 113 auth-family/editing/layering tests passed; Ruff lint/format, finding markers, OpenAPI drift and frontend build/lint/typecheck/coverage/types drift checks passed.
- Final migration proof: fresh isolated upgrade through 0061 → 0062, downgrade 0062 → 0061, reupgrade and both Alembic drift checks passed. Dev DB was actually downgraded from temporary standalone 0062 to 0060 before rebasing, then upgraded through 0061 → 0062; API restarted healthy and dev drift check passed. Disposable migration DB removed.
- Screenshot captured locally: `editing-audit-metadata-saved.png` (browser artifact; not committed).

## Checklist

- [x] Code follows existing project conventions
- [x] Existing localization keys reused
- [x] No new lint warnings in completed checks
- [x] TypeScript compiles in completed checks
- [x] Migration included; final 0061 → 0062 upgrade/downgrade/reupgrade and drift checks passed
- [x] No secrets or credentials in the diff

Final integrated head f6891a1c4 received a clear Codex review with no unresolved findings. All required PR and merge-group checks passed; merged through the required queue as f95380188468dd3b79cd78e056debe69e976bff9. Primary is clean on the merged main, API health passes, and the dev database remains at migration 0062. Cross-tenant HTTP fault injection and full reupload/browser map-consumer coverage are not claimed by this audit.






