### PR TITLE
docs(changelog): record unreleased session improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and releases use semantic versioning.
 
 ## [Unreleased]
 
+### Added
+
+- Administrators can filter the user directory by one assigned role. The filter is applied before
+  pagination, remains in the page URL, and returns to the first page when changed. Password reset
+  is disabled with an explanation for identity-provider-only accounts, while local accounts that
+  also have a linked identity provider remain eligible. (#2067)
+
+### Fixed
+
+- Large uploads through the production frontend are streamed to the API instead of being copied
+  into the frontend container's 64 MiB temporary filesystem. The configured request-size limit
+  still rejects oversized bodies, and the API retains its bounded upload staging behavior. (#2064)
+- Reusing a rotated refresh credential after its concurrency grace period revokes that device's
+  session family, including concurrent rotation branches, without ending sessions on other
+  devices. A sign-in discarded after profile loading fails is revoked instead of remaining usable.
+  (#2065)
+- Late feature, attribute, schema, and metadata responses no longer overwrite newer edits after a
+  dataset or account change. Saving a dataset flushes the active multiline metadata field, failed
+  feature creation remains retryable, and record modification timestamps advance transactionally
+  when record metadata changes. (#2066)
+- Timestamp feature fields preserve unchanged database precision, convert browser-local values to
+  explicit instants for timezone-aware columns, and retain wall-clock values for columns without
+  timezones. Invalid daylight-saving gaps and non-finite numeric values are refused before they can
+  be saved as a different value. (#2066)
+
 ## [1.19.1] - 2026-09-12
 
 ### Fixed


### PR DESCRIPTION
## Summary

Record the user-visible upload, session, editing, and admin changes completed in this development session under Unreleased. The existing README, RUNBOOK, architecture, and contributor guidance already cover these capabilities at the appropriate level; the 0061 refresh-family operator contract is already documented in detail.

This PR should merge after #2066 and #2067 so every Unreleased claim exists on `main`.

## Changes

- document production upload streaming and refresh-session family protections
- document stale editing-response, timestamp, numeric-value, and record-modification fixes
- document admin role filtering and password-reset eligibility
- keep the release version and date unchanged

## Area

- [ ] Backend (API, services, models)
- [ ] Frontend (UI, components, hooks)
- [ ] Infrastructure (Docker, nginx)
- [ ] Tiles / Rendering
- [ ] Auth / Permissions
- [ ] Import / Ingestion
- [ ] OGC / Standards
- [x] Docs / Config

## Testing

- [ ] Unit tests pass (`pytest` / `npm test`)
- [x] Manual testing (describe below)
- [ ] Playwright e2e (if UI changes)
- [x] No tests needed (docs, config, etc.)

`git diff --check` passes. A bounded relative-link check covered README, RUNBOOK, CHANGELOG, CONTRIBUTING, and ARCHITECTURE with zero broken links.

## Checklist

- [x] Code follows existing project conventions
- [ ] i18n: new user-facing strings added to all 5 locales (en, fr, es, de, zh) — no UI strings
- [x] No new lint warnings (`ruff check`, `eslint`) — no source changes
- [ ] TypeScript compiles without errors — no source changes
- [ ] Migration included (if DB schema changed) — no schema change
- [x] No secrets or credentials in the diff
- [ ] Release/docs deploys: ran `make deployed-surface-check` after the marketing/docs deploy and recorded the result in Testing — no deploy
